### PR TITLE
dashing/console-bridge: init at 0.4.3

### DIFF
--- a/dashing/console-bridge/default.nix
+++ b/dashing/console-bridge/default.nix
@@ -1,0 +1,25 @@
+{ stdenv,
+  fetchFromGitHub,
+  cmake
+}:
+
+stdenv.mkDerivation rec {
+  pname = "console_bridge";
+  version = "0.4.3";
+
+  src = fetchFromGitHub {
+    owner = "ros";
+    repo = "${pname}"; 
+    rev = "${version}";
+    sha256 = "0vk2ji4q93w3fw4s6p0i9d3x2ppsmhxm3x7qrcl4jfr0pyj96n5x"; 
+  };
+
+  nativeBuildInputs = [ cmake ];
+
+  meta = with stdenv.lib; {
+    description = "A ROS-independent package for logging that seamlessly pipes into rosconsole/rosout for ROS-dependent packages.";
+    homepage = https://github.com/ros/console_bridge;
+    license = licenses.bsdOriginal;
+    maintainers = with maintainers; [ marijanp ];
+  };
+}

--- a/dashing/generated.nix
+++ b/dashing/generated.nix
@@ -174,6 +174,8 @@ self: super: {
 
  connext-cmake-module = self.callPackage ./connext-cmake-module {};
 
+ console-bridge = self.callPackage ./console-bridge {};
+ 
  console-bridge-vendor = self.callPackage ./console-bridge-vendor {};
 
  control-msgs = self.callPackage ./control-msgs {};


### PR DESCRIPTION
Trying to enter a nix-shell with dashing/ros-core as an environment input ended up in an error that the definition for console-bridge is missing.

I've added the package to the dashing subdirectory but I suspect that it will be needed by other distributions too. Thus it might better fit in base.nix

I wanted to open this PR, to show interest in helping you maintainig this repo and discuss further improvements.

btw: @lopsided98 thank you for publishing this repo.