### PR TITLE
rosdistro sync, Sun Dec  8 19:32:57 2019

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,25 @@
+name: Update overlay using Superflore
+on:
+  schedule:
+    - cron: "0 12 * * FRI"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - name: Install Superflore
+        run: |
+          python -m pip install --upgrade pip
+          pip install git+https://github.com/lopsided98/superflore.git@nixos-support
+      - name: Update overlay
+        env:
+          SUPERFLORE_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          superflore-gen-nix \
+            --tar-archive-dir tar \
+            --output-repository-path . \
+            --all

--- a/dashing/ament-cmake-auto/default.nix
+++ b/dashing/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-auto";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_auto/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "76740cdb80e665b87e70129ab0b9844164c9e8e8af203aa04de9a76c20ec2899";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_auto/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "936deaa36b66a74c15c11f1c0abccbc42994c839213bdb334042cb2baa934379";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-core/default.nix
+++ b/dashing/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-core";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_core/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "95f05275a1866da8af17a8b413ad049a9677e0d62f14d900d29c9d1d28dde1c3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_core/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "d9e308452be90fb2dabc009319fdb70e7137307ea7e643d36b74f8b0221e45f6";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-definitions/default.nix
+++ b/dashing/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-definitions";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_definitions/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "8bf93fb5974aa4f20eb52508b888d2d95bf36efca3195093e0262791e59edda7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_definitions/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "e6a308c0724927d8ab359310f5fa4e9dc0255f6f673c5a4628931c7baae08cf2";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-dependencies/default.nix
+++ b/dashing/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-dependencies";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_dependencies/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "81f4de362cd4ad852b227cb72ba9bb9f40479cbd5c686ca33ece5426a92e618a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_dependencies/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "da4f09e9412d291d4f59208e85b69d7942c0037abd31aafe93a69eaa0927aa4d";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-include-directories/default.nix
+++ b/dashing/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-include-directories";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_include_directories/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "d6e05538b219aac40034de65c0ce9f6aece612560113145b148490a872a1f4b3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_include_directories/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "0ab2e62198c50745e4657e57527d5c3bca1df440b82aef426c5d92205ddb7507";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-interfaces/default.nix
+++ b/dashing/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-export-libraries, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-interfaces";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_interfaces/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "cc7265eeb9ebd79a8c7986c7895d989efe42c3b0da4d20aac43877c36eb053c9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_interfaces/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "83a244de9126822a35628df0bd9a12c22f19935193a216b34a3c425fcd6457fa";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-libraries/default.nix
+++ b/dashing/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-libraries";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_libraries/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "6e32f89db5364285db47a8ba1904e1c0fc1653155bcb8683526eeb7e15bb386d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_libraries/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "48adb4c4129235d2f2d693e6bdd5da88a52fe77c3c84f1995535e62d149cdd46";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-export-link-flags/default.nix
+++ b/dashing/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-link-flags";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_link_flags/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "0fcfacd5f9c78b551cbd54e7524198acbc413979b2873b2d9ab2e9fb0c4afc1c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_link_flags/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "c9e6a26f1dd9a6c7977dea8666dc8f614a7f797b67957c36213b9e490e22ab59";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-gmock/default.nix
+++ b/dashing/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gmock }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-gmock";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gmock/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "6cc97a96918c313c0e218958b05c99b96322373c24883ae920d7d22c98b835fd";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gmock/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "3c20dbe22a2991fb46f82c49a9587cad71c698c8e3503b90be0031e44e0630d8";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-gtest/default.nix
+++ b/dashing/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-test, gtest, gtest-vendor, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-gtest";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gtest/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "0d52758eaa9fd6e581271868094ab4ef4b426757273ca0860d1cedff209fff97";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gtest/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "d3134f4f8676af0eaadba25e6efdbf132a0033a5a25000373cc6d33fc044089d";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-include-directories/default.nix
+++ b/dashing/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-include-directories";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_include_directories/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "12e713b830d4b1c494f4eda2774528c6970a33d83dd6f4e0df36dee2d1fed29e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_include_directories/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "0778af87455a25e073d93635146e3d45db28bf44771432cd3abe5e17e83892e1";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-libraries/default.nix
+++ b/dashing/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-libraries";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_libraries/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e8c0e034ca253fbe355cc8f96e30cb3fbe32a565678043f78627bb9b26e6d03b";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_libraries/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "a9e580ee98b547670baacfa5abe951d5a4a0c95524792c9d9e5d92bc7ffd618e";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-nose/default.nix
+++ b/dashing/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-test, ament-cmake-core, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-nose";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_nose/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "2901f185b0dffc42878d8ff55e270b8a825a787aadda218b82a4fab648c20e65";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_nose/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5c1dcaf23d0df2f37fd484d0b7a49b297d3d24f2175e4e327ef5fa9610f48d58";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-pytest/default.nix
+++ b/dashing/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-test, pythonPackages, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pytest";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_pytest/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "c412698e38df13eec825abcec2e8dff4f76747169c78840b5dfcf5376493594f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_pytest/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "404c5c7909190f7c6ab90b44c009dd4e5bebb0ceada24caa019475852777948d";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-python/default.nix
+++ b/dashing/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-python";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_python/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "65912f08551ea941d816ea19dfb93fdda669f71ad5d7edd04cdf0f4bb099893a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_python/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5758e8d2bc0acbb8cbf7222bae792f3af0f8f748d2f238f0a819f961f8d592d1";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-target-dependencies/default.nix
+++ b/dashing/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-include-directories, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-target-dependencies";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_target_dependencies/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "769030676751241ad4424d576d44084726a7db662ddf0ad231bffab0c515834c";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_target_dependencies/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "f0b483d7d65306707eb1d93c2f68c91f2e5515dedccd233849f98451b00cb11d";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-test/default.nix
+++ b/dashing/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-test";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_test/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "63ed3c09acd53fffc92055b2251bfd72eb1bb0b9787640b2b8004633576f8ce7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_test/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "96a5a939a05e680cfb5337cc288e4dec979890c481b40da102d463b0418b8643";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-cmake-virtualenv/default.nix
+++ b/dashing/ament-cmake-virtualenv/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-virtualenv, ament-cmake-core, ament-cmake-test, ament-cmake-lint-cmake, ament-cmake-copyright }:
+buildRosPackage {
+  pname = "ros-dashing-ament-cmake-virtualenv";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/esol-community/ament_virtualenv-release/archive/release/dashing/ament_cmake_virtualenv/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "3b86f3042a1ee4a512807eca05b2f08e2a814756b1cf893be0377f3fd83cdd8f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  nativeBuildInputs = [ ament-cmake-test ament-cmake-core ament-virtualenv ];
+
+  meta = {
+    description = ''Bundle python requirements in a ament package via virtualenv.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/dashing/ament-cmake/default.nix
+++ b/dashing/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-export-link-flags, ament-cmake-export-definitions, ament-cmake-core, ament-cmake-libraries, ament-cmake-export-libraries, ament-cmake-test, ament-cmake-target-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-python, cmake, ament-cmake-export-dependencies }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e68e052b7c72bd9184bc76b8d804a184b99339d617c5f214a4a89ca976534d83";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "fe1f62c644a688180848873dc9a8a865e3a440d406163b1bf3ad3e8b46dde818";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ament-virtualenv/default.nix
+++ b/dashing/ament-virtualenv/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, pythonPackages, ament-flake8, ament-pep257 }:
+buildRosPackage {
+  pname = "ros-dashing-ament-virtualenv";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/esol-community/ament_virtualenv-release/archive/release/dashing/ament_virtualenv/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "b9a25cd1decc54ab252e83a6fdc07bff94615a92befb8edafa819bc0bcf072ae";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-copyright pythonPackages.pytest ament-pep257 ];
+
+  meta = {
+    description = ''Bundle python requirements in a ament package via virtualenv.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/dashing/behaviortree-cpp-v3/default.nix
+++ b/dashing/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppzmq, ament-cmake-gtest, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-behaviortree-cpp-v3";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/dashing/behaviortree_cpp_v3/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "81ed95918328456e1d71e6646f99e33025313518c4f4a9893428b11218a689ca";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/dashing/behaviortree_cpp_v3/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "55902e5c1e718b02a0abcfa40dc5278485bc59a1a14da9d2f466767ae1c84a2f";
   };
 
   buildType = "ament_cmake";

--- a/dashing/cloudwatch-logs-common/default.nix
+++ b/dashing/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, file-management, ament-cmake-gmock, dataflow-lite, ament-cmake-gtest, aws-common, cmake }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-logs-common";
-  version = "1.1.1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.1-0.tar.gz";
-    name = "1.1.1-0.tar.gz";
-    sha256 = "959c34399c5ba6905d20b4f08ce75fee42a853f14d72d3199fff9eb24c420267";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "02a0f0b6fa4f57da332b379dbb2b5d12a1dae647be942232c6078430f38c1ee7";
   };
 
   buildType = "cmake";

--- a/dashing/cloudwatch-metrics-common/default.nix
+++ b/dashing/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, file-management, ament-cmake-gmock, dataflow-lite, ament-cmake-gtest, aws-common, cmake }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-metrics-common";
-  version = "1.1.1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.1-0.tar.gz";
-    name = "1.1.1-0.tar.gz";
-    sha256 = "30cb38d89cab29d88538f07f4c698e89755b60a71d3e403531806549ddb84c11";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "aa6226c67e5609a4c0266f64492155d352b404564ee9839f8aaa3277bd68432e";
   };
 
   buildType = "cmake";

--- a/dashing/connext-cmake-module/default.nix
+++ b/dashing/connext-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-cmake, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-connext-cmake-module";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/connext_cmake_module/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "4afe4bbacd83e7081914c2dd7e87fe17e3d3d64bb5cc0ce69908cf5ef08c9fdf";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/connext_cmake_module/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "1495eed5b5681b0ec8f8aac28d8b1bfbfc0e4572399429032508fd0c5d4c542c";
   };
 
   buildType = "ament_cmake";

--- a/dashing/cv-bridge/default.nix
+++ b/dashing/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-ros, boost, ament-lint-common, sensor-msgs, ament-cmake-gtest, python-cmake-module, python3Packages, ament-index-python, ament-lint-auto, opencv3 }:
 buildRosPackage {
   pname = "ros-dashing-cv-bridge";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/cv_bridge/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "a2ea40ef8b0826917ff9994b9411ab0999302bf1ac025d0bb07e2d8488e62551";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/cv_bridge/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "7d8c362d9df4e63302b346cc187549171afe07d8cae4dd0996750961970e4960";
   };
 
   buildType = "ament_cmake";

--- a/dashing/cyclonedds-cmake-module/default.nix
+++ b/dashing/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-cmake, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds-cmake-module";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "a81d791e39459b58625d3bb4a4c4dfbb8ab3d64b0756ae94157fd836de1fda9e";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "99f8cea21b1700fb371f858b30a2a783330eca757017476589c148d87dab5b2a";
   };
 
   buildType = "ament_cmake";

--- a/dashing/dataflow-lite/default.nix
+++ b/dashing/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, ament-cmake-gtest, cmake, ament-cmake-gmock }:
 buildRosPackage {
   pname = "ros-dashing-dataflow-lite";
-  version = "1.1.1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.1-0.tar.gz";
-    name = "1.1.1-0.tar.gz";
-    sha256 = "f49f3faab2dd18dd15ceee8f916745ae9b724f6e49a25f3543db72f06415605c";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3b8be01f3b1b075c22c70ab6de3fbfc0ae8aa776c286eda4f426b94cad0f95a2";
   };
 
   buildType = "cmake";

--- a/dashing/depthimage-to-laserscan/default.nix
+++ b/dashing/depthimage-to-laserscan/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, sensor-msgs, image-geometry, rclcpp, ament-cmake-ros, opencv3 }:
+{ lib, buildRosPackage, fetchurl, opencv3, ament-cmake-gtest, sensor-msgs, image-geometry, rclcpp, ament-cmake-ros, rclcpp-components }:
 buildRosPackage {
   pname = "ros-dashing-depthimage-to-laserscan";
-  version = "2.2.2-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/dashing/depthimage_to_laserscan/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "253b23005498cc6f3da173db6d23e56724d60ddd3debf5b72d520deb76fd388d";
+    url = "https://github.com/ros2-gbp/depthimage_to_laserscan-release/archive/release/dashing/depthimage_to_laserscan/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "9429cdd4e2bb800cf5fda03e12524e4afc7410e8563db1aca2b1b0766a471423";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ sensor-msgs opencv3 rclcpp image-geometry ];
+  buildInputs = [ opencv3 sensor-msgs image-geometry rclcpp rclcpp-components ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ sensor-msgs opencv3 rclcpp image-geometry ];
+  propagatedBuildInputs = [ opencv3 sensor-msgs image-geometry rclcpp rclcpp-components ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/dashing/dynamic-edt-3d/default.nix
+++ b/dashing/dynamic-edt-3d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, octomap }:
+buildRosPackage {
+  pname = "ros-dashing-dynamic-edt-3d";
+  version = "1.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/dashing/dynamic_edt_3d/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "e364c405c00d4b2366997b78bfd4f0be73a42c8b123d39c58c6379a317bcf79c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ octomap ];
+  propagatedBuildInputs = [ octomap ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The dynamicEDT3D library implements an inrementally updatable Euclidean distance transform (EDT) in 3D. It comes with a wrapper to use the OctoMap 3D representation and hooks into the change detection of the OctoMap library to propagate changes to the EDT.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/file-management/default.nix
+++ b/dashing/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, dataflow-lite, ament-cmake-gtest, aws-common, cmake }:
 buildRosPackage {
   pname = "ros-dashing-file-management";
-  version = "1.1.1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.1-0.tar.gz";
-    name = "1.1.1-0.tar.gz";
-    sha256 = "02198a10c6e9c0641eebd32e5c4c99800f70549b4e1e3814cf77a9d46b068209";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "246be5b507c788ba825c691da1771ab4c2659a84e9a3153b6f9a0f1d441237e2";
   };
 
   buildType = "cmake";

--- a/dashing/generated.nix
+++ b/dashing/generated.nix
@@ -78,6 +78,8 @@ self: super: {
 
  ament-cmake-uncrustify = self.callPackage ./ament-cmake-uncrustify {};
 
+ ament-cmake-virtualenv = self.callPackage ./ament-cmake-virtualenv {};
+
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
 
  ament-copyright = self.callPackage ./ament-copyright {};
@@ -113,6 +115,8 @@ self: super: {
  ament-pyflakes = self.callPackage ./ament-pyflakes {};
 
  ament-uncrustify = self.callPackage ./ament-uncrustify {};
+
+ ament-virtualenv = self.callPackage ./ament-virtualenv {};
 
  ament-xmllint = self.callPackage ./ament-xmllint {};
 
@@ -239,6 +243,8 @@ self: super: {
  dwb-msgs = self.callPackage ./dwb-msgs {};
 
  dwb-plugins = self.callPackage ./dwb-plugins {};
+
+ dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
@@ -462,6 +468,8 @@ self: super: {
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
 
+ libphidget22 = self.callPackage ./libphidget22 {};
+
  librealsense2 = self.callPackage ./librealsense2 {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -556,6 +564,10 @@ self: super: {
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
+ novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
+
+ novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
+
  object-analytics-msgs = self.callPackage ./object-analytics-msgs {};
 
  object-analytics-node = self.callPackage ./object-analytics-node {};
@@ -563,6 +575,8 @@ self: super: {
  object-analytics-rviz = self.callPackage ./object-analytics-rviz {};
 
  object-msgs = self.callPackage ./object-msgs {};
+
+ octomap = self.callPackage ./octomap {};
 
  ompl = self.callPackage ./ompl {};
 
@@ -587,6 +601,36 @@ self: super: {
  pendulum-msgs = self.callPackage ./pendulum-msgs {};
 
  people-msgs = self.callPackage ./people-msgs {};
+
+ perception-pcl = self.callPackage ./perception-pcl {};
+
+ phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
+
+ phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
+
+ phidgets-api = self.callPackage ./phidgets-api {};
+
+ phidgets-digital-inputs = self.callPackage ./phidgets-digital-inputs {};
+
+ phidgets-digital-outputs = self.callPackage ./phidgets-digital-outputs {};
+
+ phidgets-drivers = self.callPackage ./phidgets-drivers {};
+
+ phidgets-gyroscope = self.callPackage ./phidgets-gyroscope {};
+
+ phidgets-high-speed-encoder = self.callPackage ./phidgets-high-speed-encoder {};
+
+ phidgets-ik = self.callPackage ./phidgets-ik {};
+
+ phidgets-magnetometer = self.callPackage ./phidgets-magnetometer {};
+
+ phidgets-motors = self.callPackage ./phidgets-motors {};
+
+ phidgets-msgs = self.callPackage ./phidgets-msgs {};
+
+ phidgets-spatial = self.callPackage ./phidgets-spatial {};
+
+ phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
  pluginlib = self.callPackage ./pluginlib {};
 
@@ -810,6 +854,8 @@ self: super: {
 
  rqt-action = self.callPackage ./rqt-action {};
 
+ rqt-common-plugins = self.callPackage ./rqt-common-plugins {};
+
  rqt-console = self.callPackage ./rqt-console {};
 
  rqt-graph = self.callPackage ./rqt-graph {};
@@ -833,6 +879,8 @@ self: super: {
  rqt-py-console = self.callPackage ./rqt-py-console {};
 
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
+
+ rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
 
@@ -889,6 +937,30 @@ self: super: {
  std-srvs = self.callPackage ./std-srvs {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ swri-console-util = self.callPackage ./swri-console-util {};
+
+ swri-dbw-interface = self.callPackage ./swri-dbw-interface {};
+
+ swri-geometry-util = self.callPackage ./swri-geometry-util {};
+
+ swri-image-util = self.callPackage ./swri-image-util {};
+
+ swri-math-util = self.callPackage ./swri-math-util {};
+
+ swri-opencv-util = self.callPackage ./swri-opencv-util {};
+
+ swri-prefix-tools = self.callPackage ./swri-prefix-tools {};
+
+ swri-roscpp = self.callPackage ./swri-roscpp {};
+
+ swri-route-util = self.callPackage ./swri-route-util {};
+
+ swri-serial-util = self.callPackage ./swri-serial-util {};
+
+ swri-system-util = self.callPackage ./swri-system-util {};
+
+ swri-transform-util = self.callPackage ./swri-transform-util {};
 
  system-modes = self.callPackage ./system-modes {};
 

--- a/dashing/image-geometry/default.nix
+++ b/dashing/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake-gtest, sensor-msgs, ament-cmake-ros, ament-cmake-python, opencv3 }:
 buildRosPackage {
   pname = "ros-dashing-image-geometry";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/image_geometry/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "bfe67d90fad2392c92ffb0cc8afd12b17482259266fc93b0893e9b5c4c04fbf9";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/image_geometry/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "7d8caaf5318b9290ac0649b968fc0c3052d399a05534a481805eed9d95e9ef58";
   };
 
   buildType = "ament_cmake";

--- a/dashing/kinesis-video-msgs/default.nix
+++ b/dashing/kinesis-video-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, diagnostic-msgs, rosidl-default-generators, rosidl-default-runtime, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-kinesis-video-msgs";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/dashing/kinesis_video_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "1ddec6d31c5a5a7bbfdc42d80d4ebed5a027516b99727c86d4f572e67c6d4b6a";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/dashing/kinesis_video_msgs/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2bc35c68e788573943d2bf3bc996b397091056faf911255e32584f0090c900af";
   };
 
   buildType = "ament_cmake";

--- a/dashing/kinesis-video-streamer/default.nix
+++ b/dashing/kinesis-video-streamer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-ros2-common, ament-cmake, launch-ros, ament-cmake-gmock, image-transport, ament-cmake-gtest, launch, rmw-implementation, aws-common, kinesis-video-msgs, rclcpp, kinesis-manager, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-kinesis-video-streamer";
-  version = "3.0.0-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/dashing/kinesis_video_streamer/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "4249dc41ff27f3e5851af754aa7406d45cf3847c6af5b68a1983bbb65060e4f7";
+    url = "https://github.com/aws-gbp/kinesis_video_streamer-release/archive/release/dashing/kinesis_video_streamer/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "72d1aeda46a24f217cbc5e04f60d9a71b2a12b9458f9751602aee0b29eedddec";
   };
 
   buildType = "ament_cmake";

--- a/dashing/libcurl-vendor/default.nix
+++ b/dashing/libcurl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, curl, ament-cmake, pkg-config }:
 buildRosPackage {
   pname = "ros-dashing-libcurl-vendor";
-  version = "2.1.0-r2";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/libcurl_vendor/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "4f7bb3b4b3e90736001cfd06bf7bb1c6f81d660422584e6e465f2c499a95e222";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/libcurl_vendor/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "1986856afbec5cb344157e0b0459358e2a216202c3e73d809bc029a38bb5657b";
   };
 
   buildType = "ament_cmake";

--- a/dashing/libphidget22/default.nix
+++ b/dashing/libphidget22/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, libusb1, ament-cmake, libusb }:
+buildRosPackage {
+  pname = "ros-dashing-libphidget22";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/libphidget22/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "24f2c220738f1468bad2072dfcaab8471fc5fd9ca12d3fb8180ad294335ddb37";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ libusb1 ];
+  propagatedBuildInputs = [ libusb ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package wraps the libphidget22 to use it as a ROS dependency'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/dashing/message-filters/default.nix
+++ b/dashing/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, ament-cmake-pytest, rclpy, ament-cmake-gtest, sensor-msgs, python-cmake-module, std-msgs, rclcpp, ament-cmake-ros, ament-cmake-python, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-message-filters";
-  version = "3.1.2-r1";
+  version = "3.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/dashing/message_filters/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "53ebd19fcd37731c28833d0c11f6aea1f4b00baecd246044afbf3b05f7d799a4";
+    url = "https://github.com/ros2-gbp/ros2_message_filters-release/archive/release/dashing/message_filters/3.1.3-1.tar.gz";
+    name = "3.1.3-1.tar.gz";
+    sha256 = "0d19c30447f72c1c61abbba87a8b8ebe799a11b105098977df7b30bbe9ead120";
   };
 
   buildType = "ament_cmake";

--- a/dashing/novatel-gps-driver/default.nix
+++ b/dashing/novatel-gps-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diagnostic-msgs, boost, libpcap, ament-cmake-gtest, gps-msgs, rclcpp, swri-math-util, tf2-geometry-msgs, nav-msgs, ament-index-cpp, std-msgs, swri-serial-util, sensor-msgs, diagnostic-updater, tf2, swri-roscpp, novatel-gps-msgs, ament-lint-auto, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-novatel-gps-driver";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_driver/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "bec8812154087cc0d76383a58e50cb5d24688fc817aea4b7c223c4f6c7eb1a39";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ swri-math-util swri-serial-util boost libpcap tf2-geometry-msgs sensor-msgs diagnostic-updater tf2 swri-roscpp nav-msgs gps-msgs rclcpp novatel-gps-msgs std-msgs diagnostic-msgs rclcpp-components ];
+  checkInputs = [ ament-lint-auto ament-cmake-gtest ament-index-cpp ];
+  propagatedBuildInputs = [ swri-math-util swri-serial-util boost tf2-geometry-msgs libpcap sensor-msgs diagnostic-updater swri-roscpp tf2 nav-msgs gps-msgs rclcpp novatel-gps-msgs std-msgs diagnostic-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver for NovAtel receivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/novatel-gps-msgs/default.nix
+++ b/dashing/novatel-gps-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, std-msgs, rosidl-default-generators, rosidl-default-runtime, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-novatel-gps-msgs";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_msgs/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "055a89dababf0cd077bfc3ea1a761051fe80b979dad06bf64bf9bbbd1da388b1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-msgs ];
+  propagatedBuildInputs = [ std-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ rosidl-default-generators ament-cmake ];
+
+  meta = {
+    description = ''Messages for proprietary (non-NMEA) sentences from Novatel GPS receivers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/octomap/default.nix
+++ b/dashing/octomap/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-dashing-octomap";
+  version = "1.9.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/dashing/octomap/1.9.2-1.tar.gz";
+    name = "1.9.2-1.tar.gz";
+    sha256 = "cf0eca9afa4bddd48b97b95848fcb12848f47fb3ca4331a0b3b4818ba88d9249";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The OctoMap library implements a 3D occupancy grid mapping approach, providing data structures and mapping algorithms in C++. The map implementation is based on an octree. See
+  http://octomap.github.io for details.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/orocos-kdl/default.nix
+++ b/dashing/orocos-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppunit, cmake, pkg-config, eigen }:
 buildRosPackage {
   pname = "ros-dashing-orocos-kdl";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/dashing/orocos_kdl/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "e3f32820477a0963c3b8dac5c7b008144382f1b707a9b3cacbe7e9433d06653e";
+    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/dashing/orocos_kdl/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d734e2a96069add0c6c5d1d865020de78821d63979ee3b815fdab5c2a004b091";
   };
 
   buildType = "cmake";

--- a/dashing/pcl-conversions/default.nix
+++ b/dashing/pcl-conversions/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, builtin-interfaces, ament-cmake, pcl, ament-cmake-gtest, sensor-msgs, eigen, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pcl, ament-cmake-gtest, sensor-msgs, message-filters, rclcpp, pcl-msgs, std-msgs, eigen }:
 buildRosPackage {
   pname = "ros-dashing-pcl-conversions";
   version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/pcl_conversions-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
     sha256 = "1dee570593be56530a89248cd15ba13a1eb72daad1c1a4d452ed7b396db8a134";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ builtin-interfaces pcl sensor-msgs eigen std-msgs ];
+  buildInputs = [ pcl sensor-msgs message-filters rclcpp pcl-msgs std-msgs eigen ];
   checkInputs = [ ament-cmake-gtest ];
-  propagatedBuildInputs = [ builtin-interfaces pcl sensor-msgs eigen std-msgs ];
+  propagatedBuildInputs = [ pcl sensor-msgs message-filters rclcpp pcl-msgs std-msgs eigen ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/dashing/perception-pcl/default.nix
+++ b/dashing/perception-pcl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, pcl-conversions, ament-cmake, pcl-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-perception-pcl";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/perception_pcl/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "0cf8be98de516ad10e8427f7e2ba362edc85e5b5f6a2af718998dc0b64b2e0af";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ pcl-conversions pcl-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PCL (Point Cloud Library) ROS interface stack. PCL-ROS is the preferred
+  bridge for 3D applications involving n-D Point Clouds and 3D geometry
+  processing in ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-accelerometer/default.nix
+++ b/dashing/phidgets-accelerometer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, sensor-msgs, launch, rclcpp, ament-cmake-ros, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-accelerometer";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_accelerometer/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "32b61cba5750fd07baa2d0a08e43b7e9fc3f642091c5d2cfdb48487beae87733";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ sensor-msgs rclcpp-components rclcpp phidgets-api ];
+  propagatedBuildInputs = [ phidgets-api sensor-msgs launch rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Accelerometer devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-analog-inputs/default.nix
+++ b/dashing/phidgets-analog-inputs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-analog-inputs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_analog_inputs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "812990ac8228071fd50f06add6b4c8234ca75c2558f5fae35bec4071d918f20f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-msgs phidgets-api rclcpp-components rclcpp ];
+  propagatedBuildInputs = [ phidgets-api launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Analog Input devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-api/default.nix
+++ b/dashing/phidgets-api/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, libphidget22, ament-cmake-ros }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-api";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_api/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "45f5a5fac73054a7a1aa180ac1e03009d158064a8748c16650045d22982f795f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ libphidget22 ];
+  propagatedBuildInputs = [ libphidget22 ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''A C++ Wrapper for the Phidgets C API'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-digital-inputs/default.nix
+++ b/dashing/phidgets-digital-inputs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-digital-inputs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_inputs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "300ce16fa46296560431d8b3c489f6cc8db3b955bc3c30c4a9ffc0b5d1ac9144";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-msgs phidgets-api rclcpp-components rclcpp ];
+  propagatedBuildInputs = [ phidgets-api launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Digital Input devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-digital-outputs/default.nix
+++ b/dashing/phidgets-digital-outputs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, phidgets-msgs, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-digital-outputs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_outputs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ce1d5f67aca42b09eefbc87b7ea8dee287e6ce2f62482c929350251868d438b9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ phidgets-api phidgets-msgs rclcpp std-msgs rclcpp-components ];
+  propagatedBuildInputs = [ phidgets-api phidgets-msgs launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Digital Output devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-drivers/default.nix
+++ b/dashing/phidgets-drivers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-spatial, phidgets-api, ament-cmake, phidgets-temperature, phidgets-ik, phidgets-motors, phidgets-magnetometer, phidgets-digital-outputs, phidgets-analog-inputs, phidgets-gyroscope, phidgets-digital-inputs, phidgets-high-speed-encoder, libphidget22, phidgets-accelerometer, phidgets-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-drivers";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_drivers/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5fc6c2c23d39bbacaeac470646e7b66d279a2d439abcb2d08aeb36ac8072806e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ phidgets-spatial phidgets-api phidgets-temperature phidgets-ik phidgets-magnetometer phidgets-digital-outputs phidgets-analog-inputs phidgets-accelerometer phidgets-gyroscope phidgets-digital-inputs phidgets-high-speed-encoder libphidget22 phidgets-motors phidgets-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''API and ROS drivers for Phidgets devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-gyroscope/default.nix
+++ b/dashing/phidgets-gyroscope/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, std-srvs, phidgets-api, sensor-msgs, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-gyroscope";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_gyroscope/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "385bbfab6f93ed22993d429902a1f8ca7a4bb8d61c12c5bac2d0d7678495a251";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-srvs phidgets-api sensor-msgs rclcpp std-msgs rclcpp-components ];
+  propagatedBuildInputs = [ std-srvs phidgets-api sensor-msgs launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Gyroscope devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-high-speed-encoder/default.nix
+++ b/dashing/phidgets-high-speed-encoder/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, sensor-msgs, launch, rclcpp, ament-cmake-ros, phidgets-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-high-speed-encoder";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_high_speed_encoder/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "6fd632d74a4e6f11faed8eeb4987f6cc359085b762e5618a70c813bf2c34505d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ phidgets-api sensor-msgs rclcpp phidgets-msgs rclcpp-components ];
+  propagatedBuildInputs = [ phidgets-api sensor-msgs launch rclcpp phidgets-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets high speed encoder devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-ik/default.nix
+++ b/dashing/phidgets-ik/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-digital-outputs, phidgets-analog-inputs, phidgets-digital-inputs }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-ik";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_ik/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "c4ee37d6e820426cf5144485067a721deab44a279bd76daf1d72d94a25173865";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ phidgets-analog-inputs launch phidgets-digital-inputs phidgets-digital-outputs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver for the Phidgets InterfaceKit devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-magnetometer/default.nix
+++ b/dashing/phidgets-magnetometer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, sensor-msgs, launch, rclcpp, ament-cmake-ros, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-magnetometer";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_magnetometer/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "21848f0d79f0f67eac5f1542f918df38d07390b761cfa14b308dcf9e7d777bd1";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ sensor-msgs rclcpp-components rclcpp phidgets-api ];
+  propagatedBuildInputs = [ phidgets-api sensor-msgs launch rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Magnetometer devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-motors/default.nix
+++ b/dashing/phidgets-motors/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, phidgets-msgs, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-motors";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_motors/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5f8ef698074e708c161ceaf431f90bd7e5f979931419dd8967fba645ea189fc6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ phidgets-api phidgets-msgs rclcpp std-msgs rclcpp-components ];
+  propagatedBuildInputs = [ phidgets-api phidgets-msgs launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Motor devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-msgs/default.nix
+++ b/dashing/phidgets-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, std-msgs, rosidl-default-generators, rosidl-default-runtime, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-msgs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "bbe7c95a1bc8533078b3914a63a2dba0ad754db6215b2a4c7e12296884110e6c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-msgs rosidl-default-generators ];
+  propagatedBuildInputs = [ std-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Custom ROS messages for Phidgets drivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-spatial/default.nix
+++ b/dashing/phidgets-spatial/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, std-srvs, phidgets-api, sensor-msgs, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-spatial";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_spatial/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "648e62d4392289d5f254d77ade082c4a87721e5c589cbcb9a78f8628ab799f0d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-srvs phidgets-api sensor-msgs rclcpp std-msgs rclcpp-components ];
+  propagatedBuildInputs = [ std-srvs phidgets-api sensor-msgs launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Spatial 3/3/3 devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/phidgets-temperature/default.nix
+++ b/dashing/phidgets-temperature/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, phidgets-api, launch, rclcpp, ament-cmake-ros, std-msgs, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-phidgets-temperature";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_temperature/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "08ac6d66bc1fc87d5f4bbae0e69764d5eb19c9224e19f16930b2a308670fe6de";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-msgs phidgets-api rclcpp-components rclcpp ];
+  propagatedBuildInputs = [ phidgets-api launch rclcpp std-msgs rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Driver for the Phidgets Temperature devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/python-cmake-module/default.nix
+++ b/dashing/python-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, python3, ament-cmake, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-python-cmake-module";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/python_cmake_module/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "68b3ac14449704ae48d35abaa197e2096a2b218ce8395abe6f93c3fc14f4a19b";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/python_cmake_module/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1ea605fb2a6decdf9c5c0dc0d52521db386fdcd9c0143f8da4893b8923d65487";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rclcpp-action/default.nix
+++ b/dashing/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rosidl-generator-cpp, ament-cmake, ament-lint-common, test-msgs, rcl-action, ament-cmake-gtest, rclcpp, ament-cmake-ros, action-msgs, ament-lint-auto, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-action";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "320add47877f500a4b2003207703f4e030a9ff43763842c69a004213d3573762";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "a22b2889a613dd67bd9631ff569a2319cb1bf0f3c4fb5ebdc3ccba135ced5149";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rclcpp-components/default.nix
+++ b/dashing/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rcpputils, ament-lint-common, launch-testing, class-loader, composition-interfaces, ament-cmake-gtest, rclcpp, ament-index-cpp, ament-cmake-ros, std-msgs, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-components";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "f880feb3c7a57a4331768936706384004a4370731a5a3da701c13b1bac30f9b7";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "0070b66875b9ab3fbc1bcdc5121c5fdafcc26a5c7b281ba0b779540799e113aa";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rclcpp-lifecycle/default.nix
+++ b/dashing/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-common, rcl-lifecycle, ament-cmake-gtest, rosidl-typesupport-cpp, rmw-implementation, lifecycle-msgs, rclcpp, ament-cmake-ros, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-lifecycle";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "42b03181035cd8467f4689b42d4c29e9cb0c077687893d43520eea461aab3e22";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "9e8f20a28fa9c757bc5d7a1ba64c884d074a1e248283d4fe7654f13cbde63b31";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rclcpp/default.nix
+++ b/dashing/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, rosidl-generator-cpp, rosidl-typesupport-c, ament-cmake, rmw-implementation-cmake, ament-cmake-gmock, ament-lint-common, test-msgs, ament-cmake-gtest, rosidl-typesupport-cpp, rosgraph-msgs, rmw-implementation, rcl-yaml-param-parser, rcl-interfaces, ament-cmake-ros, rcl, ament-lint-auto, rmw }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "9170c7b162643ec8ad7ac1f34e8f05bceb07d1d453075e34961322896963ae78";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "d5ff4aa3dfd5a5c8f408d0f082a5214859bb349c4f7acbbca6868f00f5a35d49";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rcutils/default.nix
+++ b/dashing/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-lint-common, ament-cmake-gmock, launch-testing, ament-cmake-gtest, launch, launch-testing-ament-cmake, python3Packages, ament-cmake-ros, ament-lint-auto, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rcutils";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/dashing/rcutils/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "74d694980d2aa8f36aa8bac7e861d432b37d837e984799860fab2231d7e75fef";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/dashing/rcutils/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "b04e61c7bffe569c664473c320a61e7e6db97e715d83295332fa101daae76c06";
   };
 
   buildType = "ament_cmake";

--- a/dashing/resource-retriever/default.nix
+++ b/dashing/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, libcurl-vendor, ament-index-cpp, ament-cmake-ros }:
 buildRosPackage {
   pname = "ros-dashing-resource-retriever";
-  version = "2.1.0-r2";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/resource_retriever/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "b1d2f1f2351bd63b1e3cd03be2eaae05456e254083a13c307c918cbdfc713a60";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/resource_retriever/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "53aec80c0e8de04c3a3665a96c4ad906b6f842a2408ec692851776121ddc5ba9";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rmw-cyclonedds-cpp/default.nix
+++ b/dashing/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, cyclonedds, rosidl-typesupport-introspection-c, cyclonedds-cmake-module, rosidl-typesupport-introspection-cpp, ament-cmake-ros, ament-lint-auto, rcutils, rmw, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rmw-cyclonedds-cpp";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "fbe937283dadeaf82a43745eb66e42b06d800555d3eca729943f18146f56a76a";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "23b18c4e499c2e3170349a288d43eec0ac3da61f654ce42cbe19565704a48e01";
   };
 
   buildType = "ament_cmake";

--- a/dashing/robot-state-publisher/default.nix
+++ b/dashing/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, kdl-parser, ament-cmake, orocos-kdl, ament-lint-common, sensor-msgs, tf2-ros, urdfdom-headers, urdf, rclcpp, ament-lint-auto, geometry-msgs }:
 buildRosPackage {
   pname = "ros-dashing-robot-state-publisher";
-  version = "2.2.4-r1";
+  version = "2.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/dashing/robot_state_publisher/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "b2b1d34a335305d923ce0ef6579b00473453fb2db9e7555af996478dccdd4df3";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/dashing/robot_state_publisher/2.2.5-1.tar.gz";
+    name = "2.2.5-1.tar.gz";
+    sha256 = "d8c69f1e1ccc6409e7252b556c8350e4125761097ce096fb90c7f517acfc72e2";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ros1-bridge/default.nix
+++ b/dashing/ros1-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, tf2-msgs, ament-cmake, rmw-implementation-cmake, actionlib-msgs, python3Packages, action-msgs, diagnostic-msgs, demo-nodes-cpp, geometry-msgs, gazebo-msgs, stereo-msgs, launch, pkg-config, example-interfaces, rclcpp, ament-index-python, ros2run, launch-testing-ros, builtin-interfaces, std-srvs, trajectory-msgs, launch-testing-ament-cmake, nav-msgs, rosidl-cmake, rosidl-parser, std-msgs, visualization-msgs, rcutils, shape-msgs, ament-lint-common, launch-testing, sensor-msgs, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-ros1-bridge";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "0f2cf605f6695a426ebc3e53d8b5b2d3eef1132a55bb5860da6154eb0c6ba8a9";
+    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "50da1aae9709becf1fd1a2db4fe646b9351320dd731fdaae96d103ceb4de6b63";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ros2action/default.nix
+++ b/dashing/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, test-msgs, rclpy, rosidl-runtime-py, pythonPackages, ament-pep257, action-msgs, ament-copyright, ament-index-python, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2action";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "7c7559cd5b76617d6c0bcbc37392539920f197390640b0ff460f759a3f577c47";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "3d76762fc41d3aeb3a11e579fcd516623427d61f43e05ee4b13890ab157d0c98";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2cli/default.nix
+++ b/dashing/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, rclpy, pythonPackages, ament-pep257, python3Packages, ament-copyright }:
 buildRosPackage {
   pname = "ros-dashing-ros2cli";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "6eaa08f15784ef4c3ff5a6c6290c85dbae796d6b3f4a1bf0a56bf5248bb76969";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "67e38bf73d5287d664e4c2200a7d640376469dc14045d57923b730bc831aa700";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2component/default.nix
+++ b/dashing/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, ros2node, rclpy, composition-interfaces, pythonPackages, ros2param, ament-pep257, rcl-interfaces, ament-copyright, ament-index-python, rclcpp-components, ros2pkg, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2component";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "ebc06c3ba04f5251f08e6f9770a1e7878683c72385a0a3749ef21c442607e6aa";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "5a46c00a9c7ed0f4f04b50c207d56347033576229ce4477a39cbe48208a25d28";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2lifecycle/default.nix
+++ b/dashing/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, ros2node, rclpy, pythonPackages, lifecycle-msgs, ament-pep257, ament-copyright, ros2service, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2lifecycle";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "376de10ffc477f5dd824c1e65eb40d2badd0648f3757fe051a9f5d34052789b9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "acb86a11c4db2d3664ec3dd619179c35f29c2e65679b353fe0df892b73698cc8";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2msg/default.nix
+++ b/dashing/ros2msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, std-srvs, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, std-msgs, ament-copyright, ament-index-python, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2msg";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "3ed9f79d25dbb8ac74f966d687a434f6c5251617dc919e0b98e4a7c22ee2656b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "be9517679ff27f944efe3e20bc90a6e6914dd3843c5780fee554692486f242be";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2multicast/default.nix
+++ b/dashing/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, ament-copyright, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2multicast";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "398f6c630c31dafb98c30c3dfede52e8d64a8f586deab40bea36fc000472ac6e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "9e2a33956ae6dbe428faebf7f39f2739e2ef5f9b33c514a96e29cb5610d034be";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2node/default.nix
+++ b/dashing/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, ament-copyright, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2node";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "52e68f40e79fc71425c1807d8d7f9cf0c5029d77d1b7eae3f0d7565e85007fe2";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "0a816063c33aa9d6de80091d6549f1e6f4f78410de46a0d080a6988396458faf";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2param/default.nix
+++ b/dashing/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, ros2node, rclpy, pythonPackages, ament-pep257, rcl-interfaces, ament-copyright, ros2service, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2param";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "6b24eb987a295979d22b54f785a8c271cc434e155f3de22004d479c8580e0678";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "0ec236992a0559de9a9d29fbe4e959e118fd9684db5694e32a7b952ed2782b9e";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2pkg/default.nix
+++ b/dashing/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, python3Packages, ament-copyright, ament-index-python, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2pkg";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "c4ee51b2085429543c1a37ecab14579441372e88982269913aa5d0bf9870c76a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "89ab52df66265e32af512b998989d231afe98bf7f2c899f3d766d91cc09b52f8";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2run/default.nix
+++ b/dashing/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, ament-copyright, ros2pkg, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2run";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "69f445dd7deea23957f9c58fbe0888ef6cee8075f40851e595ae24a0ccbf055a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "ad32899334d8f1732500ad9a13854891db06fd2b3a0d1efb0d2afb058571b54b";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2service/default.nix
+++ b/dashing/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, rclpy, ros2srv, rosidl-runtime-py, pythonPackages, ament-pep257, python3Packages, ament-copyright, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2service";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "37ccd0cb37606e4ea41887086a39a3189db31ea4be8d1542403aa31ec177f470";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "9f77faf09fc5f78f4937f2ade6fde9d05a21ba199a1bde0c71b3feb65233b520";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2srv/default.nix
+++ b/dashing/ros2srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, std-srvs, ament-xmllint, ament-flake8, pythonPackages, ament-pep257, std-msgs, ament-copyright, ament-index-python, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2srv";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "6ce157b21f6b4ff5c4b1516aff80322c3f05da893db6f290372736c141f7e200";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "51cf1feb9c87d8c7079d622cb7dfebca2f31f517b972dc6b0cdd7cd0c5c7264d";
   };
 
   buildType = "ament_python";

--- a/dashing/ros2topic/default.nix
+++ b/dashing/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, ros2msg, rclpy, rosidl-runtime-py, pythonPackages, ament-pep257, python3Packages, ament-copyright, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2topic";
-  version = "0.7.7-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "3de35e3b02f3352f563cfda520ef09fb818110263cacbbb0010712dfd7a7d31d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "43e8621002238c52b75e7e3cfa86ceda25b902e10a7de33835960d5b115895eb";
   };
 
   buildType = "ament_python";

--- a/dashing/rosidl-adapter/default.nix
+++ b/dashing/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, ament-cmake, ament-lint-common, python3Packages, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-adapter";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_adapter/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "aec1650328593d656e06dbf13e1508126a34d9a0a2cdf50f970c6fcf9c9a3fca";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_adapter/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "adb7550016f0abcfc0e2d01c04373bab25884fbe441ec4ccc798c4ec92cb2ad3";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-cmake/default.nix
+++ b/dashing/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rosidl-adapter, ament-cmake, ament-lint-common, python3Packages, rosidl-parser, ament-cmake-python, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-cmake";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_cmake/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "d2cc0ed0cc8ab87de8d77c24b784febb2b54de408ec3256150c3ebd13a38aa53";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_cmake/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "90754adaacb0883fba1a37ea6412e29f520214f050664a0338906c02f7ad1cd7";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-generator-c/default.nix
+++ b/dashing/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-typesupport-interface, ament-lint-auto, ament-cmake-gtest, rosidl-cmake, rosidl-parser, ament-cmake-ros }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-generator-c";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_c/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "25adb52d1e59d62d0ab9d75ccaf6937b610364f562f915fa251afbfe973b4255";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_c/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d962db1e0542e342cae1de57e75bff407173fd22efca8ddc83c6297de594faaa";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-generator-cpp/default.nix
+++ b/dashing/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, ament-cmake-gtest, rosidl-cmake, rosidl-parser, ament-lint-auto, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-generator-cpp";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_cpp/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "a0a7d24922aa6e8188c67ecb7b0c4c84b4f29fc1aeee3a6bab2fbba08100a943";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_cpp/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "de780f9561333d09e10f328f75ece3b391cd27e9377001ea866003742764c58c";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-generator-py/default.nix
+++ b/dashing/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, rosidl-typesupport-c, ament-cmake, rmw-implementation-cmake, ament-lint-common, rosidl-typesupport-interface, pythonPackages, python3Packages, python-cmake-module, rmw-implementation, rosidl-cmake, rosidl-parser, ament-index-python, ament-lint-auto, rmw, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-generator-py";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/rosidl_generator_py/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "197015f3db6ce2054a5798ab1c9ed066d884121d7d373400ca24df05bb208d50";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/rosidl_generator_py/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "3f4542d7f106ff2a3a88cbcfb9692c310d4866694b9566572b9cc9c5d8c6cc53";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-parser/default.nix
+++ b/dashing/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-pytest, rosidl-adapter, ament-cmake, ament-lint-common, pythonPackages, python3Packages, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-parser";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_parser/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "5cc07b79b5ce185e8dc63d1e2edf139078d019f5403dd3b56c87a857b04c1a14";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_parser/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "5599d67dccabbbd079d7f929f9364fdcd05809b0dc527517a4049b25854b5114";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-runtime-py/default.nix
+++ b/dashing/rosidl-runtime-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-xmllint, ament-flake8, rosidl-parser, test-msgs, pythonPackages, ament-pep257, python3Packages, ament-copyright }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-runtime-py";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/rosidl_runtime_py/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "9dd76507b64dd05554500a9155b68930e62a6713e843f5167601c93fbf586c3c";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/dashing/rosidl_runtime_py/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "6684a827307046043fa61a0807c8b57dc0e52c6fc9a45ab877ce92f92b701dff";
   };
 
   buildType = "ament_python";

--- a/dashing/rosidl-typesupport-connext-c/default.nix
+++ b/dashing/rosidl-typesupport-connext-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rosidl-generator-c, ament-cmake, ament-lint-common, connext-cmake-module, rosidl-cmake, rosidl-parser, ament-lint-auto, rosidl-typesupport-connext-cpp, rcutils, rmw, rosidl-generator-dds-idl }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-connext-c";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/rosidl_typesupport_connext_c/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "3d59c4dbe2b1429ea373753ebc4906a044946e55ebb67b9c3318c4b97541c210";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/rosidl_typesupport_connext_c/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "4a69fbbc8712f66b3b33c83236be72c1f2cf9a97dce5895d0c9bd441e0788cd6";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-typesupport-connext-cpp/default.nix
+++ b/dashing/rosidl-typesupport-connext-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rosidl-generator-cpp, rosidl-generator-c, ament-cmake, rosidl-typesupport-interface, ament-lint-common, connext-cmake-module, rosidl-cmake, rosidl-parser, ament-lint-auto, rcutils, rmw, rosidl-generator-dds-idl }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-connext-cpp";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/rosidl_typesupport_connext_cpp/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "f8844c4f51edc9f6c061d669939d67d42461f91fe50c6f408fdd978ac543196b";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/dashing/rosidl_typesupport_connext_cpp/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "438146213fa53cc4d3040253281bb6bd0968632921e02ebe4caf051223b87f98";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-typesupport-interface/default.nix
+++ b/dashing/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-cmake, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-interface";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_interface/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "e4d339439fdc95ca720a2e271aa12f4179a1804ef4cbabf638829bab783ad3c6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_interface/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "d5eb326572080faa965bf6cee6caaf9d1e4efdce3fad56e74279bd32cfa679b5";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-typesupport-introspection-c/default.nix
+++ b/dashing/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, ament-lint-auto, rosidl-cmake, rosidl-parser, ament-cmake-ros, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-introspection-c";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_c/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "88fa3a0817c28f3c2cc1d44f4837db8147f0a4a285f3c4be05413ebf99024b3b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_c/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "417a32362cecedea22f15c8c50f2a05d36a73082f091e066fb70b87bc3c8a1e3";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rosidl-typesupport-introspection-cpp/default.nix
+++ b/dashing/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rosidl-generator-cpp, ament-cmake, rosidl-typesupport-interface, ament-lint-common, rosidl-parser, rosidl-typesupport-introspection-c, rosidl-cmake, ament-cmake-ros, ament-lint-auto, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-introspection-cpp";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_cpp/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "1570370bff371bf30a962503558ea633353e398c9086ab32b02dbf238c0d0dd6";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_cpp/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "526226529a953bb61270f96a4be65ce203af3d2fb95060e8e0e31458a509d390";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rqt-common-plugins/default.nix
+++ b/dashing/rqt-common-plugins/default.nix
@@ -1,0 +1,34 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rqt-srv, rqt-action, ament-cmake, rqt-topic, rqt-publisher, rqt-py-console, rqt-graph, rqt-reconfigure, rqt-top, rqt-msg, rqt-service-caller, rqt-console, rqt-image-view, rqt-plot, rqt-py-common, rqt-shell }:
+buildRosPackage {
+  pname = "ros-dashing-rqt-common-plugins";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_common_plugins-release/archive/release/dashing/rqt_common_plugins/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "470b94463ad57e5e3509f1f1c81429028f63f03a3d6ee118049d7ddfe8c7ea07";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rqt-srv rqt-action rqt-topic rqt-publisher rqt-py-console rqt-graph rqt-reconfigure rqt-top rqt-service-caller rqt-msg rqt-console rqt-image-view rqt-plot rqt-py-common rqt-shell ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''rqt_common_plugins metapackage provides ROS backend graphical tools suite that can be used on/off of robot runtime.<br/>
+    <br/>
+    To run any rqt plugins, just type in a single command &quot;rqt&quot;, then select any plugins you want from the GUI that launches afterwards.<br/>
+    <br/>
+    rqt consists of three following metapackages:<br/>
+    <ul>
+     <li><a href="http://ros.org/wiki/rqt">rqt</a> - core modules of rqt (ROS GUI) framework. rqt plugin developers barely needs to pay attention to this metapackage.</li>
+     <li>rqt_common_plugins (you're here!)</li>
+     <li><a href="http://ros.org/wiki/rqt_robot_plugins">rqt_robot_plugins</a> - rqt plugins that are particularly used with robots during their runtime.</li><br/>
+    </ul>
+   <br/>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/rqt-robot-steering/default.nix
+++ b/dashing/rqt-robot-steering/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rqt-gui-py, rclpy, rqt-gui, ament-index-python, python-qt-binding, geometry-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-rqt-robot-steering";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_robot_steering-release/archive/release/dashing/rqt_robot_steering/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d35e30c90083aacf10adb112f21fefe4487f9bddc3b5b8100afc9672e67cd1d8";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ rqt-gui-py rclpy rqt-gui ament-index-python python-qt-binding geometry-msgs ];
+
+  meta = {
+    description = ''rqt_robot_steering provides a GUI plugin for steering a robot using Twist messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-console-util/default.nix
+++ b/dashing/swri-console-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rclcpp, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-swri-console-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "d5a1441bdbdb7872e3959f92fac39d9149e7da00a007146c905d7ae2ff088b01";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp ];
+  propagatedBuildInputs = [ rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_console_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-dbw-interface/default.nix
+++ b/dashing/swri-dbw-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-swri-dbw-interface";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "f622e5f827a2c8e96cb071138a2ab0f00979f9cbe5289996fbf71693e4c27ed0";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides documentation on common interface conventions for
+    drive-by-wire systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-geometry-util/default.nix
+++ b/dashing/swri-geometry-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, pkg-config, tf2, rclcpp, eigen, geos }:
+buildRosPackage {
+  pname = "ros-dashing-swri-geometry-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "0e008664d25ad8accb990b47e636e58e36685ea4dec18baa615b1f40223949c2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ cv-bridge tf2 rclcpp eigen geos ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ cv-bridge tf2 rclcpp eigen geos ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = ''swri_geometry_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-image-util/default.nix
+++ b/dashing/swri-image-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-geometry, geometry-msgs, boost, camera-calibration-parsers, image-transport, ament-cmake-gtest, message-filters, pkg-config, rclcpp, swri-opencv-util, swri-math-util, nav-msgs, ament-index-cpp, std-msgs, swri-geometry-util, rclpy, swri-roscpp, tf2, eigen, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-swri-image-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "8cc96bb11206671f37255affa38c11e8bfafb37c7d8c86bffc71b9109698cb89";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ cv-bridge image-geometry geometry-msgs boost camera-calibration-parsers image-transport message-filters rclcpp swri-opencv-util swri-math-util nav-msgs ament-index-cpp std-msgs swri-geometry-util rclpy swri-roscpp tf2 eigen rclcpp-components ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ cv-bridge image-geometry geometry-msgs boost camera-calibration-parsers image-transport message-filters rclcpp swri-opencv-util swri-math-util nav-msgs ament-index-cpp std-msgs swri-geometry-util rclpy swri-roscpp tf2 eigen rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = ''swri_image_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-math-util/default.nix
+++ b/dashing/swri-math-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, rclcpp, ament-cmake, boost }:
+buildRosPackage {
+  pname = "ros-dashing-swri-math-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "38634ebcd805107fe7cb33b6c5bf3a4cc73faf3f3a94c577aaa9863fa1473e9d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp boost ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ rclcpp boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_math_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-opencv-util/default.nix
+++ b/dashing/swri-opencv-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, swri-math-util, cv-bridge, ament-cmake, boost }:
+buildRosPackage {
+  pname = "ros-dashing-swri-opencv-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "f894ccdb0c7829a4bb1c1d97bb2469a3d10d93a6154ccfe845ae5b3bd277e436";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ swri-math-util cv-bridge boost ];
+  propagatedBuildInputs = [ swri-math-util cv-bridge boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_opencv_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-prefix-tools/default.nix
+++ b/dashing/swri-prefix-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, pythonPackages, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-swri-prefix-tools";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "2715c45d3ea6b62aca30e8e618d0dc21e1d251da502041063bd7c24f1b7a7294";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ pythonPackages.psutil ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains scripts that are useful as prefix commands for nodes
+    started by roslaunch.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-roscpp/default.nix
+++ b/dashing/swri-roscpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, std-srvs, ament-cmake, boost, gtest, ament-cmake-gtest, rosidl-default-generators, diagnostic-updater, nav-msgs, rosidl-cmake, marti-common-msgs, rclcpp, std-msgs, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-dashing-swri-roscpp";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "98af4e16c4820cfd9ecab407a569db40fba933eedd10303a8b4f2ee24f474f0b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ std-srvs boost diagnostic-updater nav-msgs rosidl-cmake marti-common-msgs rclcpp std-msgs ];
+  checkInputs = [ gtest ament-cmake-gtest ];
+  propagatedBuildInputs = [ std-srvs boost diagnostic-updater nav-msgs marti-common-msgs rclcpp std-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ rosidl-default-generators ament-cmake ];
+
+  meta = {
+    description = ''swri_roscpp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-route-util/default.nix
+++ b/dashing/swri-route-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, swri-math-util, ament-cmake, boost, marti-nav-msgs, swri-roscpp, marti-common-msgs, rclcpp, swri-geometry-util, visualization-msgs, swri-transform-util }:
+buildRosPackage {
+  pname = "ros-dashing-swri-route-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "5054602c23b534b0401d7f65d0fa1d535b58b91f25fbcc2fe539a21a16f3adae";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ swri-math-util boost marti-nav-msgs swri-roscpp marti-common-msgs rclcpp swri-geometry-util visualization-msgs swri-transform-util ];
+  propagatedBuildInputs = [ swri-math-util boost marti-nav-msgs swri-roscpp marti-common-msgs rclcpp swri-geometry-util visualization-msgs swri-transform-util ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This library provides functionality to simplify working with the
+    navigation messages defined in marti_nav_msgs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-serial-util/default.nix
+++ b/dashing/swri-serial-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost }:
+buildRosPackage {
+  pname = "ros-dashing-swri-serial-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "5a114cfe3e684b2477267df2cf2c17cbe5134faef997a7d9d3aef09f7eac0dba";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_serial_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-system-util/default.nix
+++ b/dashing/swri-system-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, ament-cmake-gtest, rclcpp, ament-index-cpp }:
+buildRosPackage {
+  pname = "ros-dashing-swri-system-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "c0651f257c3b58556bd38cfac53b79b834acb05f1da28d58f66e95782d31c45a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp boost ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ];
+  propagatedBuildInputs = [ rclcpp boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_system_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/swri-transform-util/default.nix
+++ b/dashing/swri-transform-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2019 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, diagnostic-msgs, geos, geometry-msgs, boost, pkg-config, gps-msgs, rclcpp, ament-cmake-python, swri-math-util, tf2-geometry-msgs, tf2-ros, proj, rcl-interfaces, rclpy, libyamlcpp, sensor-msgs, geographic-msgs, swri-roscpp, tf2, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-swri-transform-util";
+  version = "3.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.0.3-1.tar.gz";
+    name = "3.0.3-1.tar.gz";
+    sha256 = "ebf9275e970b3d61be4511bd15562fd2000d9f5a5d07e3d06d9e7b35a4ce3752";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ swri-math-util boost tf2-geometry-msgs rclpy libyamlcpp cv-bridge tf2-ros geographic-msgs proj swri-roscpp tf2 gps-msgs rclcpp rcl-interfaces diagnostic-msgs geos rclcpp-components geometry-msgs ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs geos geometry-msgs boost gps-msgs rclcpp swri-math-util tf2-geometry-msgs tf2-ros proj rcl-interfaces rclpy libyamlcpp sensor-msgs geographic-msgs swri-roscpp tf2 rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-python ament-cmake pkg-config ];
+
+  meta = {
+    description = ''The swri_transform_util package contains utility functions and classes for
+     transforming between coordinate frames.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/dashing/vision-opencv/default.nix
+++ b/dashing/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cv-bridge, ament-cmake, image-geometry }:
 buildRosPackage {
   pname = "ros-dashing-vision-opencv";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/vision_opencv/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "5d70f73f3e55ce12e828fc65b58cd3ae99ca485a296f3d29538b943419362c11";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/vision_opencv/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "2e7db741041cfd44315516ce2c705291b2b444a3e4e1f123fd188c013517dc3d";
   };
 
   buildType = "ament_cmake";

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+git config credential.helper '
+    echo "username=${GITHUB_ACTOR}"
+    echo "password=${SUPERFLORE_GITHUB_TOKEN}"
+'

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,5 @@
-git config credential.helper '
+git config credential.helper '!
+  f() {
     echo "username=${GITHUB_ACTOR}"
     echo "password=${SUPERFLORE_GITHUB_TOKEN}"
-'
+  }; f'


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing'] from nix-ros-overlay commit 8a1c29fddaab73c56004d42f48811dd5ed3ade02.
This pull request was generated by running the following command:

```
__init__.py --tar-archive-dir ../tar --output-repository-path ../nix-ros-overlay --ros-distro dashing
```

Dashing Changes:
================
* *ackermann-msgs 2.0.2-r1*
* *action-msgs 0.7.4-r1*
* *action-tutorials 0.7.9-r1*
* *actionlib-msgs 0.7.0-r1*
* *ament-clang-format 0.7.11-r1*
* *ament-clang-tidy 0.7.11-r1*
* *ament-cmake 0.7.4-r1*
* *ament-cmake-auto 0.7.4-r1*
* *ament-cmake-clang-format 0.7.11-r1*
* *ament-cmake-clang-tidy 0.7.11-r1*
* *ament-cmake-copyright 0.7.11-r1*
* *ament-cmake-core 0.7.4-r1*
* *ament-cmake-cppcheck 0.7.11-r1*
* *ament-cmake-cpplint 0.7.11-r1*
* *ament-cmake-export-definitions 0.7.4-r1*
* *ament-cmake-export-dependencies 0.7.4-r1*
* *ament-cmake-export-include-directories 0.7.4-r1*
* *ament-cmake-export-interfaces 0.7.4-r1*
* *ament-cmake-export-libraries 0.7.4-r1*
* *ament-cmake-export-link-flags 0.7.4-r1*
* *ament-cmake-flake8 0.7.11-r1*
* *ament-cmake-gmock 0.7.4-r1*
* *ament-cmake-gtest 0.7.4-r1*
* *ament-cmake-include-directories 0.7.4-r1*
* *ament-cmake-libraries 0.7.4-r1*
* *ament-cmake-lint-cmake 0.7.11-r1*
* *ament-cmake-nose 0.7.4-r1*
* *ament-cmake-pclint 0.7.11-r1*
* *ament-cmake-pep257 0.7.11-r1*
* *ament-cmake-pep8 0.7.11-r1*
* *ament-cmake-pyflakes 0.7.11-r1*
* *ament-cmake-pytest 0.7.4-r1*
* *ament-cmake-python 0.7.4-r1*
* *ament-cmake-ros 0.7.0-r1*
* *ament-cmake-target-dependencies 0.7.4-r1*
* *ament-cmake-test 0.7.4-r1*
* *ament-cmake-uncrustify 0.7.11-r1*
* *ament-cmake-virtualenv 0.0.3-r1*
* *ament-cmake-xmllint 0.7.11-r1*
* *ament-copyright 0.7.11-r1*
* *ament-cppcheck 0.7.11-r1*
* *ament-cpplint 0.7.11-r1*
* *ament-download 0.0.1-r1*
* *ament-flake8 0.7.11-r1*
* *ament-index-cpp 0.7.2-r1*
* *ament-index-python 0.7.2-r1*
* *ament-lint 0.7.11-r1*
* *ament-lint-auto 0.7.11-r1*
* *ament-lint-cmake 0.7.11-r1*
* *ament-lint-common 0.7.11-r1*
* *ament-package 0.7.3-r1*
* *ament-pclint 0.7.11-r1*
* *ament-pep257 0.7.11-r1*
* *ament-pep8 0.7.11-r1*
* *ament-pyflakes 0.7.11-r1*
* *ament-uncrustify 0.7.11-r1*
* *ament-virtualenv 0.0.3-r1*
* *ament-xmllint 0.7.11-r1*
* *angles 1.12.1-r1*
* *apriltag 3.1.1-r1*
* *apriltag-msgs 2.0.0-r2*
* *apriltag-ros 2.1.0-r1*
* *automotive-navigation-msgs 3.0.0-r1*
* *automotive-platform-msgs 3.0.0-r1*
* *autoware-auto-algorithm 0.0.2-r1*
* *autoware-auto-cmake 0.0.2-r1*
* *autoware-auto-create-pkg 0.0.2-r1*
* *autoware-auto-examples 0.0.2-r1*
* *autoware-auto-geometry 0.0.2-r1*
* *autoware-auto-helper-functions 0.0.2-r1*
* *autoware-auto-msgs 0.0.2-r1*
* *aws-common 2.1.0-r1*
* *aws-ros2-common 1.0.0-r1*
* *behaviortree-cpp 2.5.2-r1*
* *behaviortree-cpp-v3 3.1.1-r1*
* *builtin-interfaces 0.7.4-r1*
* *camera-calibration-parsers 2.1.1-r1*
* *camera-info-manager 2.1.1-r1*
* *can-msgs 2.0.0-r1*
* *cartographer 1.0.0-r1*
* *cartographer-ros 1.0.9000-r1*
* *cartographer-ros-msgs 1.0.9000-r1*
* *class-loader 1.3.2-r1*
* *cloudwatch-logger 3.0.0-r2*
* *cloudwatch-logs-common 1.1.2-r1*
* *cloudwatch-metrics-collector 3.0.0-r2*
* *cloudwatch-metrics-common 1.1.2-r1*
* *common-interfaces 0.7.0-r1*
* *composition 0.7.9-r1*
* *composition-interfaces 0.7.4-r1*
* *compressed-depth-image-transport 2.1.0-r1*
* *compressed-image-transport 2.1.0-r1*
* *connext-cmake-module 0.7.3-r1*
* *console-bridge-vendor 1.2.0-r1*
* *control-msgs 2.2.0-r1*
* *costmap-queue 0.2.6-r1*
* *cross-compile 0.1.1-r1*
* *cv-bridge 2.1.3-r1*
* *cyclonedds 0.1.0-r3*
* *cyclonedds-cmake-module 0.4.2-r1*
* *dataflow-lite 1.1.2-r1*
* *delphi-esr-msgs 3.0.0-r2*
* *delphi-mrr-msgs 3.0.0-r2*
* *delphi-srr-msgs 3.0.0-r2*
* *demo-nodes-cpp 0.7.9-r1*
* *demo-nodes-cpp-native 0.7.9-r1*
* *demo-nodes-py 0.7.9-r1*
* *depthimage-to-laserscan 2.2.5-r1*
* *derived-object-msgs 3.0.0-r2*
* *desktop 0.7.2-r1*
* *diagnostic-msgs 0.7.0-r1*
* *diagnostic-updater 2.0.0-r1*
* *dummy-map-server 0.7.9-r1*
* *dummy-robot-bringup 0.7.9-r1*
* *dummy-sensors 0.7.9-r1*
* *dwb-controller 0.2.6-r1*
* *dwb-core 0.2.6-r1*
* *dwb-critics 0.2.6-r1*
* *dwb-msgs 0.2.6-r1*
* *dwb-plugins 0.2.6-r1*
* *dynamic-edt-3d 1.9.2-r1*
* *dynamixel-sdk 3.7.20-r1*
* *ecl-build 1.0.2-r1*
* *ecl-command-line 1.0.4-r1*
* *ecl-concepts 1.0.4-r1*
* *ecl-config 1.0.3-r2*
* *ecl-console 1.0.3-r2*
* *ecl-containers 1.0.4-r1*
* *ecl-converters 1.0.4-r1*
* *ecl-converters-lite 1.0.3-r2*
* *ecl-core 1.0.4-r1*
* *ecl-core-apps 1.0.4-r1*
* *ecl-devices 1.0.4-r1*
* *ecl-eigen 1.0.4-r1*
* *ecl-errors 1.0.3-r2*
* *ecl-exceptions 1.0.4-r1*
* *ecl-filesystem 1.0.4-r1*
* *ecl-formatters 1.0.4-r1*
* *ecl-geometry 1.0.4-r1*
* *ecl-io 1.0.3-r2*
* *ecl-ipc 1.0.4-r1*
* *ecl-license 1.0.2-r1*
* *ecl-linear-algebra 1.0.4-r1*
* *ecl-lite 1.0.3-r2*
* *ecl-manipulators 1.0.4-r1*
* *ecl-math 1.0.4-r1*
* *ecl-mobile-robot 1.0.4-r1*
* *ecl-mpl 1.0.4-r1*
* *ecl-sigslots 1.0.4-r1*
* *ecl-sigslots-lite 1.0.3-r2*
* *ecl-statistics 1.0.4-r1*
* *ecl-streams 1.0.4-r1*
* *ecl-threads 1.0.4-r1*
* *ecl-time 1.0.4-r1*
* *ecl-time-lite 1.0.3-r2*
* *ecl-tools 1.0.2-r1*
* *ecl-type-traits 1.0.4-r1*
* *ecl-utilities 1.0.4-r1*
* *eigen-stl-containers 1.0.0-r1*
* *eigen3-cmake-module 0.1.1-r1*
* *euclidean-cluster 0.0.2-r1*
* *euclidean-cluster-nodes 0.0.2-r1*
* *example-interfaces 0.7.1-r1*
* *examples-rclcpp-minimal-action-client 0.7.4-r1*
* *examples-rclcpp-minimal-action-server 0.7.4-r1*
* *examples-rclcpp-minimal-client 0.7.4-r1*
* *examples-rclcpp-minimal-composition 0.7.4-r1*
* *examples-rclcpp-minimal-publisher 0.7.4-r1*
* *examples-rclcpp-minimal-service 0.7.4-r1*
* *examples-rclcpp-minimal-subscriber 0.7.4-r1*
* *examples-rclcpp-minimal-timer 0.7.4-r1*
* *examples-rclpy-executors 0.7.4-r1*
* *examples-rclpy-minimal-action-client 0.7.4-r1*
* *examples-rclpy-minimal-action-server 0.7.4-r1*
* *examples-rclpy-minimal-client 0.7.4-r1*
* *examples-rclpy-minimal-publisher 0.7.4-r1*
* *examples-rclpy-minimal-service 0.7.4-r1*
* *examples-rclpy-minimal-subscriber 0.7.4-r1*
* *fastcdr 1.0.11-r1*
* *fastrtps 1.8.2-r1*
* *fastrtps-cmake-module 0.7.1-r1*
* *file-management 1.1.2-r1*
* *fmi-adapter 0.1.5-r1*
* *fmi-adapter-examples 0.1.5-r1*
* *fmilibrary-vendor 0.1.0-r1*
* *foonathan-memory-vendor 0.3.0-r1*
* *gazebo-dev 3.3.4-r1*
* *gazebo-msgs 3.3.4-r1*
* *gazebo-plugins 3.3.4-r1*
* *gazebo-ros 3.3.4-r1*
* *gazebo-ros-pkgs 3.3.4-r1*
* *geodesy 1.0.1-r1*
* *geographic-info 1.0.1-r1*
* *geographic-msgs 1.0.1-r1*
* *geometry-msgs 0.7.0-r1*
* *gmock-vendor 1.8.9000-r1*
* *gps-msgs 1.0.0-r1*
* *gps-tools 1.0.0-r1*
* *gps-umd 1.0.0-r1*
* *gpsd-client 1.0.0-r1*
* *gtest-vendor 1.8.9000-r1*
* *h264-encoder-core 2.0.3-r1*
* *h264-video-encoder 2.0.0-r1*
* *health-metric-collector 3.0.1-r1*
* *hls-lfcd-lds-driver 2.0.0-r1*
* *hungarian-assigner 0.0.2-r1*
* *ibeo-msgs 3.0.0-r2*
* *image-geometry 2.1.3-r1*
* *image-tools 0.7.9-r1*
* *image-transport 2.1.1-r1*
* *image-transport-plugins 2.1.0-r1*
* *intra-process-demo 0.7.9-r1*
* *joy 2.3.2-r1*
* *joy-teleop 1.0.1*
* *kalman-filter 0.0.2-r1*
* *kartech-linear-actuator-msgs 3.0.0-r2*
* *kdl-parser 2.2.0-r1*
* *key-teleop 1.0.1*
* *kinesis-manager 2.0.1-r1*
* *kinesis-video-msgs 3.1.0-r1*
* *kinesis-video-streamer 3.1.0-r1*
* *laser-geometry 2.0.0*
* *launch 0.8.7-r1*
* *launch-ros 0.8.7-r1*
* *launch-ros-sandbox 0.0.2-r4*
* *launch-testing 0.8.7-r1*
* *launch-testing-ament-cmake 0.8.7-r1*
* *launch-testing-ros 0.8.7-r1*
* *lex-common 1.0.0-r1*
* *lex-common-msgs 3.1.0-r1*
* *lex-node 3.1.0-r1*
* *libcurl-vendor 2.1.2-r1*
* *libphidget22 2.0.1-r1*
* *librealsense2 2.16.5-r1*
* *libyaml-vendor 1.0.0-r1*
* *lidar-utils 0.0.2-r1*
* *lifecycle 0.7.9-r1*
* *lifecycle-msgs 0.7.4-r1*
* *localization-common 0.0.2-r1*
* *localization-nodes 0.0.2-r1*
* *logging-demo 0.7.9-r1*
* *map-msgs 2.0.2-r1*
* *marti-can-msgs 1.0.0-r1*
* *marti-common-msgs 1.0.0-r1*
* *marti-nav-msgs 1.0.0-r1*
* *marti-perception-msgs 1.0.0-r1*
* *marti-sensor-msgs 1.0.0-r1*
* *marti-status-msgs 1.0.0-r1*
* *marti-visualization-msgs 1.0.0-r1*
* *message-filters 3.1.3-r1*
* *ml-classifiers 1.0.1-r1*
* *mobileye-560-660-msgs 3.0.0-r2*
* *motion-model 0.0.2-r1*
* *mouse-teleop 1.0.1*
* *move-base-msgs 2.0.2-r1*
* *nav-2d-msgs 0.2.6-r1*
* *nav-2d-utils 0.2.6-r1*
* *nav-msgs 0.7.0-r1*
* *nav2-amcl 0.2.6-r1*
* *nav2-behavior-tree 0.2.6-r1*
* *nav2-bringup 0.2.6-r1*
* *nav2-bt-navigator 0.2.6-r1*
* *nav2-common 0.2.6-r1*
* *nav2-costmap-2d 0.2.6-r1*
* *nav2-dwb-controller 0.2.6-r1*
* *nav2-dynamic-params 0.2.6-r1*
* *nav2-lifecycle-manager 0.2.6-r1*
* *nav2-map-server 0.2.6-r1*
* *nav2-msgs 0.2.6-r1*
* *nav2-navfn-planner 0.2.6-r1*
* *nav2-recoveries 0.2.6-r1*
* *nav2-rviz-plugins 0.2.6-r1*
* *nav2-system-tests 0.2.6-r1*
* *nav2-util 0.2.6-r1*
* *nav2-voxel-grid 0.2.6-r1*
* *nav2-world-model 0.2.6-r1*
* *navigation2 0.2.6-r1*
* *ndt 0.0.2-r1*
* *neobotix-usboard-msgs 3.0.0-r2*
* *nmea-msgs 2.0.0-r1*
* *novatel-gps-driver 4.0.2-r1*
* *novatel-gps-msgs 4.0.2-r1*
* *object-analytics-msgs 0.5.4-r2*
* *object-analytics-node 0.5.4-r2*
* *object-analytics-rviz 0.5.4-r2*
* *object-msgs 0.4.0-r1*
* *octomap 1.9.2-r1*
* *ompl 1.4.2-r2*
* *opensplice-cmake-module 0.7.3-r1*
* *optimization 0.0.2-r1*
* *orocos-kdl 3.2.1-r1*
* *osrf-pycommon 0.1.9-r1*
* *osrf-testing-tools-cpp 1.2.1-r1*
* *pacmod-msgs 3.0.0-r2*
* *pcl-conversions 2.0.0-r1*
* *pcl-msgs 1.0.0-r1*
* *pendulum-control 0.7.9-r1*
* *pendulum-msgs 0.7.9-r1*
* *people-msgs 1.3.0-r1*
* *perception-pcl 2.0.0-r1*
* *phidgets-accelerometer 2.0.1-r1*
* *phidgets-analog-inputs 2.0.1-r1*
* *phidgets-api 2.0.1-r1*
* *phidgets-digital-inputs 2.0.1-r1*
* *phidgets-digital-outputs 2.0.1-r1*
* *phidgets-drivers 2.0.1-r1*
* *phidgets-gyroscope 2.0.1-r1*
* *phidgets-high-speed-encoder 2.0.1-r1*
* *phidgets-ik 2.0.1-r1*
* *phidgets-magnetometer 2.0.1-r1*
* *phidgets-motors 2.0.1-r1*
* *phidgets-msgs 2.0.1-r1*
* *phidgets-spatial 2.0.1-r1*
* *phidgets-temperature 2.0.1-r1*
* *pluginlib 2.3.3-r1*
* *poco-vendor 1.2.0-r1*
* *point-cloud-fusion 0.0.2-r1*
* *px4-msgs 2.0.1-r1*
* *py-trees-ros 1.2.1-r2*
* *py-trees-ros-interfaces 1.2.0-r1*
* *python-cmake-module 0.7.10-r1*
* *python-qt-binding 1.0.2-r1*
* *qt-dotgraph 1.0.7-r1*
* *qt-gui 1.0.7-r1*
* *qt-gui-app 1.0.7-r1*
* *qt-gui-core 1.0.7-r1*
* *qt-gui-cpp 1.0.7-r1*
* *qt-gui-py-common 1.0.7-r1*
* *quality-of-service-demo-cpp 0.7.9-r1*
* *quality-of-service-demo-py 0.7.9-r1*
* *radar-msgs 3.0.0-r2*
* *ray-ground-classifier 0.0.2-r1*
* *ray-ground-classifier-nodes 0.0.2-r1*
* *rcl 0.7.7-r1*
* *rcl-action 0.7.7-r1*
* *rcl-interfaces 0.7.4-r1*
* *rcl-lifecycle 0.7.7-r1*
* *rcl-logging-log4cxx 0.2.1-r1*
* *rcl-logging-noop 0.2.1-r1*
* *rcl-yaml-param-parser 0.7.7-r1*
* *rclcpp 0.7.12-r1*
* *rclcpp-action 0.7.12-r1*
* *rclcpp-components 0.7.12-r1*
* *rclcpp-lifecycle 0.7.12-r1*
* *rclpy 0.7.8-r1*
* *rcpputils 0.1.1-r1*
* *rcutils 0.7.4-r1*
* *realsense-camera-msgs 2.0.4-r2*
* *realsense-ros2-camera 2.0.4-r2*
* *realtime-tools 2.0.0-r1*
* *resource-retriever 2.1.2-r1*
* *rmw 0.7.2-r1*
* *rmw-connext-cpp 0.7.3-r1*
* *rmw-connext-shared-cpp 0.7.3-r1*
* *rmw-cyclonedds-cpp 0.4.2-r1*
* *rmw-fastrtps-cpp 0.7.6-r1*
* *rmw-fastrtps-dynamic-cpp 0.7.6-r1*
* *rmw-fastrtps-shared-cpp 0.7.6-r1*
* *rmw-implementation 0.7.1-r2*
* *rmw-implementation-cmake 0.7.2-r1*
* *rmw-opensplice-cpp 0.7.3-r1*
* *robot-state-publisher 2.2.5-r1*
* *ros-base 0.7.2-r1*
* *ros-core 0.7.2-r1*
* *ros-environment 2.3.0-r1*
* *ros-monitoring-msgs 2.0.0-r1*
* *ros-testing 0.1.1-r1*
* *ros-workspace 0.7.2-r1*
* *ros1-bridge 0.7.4-r1*
* *ros1-rosbag-storage-vendor 0.0.6-r2*
* *ros2action 0.7.9-r1*
* *ros2bag 0.1.8-r1*
* *ros2cli 0.7.9-r1*
* *ros2component 0.7.9-r1*
* *ros2launch 0.8.7-r1*
* *ros2lifecycle 0.7.9-r1*
* *ros2msg 0.7.9-r1*
* *ros2multicast 0.7.9-r1*
* *ros2node 0.7.9-r1*
* *ros2param 0.7.9-r1*
* *ros2pkg 0.7.9-r1*
* *ros2run 0.7.9-r1*
* *ros2service 0.7.9-r1*
* *ros2srv 0.7.9-r1*
* *ros2test 0.1.1-r1*
* *ros2topic 0.7.9-r1*
* *ros2trace 0.2.8-r1*
* *ros2trace-analysis 0.2.1-r1*
* *rosapi 1.0.2-r1*
* *rosauth 2.0.1-r1*
* *rosbag2 0.1.8-r1*
* *rosbag2-bag-v2-plugins 0.0.6-r2*
* *rosbag2-converter-default-plugins 0.1.8-r1*
* *rosbag2-storage 0.1.8-r1*
* *rosbag2-storage-default-plugins 0.1.8-r1*
* *rosbag2-test-common 0.1.8-r1*
* *rosbag2-tests 0.1.8-r1*
* *rosbag2-transport 0.1.8-r1*
* *rosbridge-msgs 1.0.2-r1*
* *rosbridge-server 1.0.2-r1*
* *rosbridge-suite 1.0.2-r1*
* *rosgraph-msgs 0.7.4-r1*
* *rosidl-adapter 0.7.8-r1*
* *rosidl-cmake 0.7.8-r1*
* *rosidl-default-generators 0.7.0-r1*
* *rosidl-default-runtime 0.7.0-r1*
* *rosidl-generator-c 0.7.8-r1*
* *rosidl-generator-cpp 0.7.8-r1*
* *rosidl-generator-dds-idl 0.7.1-r1*
* *rosidl-generator-py 0.7.10-r1*
* *rosidl-parser 0.7.8-r1*
* *rosidl-runtime-py 0.7.10-r1*
* *rosidl-typesupport-c 0.7.1-r1*
* *rosidl-typesupport-connext-c 0.7.3-r1*
* *rosidl-typesupport-connext-cpp 0.7.3-r1*
* *rosidl-typesupport-cpp 0.7.1-r1*
* *rosidl-typesupport-fastrtps-c 0.7.1-r1*
* *rosidl-typesupport-fastrtps-cpp 0.7.1-r1*
* *rosidl-typesupport-interface 0.7.8-r1*
* *rosidl-typesupport-introspection-c 0.7.8-r1*
* *rosidl-typesupport-introspection-cpp 0.7.8-r1*
* *rosidl-typesupport-opensplice-c 0.7.3-r1*
* *rosidl-typesupport-opensplice-cpp 0.7.3-r1*
* *rqt 1.0.5-r1*
* *rqt-action 1.0.1-r1*
* *rqt-common-plugins 1.0.0-r1*
* *rqt-console 1.1.0-r1*
* *rqt-graph 1.0.2-r1*
* *rqt-gui 1.0.5-r1*
* *rqt-gui-cpp 1.0.5-r1*
* *rqt-gui-py 1.0.5-r1*
* *rqt-image-view 1.0.2-r1*
* *rqt-msg 1.0.2-r1*
* *rqt-plot 1.0.7-r1*
* *rqt-publisher 1.1.0-r1*
* *rqt-py-common 1.0.5-r1*
* *rqt-py-console 1.0.0-r1*
* *rqt-reconfigure 1.0.4-r1*
* *rqt-robot-steering 1.0.0-r1*
* *rqt-service-caller 1.0.3-r1*
* *rqt-shell 1.0.0-r1*
* *rqt-srv 1.0.1-r1*
* *rqt-top 1.0.0-r1*
* *rqt-topic 1.0.0-r1*
* *rttest 0.7.1-r1*
* *rviz-assimp-vendor 6.1.4-r1*
* *rviz-common 6.1.4-r1*
* *rviz-default-plugins 6.1.4-r1*
* *rviz-ogre-vendor 6.1.4-r1*
* *rviz-rendering 6.1.4-r1*
* *rviz-rendering-tests 6.1.4-r1*
* *rviz-visual-testing-framework 6.1.4-r1*
* *rviz2 6.1.4-r1*
* *self-test 2.0.0-r1*
* *sensor-msgs 0.7.0-r1*
* *serial-driver 0.0.2-r1*
* *shape-msgs 0.7.0-r1*
* *shared-queues-vendor 0.1.8-r1*
* *sick-scan2 0.1.4-r1*
* *slam-toolbox 2.0.2-r1*
* *sophus 1.0.2*
* *sqlite3-vendor 0.1.8-r1*
* *sros2 0.7.1-r1*
* *sros2-cmake 0.7.1-r1*
* *std-msgs 0.7.0-r1*
* *std-srvs 0.7.0-r1*
* *stereo-msgs 0.7.0-r1*
* *swri-console-util 3.0.3-r1*
* *swri-dbw-interface 3.0.3-r1*
* *swri-geometry-util 3.0.3-r1*
* *swri-image-util 3.0.3-r1*
* *swri-math-util 3.0.3-r1*
* *swri-opencv-util 3.0.3-r1*
* *swri-prefix-tools 3.0.3-r1*
* *swri-roscpp 3.0.3-r1*
* *swri-route-util 3.0.3-r1*
* *swri-serial-util 3.0.3-r1*
* *swri-system-util 3.0.3-r1*
* *swri-transform-util 3.0.3-r1*
* *system-modes 0.1.4-r1*
* *system-modes-examples 0.1.4-r1*
* *teleop-tools 1.0.1*
* *teleop-tools-msgs 1.0.1*
* *teleop-twist-joy 2.2.1-r1*
* *teleop-twist-keyboard 2.3.1-r1*
* *test-interface-files 0.7.1-r1*
* *test-msgs 0.7.4-r1*
* *test-osrf-testing-tools-cpp 1.2.1-r1*
* *tf2 0.11.5-r1*
* *tf2-eigen 0.11.5-r1*
* *tf2-geometry-msgs 0.11.5-r1*
* *tf2-kdl 0.11.5-r1*
* *tf2-msgs 0.11.5-r1*
* *tf2-ros 0.11.5-r1*
* *tf2-sensor-msgs 0.11.5-r1*
* *theora-image-transport 2.1.0-r1*
* *tinydir-vendor 1.1.0-r1*
* *tinyxml-vendor 0.7.0-r1*
* *tinyxml2-vendor 0.6.1-r1*
* *tlsf 0.5.0-r1*
* *tlsf-cpp 0.7.1-r1*
* *topic-monitor 0.7.9-r1*
* *tracetools 0.2.8-r1*
* *tracetools-analysis 0.2.1-r1*
* *tracetools-launch 0.2.8-r1*
* *tracetools-test 0.2.8-r1*
* *trajectory-msgs 0.7.0-r1*
* *tts-interfaces 2.0.1-r1*
* *turtlebot3 2.0.1-r1*
* *turtlebot3-bringup 2.0.1-r1*
* *turtlebot3-cartographer 2.0.1-r1*
* *turtlebot3-description 2.0.1-r1*
* *turtlebot3-gazebo 2.0.1-r1*
* *turtlebot3-msgs 2.2.0-r1*
* *turtlebot3-navigation2 2.0.1-r1*
* *turtlebot3-node 2.0.1-r1*
* *turtlebot3-simulations 2.0.1-r1*
* *turtlebot3-teleop 2.0.1-r1*
* *turtlesim 1.0.1-r1*
* *udp-driver 0.0.3-r1*
* *uncrustify-vendor 1.2.0-r1*
* *unique-identifier-msgs 2.1.0-r1*
* *urdf 2.2.0-r1*
* *urdfdom 2.2.0-r1*
* *urdfdom-headers 1.0.4-r1*
* *v4l2-camera 0.1.1-r1*
* *velodyne-driver 0.0.2-r1*
* *velodyne-node 0.0.2-r1*
* *vision-opencv 2.1.3-r1*
* *visualization-msgs 0.7.0-r1*
* *voxel-grid 0.0.2-r1*
* *voxel-grid-nodes 0.0.2-r1*
* *web-video-server 1.0.0-r1*
* *xacro 2.0.1-r2*
* *yaml-cpp-vendor 6.0.1-r1*


Missing Dependencies:
=====================
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] pyqt5-dev-tools
 * [ ] python-gst-1.0
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rospkg
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
