### PR TITLE
rosdistro sync, Fri Dec 13 17:08:52 2019

### DIFF
--- a/dashing/pcl-conversions/default.nix
+++ b/dashing/pcl-conversions/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
-    sha256 = "1dee570593be56530a89248cd15ba13a1eb72daad1c1a4d452ed7b396db8a134";
+    sha256 = "7e5a799ac5e1a196d385a9247cffabe2b8589c554b22a4a1cb10896ff3bfcb07";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rcl-action/default.nix
+++ b/dashing/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-generator-c, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rcl-action";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_action/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "782ae4c3e5b4e96398c1bb4247d32f0a0d8683959df623c8316d543b85a21662";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_action/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "c2aa2a6c51c98588202b0f7f7e71209501c64e8bae984ec56a405ff09bc6236e";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rcl-lifecycle/default.nix
+++ b/dashing/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw-implementation, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rcl-lifecycle";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_lifecycle/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "f49282cff0b556891f09bf68d90b65951e3230a137b67b58b92243a23326b06a";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_lifecycle/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "59a79008952060bc9f9e15080d4aeb5c48d320ba22ce9c7cafaf23069abf0fd9";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rcl-yaml-param-parser/default.nix
+++ b/dashing/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, rcl, rcutils }:
 buildRosPackage {
   pname = "ros-dashing-rcl-yaml-param-parser";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_yaml_param_parser/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "772ed9b47fb3466c5e27c56516181333b36f979c7e7f716b56db199252ec58e3";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_yaml_param_parser/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "0c190303a560004d69964b50ef4725ee4168a12925524257e0ad8ebc48817125";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rcl/default.nix
+++ b/dashing/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-noop, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-default-runtime, rosidl-generator-c, test-msgs, tinydir-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rcl";
-  version = "0.7.7-r1";
+  version = "0.7.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl/0.7.7-1.tar.gz";
-    name = "0.7.7-1.tar.gz";
-    sha256 = "149d5bac7f4503b4942ec2f23c9808fb7db5e761415bcffaf2e5ad1213be7b99";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl/0.7.8-1.tar.gz";
+    name = "0.7.8-1.tar.gz";
+    sha256 = "a453c70b1aae81a4df3ac2888e472465dce6ae88af1ce71296d9ca963b28d5c2";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rclpy/default.nix
+++ b/dashing/rclpy/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclpy";
-  version = "0.7.8-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/dashing/rclpy/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "367c1f3ea1a7f087f46d4c0ed4cacbf6c1afa8a7385db82fb26922a1a37c505b";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/dashing/rclpy/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "ec1cc65437379102035181934e7a1e68b72d33abfcd94ff08d2a51e6fe527bb7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rcutils rmw-implementation-cmake ];
-  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest rcl-interfaces rosidl-generator-py test-msgs ];
-  propagatedBuildInputs = [ ament-index-python builtin-interfaces rcl rcl-action rcl-yaml-param-parser rmw-implementation rosgraph-msgs unique-identifier-msgs ];
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common pythonPackages.pytest rosidl-generator-py test-msgs ];
+  propagatedBuildInputs = [ ament-index-python builtin-interfaces rcl rcl-action rcl-interfaces rcl-yaml-param-parser rmw-implementation rosgraph-msgs unique-identifier-msgs ];
   nativeBuildInputs = [ ament-cmake python-cmake-module ];
 
   meta = {

--- a/dashing/rcutils/default.nix
+++ b/dashing/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-rcutils";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/dashing/rcutils/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "b04e61c7bffe569c664473c320a61e7e6db97e715d83295332fa101daae76c06";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/dashing/rcutils/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "e02c8986a52e3379999f3a7aad03a32c6a8f4b952709bce1f92af1ff24ccbbb6";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rmw-connext-cpp/default.nix
+++ b/dashing/rmw-connext-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rmw-connext-shared-cpp, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-generator-dds-idl, rosidl-typesupport-connext-c, rosidl-typesupport-connext-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-connext-cpp";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_cpp/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "ae092ccf840be05132e3eff8979faa4d2e1c93820c36e798e87dd327e2088d9e";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_cpp/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "e93e9082d98e287fb1e91d43aa7b018ea5db1399beaf32d039219b1ffd2b59d5";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rmw-connext-shared-cpp/default.nix
+++ b/dashing/rmw-connext-shared-cpp/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rosidl-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcpputils, rcutils, rmw, rosidl-cmake }:
 buildRosPackage {
   pname = "ros-dashing-rmw-connext-shared-cpp";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_shared_cpp/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "f29e918f46e28debc3f7f0648c7698a53d9a912cc7450274f6d511195f84e3e0";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_shared_cpp/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "1ac2c7c9d13c2db20015463c8c9ba90bb1020028bf383a2fc6151520dc7f628b";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ rcutils rmw ];
+  buildInputs = [ rcpputils rcutils rmw ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake connext-cmake-module ];
   nativeBuildInputs = [ ament-cmake rosidl-cmake ];

--- a/dashing/rmw-implementation/default.nix
+++ b/dashing/rmw-implementation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, poco, poco-vendor, rcutils, rmw, rmw-connext-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake, rmw-opensplice-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-implementation";
-  version = "0.7.1-r2";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/dashing/rmw_implementation/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "d5ffa073fa3d8741f654aa0abd3f893f1a6c4923db292e28c8c416a9995eebb3";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/dashing/rmw_implementation/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "69859dfd18ad79681ce7e76be437cedc989c689002bace7c1febc8b864d5dbc8";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-assimp-vendor/default.nix
+++ b/dashing/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-dashing-rviz-assimp-vendor";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_assimp_vendor/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "21ef967c27df3eb278ad17c46848b60880d364bc260005c43cb71ee77791c74b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_assimp_vendor/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "16e30c0eac1bfee1ce1550b0eb1545efa151a01d0049e8e65a68c4411a8e51e1";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-common/default.nix
+++ b/dashing/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rviz-common";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_common/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "e814715a70af5c9d2122d5782512446c24437ea9debdfa33ec81a1f52d9e9e08";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_common/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "18c0f221ac4ebc600d52df42864aefa6d05220d54f41f4c9cfa013ee9f43cc2d";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-default-plugins/default.nix
+++ b/dashing/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rviz-default-plugins";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_default_plugins/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "e00f52eb0ba6e7b0755b9228490dd982eb1306222ddac9b47eb0a8fd0bf8c33b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_default_plugins/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "58fa0a7a0f99c53fcfbf05c11f4d29a040e41f4f190aa22aafe6f5a797979eeb";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-ogre-vendor/default.nix
+++ b/dashing/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-dashing-rviz-ogre-vendor";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_ogre_vendor/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "b58123f893d62043ec947ce1ed627462139bb474a10ba3cbec9d8cf02e5e63c4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_ogre_vendor/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "4c5f6855267c89c348087aa95a50c8f5abd27947194f8c7b79582d4d726a79f9";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-rendering-tests/default.nix
+++ b/dashing/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-dashing-rviz-rendering-tests";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering_tests/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "de5bba689953b50de113794305b280d18365d1e49f6f0043380773fcf30d32a6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering_tests/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "89b580a8005ee307108d7dc29d02cd3fddf018ccddafec53dc286731382a349a";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-rendering/default.nix
+++ b/dashing/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rviz-rendering";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "cd9a88775269a779c24c15dd303920eb7b023daf970854191e79d9e336136e05";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "f4d2ccdbcd2124d6357870375fb859aac8c4c34a0d255fc5cd3a15cdeff08bee";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz-visual-testing-framework/default.nix
+++ b/dashing/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-dashing-rviz-visual-testing-framework";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_visual_testing_framework/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "fd18f9fd580cc4504bd416c655b47e00472615fb15f55a047d58481319fe4b49";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_visual_testing_framework/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "f42359c9869ba7d26ef732be855d801a9eac100ce3c3c9bad833b586fd73bc5c";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rviz2/default.nix
+++ b/dashing/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rviz2";
-  version = "6.1.4-r1";
+  version = "6.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz2/6.1.4-1.tar.gz";
-    name = "6.1.4-1.tar.gz";
-    sha256 = "27e060c12465283bb824dbfc80ec0dfaa547d05755c24c0c915efbb106c98822";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz2/6.1.5-1.tar.gz";
+    name = "6.1.5-1.tar.gz";
+    sha256 = "377500f6ea8558a149975e30e1ede7b874458b2cfbc4938116977a3c5b2fbc2f";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ament-package/default.nix
+++ b/eloquent/ament-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-ament-package";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/eloquent/ament_package/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "5f36b1a8fa0ca50311b85dd861a13970f9d3351a14c80a0744fdd960fa6c56ac";
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/eloquent/ament_package/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "15d7727a71a534342a8881486050f01ac9f3f775a30dbe8cddc9a491570045f4";
   };
 
   buildType = "ament_python";

--- a/kinetic/area-division/default.nix
+++ b/kinetic/area-division/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/area_division/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "08224e207a79a56651930a2653d25bb2c87aff83975cb05614b67fc5be6297f3";
+    sha256 = "705892330f17a4eaba1e6483bece0282f2e1cb0ed94b684ade002ae1d1127ed5";
   };
 
   buildType = "catkin";

--- a/kinetic/assimp-devel/default.nix
+++ b/kinetic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-kinetic-assimp-devel";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/assimp_devel/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "d2463baec0806b02f96ccd2444890ebe81fd0503e573c01051e94deb026e1da2";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/assimp_devel/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "afdb80c7c69753f5fd371a86bcc0ab74f41a1d96a369e926b2291833b4aab5ef";
   };
 
   buildType = "catkin";

--- a/kinetic/bayesian-belief-networks/default.nix
+++ b/kinetic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-bayesian-belief-networks";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/bayesian_belief_networks/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "01dd4418d8159368c4e96c5010ae632644b1df9ef28c7d394bad665cb0e71d33";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/bayesian_belief_networks/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "c1e4e187ce194b5d950abba6650820d1cf0b57720d4b06f15242d98bd1080716";
   };
 
   buildType = "catkin";

--- a/kinetic/coverage-path/default.nix
+++ b/kinetic/coverage-path/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/coverage_path/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "a67ebc957c654908124170d240c75382d86734be4d813a48b57644155a0fac17";
+    sha256 = "357eb5b7ac47f29f5fa009322f0f06184d30e7a63179e3d91ab604aac10ebab5";
   };
 
   buildType = "catkin";

--- a/kinetic/cpswarm-msgs/default.nix
+++ b/kinetic/cpswarm-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/cpswarm_msgs-release/archive/release/kinetic/cpswarm_msgs/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "560f72b50d8da37e4fb4afaa35511a692f58991f1a3bf5f892d2b7f6f29b1fc4";
+    sha256 = "c8e0320357d7ffc4c72eefcfab586308d90df226473b3b7cf7139ee163aea39a";
   };
 
   buildType = "catkin";

--- a/kinetic/downward/default.nix
+++ b/kinetic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-kinetic-downward";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/downward/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "d1e1a2b6cf02c91b3893da2d6903b848533964ba8b1b1d13ed57beb231113ce3";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/downward/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "2b6bdc5eae55a2cf6606212a209a25d339891337a0148ecc4870396c328cdc49";
   };
 
   buildType = "catkin";

--- a/kinetic/ff/default.nix
+++ b/kinetic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-kinetic-ff";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/ff/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "42bcfd2c0fd4b72cf4f113832aa1c6cbab5c78ab9a920a9acb307687ce8709ae";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/ff/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "a58b5a16922f6b2429c7faac7bf8f677c846bb70c7a325174e87abb3deda62dc";
   };
 
   buildType = "catkin";

--- a/kinetic/ffha/default.nix
+++ b/kinetic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-kinetic-ffha";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/ffha/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "1e342d35e5a6a2e9a03d02e6856ad9a73ed7c22aaddce73ce3a4a0bbaee524a4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/ffha/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "62ba2afcc929176a462da92fe597e2ad42126d6534bbb3d3b8802aa944039a26";
   };
 
   buildType = "catkin";

--- a/kinetic/jsk-3rdparty/default.nix
+++ b/kinetic/jsk-3rdparty/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, downward, ff, ffha, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, sesame-ros, slic, voice-text }:
+{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-3rdparty";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/jsk_3rdparty/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "7684da53f0670e72b9486f969749c318e49534fb315b6c339e5695f3368d6402";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/jsk_3rdparty/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "5d432d4d46dada5a68c0e8c182ddc020bdd961f6c006eae38823312a2cc2248e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks downward ff ffha julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping sesame-ros slic voice-text ];
+  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks dialogflow-task-executive downward ff ffha gdrive-ros julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping sesame-ros slic voice-text ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/julius/default.nix
+++ b/kinetic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-kinetic-julius";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/julius/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "38a3a0453d5a153bf75a2e17b6dcda93e1935313fbb5152f5097c994a9164efa";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/julius/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "43d731d49103582f6c0bfaabfb4e23a93585b8ca9b2ad42fb893d9d301a8761a";
   };
 
   buildType = "catkin";

--- a/kinetic/kinematics-exchanger/default.nix
+++ b/kinetic/kinematics-exchanger/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/kinematics_exchanger/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "3eee44d062a9f3d98ac8b203cbf7d9d1ab115621fe991160cf79d49289853f2b";
+    sha256 = "02baec3d78be0b19ae340d3e1dd2f2a8798ea284ec36109f74253e1c2a3bb1fc";
   };
 
   buildType = "catkin";

--- a/kinetic/laser-filters-jsk-patch/default.nix
+++ b/kinetic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-kinetic-laser-filters-jsk-patch";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/laser_filters_jsk_patch/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "c492529a4e3359094f831613024ad57e474cef509464a8b0451bc4e759994ac0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/laser_filters_jsk_patch/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "40624aebdb09812424bbb20c11f6d86d5f202fd1d4aefd3c15052de153122d8c";
   };
 
   buildType = "catkin";

--- a/kinetic/libcmt/default.nix
+++ b/kinetic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-kinetic-libcmt";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/libcmt/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "cc83273954285ef9ce2393ba5e23a8d77ca7d73db8cc91a8bf7b89feb13eb65d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/libcmt/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "a507cf8d5a41c64a96d6f0ca51d0a4af13b76b101d48ab8b41624ca1f40ee7b4";
   };
 
   buildType = "cmake";

--- a/kinetic/libsiftfast/default.nix
+++ b/kinetic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-kinetic-libsiftfast";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/libsiftfast/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "edc3538c35c0ea357405807b40006c6afc9df91530ccc3ace0ef192664ba49f9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/libsiftfast/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "517d18b4401171f6ed1ec048cfa350168013a2bcdfe0ec15ceb716e5743258e1";
   };
 
   buildType = "catkin";

--- a/kinetic/lpg-planner/default.nix
+++ b/kinetic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-lpg-planner";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/lpg_planner/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "500a2cf29200b10be40d998eb88b6606a978404ca9f8ee1ff3a46127de088420";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/lpg_planner/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "16c88bd9a8763a143140184076dc463c9277d690cd546835d9c8101796897f2a";
   };
 
   buildType = "catkin";

--- a/kinetic/mini-maxwell/default.nix
+++ b/kinetic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-kinetic-mini-maxwell";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/mini_maxwell/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "c056847379ff23803dd59df66a4c03501157b059d76ed1bac821347bd2ca0fe6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/mini_maxwell/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "d4e8525af88bbf73fde054c1e93d4f3ca1bf0e4d6f1690f4167b05f5a4e67eef";
   };
 
   buildType = "catkin";

--- a/kinetic/nlopt/default.nix
+++ b/kinetic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-kinetic-nlopt";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/nlopt/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "801b7246d829a75fd9eb84d52fef2dc03dbeb3bfd595ba4e951e2135ea27ddf4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/nlopt/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "c48f0d479f1e933231a3f05555bcf4decbeea786c5a47344dec13175c56226a3";
   };
 
   buildType = "catkin";

--- a/kinetic/opt-camera/default.nix
+++ b/kinetic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-opt-camera";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/opt_camera/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "324e29b2e488ee3361c8c552959b8cebde3cededb0dffc5fa716717976d76ef9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/opt_camera/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "72e0a4898deedde17cdea3f62645debd9601b517c19ac10cbfc8074f4c063499";
   };
 
   buildType = "catkin";

--- a/kinetic/pgm-learner/default.nix
+++ b/kinetic/pgm-learner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-pgm-learner";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/pgm_learner/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "4ea596fa5a756d9397f57e599eec3493595a623dfd06dc12cb59162a90cc8b95";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/pgm_learner/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "785335a5569271ba95841e304ec771f5d0b20b21832f4133e64b6e0d5a0b4fd0";
   };
 
   buildType = "catkin";

--- a/kinetic/rospatlite/default.nix
+++ b/kinetic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rospatlite";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/rospatlite/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "166bce24a088dd53c5a857261e70e6b29d1b57b40a4283172f95866947238608";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/rospatlite/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "6c54f7eb9670f320fbe4777ea27f751ecce68b652573ac73b61b99c7e48de105";
   };
 
   buildType = "catkin";

--- a/kinetic/rosping/default.nix
+++ b/kinetic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosping";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/rosping/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "cc26b6cb500d078bb7068e815b57cde51a3669c25575dc438082e1ec3703c679";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/rosping/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "65f42f9f9e929b6f7612472f010fcad2b16d2dbd0735ffe930db7cae24d71bd7";
   };
 
   buildType = "catkin";

--- a/kinetic/sesame-ros/default.nix
+++ b/kinetic/sesame-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, message-generation, message-runtime }:
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-kinetic-sesame-ros";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/sesame_ros/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "45f9d1ca3071d04da84ffe0b83d0f474a47be9be86f21e606654cc691c413327";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/sesame_ros/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "d0a1f9f06363343c52fef3c4e2f6972ca4cbc56987bbac6fa759abd71f73dfd2";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin-virtualenv message-generation ];
+  buildInputs = [ catkin-virtualenv libffi message-generation openssl ];
   propagatedBuildInputs = [ message-runtime ];
   nativeBuildInputs = [ catkin ];
 

--- a/kinetic/slic/default.nix
+++ b/kinetic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-kinetic-slic";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/slic/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "535adb5b099fe7dad452dce9a88373ccb762dbd134fb8465c26b7fe209624dd5";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/slic/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "173a70ee694e8a075781c39ae19a6617630069d129776057a6597d5d729b5fad";
   };
 
   buildType = "cmake";

--- a/kinetic/state-exchanger/default.nix
+++ b/kinetic/state-exchanger/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/state_exchanger/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "6ccdd3c450b331704b4700c8346a92eaf66806fb44d7914cee25cf377f5940ac";
+    sha256 = "8217d057f69a883ecef8385f234358d46d09c9aae5a4612513e80f9d680da8bd";
   };
 
   buildType = "catkin";

--- a/kinetic/swarm-functions/default.nix
+++ b/kinetic/swarm-functions/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/swarm_functions/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "4fe3f0bdb2e77fc5523bc763d26edbf2b5e85ca70255f29bd8d43a5c8d4140dd";
+    sha256 = "ec6006a233b0691e3400dfc342cc3f13f424441c6d4b547db9306af7f87fed74";
   };
 
   buildType = "catkin";

--- a/kinetic/target-monitor/default.nix
+++ b/kinetic/target-monitor/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/target_monitor/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "543537106fa90939a2c368947fec9b62db886b170d82e2ecf007a1b319ef9468";
+    sha256 = "6c77992ee6e908a2d3885704b4e05fdcdb7453ffb9046b02a1c5e2deac89f3ae";
   };
 
   buildType = "catkin";

--- a/kinetic/task-allocation/default.nix
+++ b/kinetic/task-allocation/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/cpswarm/swarm_functions-release/archive/release/kinetic/task_allocation/1.1.0-1.tar.gz";
     name = "1.1.0-1.tar.gz";
-    sha256 = "cc059f8347be9d0f24d6135dcd1e763e44fea2e63a82c9d3b9d9a4f61dd854ff";
+    sha256 = "235436d8e702b5ccc43a1471b7fb4865949acf1048e56699299bad91794a0c10";
   };
 
   buildType = "catkin";

--- a/kinetic/tracetools/default.nix
+++ b/kinetic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/bosch-robotics-cr/tracetools-release/archive/release/kinetic/tracetools/0.2.1-0.tar.gz";
     name = "0.2.1-0.tar.gz";
-    sha256 = "59ed304f0ac9078e5b0875444b5594170921f29d35ba304a7f60f17eadd54f57";
+    sha256 = "0c51e131b0461a9aeb8822e368147433d331bbf9c972062f775d9f4e73a0636e";
   };
 
   buildType = "catkin";

--- a/kinetic/voice-text/default.nix
+++ b/kinetic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-kinetic-voice-text";
-  version = "2.1.14-r1";
+  version = "2.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/voice_text/2.1.14-1.tar.gz";
-    name = "2.1.14-1.tar.gz";
-    sha256 = "193cd3ab182bf5a8d4edfbc077374f2f6dc32e3e72f36f9d7f71d296525b35cd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/kinetic/voice_text/2.1.15-1.tar.gz";
+    name = "2.1.15-1.tar.gz";
+    sha256 = "7e4aa2eb7e60422f0770c8f8b19a34643d569847bcf1047ffbf41e5cb90cfe60";
   };
 
   buildType = "catkin";

--- a/melodic/blender-gazebo/default.nix
+++ b/melodic/blender-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros }:
 buildRosPackage {
   pname = "ros-melodic-blender-gazebo";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/david0429-gbp/blender_gazebo_gbp/archive/release/melodic/blender_gazebo/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "0dda68ea5dfd6579742c047ffedbeff449bd31f319aa1e47ae263cbac7ac3e1e";
+    url = "https://github.com/david0429-gbp/blender_gazebo_gbp/archive/release/melodic/blender_gazebo/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "ca41a7b8fbb299e647314ea3aefbca8b162617487784140646726df92a8909f3";
   };
 
   buildType = "catkin";

--- a/melodic/catkin/default.nix
+++ b/melodic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-catkin";
-  version = "0.7.19-r1";
+  version = "0.7.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/melodic/catkin/0.7.19-1.tar.gz";
-    name = "0.7.19-1.tar.gz";
-    sha256 = "10d50731008b2ab232a17cd1717d0b81d75d175b6f4b99a2e28ed4acc59df055";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/melodic/catkin/0.7.20-1.tar.gz";
+    name = "0.7.20-1.tar.gz";
+    sha256 = "24e182f20635f79f4980ecc56d2f5baad8000b02f7201f690c1feab92f4c8651";
   };
 
   buildType = "catkin";

--- a/melodic/cis-camera/default.nix
+++ b/melodic/cis-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2019 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, jsk-rviz-plugins, libuvc, nodelet, pcl-ros, pluginlib, rgbd-launch, roscpp, roslaunch, rostest, rqt-reconfigure, rviz, sensor-msgs, tf, tf-conversions }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, jsk-rviz-plugins, libuvc, nodelet, pcl-ros, pluginlib, rgbd-launch, roscpp, roslaunch, roslint, rostest, rqt-reconfigure, rviz, sensor-msgs, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-cis-camera";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/cis_camera-release/archive/release/melodic/cis_camera/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "23afb3a9a394bc89c389da55add4a57c7a4e0731e7530f7dd078a014b577e0f6";
+    url = "https://github.com/tork-a/cis_camera-release/archive/release/melodic/cis_camera/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "5f4a44afefb77a6887cd8531b450cf19f18d5e9159d2a3b4a1ad272c6b678841";
   };
 
   buildType = "catkin";
-  buildInputs = [ rostest ];
+  buildInputs = [ roslint rostest ];
   checkInputs = [ roslaunch ];
   propagatedBuildInputs = [ camera-info-manager cv-bridge dynamic-reconfigure image-transport jsk-rviz-plugins libuvc nodelet pcl-ros pluginlib rgbd-launch roscpp rqt-reconfigure rviz sensor-msgs tf tf-conversions ];
   nativeBuildInputs = [ catkin ];

--- a/melodic/executive-smach-visualization/default.nix
+++ b/melodic/executive-smach-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, smach-viewer }:
 buildRosPackage {
   pname = "ros-melodic-executive-smach-visualization";
-  version = "2.0.2";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/2.0.2-0.tar.gz";
-    name = "2.0.2-0.tar.gz";
-    sha256 = "75b50684f1fcbe42e1b5307402ff4ac6f5b598d2f2ff67acc3c746af9e83b2c8";
+    url = "https://github.com/jbohren/executive_smach_visualization-release/archive/release/melodic/executive_smach_visualization/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "ee755a0a534f5e577f3b6bd6a5af3eb30a8056f2e2a7544d0cf50455ad60a73a";
   };
 
   buildType = "catkin";

--- a/melodic/generated.nix
+++ b/melodic/generated.nix
@@ -2846,8 +2846,6 @@ self: super: {
 
  smach-ros = self.callPackage ./smach-ros {};
 
- smach-viewer = self.callPackage ./smach-viewer {};
-
  smclib = self.callPackage ./smclib {};
 
  social-navigation-layers = self.callPackage ./social-navigation-layers {};

--- a/melodic/husky-base/default.nix
+++ b/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0e3a08f2275b71b5c1136a17d0857857e20df49fc2de2ad5d88cb180801dedd3";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "563aa35de332fa99821c0756f900c27bf44185757f9d745d20842c321457d1f7";
   };
 
   buildType = "catkin";

--- a/melodic/husky-bringup/default.nix
+++ b/melodic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7 }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "d94a3ac3e2d841447e45337001c85b359031895c14c7330d9c26997a851b4589";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f407b778f65237dcf58ff694a305a30ac104e394aacc1df4175a63e22ad01c57";
   };
 
   buildType = "catkin";

--- a/melodic/husky-control/default.nix
+++ b/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "7eb61be9b4b8876ca17bcc6a45846d47a5145e9f36598087c769a821c3829119";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "bceb125b2585ee266ec050570247422ad633aa859e42377140f3d20d28929425";
   };
 
   buildType = "catkin";

--- a/melodic/husky-description/default.nix
+++ b/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "d4c33dfc90776e53c36ce501ac33351d2567eafce3da02d56fe818a43c52c7f0";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "79f2f85a823b49a15f1d81cbffe530aeb28f3dc8c08c8b4c95c762c9fb722855";
   };
 
   buildType = "catkin";

--- a/melodic/husky-desktop/default.nix
+++ b/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "f0f545eb9930687278ea4f5e93c89858fa430187d80c27567c26513a9cc33aea";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "b5332794b91af65a13ba560e935f1b0008e9703de67598175ddfd4e2eeb3518a";
   };
 
   buildType = "catkin";

--- a/melodic/husky-gazebo/default.nix
+++ b/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "f8001d977d7740b7401878c8372438101e9669c9111838380973a41ede2bb4cf";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "19ba9b5eaf533e3685eca5564218f3e6086ad5fabab3e59d988f8028d72757da";
   };
 
   buildType = "catkin";

--- a/melodic/husky-msgs/default.nix
+++ b/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "db4b3f8cd81bebcafb363152242495c2fc9438a37141323d40238ed8a28ccc8e";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "ff3b6b60aebe40d7de6b4cc679f32942797b7d5aa57f36a882cf0425f933ebc5";
   };
 
   buildType = "catkin";

--- a/melodic/husky-navigation/default.nix
+++ b/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "91db7fc019d68d7575152dafb0ea8ac59f803cd6cdd727aece323d03f6e10c1f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "605a9afe049cfec4eb315037bf7973ac4bba43217da55c7b7a2b880eb44acae0";
   };
 
   buildType = "catkin";

--- a/melodic/husky-robot/default.nix
+++ b/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "01a169c35acc692f79802efb5f66cbac9f11ca9e0e653fbde85a92242b81eb0f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "0a9259108259aa128424730f996fb2c7496e7e1deaf8c4c2318ede571653c669";
   };
 
   buildType = "catkin";

--- a/melodic/husky-simulator/default.nix
+++ b/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "9f73115dee3431c7262dcc6921ba8d83d42a240c777095d9e7f2605845b7b05a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "957f8edd097f405656df436cf93bc1f7fdb3b4cc2a8fd2c465b56b3596c43a94";
   };
 
   buildType = "catkin";

--- a/melodic/husky-viz/default.nix
+++ b/melodic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0929c37c262a5e06e49f8fe52bfaae70d7447e820fa8573a10b833ad1ec59325";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "c22a2d95e4ad42762a0c1c39e4941dff2f7ec2a645486b0d870b9c370de6f544";
   };
 
   buildType = "catkin";

--- a/melodic/libmavconn/default.nix
+++ b/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "0.33.3-r1";
+  version = "0.33.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/0.33.3-1.tar.gz";
-    name = "0.33.3-1.tar.gz";
-    sha256 = "6f40274397216a8d4b7b53b4277e8a6423d56c5f4b59698e4d5d0a9504faa7f3";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/0.33.4-1.tar.gz";
+    name = "0.33.4-1.tar.gz";
+    sha256 = "23446628885030513710d76c6435fe5530b26c5f849ddc481e355fe6889e01f3";
   };
 
   buildType = "catkin";

--- a/melodic/mavlink/default.nix
+++ b/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2019.11.11-r1";
+  version = "2019.12.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2019.11.11-1.tar.gz";
-    name = "2019.11.11-1.tar.gz";
-    sha256 = "3dfeb366675dfdf90af26e764e82a8c22922ac06b6adf7890f380454db5aca8a";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2019.12.12-1.tar.gz";
+    name = "2019.12.12-1.tar.gz";
+    sha256 = "500ee01dc1de5c90b16514c74ea1ca078cfebfaa8524dbf52862d9ffcd8c5689";
   };
 
   buildType = "cmake";

--- a/melodic/mavros-extras/default.nix
+++ b/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "0.33.3-r1";
+  version = "0.33.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/0.33.3-1.tar.gz";
-    name = "0.33.3-1.tar.gz";
-    sha256 = "dc9f17b2c94a1ba600192153a294c20089af28cda7fdc629ae42ffbb67845b22";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/0.33.4-1.tar.gz";
+    name = "0.33.4-1.tar.gz";
+    sha256 = "4e570368999aa52b0783de10865e85602c53f5a90e6a600da509e146985c3242";
   };
 
   buildType = "catkin";

--- a/melodic/mavros-msgs/default.nix
+++ b/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "0.33.3-r1";
+  version = "0.33.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/0.33.3-1.tar.gz";
-    name = "0.33.3-1.tar.gz";
-    sha256 = "18eaf499af8b2929cc5f0cc1a701f48b833241bda7815eaeb2991d04a40aaf74";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/0.33.4-1.tar.gz";
+    name = "0.33.4-1.tar.gz";
+    sha256 = "6829689112df3f3191865848236c6430a2d5d82381bf6195c38f34cca8c40235";
   };
 
   buildType = "catkin";

--- a/melodic/ompl/default.nix
+++ b/melodic/ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, eigen, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-ompl";
-  version = "1.4.2-r3";
+  version = "1.4.2-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ompl-release/archive/release/melodic/ompl/1.4.2-3.tar.gz";
-    name = "1.4.2-3.tar.gz";
-    sha256 = "74c8448f36a36f6fae0f8eeb78fc259a4d9e3b1a6b7a51b190a113039324e77e";
+    url = "https://github.com/ros-gbp/ompl-release/archive/release/melodic/ompl/1.4.2-5.tar.gz";
+    name = "1.4.2-5.tar.gz";
+    sha256 = "9d948c9a1b3172665a402240eaa980066db8ce1ca27a5d1646d1798d083c518f";
   };
 
   buildType = "cmake";

--- a/melodic/rc-common-msgs/default.nix
+++ b/melodic/rc-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-common-msgs";
-  version = "0.3.0-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/melodic/rc_common_msgs/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c1825f1534ee3e8186d61dff3462b0bf7fcd0e54104be8d09180220a5a1cd3c2";
+    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/melodic/rc_common_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b9ac40ea5d7627deaa9b8b1b12214fddf4a2a3f33e53c49c49205e90000e8e6d";
   };
 
   buildType = "catkin";

--- a/melodic/rc-genicam-api/default.nix
+++ b/melodic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, libusb }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "3d0e150794ab2b8363be54bb37e4fdb35737aa99c7c58fb1fd17c6dfc1dc745c";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "951cf2237ed9392b7ee23fbebefeb992a7dcdd4f8f51ba40590f66f22c9073c5";
   };
 
   buildType = "cmake";

--- a/melodic/test-mavros/default.nix
+++ b/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "0.33.3-r1";
+  version = "0.33.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/0.33.3-1.tar.gz";
-    name = "0.33.3-1.tar.gz";
-    sha256 = "9e20ed9fb79f6e02c5dc08648f7b68bb5a18e6ef59000ddc0803ca211c5d4b1b";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/0.33.4-1.tar.gz";
+    name = "0.33.4-1.tar.gz";
+    sha256 = "2c1c421b329237ff35c3295fd394acf6cae7e0ef6c4aa3583a8cb4a0d46162cd";
   };
 
   buildType = "catkin";

--- a/melodic/tracetools/default.nix
+++ b/melodic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/bosch-robotics-cr/tracetools-release/archive/release/melodic/tracetools/0.2.1-1.tar.gz";
     name = "0.2.1-1.tar.gz";
-    sha256 = "1c5114e1acce416cfb16dfca419508fd9dfcfd682ffdd63eafbe7a609d5f14f7";
+    sha256 = "1432003c36ab6c12cd03dc132dba1e8dd87986ae2fbf3bb4537001369bd47fc4";
   };
 
   buildType = "catkin";

--- a/melodic/xacro/default.nix
+++ b/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.4-r1";
+  version = "1.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.4-1.tar.gz";
-    name = "1.13.4-1.tar.gz";
-    sha256 = "2f4797a60fdb2ac1dbbaa681b2fa1d5e035a34645fe9dcfd9ea1006e3f507b73";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.5-1.tar.gz";
+    name = "1.13.5-1.tar.gz";
+    sha256 = "e80b1d5e3c6fdd1581b7516081ee9d730391f499201789586914a5dc3ae321f0";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['crystal', 'dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 690eaf731eaaff50793a02f8f9ce4a92a25c6986.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *rcl 0.7.7-r1 --> 0.7.8-r1*
* *rcl-action 0.7.7-r1 --> 0.7.8-r1*
* *rcl-lifecycle 0.7.7-r1 --> 0.7.8-r1*
* *rcl-yaml-param-parser 0.7.7-r1 --> 0.7.8-r1*
* *rclpy 0.7.8-r1 --> 0.7.10-r1*
* *rcutils 0.7.4-r1 --> 0.7.5-r1*
* *rmw-connext-cpp 0.7.3-r1 --> 0.7.4-r1*
* *rmw-connext-shared-cpp 0.7.3-r1 --> 0.7.4-r1*
* *rmw-implementation 0.7.1-r2 --> 0.7.2-r1*
* *rviz-assimp-vendor 6.1.4-r1 --> 6.1.5-r1*
* *rviz-common 6.1.4-r1 --> 6.1.5-r1*
* *rviz-default-plugins 6.1.4-r1 --> 6.1.5-r1*
* *rviz-ogre-vendor 6.1.4-r1 --> 6.1.5-r1*
* *rviz-rendering 6.1.4-r1 --> 6.1.5-r1*
* *rviz-rendering-tests 6.1.4-r1 --> 6.1.5-r1*
* *rviz-visual-testing-framework 6.1.4-r1 --> 6.1.5-r1*
* *rviz2 6.1.4-r1 --> 6.1.5-r1*

Eloquent Changes:
-----------------
* *ament-package 0.8.7-r1 --> 0.8.8-r1*

Kinetic Changes:
----------------
* *assimp-devel 2.1.14-r1 --> 2.1.15-r1*
* *bayesian-belief-networks 2.1.14-r1 --> 2.1.15-r1*
* *downward 2.1.14-r1 --> 2.1.15-r1*
* *ff 2.1.14-r1 --> 2.1.15-r1*
* *ffha 2.1.14-r1 --> 2.1.15-r1*
* *jsk-3rdparty 2.1.14-r1 --> 2.1.15-r1*
* *julius 2.1.14-r1 --> 2.1.15-r1*
* *laser-filters-jsk-patch 2.1.14-r1 --> 2.1.15-r1*
* *libcmt 2.1.14-r1 --> 2.1.15-r1*
* *libsiftfast 2.1.14-r1 --> 2.1.15-r1*
* *lpg-planner 2.1.14-r1 --> 2.1.15-r1*
* *mini-maxwell 2.1.14-r1 --> 2.1.15-r1*
* *nlopt 2.1.14-r1 --> 2.1.15-r1*
* *opt-camera 2.1.14-r1 --> 2.1.15-r1*
* *pgm-learner 2.1.14-r1 --> 2.1.15-r1*
* *rospatlite 2.1.14-r1 --> 2.1.15-r1*
* *rosping 2.1.14-r1 --> 2.1.15-r1*
* *sesame-ros 2.1.14-r1 --> 2.1.15-r1*
* *slic 2.1.14-r1 --> 2.1.15-r1*
* *voice-text 2.1.14-r1 --> 2.1.15-r1*

Melodic Changes:
----------------
* *blender-gazebo 0.0.3-r1 --> 0.0.4-r1*
* *catkin 0.7.19-r1 --> 0.7.20-r1*
* *cis-camera 0.0.3-r1 --> 0.0.4-r1*
* *executive-smach-visualization 2.0.2 --> 3.0.0-r1*
* *husky-base 0.4.1-r1 --> 0.4.2-r1*
* *husky-bringup 0.4.1-r1 --> 0.4.2-r1*
* *husky-control 0.4.1-r1 --> 0.4.2-r1*
* *husky-description 0.4.1-r1 --> 0.4.2-r1*
* *husky-desktop 0.4.1-r1 --> 0.4.2-r1*
* *husky-gazebo 0.4.1-r1 --> 0.4.2-r1*
* *husky-msgs 0.4.1-r1 --> 0.4.2-r1*
* *husky-navigation 0.4.1-r1 --> 0.4.2-r1*
* *husky-robot 0.4.1-r1 --> 0.4.2-r1*
* *husky-simulator 0.4.1-r1 --> 0.4.2-r1*
* *husky-viz 0.4.1-r1 --> 0.4.2-r1*
* *libmavconn 0.33.3-r1 --> 0.33.4-r1*
* *mavlink 2019.11.11-r1 --> 2019.12.12-r1*
* *mavros-extras 0.33.3-r1 --> 0.33.4-r1*
* *mavros-msgs 0.33.3-r1 --> 0.33.4-r1*
* *ompl 1.4.2-r3 --> 1.4.2-r5*
* *rc-common-msgs 0.3.0-r1 --> 0.4.0-r1*
* *rc-genicam-api 2.2.2-r1 --> 2.2.3-r1*
* *test-mavros 0.33.3-r1 --> 0.33.4-r1*
* *xacro 1.13.4-r1 --> 1.13.5-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] geographiclib
 * [ ] geographiclib-tools
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libgconf2
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libstdc++6
 * [ ] libxml++-2.6
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micro-xrce-dds-agent
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] nodejs-legacy
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gi-cairo
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-jinja2
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-ruamel.yaml
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-sympy
 * [ ] python-tabulate-pip
 * [ ] python-unittest2
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

