### PR TITLE
rosdistro sync, Fri Jan 17 12:40:05 2020

### DIFF
--- a/dashing/ament-cmake-virtualenv/default.nix
+++ b/dashing/ament-cmake-virtualenv/default.nix
@@ -5,17 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-virtualenv }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-virtualenv";
-  version = "0.0.4-r1";
+  version = "0.0.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/esol-community/ament_virtualenv-release/archive/release/dashing/ament_cmake_virtualenv/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "a3a196f666f855847864da400ccadf73434aaaf514f788b7e75174e6bdeb9815";
+    url = "https://github.com/esol-community/ament_virtualenv-release/archive/release/dashing/ament_cmake_virtualenv/0.0.5-5.tar.gz";
+    name = "0.0.5-5.tar.gz";
+    sha256 = "3de5000f59569b6e3770a576a2a7199e5a043b2a8091cec1a3e0b840470ce87c";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
-  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ament-virtualenv ];
+  propagatedBuildInputs = [ ament-virtualenv ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ];
 
   meta = {
     description = ''Bundle python requirements in a ament package via virtualenv.'';

--- a/dashing/generated.nix
+++ b/dashing/generated.nix
@@ -116,8 +116,6 @@ self: super: {
 
  ament-uncrustify = self.callPackage ./ament-uncrustify {};
 
- ament-virtualenv = self.callPackage ./ament-virtualenv {};
-
  ament-xmllint = self.callPackage ./ament-xmllint {};
 
  angles = self.callPackage ./angles {};
@@ -902,8 +900,6 @@ self: super: {
 
  rqt-srv = self.callPackage ./rqt-srv {};
 
- rqt-tf-tree = self.callPackage ./rqt-tf-tree {};
-
  rqt-top = self.callPackage ./rqt-top {};
 
  rqt-topic = self.callPackage ./rqt-topic {};
@@ -929,6 +925,8 @@ self: super: {
  self-test = self.callPackage ./self-test {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
+
+ serial-driver = self.callPackage ./serial-driver {};
 
  shape-msgs = self.callPackage ./shape-msgs {};
 

--- a/dashing/ouster-msgs/default.nix
+++ b/dashing/ouster-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ouster-msgs";
-  version = "0.0.0-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/dashing/ouster_msgs/0.0.0-1.tar.gz";
-    name = "0.0.0-1.tar.gz";
-    sha256 = "9ef066ac669030c800af120ab7359e8314b9fc9042087b869f87146559fd64d5";
+    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/dashing/ouster_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "ea52e9a43127705ef30229b632db93893b3335f9cbfd9cd03569951b69801166";
   };
 
   buildType = "ament_cmake";

--- a/dashing/ros2-ouster/default.nix
+++ b/dashing/ros2-ouster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, launch, launch-ros, ouster-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ros2-ouster";
-  version = "0.0.0-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/dashing/ros2_ouster/0.0.0-1.tar.gz";
-    name = "0.0.0-1.tar.gz";
-    sha256 = "80c6f43f6d573562f30a74d4182989c18b92185f2615b001cb81c3b957c33392";
+    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/dashing/ros2_ouster/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "79ff69674b3ac826498810c2ffdf57c42be0d78641ebe645ebfbfc9f45269687";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rqt-console/default.nix
+++ b/dashing/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-dashing-rqt-console";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/dashing/rqt_console/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "76504c7586c5247da4313e82120f11ce83199e1496ec3bd6b46c2a35acdd47bf";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/dashing/rqt_console/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "f817950d6b73508a8891518aae9e7884e0aaf47e67b332a4049322124a645721";
   };
 
   buildType = "ament_cmake";

--- a/dashing/rqt-image-view/default.nix
+++ b/dashing/rqt-image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-transport, qt-gui-cpp, qt5, rclcpp, rqt-gui, rqt-gui-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rqt-image-view";
-  version = "1.0.2-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_view-release/archive/release/dashing/rqt_image_view/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "cac35f6279ac390c87cf5bfb6b6b49286189167941fa878584fe35119e7ff202";
+    url = "https://github.com/ros2-gbp/rqt_image_view-release/archive/release/dashing/rqt_image_view/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "2f97dedbebbc02fe2e1c6a0addf1302eee96551adedc3e2b9ac32fe8b7698e1e";
   };
 
   buildType = "ament_cmake";

--- a/dashing/serial-driver/default.nix
+++ b/dashing/serial-driver/default.nix
@@ -1,16 +1,16 @@
 
-# Copyright 2019 Open Source Robotics Foundation
+# Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, autoware-auto-cmake, autoware-auto-helper-functions, boost, rclcpp, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-serial-driver";
-  version = "0.0.2-r1";
+  version = "0.0.4-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/AutowareAuto/AutowareAuto-release/repository/archive.tar.gz?ref=release/dashing/serial_driver/0.0.2-1";
-    name = "archive.tar.gz";
-    sha256 = "24baf8367a4ffe543bd3641c50254486a898a851131e5f48276652252d2c9d4e";
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/serial_driver/0.0.4-3.tar.gz";
+    name = "0.0.4-3.tar.gz";
+    sha256 = "34e98d412595d93128717cd49398695c347f2a879873e36dcb1e76f11c383349";
   };
 
   buildType = "ament_cmake";

--- a/dashing/udp-driver/default.nix
+++ b/dashing/udp-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-udp-driver";
-  version = "0.0.3-r1";
+  version = "0.0.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/udp_driver/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "920119abfe5338991a477d3b28d8751044506aa577c5914ffb38882cbb68521f";
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/udp_driver/0.0.4-3.tar.gz";
+    name = "0.0.4-3.tar.gz";
+    sha256 = "150a7a7a507281fe163b5a2b4fa01bb1fc3da7719b75fabbf1036d78e3b9e76b";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-command-line/default.nix
+++ b/eloquent/ecl-command-line/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-command-line";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_command_line/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c114689b0b649ea51bf7507fc88ff328871de6ba65413598923a412c7fd4658d";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_command_line/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "1dd117ab35e56ee49deff922b974ff1df7fd8a92bde48c4605036483dbf742bb";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-concepts/default.nix
+++ b/eloquent/ecl-concepts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-concepts";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_concepts/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "b82300ed0bedb50d15de4229061cdb76a5f3790160603746f97fa7a256dcf56a";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_concepts/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "34bf5886cf4e2b73434306414cf748b791c316dd11b7a47d02f14fa5f6b25202";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-config/default.nix
+++ b/eloquent/ecl-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-config";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_config/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "76d90143362391eaab9330dfaa3ea3fdb76ef69ac2720c8c1f3efe96a0c7057b";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_config/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "60f968a02afdc8b59f8e2b2eddfefac5717ffa9035a27f0c066c665a42384142";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-console/default.nix
+++ b/eloquent/ecl-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-console";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_console/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "e86efea4595d133eb7bbd3ffb80bc843765dbb43e9d0a15716eb9cb02882a6c5";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_console/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f2fa32ecff2ac3444b2c88b1dc15ab5987acf49fffa56909a29e3b1fc18e5dbe";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-containers/default.nix
+++ b/eloquent/ecl-containers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-converters, ecl-errors, ecl-exceptions, ecl-formatters, ecl-license, ecl-mpl, ecl-type-traits, ecl-utilities }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-containers";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_containers/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "07408454b7db39741bc57303cdcda563b61560a94649a0b76ad410f6b931cbcc";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_containers/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "696bb5ed02993e0e3f314630eeff21410f2b3aaccf7e3a7f5ee98d14dc38f7a5";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-converters-lite/default.nix
+++ b/eloquent/ecl-converters-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-config, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-converters-lite";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_converters_lite/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "06ca2a6db93a33e3fff24f4417896437558f10c8e6938424a2b7af290420ad74";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_converters_lite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "1b178bb45cb4e9187980603147ea905897f023757178aec88b86000cae9ae072";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-converters/default.nix
+++ b/eloquent/ecl-converters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-mpl, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-converters";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_converters/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "63a53116941101abd2018330437c90c8326e48b800a46117c28a6b27e008769c";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_converters/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "1157c7073672566e38d8f8cb962f3969fe85074da45ef03632bee855a0de8e7d";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-core-apps/default.nix
+++ b/eloquent/ecl-core-apps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, ecl-config, ecl-containers, ecl-converters, ecl-devices, ecl-errors, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-license, ecl-linear-algebra, ecl-sigslots, ecl-streams, ecl-threads, ecl-time-lite, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-core-apps";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_core_apps/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "4567352de493001a48ad76d62db3ab88a9f0cad3084d8c1ddf31162077439b2a";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_core_apps/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "4633f4d9c7cac792868c9716fe6929c36d503c035c0d095eedadb342da47d252";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-core/default.nix
+++ b/eloquent/ecl-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-command-line, ecl-concepts, ecl-containers, ecl-converters, ecl-core-apps, ecl-devices, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-sigslots, ecl-statistics, ecl-streams, ecl-threads, ecl-time, ecl-type-traits, ecl-utilities }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-core";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_core/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "a6d97aa41444cbe7b6ed00746aa0cb14f52f0af17112134f0dcc4929bf09c363";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_core/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "4d692cd972fbcac609e1e358fbf5ed7f7adeb95ef0edd153ca96b4b1fa79c427";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-devices/default.nix
+++ b/eloquent/ecl-devices/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-containers, ecl-errors, ecl-license, ecl-mpl, ecl-threads, ecl-type-traits, ecl-utilities }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-devices";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_devices/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ffae28dfbfa9aecbac3ba63f19bb3f54bdfbbe7cebf4c5e8dbff5609ec7c0945";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_devices/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "5d7247f647f5cee95715e8e59bee30449cb5d22e36684ead2ad7118eff9000ff";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-eigen/default.nix
+++ b/eloquent/ecl-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, eigen }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-eigen";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_eigen/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1eb3a284654d9d60f27f09090535a64d8cb5a071f215d50346e4b3d0e8396ab0";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_eigen/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6ddb99f51bf87c6a23a36d920506855b166ce7936789d6b56cc86166ba57a321";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-errors/default.nix
+++ b/eloquent/ecl-errors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-errors";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_errors/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2662b247da5a8a8114fd46f0363d0f88ee44df7786c3d5a2bbe5caab906ab936";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_errors/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e65cbb05540a0ffa2fb8a34223c86693a6a13e23d6b1a2333af2d19e1084894b";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-exceptions/default.nix
+++ b/eloquent/ecl-exceptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-exceptions";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_exceptions/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ba32d707e2fe52162c9342bb4bde49911550f76beda6697805b12774daa0acd9";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_exceptions/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "185084a09c7aedb5dbbecb5ff3cabfa48068e04226fec2e09d6fc689f5c75aa9";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-filesystem/default.nix
+++ b/eloquent/ecl-filesystem/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-filesystem";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_filesystem/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "2de970c368bec3fc89d866d612f7976bd632724f0c1808bf9bb569529164595d";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_filesystem/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "044e76b89e3c3c6b7df41ecf9484a54d3bc67212838dd7eaa2137fd56bd5cdd1";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-formatters/default.nix
+++ b/eloquent/ecl-formatters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-converters, ecl-exceptions, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-formatters";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_formatters/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "f2d5367ed88d799d423494f1ff86fba1ab607206cdbb906d29c2dc703d2749fe";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_formatters/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "422d4452c2d5ad36b25b84c7ca2cddcc5c713074cd07d8709e1df80023459497";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-geometry/default.nix
+++ b/eloquent/ecl-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-containers, ecl-exceptions, ecl-formatters, ecl-license, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-geometry";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_geometry/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1cad12be6a24ea610585b4956e8b9a36ed3dc3dafa3df4c1b2e447fd4176a4c8";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_geometry/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "0b86d75bd1ebbab8381900d95e643853e7603df37ad28cc2db65d5953de1fe41";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-io/default.nix
+++ b/eloquent/ecl-io/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-io";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_io/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "4cd5d0a91f02f8d4b8f8e47603ea6dd6825c176c7e04f049bb5512ad9b6fe380";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_io/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "2bfe44bfb2ecf4e227ebfb0739542ab6c9fc65521adb49ade54bb0b2fe70c6d2";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-ipc/default.nix
+++ b/eloquent/ecl-ipc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-threads, ecl-time, ecl-time-lite }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-ipc";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_ipc/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "3017494354cc87eeefa6f467ad3c53be8f39a1b72d9037c5b66f05dc14b99592";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_ipc/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a2724348ed4b36a38460749debb32389e9630dd16ab7ee4a717f783c74296aa5";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-linear-algebra/default.nix
+++ b/eloquent/ecl-linear-algebra/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-converters, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-license, ecl-math, sophus }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-linear-algebra";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_linear_algebra/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "317a6ad2ed44ad96181822d98bc43c5e3bb7512308eb467ecbf2a1e6849f25e7";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_linear_algebra/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "75d6db9b1cec5ea6216efd12fb8fa0f7824088763f82b8b97b5a5a9520c10790";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-lite/default.nix
+++ b/eloquent/ecl-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-config, ecl-converters-lite, ecl-errors, ecl-io, ecl-sigslots-lite, ecl-time-lite }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-lite";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_lite/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "0a3dc539837274a7b0806f314da04cf8750c73b31728b917ee0fb489ecae740e";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_lite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "dd86c1cf835fcfbd07282d4f6bc4965e71e04c66dca617cead4f14cf1fed91e8";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-manipulators/default.nix
+++ b/eloquent/ecl-manipulators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-manipulators";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_manipulators/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "3f3a7fc2e83249d1b1edafaf43e0638c8adeb34252b77cd5a35757497295f705";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_manipulators/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "d781d84759f46ad9f33c7e1de45bb157e47f6dbdc1243b5ababf8c6124dc1eba";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-math/default.nix
+++ b/eloquent/ecl-math/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-math";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_math/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "74b34929a4afff2518c12714fe9d6b261cfb15d24273582b246608db15695bdc";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_math/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "f163c33e2aa213310e2666f7f4741c05d62b47fbdbb798685f2c8b7d2b84c7c5";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-mobile-robot/default.nix
+++ b/eloquent/ecl-mobile-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-errors, ecl-formatters, ecl-geometry, ecl-license, ecl-linear-algebra, ecl-math }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-mobile-robot";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_mobile_robot/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "e12835c67f100c89fa1a19d34dd61bc33b4171d6ad3ff66c0f366c430bbdcf4d";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_mobile_robot/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "17dfa07c13427e0a130589e296a0be2944814ae0e5538a67dd67cf0c15d1bed2";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-mpl/default.nix
+++ b/eloquent/ecl-mpl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-mpl";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_mpl/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "b450d99f81a9e3f903019580d20dd241605a4abb186c02fdd51e1e4bb38c067e";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_mpl/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "d4021c728c16f4100f8fd19e17a96344c0a336d84419db3e3671e83edfdf2e8f";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-sigslots-lite/default.nix
+++ b/eloquent/ecl-sigslots-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-sigslots-lite";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_sigslots_lite/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "a5bc6e5196e774a12156b24d61eaf993df3e4d0bb301569698cc16868323294c";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_sigslots_lite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "542a1012fd149126354f7a58100698b538843b3e4e544b84ad6f4953d98db0c9";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-sigslots/default.nix
+++ b/eloquent/ecl-sigslots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-threads }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-sigslots";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_sigslots/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "09b209c2ff2499d94173b7c855544139693d4435b2059c2b92c2f053c1d34f0f";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_sigslots/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6c083e5df6db828c49804ece4b9b68bd78463c881bb7ca241d94bc6ac964b661";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-statistics/default.nix
+++ b/eloquent/ecl-statistics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-linear-algebra, ecl-mpl, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-statistics";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_statistics/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "b64bc3d385cc4bfe402988120e29007cabb1fb0452857d96a58d39bfe5a649b6";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_statistics/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "154f575ba1dda6c847cbce7376ce008941956fd364ccbb35ddff18686990972c";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-streams/default.nix
+++ b/eloquent/ecl-streams/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-converters, ecl-devices, ecl-errors, ecl-license, ecl-time, ecl-type-traits }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-streams";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_streams/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "67a27b34e66ffce171a737e823ffc574d0d462ba77fdd15c440ee3053e814a95";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_streams/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3addd353b2d38197742e49f90637d4af177b27c1f20b85c0ed1d70b11390d05b";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-threads/default.nix
+++ b/eloquent/ecl-threads/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time, ecl-utilities }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-threads";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_threads/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "509937d436f51b900f22740008375b17b56956c906009c95fba542eaddd65dae";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_threads/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c57286ca8cd422f646a6bfbf39f884c2061fa632d6deabc1b29e36a2e99c4132";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-time-lite/default.nix
+++ b/eloquent/ecl-time-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-time-lite";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_time_lite/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "95324e631bc37b28e8f0d3663684b5deb324a581dc99403d579ad9de73225dcb";
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/eloquent/ecl_time_lite/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "641638e37aa2855735d8aefee7dc905fa7ac9682b881bea3d811e1371e988361";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-time/default.nix
+++ b/eloquent/ecl-time/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time-lite }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-time";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_time/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "95bd07c5b6660d8c4cb58ec240805ca789fe908a6c18ad7c1920ac4b212e0609";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_time/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "f425606e29dfdffc01072d54d79fe2fcbb5a8f3cbac5a40f21bd7748c45e3615";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-type-traits/default.nix
+++ b/eloquent/ecl-type-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-mpl }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-type-traits";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_type_traits/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "260ecaef606acee15e336637132ce0b61f0e13b7fa5422ca083764ea550ac715";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_type_traits/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "e2439f7ef7a5f094d97b2e215600fa1648701d2863548ef7de5e1c48c0160e60";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/ecl-utilities/default.nix
+++ b/eloquent/ecl-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-license, ecl-mpl }:
 buildRosPackage {
   pname = "ros-eloquent-ecl-utilities";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_utilities/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "6386cae44f3440f1debeeecfd29d47a0303bfed9756fe0997ddc95628892583c";
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/eloquent/ecl_utilities/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "b15cb1698d118f7e597bf3badb51cd24e82866c0b00cde07a2351efa723f58a7";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/generated.nix
+++ b/eloquent/generated.nix
@@ -392,7 +392,7 @@ self: super: {
 
  kobuki-ftdi = self.callPackage ./kobuki-ftdi {};
 
- kobuki-msgs = self.callPackage ./kobuki-msgs {};
+ kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
  laser-geometry = self.callPackage ./laser-geometry {};
 
@@ -544,6 +544,8 @@ self: super: {
 
  plansys2-msgs = self.callPackage ./plansys2-msgs {};
 
+ plansys2-multidomain-example = self.callPackage ./plansys2-multidomain-example {};
+
  plansys2-patrol-navigation-example = self.callPackage ./plansys2-patrol-navigation-example {};
 
  plansys2-pddl-parser = self.callPackage ./plansys2-pddl-parser {};
@@ -615,6 +617,8 @@ self: super: {
  rcpputils = self.callPackage ./rcpputils {};
 
  rcutils = self.callPackage ./rcutils {};
+
+ realtime-tools = self.callPackage ./realtime-tools {};
 
  resource-retriever = self.callPackage ./resource-retriever {};
 

--- a/eloquent/kobuki-core/default.nix
+++ b/eloquent/kobuki-core/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, kobuki-dock-drive, kobuki-driver, kobuki-ftdi }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, kobuki-dock-drive, kobuki-driver }:
 buildRosPackage {
   pname = "ros-eloquent-kobuki-core";
-  version = "0.8.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/kobuki_core-release/archive/release/eloquent/kobuki_core/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "a574baa6b5816942230a38b1998019c70f10dfbc2dd588a9c4b2c144637e7be5";
+    url = "https://github.com/stonier/kobuki_core-release/archive/release/eloquent/kobuki_core/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6d80c6c12c4176e6b6af665d72e6fffe5b8f0cfaaaffdcdfc094b082181561a9";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ kobuki-dock-drive kobuki-driver kobuki-ftdi ];
+  propagatedBuildInputs = [ kobuki-dock-drive kobuki-driver ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/eloquent/kobuki-dock-drive/default.nix
+++ b/eloquent/kobuki-dock-drive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-geometry, ecl-linear-algebra, ecl-threads }:
 buildRosPackage {
   pname = "ros-eloquent-kobuki-dock-drive";
-  version = "0.8.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/kobuki_core-release/archive/release/eloquent/kobuki_dock_drive/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c145fea1cfb08789908978bca29de6bcd91f89bd0e91d388bc2b1fd94b59470f";
+    url = "https://github.com/stonier/kobuki_core-release/archive/release/eloquent/kobuki_dock_drive/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7e3d8225fb246bdb5cf0416eb6c3b116cc7dca20c9a375000f0e2f4020e6d554";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/kobuki-driver/default.nix
+++ b/eloquent/kobuki-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, ecl-config, ecl-converters, ecl-devices, ecl-geometry, ecl-mobile-robot, ecl-sigslots, ecl-threads, ecl-time }:
 buildRosPackage {
   pname = "ros-eloquent-kobuki-driver";
-  version = "0.8.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/kobuki_core-release/archive/release/eloquent/kobuki_driver/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9f435ac33085bf92940595750beea6c27b60261b18f63349e2c29f098a78feb7";
+    url = "https://github.com/stonier/kobuki_core-release/archive/release/eloquent/kobuki_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4816469367b534f5502a9fe3d1021d9ca0a9578c577b8bd239f4a4f00b52fa11";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/kobuki-ftdi/default.nix
+++ b/eloquent/kobuki-ftdi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, libftdi, libusb, pkg-config }:
 buildRosPackage {
   pname = "ros-eloquent-kobuki-ftdi";
-  version = "0.8.1-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/kobuki_core-release/archive/release/eloquent/kobuki_ftdi/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "6282082eaca2a2328c354ad988cfb624b84d254e37957268cf9bea9a656ac50c";
+    url = "https://github.com/stonier/kobuki_ftdi-release/archive/release/eloquent/kobuki_ftdi/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "192a6be15b73bf34295390a3adb9a55b96ff0007513771e44c285a072bff0992";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/kobuki-ros-interfaces/default.nix
+++ b/eloquent/kobuki-ros-interfaces/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-kobuki-ros-interfaces";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/kobuki_ros_interfaces-release/archive/release/eloquent/kobuki_ros_interfaces/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "80dba437b5fdeff1b8f83cba1ffe0f05ddb98720c0847c7fb1005102bba80e75";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      ROS2 message, service and action interfaces for the Kobuki.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/eloquent/ouster-msgs/default.nix
+++ b/eloquent/ouster-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ouster-msgs";
-  version = "0.0.1-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/eloquent/ouster_msgs/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "86320ecd5a669b6a2799d065fb03eed7128ec384f634fc54f5a621be912e5efb";
+    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/eloquent/ouster_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "c6ea53cb98ef2653d9fd9abb79156afa3a54135d5d6999e6c4183451ca1c756a";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-bringup/default.nix
+++ b/eloquent/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-bringup";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "6f3550b09dcb4d82b9a57fab28dc20e1c151b8d9f052d9b36d3b79b10ad78159";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "bd4175a447a3e0b4736f8f1ef94b4b03a1003a9051b3db1a1feed16b8f19d86c";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-domain-expert/default.nix
+++ b/eloquent/plansys2-domain-expert/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-domain-expert";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "468c0bf2b7349f2df7116ab72a06eba28d411d49b75c6f90cf441d1af4b262f7";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "743e6c50a3db068978c76c47db4eca5d320038d94e6178b764f7557a96d5faaf";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/eloquent/plansys2-executor/default.nix
+++ b/eloquent/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-executor";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "da929d408c1a0fb37cd3a81cca538541d34e4451e04379977d3ad8baaacdb91a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "6ccb343ef7a9cdebca528f3d93048ebfcac4d91d81d80df52b25fb0e337f41eb";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-lifecycle-manager/default.nix
+++ b/eloquent/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-lifecycle-manager";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "be3d2e7aabc6a9d90d03a1dcac52aecbd319a8e2261352a2fd3aae1e53b4592c";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "7244fe278ac1db554bbf87a967d38cf3ac0ca298cbeabcfea5e09c2c75e4dc0e";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-msgs/default.nix
+++ b/eloquent/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-msgs";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "74b2ff0de7eb314c8925e4e8c27116825f5583faf2309cb9daf93ba73f406355";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "1e1610d45e229376dbe42bf2288bdad7fc8eed31685a29e35fdaaf5b33bdb3f2";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-multidomain-example/default.nix
+++ b/eloquent/plansys2-multidomain-example/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action }:
+buildRosPackage {
+  pname = "ros-eloquent-plansys2-multidomain-example";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_multidomain_example/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "9ba51c1e68a85ec42fe4cb16ad9548700aaf5b45dcd52eb14f5c61bd269462c2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-executor plansys2-msgs rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A simple example of ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/eloquent/plansys2-patrol-navigation-example/default.nix
+++ b/eloquent/plansys2-patrol-navigation-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-patrol-navigation-example";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_patrol_navigation_example/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "bb0609f3fb15954c4bfcbbf898ef864982b7549fcc9b5a6777f826c6e8efcd54";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_patrol_navigation_example/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "a46624b276e015765339c6afed65f4d9ff0ffcdac9ef9a464087c81c688fdb39";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-pddl-parser/default.nix
+++ b/eloquent/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-pddl-parser";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "320c9a01cdf04056959d8f07c2a3bb95d37cc0224fb770fe97879736c840f902";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "d6aa32718cbfacc059f0dfcb1664b6e8de2568b74c57c8a3d7e616f4a0bd028b";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-planner/default.nix
+++ b/eloquent/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-planner";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "274232cdded4d874317ec6194b484f44c26e5bc218b3afe4404d5bf1eed59957";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "de036fee896ceafbb538b5648d1b862f7d614b691ac99b203939c785d86b8b6f";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-problem-expert/default.nix
+++ b/eloquent/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-problem-expert";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "a7399eebd38ad0f66a9d3e0778c21a9a3e29a1ace468d35e7aecc914da329caf";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "8803f3c271c074536df573671c1717a40350a690162b39a956aa552cd24ebc13";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-simple-example/default.nix
+++ b/eloquent/plansys2-simple-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-simple-example";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_simple_example/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "a030edc324c5a06874385cc407dbd99ddf0b3e60384a4f04722f60e7a92ea6c9";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_simple_example/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "7418d02c14148b600746952db1b309637bbeb9e2bdb0705a0ce34344dd990688";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/plansys2-terminal/default.nix
+++ b/eloquent/plansys2-terminal/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-terminal";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "5943cc7c2dacfe26d5ef489bde82c9e0ea2204a22f43a0f8cc5f9c5ece217e04";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "98b35ee8e9c51e036355f6f426571faa389f923b41bc2f5e37046fdc1a95210c";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/eloquent/realtime-tools/default.nix
+++ b/eloquent/realtime-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, rclcpp, rclcpp-action, test-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-realtime-tools";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/eloquent/realtime_tools/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "5f3e1cfc4340a01ab8865360281ed9159dbecf6ed29d5adc5d2c6f122beb9082";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock rclcpp-action test-msgs ];
+  propagatedBuildInputs = [ ament-cmake rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains a set of tools that can be used from a hard
+    realtime thread, without breaking the realtime behavior.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/eloquent/ros2-ouster/default.nix
+++ b/eloquent/ros2-ouster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, launch, launch-ros, ouster-msgs, pcl, pcl-conversions, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2-ouster";
-  version = "0.0.1-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/eloquent/ros2_ouster/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "3200aaa1ab5457cd3eb3e9c2d5ea41c6c6e7b5f7c1f8688f3bd8d188d8f6b7b1";
+    url = "https://github.com/SteveMacenski/ros2_ouster_drivers-release/archive/release/eloquent/ros2_ouster/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f43de0fcc8e6904421be9d0412ef1c9b8a829ac4556dc183ca25d9b2b4599ad5";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/rqt-console/default.nix
+++ b/eloquent/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, python-qt-binding, rcl-interfaces, rclpy, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-eloquent-rqt-console";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/eloquent/rqt_console/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "fc268867fa9eadb73a09922bdef34378b7b395e4025857361d8b7a7658b618e0";
+    url = "https://github.com/ros2-gbp/rqt_console-release/archive/release/eloquent/rqt_console/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b586ea488f5d642cdc1d0ef360545ee700a2a21609e18ab34a69fc531c93162b";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/rqt-image-view/default.nix
+++ b/eloquent/rqt-image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, geometry-msgs, image-transport, qt-gui-cpp, qt5, rclcpp, rqt-gui, rqt-gui-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rqt-image-view";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_image_view-release/archive/release/eloquent/rqt_image_view/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "8cd6b1d668fe49181fbca2c5c834a65d954ba07045212230c82f664cf546d989";
+    url = "https://github.com/ros2-gbp/rqt_image_view-release/archive/release/eloquent/rqt_image_view/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "eb07ef4833f4fcf8d227e9a2ef3aa802df3e81cca176fe4b4d835682f9fe9156";
   };
 
   buildType = "ament_cmake";

--- a/eloquent/rqt-tf-tree/default.nix
+++ b/eloquent/rqt-tf-tree/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, geometry-msgs, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-rqt-tf-tree";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/eloquent/rqt_tf_tree/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "17b65f6ffc11ee3573c322b058e993d1c62aad6208937f6e4366f3e1292ed47b";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/eloquent/rqt_tf_tree/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cca82385b50c00b8ea77549e413b507889f87bacba33fd77ac8e85f821da87c4";
   };
 
   buildType = "ament_python";
   checkInputs = [ python3Packages.mock ];
-  propagatedBuildInputs = [ geometry-msgs python-qt-binding python3Packages.rospkg qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2 tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ python-qt-binding qt-dotgraph rclpy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
 
   meta = {
     description = ''rqt_tf_tree provides a GUI plugin for visualizing the ROS TF frame tree.'';

--- a/kinetic/ackermann-steering-controller/default.nix
+++ b/kinetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, diff-drive-controller, gazebo-ros, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, rosunit, std-msgs, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-ackermann-steering-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/ackermann_steering_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "2fcad6fb4a913c7ffcd316f9fc665c3d1e00838b892dad0dce0847e5e8c19dde";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/ackermann_steering_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "03372dc7475ef946eb4637c9c544d78dab13530ca0bd884c91b3698f6d06ba55";
   };
 
   buildType = "catkin";

--- a/kinetic/combined-robot-hw-tests/default.nix
+++ b/kinetic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-tests, hardware-interface, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-combined-robot-hw-tests";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw_tests/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "e32b1cb024910e272987686faa470d1bdf98860227eb0a2e368415ca3ac9102f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw_tests/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "062bc3b2a7136efa85a876a91e4d6136d84ee05a97eba7f52e5c0f728227852a";
   };
 
   buildType = "catkin";

--- a/kinetic/combined-robot-hw/default.nix
+++ b/kinetic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-combined-robot-hw";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "b57f1ab96096e0d1f8ca5b47251e3a1cb9901f6b311488edda68b5178fa0af2a";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "7e38dbeef1b656cd09fe29ed945315fde50cd4593ab867364a0fa6142b7499eb";
   };
 
   buildType = "catkin";

--- a/kinetic/controller-interface/default.nix
+++ b/kinetic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-controller-interface";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_interface/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "5db8ab2db8d3bdfbaa79743ec62a1932d3763d016812652cc145b674cb58ea8c";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_interface/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "f18d88901d6e04e1001f85041f93aaafb8f3b569a1b666b060bb37753b15f7a3";
   };
 
   buildType = "catkin";

--- a/kinetic/controller-manager-msgs/default.nix
+++ b/kinetic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager-msgs";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_msgs/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "14f1c504b6a28cc2cdce210d42be3f84a9d7f1b7aad39e0c6cb8e959629dc81b";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_msgs/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "8f7c8b12ccfb1134afd671f78a6769070e3a33e5d308d3234513c841acc731ac";
   };
 
   buildType = "catkin";

--- a/kinetic/controller-manager-tests/default.nix
+++ b/kinetic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, rosbash, rosnode, rosservice, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager-tests";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_tests/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "2c53a56ac8a4397ae21b4a814691fe728d011d25d76e5386b840f3bc5bf8de29";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_tests/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "98db7d491de2f2ffa7d08866f6c276920ff5ce7ed6da6412b46267e24230c60a";
   };
 
   buildType = "catkin";

--- a/kinetic/controller-manager/default.nix
+++ b/kinetic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "03176b3abcec6e00f0e13e6e8b62b2b2291f3f5773510249958bb0f0ca4778ac";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "e2e4d37d8f4b682b825caca7fe740e8991e9a7d1db3d2103235ab04f19946d75";
   };
 
   buildType = "catkin";

--- a/kinetic/diff-drive-controller/default.nix
+++ b/kinetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, dynamic-reconfigure, nav-msgs, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-diff-drive-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/diff_drive_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "ad89d6037ec24fd9d0b324832cb333a637182b98e49d3b5bca66baa5a74ddf0b";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/diff_drive_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "71c9eb53ee891a94e2bde2ad37ce2bf107ca42c7ab70a4be6c64bf140ec20746";
   };
 
   buildType = "catkin";

--- a/kinetic/effort-controllers/default.nix
+++ b/kinetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-effort-controllers";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/effort_controllers/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "d113b5a066e0db7b84bdfe30a11c7bdb826d1243b2a3329094c4225406c5fd7b";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/effort_controllers/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "4c89d8dcc2f9fb685023aa50e6a8d2148c7bd3a4fda12703753e5a05dd49afbf";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-behavior-engine/default.nix
+++ b/kinetic/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-behavior-engine";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "ee39b8dbf01f2ec035433251875fcff4a6a1f448c6102b69b7a5c93cc3f244d9";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "9e73bc328b29b036c37e52a31b04e862032851fe12ff2dd539bb0c2d74ea5d0f";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-core/default.nix
+++ b/kinetic/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, smach-ros, tf }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-core";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "022c44d36238d53b21d46e7d34096cce898f23a460366f6fd21522b1669a6b9c";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "0a2b6b6622e61c48a8eeab2c2a40c3837e430fd14c8b9fd966aa7877e8488bbd";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-input/default.nix
+++ b/kinetic/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-input";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "bc6c1045b8caf3a87f19c64637d4bcdb71b1b1246f63c4a5c61c3100b0bc77e1";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "b0b6158004aae220e4b9b8f8410b1bef3bc60e499586d1a3c59b63171083f967";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-mirror/default.nix
+++ b/kinetic/flexbe-mirror/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-widget, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-mirror";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "02940d31bb8d12bacd81128a749d93bf8a5c5f466a3df61b7c4efb6607351dd9";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "81ad28b1f0fb458af4e37c60cb0017f8115e58ffd84b85a3e4b32644d9f307d6";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-widget rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/flexbe-msgs/default.nix
+++ b/kinetic/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-msgs";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "4c0842514f23eaa19e284d194e08f4c67f5a3381333c8ca2cac8b26cedb30864";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "9c22dfa30d6d7e976b720dd7d1cf99fa3e91fc89e25f30276776fa91f4c8a84e";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-onboard/default.nix
+++ b/kinetic/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-onboard";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "bdb90154be0463309e7565bb89425161d2c04f9e449646ce71625e6b962bdbd5";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "51875d6a9ad3b341d96ab9f8e3c85b4f6c770b87795303b559f6d824a1210d02";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-states/default.nix
+++ b/kinetic/flexbe-states/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-states";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "a142828502bd05fb8c25044c85597542a9c5e05f69d475d4eea848f94121d772";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "3536d606d68e640348008bc17facbd0bacbe59f296f78a5cdb4098c1860c7801";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
   checkInputs = [ geometry-msgs ];
-  propagatedBuildInputs = [ flexbe-msgs flexbe-testing rosbag rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rosbag rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/flexbe-testing/default.nix
+++ b/kinetic/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, smach-ros, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-testing";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "4322944ad11a6b5337a2a3780566785d2d1e5cab6a1586ca8b4c3cbac313cd4b";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "ed5d15792b8389d419d2f678ed38b6b1fb8cf9dbf0e104bd5888d68fadd7309e";
   };
 
   buildType = "catkin";

--- a/kinetic/flexbe-widget/default.nix
+++ b/kinetic/flexbe-widget/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-widget";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "07478d66a83de47880cb6c1964047cd96d6a55f04b3d8521797dc096bcee57ea";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "f79cad9f60f591c37a79ebb9b50dfeec149903904de38be0c6509770d82f3027";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/force-torque-sensor-controller/default.nix
+++ b/kinetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-force-torque-sensor-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/force_torque_sensor_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "8777d68ce69e252a16588b0b4b89418c25ed94ff674fd93f260ba56f596a939c";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/force_torque_sensor_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "a223e470525af69cbe42203b19ef015edbacfa24bf1de9402548d702aabdc9bf";
   };
 
   buildType = "catkin";

--- a/kinetic/forward-command-controller/default.nix
+++ b/kinetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-forward-command-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/forward_command_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "c837c1c4f2e07d4a0709cf9d824f9e4add7dd083a5bd26945d335746e78b6e66";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/forward_command_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "2bcfb6276c7475845ee32badf7aec6822ecb142dc499a4b8aaa22bef7daceb14";
   };
 
   buildType = "catkin";

--- a/kinetic/four-wheel-steering-controller/default.nix
+++ b/kinetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, nav-msgs, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf-geometry-parser }:
 buildRosPackage {
   pname = "ros-kinetic-four-wheel-steering-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/four_wheel_steering_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "79f36288c0a3bebd6987b95033f450c70564980ce68ba8e3bf5bd27b85c14df4";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/four_wheel_steering_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "2fe02add9f752db43a4074d1da59fdec72bf82686f7a32c152ed5b965d6cbb86";
   };
 
   buildType = "catkin";

--- a/kinetic/gripper-action-controller/default.nix
+++ b/kinetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, realtime-tools, roscpp, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-gripper-action-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/gripper_action_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "8acc4c5f399d60512547b3fdf18321609c3c7ed5b57b1275185d30ed01da68a0";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/gripper_action_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "613a2a585a6cf4e74c6f92fcc1c910249c5f207b3e1fcf4ea71d2e6da811e7d8";
   };
 
   buildType = "catkin";

--- a/kinetic/hardware-interface/default.nix
+++ b/kinetic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-hardware-interface";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/hardware_interface/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "87d812bfa3d2a03df47ff2cb240d6b8cfeb66511d622dd71453a76185e1b5641";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/hardware_interface/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "575a20e649c9b44fbad6362ed6f2acb2810a738b778ff520ba70c8e67e70bd1b";
   };
 
   buildType = "catkin";

--- a/kinetic/imu-sensor-controller/default.nix
+++ b/kinetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-imu-sensor-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/imu_sensor_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "0499419cd9f77c00890c12bd32da24c3c82e7b8120d7a0e1f5dbd174b72698fa";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/imu_sensor_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "6261bab47ec1524045acbd4b9b661deec1476951d5a7a0aa15c883c9bc1bb890";
   };
 
   buildType = "catkin";

--- a/kinetic/joint-limits-interface/default.nix
+++ b/kinetic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-kinetic-joint-limits-interface";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/joint_limits_interface/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "278edecef58248e58f6d90bd35d943199460d213869b77178dd5d0a8685367df";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/joint_limits_interface/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "42c1a2cfc42f096eb00dc5af396c03733a814dcf1d2c41248166a898019d905d";
   };
 
   buildType = "catkin";

--- a/kinetic/joint-state-controller/default.nix
+++ b/kinetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-joint-state-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/joint_state_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "50d0f2fa818edd65260c974843e584e7556fecc7ca3058950d6f9aef30162951";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/joint_state_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "61c6b90e92c4f6a8aab7d04b3f69caafd4c6b0428305a8af0267b5a489b5c583";
   };
 
   buildType = "catkin";

--- a/kinetic/joint-trajectory-controller/default.nix
+++ b/kinetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-joint-trajectory-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/joint_trajectory_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "8e5e0ddc6068ab10e9d248f3fcd7c47ad5b2bcb37d1cfa50b212f8755fe34260";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/joint_trajectory_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "05bc50b714e23a6c4bf2d03a758040545a52f43184d0f7ef847a2fabaafd355f";
   };
 
   buildType = "catkin";

--- a/kinetic/osm-cartography/default.nix
+++ b/kinetic/osm-cartography/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, roslaunch, rospy, route-network, rviz, std-msgs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, roslaunch, rospy, route-network, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-osm-cartography";
-  version = "0.2.4";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/osm_cartography/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "b7b44c6d2025f65348f479c1c748e9dc56d9bb6fbda5c6f37fac01de6c428f40";
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/osm_cartography/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "3ec12db5c5af5db9918c1badff1817c29278daa405a71afe6dd3c09fd2b9b484";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs rospy route-network rviz std-msgs tf visualization-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs rospy route-network std-msgs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/position-controllers/default.nix
+++ b/kinetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller }:
 buildRosPackage {
   pname = "ros-kinetic-position-controllers";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/position_controllers/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "47b5e54e19a9ada4e0d4355f4c1ff1e0eeb9a58c2d09bc9474c23848bf718de3";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/position_controllers/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "e4faa483453aff3e02ed4ca7d00bd93b9b5db3ef6852eccdcf0c1b13f221b0b8";
   };
 
   buildType = "catkin";

--- a/kinetic/robot-calibration-msgs/default.nix
+++ b/kinetic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-robot-calibration-msgs";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration_msgs/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "80d6f8cd645f0be2c22fb50486018451453c634f6f149abea05aa1364bd9d10f";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration_msgs/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "6d5a257a5fdb203d09db0235dfa25f5ac1c665ab66ca489e82085cf2a45a7d41";
   };
 
   buildType = "catkin";

--- a/kinetic/robot-calibration/default.nix
+++ b/kinetic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-robot-calibration";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "cf6b61a2f7152f3cb9a8d7ce8ad196a8610f08590d536a95009770c3a53f00bf";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "1af1165e28690ee3d217c54b06513d7f7b1c33180eb4b8c47214e2b1712c8ec0";
   };
 
   buildType = "catkin";

--- a/kinetic/ros-control/default.nix
+++ b/kinetic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, combined-robot-hw-tests, controller-interface, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-kinetic-ros-control";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/ros_control/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "c7e50173396616ebb092aab1dc0159c2221c2402e0b7bcaaccb4c5d164653f18";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/ros_control/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "77df478bf9b1d047065ae307a396ee325143bd260ce89011c90e0faf86c2fcf7";
   };
 
   buildType = "catkin";

--- a/kinetic/ros-controllers/default.nix
+++ b/kinetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, rqt-joint-trajectory-controller, velocity-controllers }:
 buildRosPackage {
   pname = "ros-kinetic-ros-controllers";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/ros_controllers/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "8d593d537c640465ba826bac38818ecba4e3bf064b7f89857d1642f7c6c22e9d";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/ros_controllers/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "40caa31647c9b4739fa74fedb346fb0aa38bbb4ff163dd2762919512a56bae02";
   };
 
   buildType = "catkin";

--- a/kinetic/route-network/default.nix
+++ b/kinetic/route-network/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, nav-msgs, roslaunch, rospy, rostest, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-route-network";
-  version = "0.2.4";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/route_network/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "8aa80c3077576ce20a1b468ced79a0cd74b98c2d21aa8cce04f124b7719e7232";
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/route_network/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "6eb0ef1b5f46619843f436f4e7fae9b7dd5f738239be6a491e5aa988ad05565f";
   };
 
   buildType = "catkin";

--- a/kinetic/rqt-console/default.nix
+++ b/kinetic/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-console";
-  version = "0.4.8";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/kinetic/rqt_console/0.4.8-0.tar.gz";
-    name = "0.4.8-0.tar.gz";
-    sha256 = "5c1685fb32ec44daadfabf5ac6c0a7423694b7ebe8256ce05556fde892dbf47c";
+    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/kinetic/rqt_console/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "7d242765adcd6694d7ad550938c5590970b664ce02a398941d4cffa8b4f600db";
   };
 
   buildType = "catkin";

--- a/kinetic/rqt-controller-manager/default.nix
+++ b/kinetic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, rqt-gui }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-controller-manager";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/rqt_controller_manager/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "7aadbd43094407f5847c4ee805b04d3bae6134877d2563b8aba9a64d87aa99fc";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/rqt_controller_manager/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "cff3814b9b0010aa55c60b1dc2b773dc71bffbf91c9df9ef2892f1f7178e49b4";
   };
 
   buildType = "catkin";

--- a/kinetic/rqt-image-view/default.nix
+++ b/kinetic/rqt-image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, qt5, rqt-gui, rqt-gui-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-image-view";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/kinetic/rqt_image_view/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "27615c3623254361328cf89fdb5c576618b9dff45cfed6221e493313f3cc3cf5";
+    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/kinetic/rqt_image_view/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "72d15e3dda45149a40cb1381e0a8dba8dc3f806509ef01f74e677dd31e106692";
   };
 
   buildType = "catkin";

--- a/kinetic/rqt-joint-trajectory-controller/default.nix
+++ b/kinetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-joint-trajectory-controller";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/rqt_joint_trajectory_controller/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "6870251fde88d2b747a3aa2fd4d0fbf84d69e65cf40bb11fd05e4cc505dee53f";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/rqt_joint_trajectory_controller/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "3afc0019a023b65c1cadf92eb2b4061ae6979d633a1aa484ddda89d587d63240";
   };
 
   buildType = "catkin";

--- a/kinetic/test-osm/default.nix
+++ b/kinetic/test-osm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geodesy, geographic-msgs, osm-cartography, route-network }:
 buildRosPackage {
   pname = "ros-kinetic-test-osm";
-  version = "0.2.4";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/test_osm/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "7fd6af55b0a2548b5d501882bcac1429f7ad9039be66bc07a5049b6229cdeb17";
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/kinetic/test_osm/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "b77fcee167eb3d7b08205c42585aaa191e60585fb3fce3b389c733855292894e";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-description/default.nix
+++ b/kinetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-description";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "a7a490fa5dbe4cf503195b8829440e9c3dc62db73f43d35ac4d9f047f636e55d";
+    sha256 = "7514e02924b8b431b2a8bd54da65e63e3716ae8b2cb83a7ab2a019ef8a25168e";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-driver/default.nix
+++ b/kinetic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-driver";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "b51ce477d8d8ec3c157a74b0e56bfe6c0232d8dde7cda28a551bbc40b868939b";
+    sha256 = "48cbc6ef56b9f66da4344a0511aca4bd0b7764b9de7e5c5748ced40e5054504b";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-markers/default.nix
+++ b/kinetic/toposens-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-markers";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "706afdde0178d5d631ee7423621a824789ffab08cb6dab391597fbd56a65ac94";
+    sha256 = "122966fc03468f9ac3c96497700ba97223c53878e43c48187eb098d99b3d861d";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-msgs/default.nix
+++ b/kinetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-msgs";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "7c3393402e679f65c4b1b7a69e8858920b533383e2d3aace34b02806974c57a5";
+    sha256 = "913b7d55d0e40d501e64dee5a565c71652ece7e70cf18aa5c3e820c4cc03c3a1";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-pointcloud/default.nix
+++ b/kinetic/toposens-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-pointcloud";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "022c1e8bdcc84ab88abee36dd264f824dd4e65a4fda52da683321e03a1c90a00";
+    sha256 = "974631470d3d0eb46536435f7afc2836e33e4b478449e38c69a00c8a676f5cea";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens-sync/default.nix
+++ b/kinetic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-sync";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "5f38e63cec88fa3d3c90920eb47b0a2cd137c35258422b5a5cb80cb6f7135d31";
+    sha256 = "58b17fa7ab219312c0600a3b35279cd4abc7bc8fd712a0b4f75b7b2a6cb621d1";
   };
 
   buildType = "catkin";

--- a/kinetic/toposens/default.nix
+++ b/kinetic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-kinetic-toposens";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "f9361253e775f56801e5c807dacb7aba6e3f8ccb3488cedc8c80978e1b089a2c";
+    sha256 = "59d950c08bb50f93856a6a47b7a55293b5ea279990f8db39210dd16c793c068e";
   };
 
   buildType = "catkin";

--- a/kinetic/transmission-interface/default.nix
+++ b/kinetic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, rosunit, tinyxml }:
 buildRosPackage {
   pname = "ros-kinetic-transmission-interface";
-  version = "0.13.3";
+  version = "0.13.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/transmission_interface/0.13.3-0.tar.gz";
-    name = "0.13.3-0.tar.gz";
-    sha256 = "5ea69c02ba27cce7d5bb727821595ff1eacfeda4febdb5a56ed243d779dd825d";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/transmission_interface/0.13.4-1.tar.gz";
+    name = "0.13.4-1.tar.gz";
+    sha256 = "9239320500fa34cf57b3e8319af7b10c31245272c7a8ce388bec031e7c1c0039";
   };
 
   buildType = "catkin";

--- a/kinetic/uwb-hardware-driver/default.nix
+++ b/kinetic/uwb-hardware-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, jsoncpp, message-generation, message-runtime, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-uwb-hardware-driver";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/inomuh/uwb_hardware_driver-release/archive/release/kinetic/uwb_hardware_driver/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "89972f595fb5ff5cfe5fd62f0738c98f9e5fe17923f217cc48eea0b2f8d0eed1";
+    url = "https://github.com/inomuh/uwb_hardware_driver-release/archive/release/kinetic/uwb_hardware_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "18de9095bb6b1a634865787ce89ff92a68625aa060a5dda8aeb67116bb6d3316";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs ];
+  propagatedBuildInputs = [ jsoncpp message-runtime roscpp rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/kinetic/velocity-controllers/default.nix
+++ b/kinetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-velocity-controllers";
-  version = "0.13.5";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/velocity_controllers/0.13.5-0.tar.gz";
-    name = "0.13.5-0.tar.gz";
-    sha256 = "b31a0c50e6842d6121644581506f5455a8c25f45fcd173fcbca8f702f54a5952";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/kinetic/velocity_controllers/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "8b1ec59295221c870c9ec1f21cb8768fbbf5e670bf8d3501287995144c9f292b";
   };
 
   buildType = "catkin";

--- a/kinetic/webots-ros/default.nix
+++ b/kinetic/webots-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-webots-ros";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/kinetic/webots_ros/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "599d07fccbf6377bd4785b8b2632b6485a7b1ec5f919ccdf5f5b10fa8eee80c6";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/kinetic/webots_ros/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "65c5871ded85992b98eabb9fdc8e4a2fc01afaf0ed55ed2ad0c1e08aa482b64f";
   };
 
   buildType = "catkin";

--- a/melodic/angles/default.nix
+++ b/melodic/angles/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-angles";
-  version = "1.9.11";
+  version = "1.9.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_angles_utils-release/archive/release/melodic/angles/1.9.11-0.tar.gz";
-    name = "1.9.11-0.tar.gz";
-    sha256 = "e234fbb316d2e74febab2c47710ecb9c1c7231c439d68a2f8540b416245b2b9a";
+    url = "https://github.com/ros-gbp/geometry_angles_utils-release/archive/release/melodic/angles/1.9.12-1.tar.gz";
+    name = "1.9.12-1.tar.gz";
+    sha256 = "db7a41b9e761db8f81c749170e1b949366a0a125b50d37617a7bac34058a1a58";
   };
 
   buildType = "catkin";
@@ -22,10 +22,10 @@ buildRosPackage {
         with angles. The utilities cover simple things like
         normalizing an angle and conversion between degrees and
         radians. But even if you're trying to calculate things like
-        the shortest angular distance between two joinst space
+        the shortest angular distance between two joint space
         positions of your robot, but the joint motion is constrained
         by joint limits, this package is what you need. The code in
-        this packge is stable and well tested. There are no plans for
+        this package is stable and well tested. There are no plans for
         major changes in the near future.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/melodic/camera-calibration/default.nix
+++ b/melodic/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, message-filters, rospy, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-camera-calibration";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "5577d92469b4793887ee0b8496c46dcd0c83e53bf1eab4d33bad51d598e65cfc";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "95993469bff9fc345dc7571a24f041567125700df8ea75906cd4e7d45f67d18a";
   };
 
   buildType = "catkin";

--- a/melodic/depth-image-proc/default.nix
+++ b/melodic/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cv-bridge, eigen-conversions, image-geometry, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-depth-image-proc";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "9ef587dfb94e1ce789b97f3287d361570fd4e14019c248fa388797d388e839a2";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "9bb74785d59b1e2cdecb8387b842bd95239d7b280f17d6c2a2284f593f69736b";
   };
 
   buildType = "catkin";

--- a/melodic/dynamic-edt-3d/default.nix
+++ b/melodic/dynamic-edt-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, octomap }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, octomap }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-edt-3d";
-  version = "1.9.3-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.3-1.tar.gz";
-    name = "1.9.3-1.tar.gz";
-    sha256 = "68d2bd30f42d15be91cc632bf371c179d454a00c96eb2719496644cb4620944f";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "b3da422d3baebaea5aa422558b878f02058f7695617e5b116ee7bdf1723c12cc";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ octomap ];
+  propagatedBuildInputs = [ catkin octomap ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/melodic/flexbe-behavior-engine/default.nix
+++ b/melodic/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-behavior-engine";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_behavior_engine/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "f92a236be23a7556d107988e52fdde47cf251844cdd9eaa6d8c66f2f5a363472";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_behavior_engine/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "8762c40e4d6f87b634f7e699ecdc2fa8b9f0eaf342f6110a64788c59f5d33b78";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-core/default.nix
+++ b/melodic/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, smach-ros, tf }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-core";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_core/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "cddf2023ea8181e51a61692ba2ed36c1ad295a26ce047a223d92d1f17bd9e2b1";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_core/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "a4d6ccb29b7958df989238f4a2ef52eb4a4149d37f9e9f53b2c7d113b40818c5";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-input/default.nix
+++ b/melodic/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-input";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_input/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "49e9b58df818ce46656a7482b8c0b260f8cc45f0c04dc986dd06163ba36a3245";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_input/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "f67450ffc384ded4721851e15457b372481df29f1fea066cd6ea496f1d49f4ed";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-mirror/default.nix
+++ b/melodic/flexbe-mirror/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-widget, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-mirror";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_mirror/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "7f9f4ad139201af0366254fb0f2fc7b3b4120a4b3c0dab729b03ef5f30a14339";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_mirror/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7cada5e532a6b51657b8dc5c718bf941b82b3b610406730d5a26e9c0f2ac938d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-widget rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/melodic/flexbe-msgs/default.nix
+++ b/melodic/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-msgs";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "adde3f5455d430996b8139ddba6be0e1e9b35bbde315b1faa3c27458e18a9510";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_msgs/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "abb0d1bc8eabeadaa2d9c4ffce352203e773585743e0f40585790cc23508891e";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-onboard/default.nix
+++ b/melodic/flexbe-onboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-onboard";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_onboard/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "834f106732efdadb8b8bd5df9d79feffb0f2cdcff13209eb626fb8faa52903cb";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_onboard/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "32f2c2d1845abe5bcdcb1f399350a4659b7ae5be1d4f7a0dd1fb1b5d3aee5d9d";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-states/default.nix
+++ b/melodic/flexbe-states/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-states";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_states/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "85def34946171a90fdc3dfeb21e7507d40edaff16376e7883136ba496bd199ba";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_states/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "775d54a88d6debbda5a6ad8f5af6f9aee4b6842ff5cf195eabbb875fe8eec0b8";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
   checkInputs = [ geometry-msgs ];
-  propagatedBuildInputs = [ flexbe-msgs flexbe-testing rosbag rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rosbag rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/melodic/flexbe-testing/default.nix
+++ b/melodic/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, smach-ros, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-testing";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_testing/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "e19a18bd897d936a6fe6c199124ea3faf232f435c5588a91301973575838825d";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_testing/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "3f5035bec2c92dddbddc06dbb982657f6f01ff04a7bfa82139aaf0c8f2824d9c";
   };
 
   buildType = "catkin";

--- a/melodic/flexbe-widget/default.nix
+++ b/melodic/flexbe-widget/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-widget";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_widget/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "f819f570ebe1a4e899edd92f7e26e63068466e4db3e652be4c0fc763f8e6c4cf";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_widget/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "fdb723dadbd6c996f88efc878b30673af12e9ec480a1204beeef30b7b6dcfefb";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/melodic/generated.nix
+++ b/melodic/generated.nix
@@ -1938,6 +1938,8 @@ self: super: {
 
  osg-utils = self.callPackage ./osg-utils {};
 
+ osm-cartography = self.callPackage ./osm-cartography {};
+
  ouster-driver = self.callPackage ./ouster-driver {};
 
  oxford-gps-eth = self.callPackage ./oxford-gps-eth {};
@@ -2658,6 +2660,8 @@ self: super: {
 
  rotors-simulator = self.callPackage ./rotors-simulator {};
 
+ route-network = self.callPackage ./route-network {};
+
  rplidar-ros = self.callPackage ./rplidar-ros {};
 
  rqt = self.callPackage ./rqt {};
@@ -2985,6 +2989,8 @@ self: super: {
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 
  test-mavros = self.callPackage ./test-mavros {};
+
+ test-osm = self.callPackage ./test-osm {};
 
  tf = self.callPackage ./tf {};
 

--- a/melodic/geometry2/default.nix
+++ b/melodic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-melodic-geometry2";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/geometry2/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "077b18d3f1afdc72a99c3fb4e14168da26d82e4ae2e5b18ef90960e187209140";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/geometry2/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "5374628e91d1625a9ee267b484d77b7672b3fa9ea1bd1e3ebb9660e0e1d4fcba";
   };
 
   buildType = "catkin";

--- a/melodic/image-pipeline/default.nix
+++ b/melodic/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration, catkin, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-image-pipeline";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "f036a5cd94826cc5b2d5713cb2594dc5835ff3245d64637f476c0564d510a99c";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "34c43d0ef5669dbc9727277b88207348a12155fe30033e2e5d3f033dbfa56729";
   };
 
   buildType = "catkin";

--- a/melodic/image-proc/default.nix
+++ b/melodic/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-transport, nodelet, nodelet-topic-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-proc";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "0766ca147ac73ee475bc3afef52a7baa337922abc116a4a4fc835001e098faa9";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "8719ff0e5343cd91a069b4f258ceae8efc2e5b46d88b42eb201a32795306a3d3";
   };
 
   buildType = "catkin";

--- a/melodic/image-publisher/default.nix
+++ b/melodic/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-publisher";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "8b0416edac96a5993367ff887c7187345ce36d6a2e52c0f7cd5d6501642d1da4";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "c9869c11a9829621393af0ce79d2530accfe38cfec200aadb5c826d9c19c3c1d";
   };
 
   buildType = "catkin";

--- a/melodic/image-rotate/default.nix
+++ b/melodic/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, nodelet, roscpp, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-image-rotate";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "bbfb1e066ba98a6f4ea1d3b7586dc0f25219e3716f025a97f6d1b7b1587ddaf5";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "4de3017fa1326bb63f07d03492be9cb7349601c3302a99230f2f2dc2687b65a3";
   };
 
   buildType = "catkin";

--- a/melodic/image-view/default.nix
+++ b/melodic/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, gtk2, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-view";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "fc40f5ff8c4840e241be2c61a4cec0fa5cb904134352249cde4f5df0ff63bf62";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "318afe307395af61d529710e5fa4ca22acc92eb35910e3ed1fad8b333bf73b81";
   };
 
   buildType = "catkin";

--- a/melodic/octomap/default.nix
+++ b/melodic/octomap/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-octomap";
-  version = "1.9.3-r1";
+  version = "1.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.3-1.tar.gz";
-    name = "1.9.3-1.tar.gz";
-    sha256 = "1904321f8d5f643d9636cc7c3a2aaaac07838a3db3a78bbbd08c5f6c40c428ac";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "20a5bb7d159129053c2b25f7c02a76ad4ffec83c31e2fb4486753c88115caee6";
   };
 
   buildType = "cmake";
+  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/melodic/osm-cartography/default.nix
+++ b/melodic/osm-cartography/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, roslaunch, rospy, route-network, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-osm-cartography";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/melodic/osm_cartography/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "82a7389d369b7bbe5f2fa2f796d5b4994b7b4306ca79a1080882476ee9194d83";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs rospy route-network std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Geographic mapping using Open Street Map data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/melodic/realsense2-camera/default.nix
+++ b/melodic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.11-r1";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.11-1.tar.gz";
-    name = "2.2.11-1.tar.gz";
-    sha256 = "756b3dbd06e06242c0499af747106101e40b64562245ab0a239a45d4cd6c9fa3";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "5d7c51ae9754aef43318a19fd0e638b190969557b830fc74be812488661c209a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/melodic/realsense2-description/default.nix
+++ b/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.11-r1";
+  version = "2.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.11-1.tar.gz";
-    name = "2.2.11-1.tar.gz";
-    sha256 = "76ba77032a4e1917fbd2c0ddf5b41a9e6ddc46ae287a41512008ca2dcc71446e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.12-1.tar.gz";
+    name = "2.2.12-1.tar.gz";
+    sha256 = "9acfcae0896e5a49f694c7d786be8654b176318d27137b6619739091dc7114af";
   };
 
   buildType = "catkin";

--- a/melodic/robot-calibration-msgs/default.nix
+++ b/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "aa425371dddddf731cb4c5397cecc801e55a9f3f92c05475834f09a81a095a89";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "4a07a06b1397c6eea1a2c2bf954b3e896e7c862cd74f93108b28cf7164249e7e";
   };
 
   buildType = "catkin";

--- a/melodic/robot-calibration/default.nix
+++ b/melodic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "793b704997d33cd33c6f8848cf6e734a23e3ff04f977cccb8e7183a2e05e2122";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "c422f0ddb088f4fb73a7b17c11db4cbefc351c76413b6c6395af17bbe2e0f043";
   };
 
   buildType = "catkin";

--- a/melodic/route-network/default.nix
+++ b/melodic/route-network/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, nav-msgs, roslaunch, rospy, rostest, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-route-network";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/melodic/route_network/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "4100ef3d698459819f6f5ce27ece00c7f361daa3a7fe69e64ad6d2725e173ec0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs nav-msgs rospy visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Route network graphing and path planning.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/melodic/rqt-console/default.nix
+++ b/melodic/rqt-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
 buildRosPackage {
   pname = "ros-melodic-rqt-console";
-  version = "0.4.8";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/melodic/rqt_console/0.4.8-0.tar.gz";
-    name = "0.4.8-0.tar.gz";
-    sha256 = "bd66d6c711910fb8db8804b403bf5cedcce83ecfc82eaa4c12afb5e035a6eeb3";
+    url = "https://github.com/ros-gbp/rqt_console-release/archive/release/melodic/rqt_console/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "e01cb923bec977383fddbb9ee64baf50ceb167645989b018c4fa47acf43db003";
   };
 
   buildType = "catkin";

--- a/melodic/rqt-image-view/default.nix
+++ b/melodic/rqt-image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-transport, qt5, rqt-gui, rqt-gui-cpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-image-view";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/melodic/rqt_image_view/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "adbd60be7c1f3517942285d3bcb166f838d362e88a910192bdaa35dc193126e3";
+    url = "https://github.com/ros-gbp/rqt_image_view-release/archive/release/melodic/rqt_image_view/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "aa8786eb047273139cba8c1a2fe4ea2214060385494e743ee777b41ff155fd26";
   };
 
   buildType = "catkin";

--- a/melodic/stereo-image-proc/default.nix
+++ b/melodic/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-stereo-image-proc";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "1fdf61f54066371c870907f5e6027d64e4c3f152abb74190048a6642d48d2f7f";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "2f585cfbd533c88245330dfe58799c9ac7ffe7c03a54dd5fb2c5f01c8dd0adc4";
   };
 
   buildType = "catkin";

--- a/melodic/test-osm/default.nix
+++ b/melodic/test-osm/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geodesy, geographic-msgs, osm-cartography, route-network }:
+buildRosPackage {
+  pname = "ros-melodic-test-osm";
+  version = "0.2.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/melodic/test_osm/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "b03e821df33ef8a22f1ca6b22cdc84711879e74e55df49077beb761e72caffd4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geodesy geographic-msgs osm-cartography route-network ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These are regression tests for the osm_cartography and
+     route_network packages. They are packaged separately to avoid
+     unnecessary implementation dependencies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/melodic/tf2-bullet/default.nix
+++ b/melodic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-bullet";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_bullet/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "2cb1d1e6d4ba180010c3f53ac138ba147ef4fb2c037d1b76be5cfb7d60ecd8e8";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_bullet/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "0cd02f568c25969428c38c409badfab9ab5b1a16598bc029f7de133b5938943b";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-eigen/default.nix
+++ b/melodic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-eigen";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_eigen/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "0097c690bd551d83154cc551b7d50439d86e8acda2bc4ebc307d1157cdf8c24d";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_eigen/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "635b0400d430496ff935616aba342c9d1481ff6c01689d8b07f4e8c7837ddddc";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-geometry-msgs/default.nix
+++ b/melodic/tf2-geometry-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python-orocos-kdl, rostest, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python-orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-geometry-msgs";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_geometry_msgs/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "f1516df538999a5fb7cb8eeaf71636c9572bba758adac8cdafbf5446918b7bbc";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_geometry_msgs/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "b660accdb1497e291e5bbfce2746f3da5da2b072acad53d40afb03fe6eb3d91c";
   };
 
   buildType = "catkin";
-  checkInputs = [ rostest ];
+  checkInputs = [ ros-environment rostest ];
   propagatedBuildInputs = [ geometry-msgs orocos-kdl python-orocos-kdl tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/melodic/tf2-kdl/default.nix
+++ b/melodic/tf2-kdl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, rostest, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-kdl";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_kdl/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "af0a21267f7ff0d435f5b54a3b55575e399daaf75ed8e01f09906e1b9af018cf";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_kdl/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "092567486d57feaad61f7b83432dcbd0b3450b189fcc74ec121d71cb57f1edbc";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  checkInputs = [ rostest ];
+  checkInputs = [ ros-environment rostest ];
   propagatedBuildInputs = [ eigen orocos-kdl tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/melodic/tf2-msgs/default.nix
+++ b/melodic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
 buildRosPackage {
   pname = "ros-melodic-tf2-msgs";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_msgs/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "27ecf00eef462615bab0dd0ff5232f6aaad8712e79bbf5912c008705f27c1d5d";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_msgs/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "e688a6782f1f34bbd114c600c6cf3f569cebf04e0175981ce07546a5d3f1fc0e";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-py/default.nix
+++ b/melodic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-py";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_py/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "24fc32a89eb1f6714d2f05c138c5d85741aabe819fc18475e63564aa0e2c388b";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_py/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "949ec60f60bd8d454949978aa90e7358e18c5e89d4c5ba297162734f051097dd";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-ros/default.nix
+++ b/melodic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-filters, roscpp, rosgraph, rospy, rostest, std-msgs, tf2, tf2-msgs, tf2-py, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-tf2-ros";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_ros/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "f5ea730b28e1668228c151fec493a768164843aa867770570c93ba3dcbda2d0f";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_ros/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "542cfe5dae5ea30237dedd044ed957a87fe9dc77b6a35600654a724c84adced2";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-sensor-msgs/default.nix
+++ b/melodic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, python-orocos-kdl, rospy, rostest, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-sensor-msgs";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_sensor_msgs/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "1a5247c2cfec650cb26758f587e6af12e90b0a99749eb861813ab39f83c7b2e6";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_sensor_msgs/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "f73e69b735c5c8b0bae8303e9f56ab887becb58c59d7a708eb4d5a8cf6ec8185";
   };
 
   buildType = "catkin";

--- a/melodic/tf2-tools/default.nix
+++ b/melodic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-tools";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_tools/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "c474f792ecac52bec866f11bb705444141ea38f2e9f23fc1513307a4681ef724";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_tools/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "f38f0bd20aeeaf8a353fc1e76c511d1a0aa9973772412911f012c9c046cdbfcf";
   };
 
   buildType = "catkin";

--- a/melodic/tf2/default.nix
+++ b/melodic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, geometry-msgs, rostime, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-tf2";
-  version = "0.6.5";
+  version = "0.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2/0.6.5-0.tar.gz";
-    name = "0.6.5-0.tar.gz";
-    sha256 = "f6776b600f397998cef387bfa57b6ad3e1e396f7a0015521ba7389ce2ca211c4";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2/0.6.6-1.tar.gz";
+    name = "0.6.6-1.tar.gz";
+    sha256 = "dce6877a97b38551633d530e72b90ed18a3db6701e4e90ca93673c8e7336b16c";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-description/default.nix
+++ b/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "a73cf14def24b3dfea243ff4f64635861f402212dcf71f211a1bd18695d6812c";
+    sha256 = "230a1079f3670501c9d1882cde91caed576760d81e0999f53cbcb9024c5184b4";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-driver/default.nix
+++ b/melodic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "3521f098153ffeb470caf3f378b34694bd912be9bc49e47336bba69e265d355c";
+    sha256 = "2dde23232c45363f4323046520dfc7f4af273c3d55d2b8019853904b3842c3df";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-markers/default.nix
+++ b/melodic/toposens-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "24acbd00e98e7a853e4d2fba76494626ef3d02d686b1bc7bea52f5ba57d5acee";
+    sha256 = "29bc699a2f35279cd898997122cb404f6e362cf0cf3f1be6e046b7352a40c6ac";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-msgs/default.nix
+++ b/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "d047de71633467c80521c982ead88f996aa29259c510278caf52fbcfc1080805";
+    sha256 = "465af17d2a36bffa74b571fbb761ef3d33288398edd0676def469795c7ae5393";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-pointcloud/default.nix
+++ b/melodic/toposens-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "63768a1d8acd5eadfa7352cb5a37b77edc960fab76f3def796c2b788f1254754";
+    sha256 = "4211f8fd0f4d0430de1ddf254337f0d3a1d6f33b6cf4764087db990dd2e20613";
   };
 
   buildType = "catkin";

--- a/melodic/toposens-sync/default.nix
+++ b/melodic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "f71925faff63247c04fb1515e0441521fa536159c58ed7fe91a140233ff55b51";
+    sha256 = "c4c06ac461a324ace265057eb911a34c301e4d207422cf4768ee27c76c4b0c02";
   };
 
   buildType = "catkin";

--- a/melodic/toposens/default.nix
+++ b/melodic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "1.3.0-r1";
+  version = "2.0.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/1.3.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.0-1";
     name = "archive.tar.gz";
-    sha256 = "d2ffaef31e99fda72b09adc3e41c518e6dc44ed265ba46f8c76cc454da96db8e";
+    sha256 = "7a79d55f175374b8426cd02972c8830eef662b8bbf6bc9fb4fce4437c97f55a3";
   };
 
   buildType = "catkin";

--- a/melodic/ublox-gps/default.nix
+++ b/melodic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-gps";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "74f0ab6bc045b340e9fe9e19193dc8f3d44076a706aa7029e3e0e01aaca34101";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "ef380666fecf4c3b12c7ac0b2c7e8f59548898a8774616eadb03b42b171859ef";
   };
 
   buildType = "catkin";

--- a/melodic/ublox-msgs/default.nix
+++ b/melodic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-msgs";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "71cc141fd9777fae71ac599811dc414d4cc1f393d8aa7dbcca29cec3a72a417b";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "512c2afd61e324fb5dc06e9e90ee3403389a9d6ba4b0f858217b3a0a8ba575e6";
   };
 
   buildType = "catkin";

--- a/melodic/ublox-serialization/default.nix
+++ b/melodic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-serialization";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "3b2bef917432f459fc77df8acbd794dbaaaf5c5f60492ee8495eeaf60a60f8bb";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "237e337629963a1222b01e068886f5b69fd6a507844555ee14df1b7d4e266c77";
   };
 
   buildType = "catkin";

--- a/melodic/ublox/default.nix
+++ b/melodic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-ublox";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "bfd357e219781c9b45616712b6e7004b8e0d4204852df3789fbff9a2cbf431c9";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b51feba373e616f8bb6f28d93cc61aa6738645d5587d671e6911ed19ade5bbf6";
   };
 
   buildType = "catkin";

--- a/melodic/webots-ros/default.nix
+++ b/melodic/webots-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-webots-ros";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "af8cddb4486838d1bd6bc1bdecae612faa1b03b47d06c7a5d7dce0a3b999bb69";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "e7b25106b14d6613f2848ddef54308f7a3eb1a2d1e1a16c94a35a7267a2b1a38";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit a59f9d371b0914b810d85943c1d60c92abc6caa3.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *ament-cmake-virtualenv 0.0.4-r1 --> 0.0.5-r5*
* *ouster-msgs 0.0.0-r1 --> 0.0.2-r1*
* *ros2-ouster 0.0.0-r1 --> 0.0.2-r1*
* *rqt-console 1.1.0-r1 --> 1.1.1-r1*
* *rqt-image-view 1.0.2-r1 --> 1.0.4-r1*
* *serial-driver 0.0.2-r1 --> 0.0.4-r3*
* *udp-driver 0.0.3-r1 --> 0.0.4-r3*

Eloquent Changes:
-----------------
* *ecl-command-line 1.0.4-r1 --> 1.0.6-r1*
* *ecl-concepts 1.0.4-r1 --> 1.0.6-r1*
* *ecl-config 1.0.3-r1 --> 1.0.5-r1*
* *ecl-console 1.0.3-r1 --> 1.0.5-r1*
* *ecl-containers 1.0.4-r1 --> 1.0.6-r1*
* *ecl-converters 1.0.4-r1 --> 1.0.6-r1*
* *ecl-converters-lite 1.0.3-r1 --> 1.0.5-r1*
* *ecl-core 1.0.4-r1 --> 1.0.6-r1*
* *ecl-core-apps 1.0.4-r1 --> 1.0.6-r1*
* *ecl-devices 1.0.4-r1 --> 1.0.6-r1*
* *ecl-eigen 1.0.4-r1 --> 1.0.6-r1*
* *ecl-errors 1.0.3-r1 --> 1.0.5-r1*
* *ecl-exceptions 1.0.4-r1 --> 1.0.6-r1*
* *ecl-filesystem 1.0.4-r1 --> 1.0.6-r1*
* *ecl-formatters 1.0.4-r1 --> 1.0.6-r1*
* *ecl-geometry 1.0.4-r1 --> 1.0.6-r1*
* *ecl-io 1.0.3-r1 --> 1.0.5-r1*
* *ecl-ipc 1.0.4-r1 --> 1.0.6-r1*
* *ecl-linear-algebra 1.0.4-r1 --> 1.0.6-r1*
* *ecl-lite 1.0.3-r1 --> 1.0.5-r1*
* *ecl-manipulators 1.0.4-r1 --> 1.0.6-r1*
* *ecl-math 1.0.4-r1 --> 1.0.6-r1*
* *ecl-mobile-robot 1.0.4-r1 --> 1.0.6-r1*
* *ecl-mpl 1.0.4-r1 --> 1.0.6-r1*
* *ecl-sigslots 1.0.4-r1 --> 1.0.6-r1*
* *ecl-sigslots-lite 1.0.3-r1 --> 1.0.5-r1*
* *ecl-statistics 1.0.4-r1 --> 1.0.6-r1*
* *ecl-streams 1.0.4-r1 --> 1.0.6-r1*
* *ecl-threads 1.0.4-r1 --> 1.0.6-r1*
* *ecl-time 1.0.4-r1 --> 1.0.6-r1*
* *ecl-time-lite 1.0.3-r1 --> 1.0.5-r1*
* *ecl-type-traits 1.0.4-r1 --> 1.0.6-r1*
* *ecl-utilities 1.0.4-r1 --> 1.0.6-r1*
* *kobuki-core 0.8.1-r1 --> 1.0.0-r1*
* *kobuki-dock-drive 0.8.1-r1 --> 1.0.0-r1*
* *kobuki-driver 0.8.1-r1 --> 1.0.0-r1*
* *kobuki-ftdi 0.8.1-r1 --> 1.0.0-r1*
* *kobuki-ros-interfaces 1.0.0-r1*
* *ouster-msgs 0.0.1-r1 --> 0.1.0-r1*
* *plansys2-bringup 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-domain-expert 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-executor 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-lifecycle-manager 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-msgs 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-multidomain-example 0.0.5-r1*
* *plansys2-patrol-navigation-example 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-pddl-parser 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-planner 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-problem-expert 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-simple-example 0.0.4-r1 --> 0.0.5-r1*
* *plansys2-terminal 0.0.4-r1 --> 0.0.5-r1*
* *realtime-tools 2.0.0-r2*
* *ros2-ouster 0.0.1-r1 --> 0.1.0-r1*
* *rqt-console 1.1.0-r1 --> 1.1.1-r1*
* *rqt-image-view 1.0.3-r1 --> 1.0.4-r1*
* *rqt-tf-tree 1.0.0-r1 --> 1.0.1-r1*

Kinetic Changes:
----------------
* *ackermann-steering-controller 0.13.5 --> 0.13.6-r1*
* *combined-robot-hw 0.13.3 --> 0.13.4-r1*
* *combined-robot-hw-tests 0.13.3 --> 0.13.4-r1*
* *controller-interface 0.13.3 --> 0.13.4-r1*
* *controller-manager 0.13.3 --> 0.13.4-r1*
* *controller-manager-msgs 0.13.3 --> 0.13.4-r1*
* *controller-manager-tests 0.13.3 --> 0.13.4-r1*
* *diff-drive-controller 0.13.5 --> 0.13.6-r1*
* *effort-controllers 0.13.5 --> 0.13.6-r1*
* *flexbe-behavior-engine 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-core 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-input 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-mirror 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-msgs 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-onboard 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-states 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-testing 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-widget 1.2.2-r1 --> 1.2.3-r1*
* *force-torque-sensor-controller 0.13.5 --> 0.13.6-r1*
* *forward-command-controller 0.13.5 --> 0.13.6-r1*
* *four-wheel-steering-controller 0.13.5 --> 0.13.6-r1*
* *gripper-action-controller 0.13.5 --> 0.13.6-r1*
* *hardware-interface 0.13.3 --> 0.13.4-r1*
* *imu-sensor-controller 0.13.5 --> 0.13.6-r1*
* *joint-limits-interface 0.13.3 --> 0.13.4-r1*
* *joint-state-controller 0.13.5 --> 0.13.6-r1*
* *joint-trajectory-controller 0.13.5 --> 0.13.6-r1*
* *osm-cartography 0.2.4 --> 0.2.5-r1*
* *position-controllers 0.13.5 --> 0.13.6-r1*
* *robot-calibration 0.6.1-r1 --> 0.6.2-r1*
* *robot-calibration-msgs 0.6.1-r1 --> 0.6.2-r1*
* *ros-control 0.13.3 --> 0.13.4-r1*
* *ros-controllers 0.13.5 --> 0.13.6-r1*
* *route-network 0.2.4 --> 0.2.5-r1*
* *rqt-console 0.4.8 --> 0.4.9-r1*
* *rqt-controller-manager 0.13.3 --> 0.13.4-r1*
* *rqt-image-view 0.4.13 --> 0.4.14-r1*
* *rqt-joint-trajectory-controller 0.13.5 --> 0.13.6-r1*
* *test-osm 0.2.4 --> 0.2.5-r1*
* *toposens 1.3.0-r1 --> 2.0.0-r1*
* *toposens-description 1.3.0-r1 --> 2.0.0-r1*
* *toposens-driver 1.3.0-r1 --> 2.0.0-r1*
* *toposens-markers 1.3.0-r1 --> 2.0.0-r1*
* *toposens-msgs 1.3.0-r1 --> 2.0.0-r1*
* *toposens-pointcloud 1.3.0-r1 --> 2.0.0-r1*
* *toposens-sync 1.3.0-r1 --> 2.0.0-r1*
* *transmission-interface 0.13.3 --> 0.13.4-r1*
* *uwb-hardware-driver 0.1.0-r1 --> 0.1.2-r1*
* *velocity-controllers 0.13.5 --> 0.13.6-r1*
* *webots-ros 2.0.5-r1 --> 2.0.6-r1*

Melodic Changes:
----------------
* *angles 1.9.11 --> 1.9.12-r1*
* *camera-calibration 1.13.0-r1 --> 1.14.0-r1*
* *depth-image-proc 1.13.0-r1 --> 1.14.0-r1*
* *dynamic-edt-3d 1.9.3-r1 --> 1.9.0-r1*
* *flexbe-behavior-engine 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-core 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-input 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-mirror 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-msgs 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-onboard 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-states 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-testing 1.2.2-r1 --> 1.2.3-r1*
* *flexbe-widget 1.2.2-r1 --> 1.2.3-r1*
* *geometry2 0.6.5 --> 0.6.6-r1*
* *image-pipeline 1.13.0-r1 --> 1.14.0-r1*
* *image-proc 1.13.0-r1 --> 1.14.0-r1*
* *image-publisher 1.13.0-r1 --> 1.14.0-r1*
* *image-rotate 1.13.0-r1 --> 1.14.0-r1*
* *image-view 1.13.0-r1 --> 1.14.0-r1*
* *octomap 1.9.3-r1 --> 1.9.0-r1*
* *osm-cartography 0.2.5-r1*
* *realsense2-camera 2.2.11-r1 --> 2.2.12-r1*
* *realsense2-description 2.2.11-r1 --> 2.2.12-r1*
* *robot-calibration 0.6.1-r1 --> 0.6.2-r1*
* *robot-calibration-msgs 0.6.1-r1 --> 0.6.2-r1*
* *route-network 0.2.5-r1*
* *rqt-console 0.4.8 --> 0.4.9-r1*
* *rqt-image-view 0.4.13 --> 0.4.14-r1*
* *stereo-image-proc 1.13.0-r1 --> 1.14.0-r1*
* *test-osm 0.2.5-r1*
* *tf2 0.6.5 --> 0.6.6-r1*
* *tf2-bullet 0.6.5 --> 0.6.6-r1*
* *tf2-eigen 0.6.5 --> 0.6.6-r1*
* *tf2-geometry-msgs 0.6.5 --> 0.6.6-r1*
* *tf2-kdl 0.6.5 --> 0.6.6-r1*
* *tf2-msgs 0.6.5 --> 0.6.6-r1*
* *tf2-py 0.6.5 --> 0.6.6-r1*
* *tf2-ros 0.6.5 --> 0.6.6-r1*
* *tf2-sensor-msgs 0.6.5 --> 0.6.6-r1*
* *tf2-tools 0.6.5 --> 0.6.6-r1*
* *toposens 1.3.0-r1 --> 2.0.0-r1*
* *toposens-description 1.3.0-r1 --> 2.0.0-r1*
* *toposens-driver 1.3.0-r1 --> 2.0.0-r1*
* *toposens-markers 1.3.0-r1 --> 2.0.0-r1*
* *toposens-msgs 1.3.0-r1 --> 2.0.0-r1*
* *toposens-pointcloud 1.3.0-r1 --> 2.0.0-r1*
* *toposens-sync 1.3.0-r1 --> 2.0.0-r1*
* *ublox 1.2.0-r1 --> 1.3.0-r1*
* *ublox-gps 1.2.0-r1 --> 1.3.0-r1*
* *ublox-msgs 1.2.0-r1 --> 1.3.0-r1*
* *ublox-serialization 1.2.0-r1 --> 1.3.0-r1*
* *webots-ros 2.0.5-r1 --> 2.0.6-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] geographiclib
 * [ ] geographiclib-tools
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxml++-2.6
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

