### PR TITLE
rosdistro sync, Fri Jan 24 12:40:24 2020

### DIFF
--- a/distros/dashing/cv-bridge/default.nix
+++ b/distros/dashing/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, boost, opencv3, python-cmake-module, python3Packages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-cv-bridge";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/cv_bridge/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "7d8c362d9df4e63302b346cc187549171afe07d8cae4dd0996750961970e4960";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/cv_bridge/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "0786dfd1c86ac26cac76ff067bfd432c4dbac29c48b56fed87b5c385e3590fc6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/image-geometry/default.nix
+++ b/distros/dashing/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, opencv3, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-image-geometry";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/image_geometry/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "7d8caaf5318b9290ac0649b968fc0c3052d399a05534a481805eed9d95e9ef58";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/image_geometry/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "796deed577f3d737a7a4ee7dae327a793583f9ed15a2858005dfd5cfc257d785";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/vision-opencv/default.nix
+++ b/distros/dashing/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-geometry }:
 buildRosPackage {
   pname = "ros-dashing-vision-opencv";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/vision_opencv/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "2e7db741041cfd44315516ce2c705291b2b444a3e4e1f123fd188c013517dc3d";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/dashing/vision_opencv/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "3ef18bee5f7dc2d00d5f694d0ca8e13d218bb6736f1da5bb5a7cc00667d1c5c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/ament-cmake-virtualenv/default.nix
+++ b/distros/eloquent/ament-cmake-virtualenv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-virtualenv }:
+buildRosPackage {
+  pname = "ros-eloquent-ament-cmake-virtualenv";
+  version = "0.0.5-r6";
+
+  src = fetchurl {
+    url = "https://github.com/esol-community/ament_virtualenv-release/archive/release/eloquent/ament_cmake_virtualenv/0.0.5-6.tar.gz";
+    name = "0.0.5-6.tar.gz";
+    sha256 = "4530c795d293bc036ae3af1d11dbe7c59e7a602106bbe1fec5ba3f414c8b832e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  propagatedBuildInputs = [ ament-virtualenv ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''Bundle python requirements in a ament package via virtualenv.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/eloquent/class-loader/default.nix
+++ b/distros/eloquent/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, poco, poco-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-class-loader";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/eloquent/class_loader/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "79177401ea6ace156ebba466796cff3ee598e291b0b04ee8e329d8e9f4ca6205";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/eloquent/class_loader/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "2f7ac281b03aaf3846010225098a22714810f738270f08e662fbf5f0df30d10a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cv-bridge/default.nix
+++ b/distros/eloquent/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, boost, opencv3, python-cmake-module, python3Packages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-cv-bridge";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/cv_bridge/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "2556666f3b3a83fba7c394b38bd9fba97a6a52b00eba3696d90b7d73ed57ff8d";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/cv_bridge/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "c8b997e4e437cf2341fd4cea03dd14ac0f8f22464e1949798bf2ebc04c58d48d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/examples-tf2-py/default.nix
+++ b/distros/eloquent/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-examples-tf2-py";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/examples_tf2_py/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "49be6059b15823372fe7a82a4aea7613cb65ec627c5c58df2a124d1bd2d028d7";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/examples_tf2_py/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "23a0d1fa54e9dcbadaa1e50b616a3bdd4a3307505b3521cc9e562b59168105dd";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -84,6 +84,8 @@ self: super: {
 
  ament-cmake-version = self.callPackage ./ament-cmake-version {};
 
+ ament-cmake-virtualenv = self.callPackage ./ament-cmake-virtualenv {};
+
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
 
  ament-copyright = self.callPackage ./ament-copyright {};
@@ -391,6 +393,8 @@ self: super: {
  kobuki-driver = self.callPackage ./kobuki-driver {};
 
  kobuki-ftdi = self.callPackage ./kobuki-ftdi {};
+
+ kobuki-ros = self.callPackage ./kobuki-ros {};
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 

--- a/distros/eloquent/geometry2/default.nix
+++ b/distros/eloquent/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-geometry2";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/geometry2/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "da419f0c9ecae71424f7325a5c9d32e6aea1bfb8df617bba77d5858ed3a34287";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/geometry2/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "dfbe43f408ef50be35516629b3c0fe581073a5bf211d760144738af0b8e8dd39";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/image-geometry/default.nix
+++ b/distros/eloquent/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, opencv3, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-image-geometry";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/image_geometry/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "3a40c79700b3efdfee78bcff30e7853ca751531f6ba94ca5102010a7006683a3";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/image_geometry/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "327376f160f8acdc50ca82385d2861f0b2cbd2b82ab0d001692320f00ef29f8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/kobuki-ros/default.nix
+++ b/distros/eloquent/kobuki-ros/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-eloquent-kobuki-ros";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/kobuki_ros-release/archive/release/eloquent/kobuki_ros/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "a86802618dff3b3ec9b6ec23d1b8f9c8404b5bac98a6179f78e40df0a0d65ae8";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 runtime software for Kobuki, Yujin Robot's mobile research base.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/launch-ros/default.nix
+++ b/distros/eloquent/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-eloquent-launch-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/launch_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "b13f094e943a71ea34aa09989a6f7cccfcf83e486fbb18b75b5f4ed0c4669521";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/launch_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "073814da64a69d721cdcc88c791f5817cc8917db7112cde84e4959bfc571ba80";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/launch-testing-ament-cmake/default.nix
+++ b/distros/eloquent/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-eloquent-launch-testing-ament-cmake";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_testing_ament_cmake/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "76c6e60a1a5f11e0b2d405b31e53dbbe4864a76457e32cb39ae394587ac82610";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_testing_ament_cmake/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "f7edd15a799b233d2cf518d392e4b4af95c88bc80eeaa6722740095a88110e15";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/launch-testing-ros/default.nix
+++ b/distros/eloquent/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-launch-testing-ros";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/launch_testing_ros/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "d712c7653423bb8ea663133cb26c0b76d5665182451c4a32af130650b40a5bd7";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/launch_testing_ros/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "27390efada4f3b0d1d191db1bf3796588baa0773a9be576d3c6cde45c6128f07";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/launch-testing/default.nix
+++ b/distros/eloquent/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-launch-testing";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_testing/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "9484d8e927fbec533394ddec67e9683dba6a514fb655a85cd4454480fe5539d3";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_testing/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "2097ad1d4926c5eebd96a4f5abcacfcd3411e6e4db9b323cfe9df2692f5f920e";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/launch-xml/default.nix
+++ b/distros/eloquent/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-launch-xml";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_xml/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "b0ea48c11ba3c5c1f3345bb5fa0c4fd4f7546878f32ac25f1a9bc453f932c272";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_xml/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "c4dda11423cc023fb4eab4739250f096c3fbb49d84b49e1d6d6980122759cce0";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/launch-yaml/default.nix
+++ b/distros/eloquent/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-launch-yaml";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_yaml/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "87fc07415c7da6d92331041540eebce0eeae3779815b399ed91c630ed6f88210";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch_yaml/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "63982e82ccacf15ff46d803a45335cea8d3b9fa3f795af3aecbf973b65e77fe4";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/launch/default.nix
+++ b/distros/eloquent/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-launch";
-  version = "0.9.5-r1";
+  version = "0.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch/0.9.5-1.tar.gz";
-    name = "0.9.5-1.tar.gz";
-    sha256 = "84e4293e60821d3c57e1a0c74c9374bede4aa6e20cf83a75bfcbea052d60d1f6";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/eloquent/launch/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "637072755a0ade1b21ae5e9fb440744da9b06c7d1d569e50972052f7e8ba6405";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/rcl-action/default.nix
+++ b/distros/eloquent/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-generator-c, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rcl-action";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_action/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "cdc7d21298ac5551d8212bae291fdb774cba6bb67dc9587a5aa5ec7565d97937";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_action/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "f3cd6dd84eae5a7a07563d97e98252ddeaead9a82d858fbaf4dae7c0759bc0a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rcl-lifecycle/default.nix
+++ b/distros/eloquent/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw-implementation, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-eloquent-rcl-lifecycle";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_lifecycle/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "e18b46b0be4df73f9a3cca62f006896ab55d658604a690c19a354f859cce10bc";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_lifecycle/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "adef015cbd468ac119704aa6b18a155ba43a85a13b69be0253f7ceea1f140290";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rcl-yaml-param-parser/default.nix
+++ b/distros/eloquent/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, osrf-testing-tools-cpp, rcutils }:
 buildRosPackage {
   pname = "ros-eloquent-rcl-yaml-param-parser";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_yaml_param_parser/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "3e8ada793c0c5728c097cceee95c98881b62d03c34a5446d2fd1d9bfbe33cdab";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl_yaml_param_parser/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "db67177cbc1b228643030e431011c89ada235b40744ae156e0e18d7f320258ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rcl/default.nix
+++ b/distros/eloquent/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-generator-c, test-msgs, tinydir-vendor, tracetools }:
 buildRosPackage {
   pname = "ros-eloquent-rcl";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "9d9f78172efa7946dac63b610d9b0fdb4b2a9a63d1511a4522a8eefc7323cab3";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/eloquent/rcl/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "c9ccad382d5150db3fb31cd21ff7e618ec1572113e4aaea69b63701bcc67da1e";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclcpp-action/default.nix
+++ b/distros/eloquent/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcl-action, rclcpp, rosidl-generator-c, rosidl-generator-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rclcpp-action";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_action/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "48c76f55e1ec0749d46bca475f5f7f9beb17d7c25dd6a1c1bb5f2054fa113b83";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_action/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "3cfa4adde6aa9c3eff9c652de5ec3f2cbbdfed030b22f8df87b84e0302ac8d51";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclcpp-components/default.nix
+++ b/distros/eloquent/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rclcpp-components";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_components/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "ebbd60a1bd4e9c8190acfd73e92d0933f6b53dd84061a611213b585c47465276";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_components/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "289f1b0cac85ca86c01501957217da62ba7c74a38e7fe15ffe44f0e761f997e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclcpp-lifecycle/default.nix
+++ b/distros/eloquent/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, rcl-lifecycle, rclcpp, rmw-implementation, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-eloquent-rclcpp-lifecycle";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_lifecycle/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "aa2c7e58e2d6ff0a28bc1e00d1c6ac8f89a6e08f6a648e2cf76105002f4b469f";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp_lifecycle/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "f046a4c85fbd95ee1922095f1778767c6229791e6960e7260d4b974300a6a644";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclcpp/default.nix
+++ b/distros/eloquent/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-eloquent-rclcpp";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "811ebb18ae97a1faa47c30c4431c678153d1aee605e35560cff99eb9517a480e";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/eloquent/rclcpp/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "e3d2d02a648e2bef5a8d1900febfbb624c30d4a4708e3a7e195da4ef7c93287f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclpy/default.nix
+++ b/distros/eloquent/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rclpy";
-  version = "0.8.3-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/eloquent/rclpy/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "5fb74c29e3b4d252691b63069099b3a0c6802b0f5dc1ebaeee9ff09c9b4bb551";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/eloquent/rclpy/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "917d70d094a0ff49fff59f3cac06e76411af5e10241e875a20fd906adb43f899";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/ros1-bridge/default.nix
+++ b/distros/eloquent/ros1-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, actionlib-msgs, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, demo-nodes-cpp, diagnostic-msgs, example-interfaces, gazebo-msgs, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, pkg-config, python3Packages, rclcpp, rcutils, rmw-implementation-cmake, ros2run, rosidl-cmake, rosidl-parser, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros1-bridge";
-  version = "0.8.1-r4";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/eloquent/ros1_bridge/0.8.1-4.tar.gz";
-    name = "0.8.1-4.tar.gz";
-    sha256 = "002822dcb1f9778f4efaf05d607712a693a574cd4bbbac9a26fb0e786601f1d2";
+    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/eloquent/ros1_bridge/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "f0551caec51081fecd30e826e4f2e4d1742103e2065f51479219ff20213cc6dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/ros2action/default.nix
+++ b/distros/eloquent/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2action";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2action/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "6a67b2bc605f6a5bb40db2d65b543702f4bbfbdd1a52d82acdf68903d86ad0bb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2action/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "476899f6829b9246ed32cf95db2b1fa8edfa1bf98bc07a16d94e42357332f0e4";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2cli/default.nix
+++ b/distros/eloquent/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-eloquent-ros2cli";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2cli/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "7221c8c8ff3fc365ee0698ac3089365ebadca7a62c1a3226f02b2abf38a86895";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2cli/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "530fe93eb1e8fea34107b5d3c360f9e9da8412f27d052d97490a5a63672233fe";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2component/default.nix
+++ b/distros/eloquent/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-eloquent-ros2component";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2component/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "0848d164e625dd9f903c7d8fae6fb458b12c7457b4d2d41e6cdd3c8b09e14b23";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2component/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "1ed9681b6261a3ccb57803196fb564d91b782d2462510b21615141c98a85d8ac";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2interface/default.nix
+++ b/distros/eloquent/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2interface";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2interface/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "52ae45dcee9398baaa939b18fdd7c4c578d402d8557012e61ca190c1c546fd32";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2interface/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "a09bee708fbd6aedaa5e41e3e019a9c1792d7bf4d981a57034460b9c6045340e";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2launch/default.nix
+++ b/distros/eloquent/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-eloquent-ros2launch";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/ros2launch/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "6e9d51f8a9ab454ca30d8acb2fa28797185c5481fe20337c6118a2455f068c60";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/eloquent/ros2launch/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "584110cd4bf223d9993d1ec1300d41082bdab973ee63e251cd211b36812b516c";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/eloquent/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-ros2lifecycle-test-fixtures";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2lifecycle_test_fixtures/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "e9bcd60d3a52991d3b3291b52e2557a1b6cd782071f429d83227dd2e8ce871a7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2lifecycle_test_fixtures/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "656e707290ae46988ee3c32d70e686e2ecfd9fbe9745bc860ccd99e2a52f1376";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/ros2lifecycle/default.nix
+++ b/distros/eloquent/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros-testing, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-eloquent-ros2lifecycle";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2lifecycle/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "95200f7f13576c59265c1c1ee9e9e935b9593c83425cfecf0a21c2dd81c39088";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2lifecycle/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "4a60b9c82606dd6690b6fae590770265ddb948d94622348b5cbf15a3821ff5a0";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2msg/default.nix
+++ b/distros/eloquent/ros2msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2msg";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2msg/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "81eb2b04119fa6be77d31326bd6062d072d1379e2887bb67da08281a2433b4f7";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2msg/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "c72978b24daa4a649c6130eff4895b14155964479e5ce694684cfab1948305dc";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2multicast/default.nix
+++ b/distros/eloquent/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-eloquent-ros2multicast";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2multicast/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "a8977918b022ef851536018127232d6970fd8f9e55513280261b5b82de8453ef";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2multicast/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "3de75fd814cd9d0ab20e82d3ecc043a5f3c5121a637d696955a9e53ddd8f1480";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2node/default.nix
+++ b/distros/eloquent/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2node";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2node/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "051db62d9d67ae9934c9bc46d76c7b5e7e24f670cb48147dd95240d617192a4e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2node/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "ba5ae998a8a044785897b3a967aa35adb367b1378c5a9b2f5af34a11136a6985";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2param/default.nix
+++ b/distros/eloquent/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-eloquent-ros2param";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2param/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "d0c94e3dfdc919b140df2d26ca79691551320d862637c7974bb117f34b0e3dfe";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2param/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "f312b90a08f27ae1adbc4348cb5562d68100adb3cc10888b8b44d1e543f501e3";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2pkg/default.nix
+++ b/distros/eloquent/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
 buildRosPackage {
   pname = "ros-eloquent-ros2pkg";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2pkg/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "0d10abd03d264b1858a04125de912373747d446aed4068146b64c1beb63b02d5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2pkg/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "3d12709c3f67af267fb11f7aeee1bb5400090b7f07c44b16aa28748c4322cc23";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2run/default.nix
+++ b/distros/eloquent/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-eloquent-ros2run";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2run/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "e31e43a6147462b737ef5b10ee117916cbf91707f7aa2377ad15c357dd7b5157";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2run/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "61e2dff47aabbc805c1a0eebafdecdf6847f0a492b682255b72e8b95f81d86b2";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2service/default.nix
+++ b/distros/eloquent/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2service";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2service/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "2df820e535ef2afe301ad6ced303d91ad49e32ef9aa17405c42f8880748446ab";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2service/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "cecf475b385a0fb86ea88f7d9775171fe8c511554f63664c10107f8d651fc062";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2srv/default.nix
+++ b/distros/eloquent/ros2srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2srv";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2srv/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "53baf91357d032c70e0ff6e0084b3c4d23010c0f338f966938aa3df490e446ac";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2srv/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "630d0dd2801579739e130f71c876689e97b6d4cc92049d5a8b6d3494c4c4970b";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/ros2topic/default.nix
+++ b/distros/eloquent/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-ros2topic";
-  version = "0.8.6-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2topic/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "c5cb6ad3ba81a772a5b66a09188176be402282aace4158bb2a8e82fd52cf33aa";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/eloquent/ros2topic/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "fe924ce8778794808a4f5e5828d7587047cf2ad0c92e5670c1ca09eaf08d7277";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/rosidl-adapter/default.nix
+++ b/distros/eloquent/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-adapter";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_adapter/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "12c9f3e998dbc4622446b99bab173bb5c854d8bb5a5489bf6fb9eb39a76e1c40";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_adapter/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "0a8b4d5a803c95cb5b9401b80601eb2b0e61ba311dc274372721a8417aa117a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-cmake/default.nix
+++ b/distros/eloquent/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-cmake";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_cmake/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "caace357518239897cf1ed2ad2b0157faf0952f87e1147a9622c734b06631c12";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_cmake/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "7352805d5b47afb8a8b2ce223904f4ad5a4b17bb11f36bd6d89d23befa8f9221";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-generator-c/default.nix
+++ b/distros/eloquent/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-parser, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-generator-c";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_generator_c/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "c045090a47172b3c9806fcf7b8ecb1d7dce83ff72d833ef923975a5e332f67df";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_generator_c/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "2a5992b8447081c93e262cfaeb2a8f7b7cba8079f4ef83c027cc8c9d74553526";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-generator-cpp/default.nix
+++ b/distros/eloquent/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-parser, test-interface-files }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-generator-cpp";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_generator_cpp/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "8c77afbe3c1d981ecc13b7f7786d763956b2ae17e30769f7999fee0a2f18b964";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_generator_cpp/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "04af870646ccfd8cf4014afa3f508925c373532d463cc184fdbca4c2b3fc7606";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-parser/default.nix
+++ b/distros/eloquent/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-parser";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_parser/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "346d1a443bd977f5783cea2de8671cb889668b180ce3f1b05fe2c80d7a70e5d1";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_parser/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "293b7701f3da8f614a7f65fe0ddeafb8a9765fe2d9d25818bb40fb31c17599fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-typesupport-interface/default.nix
+++ b/distros/eloquent/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-typesupport-interface";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_interface/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "4bb2cc4a1f5130559531839f50d577d72f4298c8167dae08e5500265882c5abf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_interface/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "bcecc62d843b39fcc50dae07d84abc0b5670a95734fe756a66cf7fbcf3aedb73";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/eloquent/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-parser }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-typesupport-introspection-c";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_introspection_c/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "df6436a23de281c53ca490d059dcb3452fc8cd7813b263b6bce43f7c90217e2f";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_introspection_c/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "a0af71995334a91d852b55ed692156ca4d8b5949fbe19309e9c95cb65dfc60aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/eloquent/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-eloquent-rosidl-typesupport-introspection-cpp";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_introspection_cpp/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "ae6e56889d4ee0f6e4b7b38277d055c2dfc9c596257e4554204396d3e30231f5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/eloquent/rosidl_typesupport_introspection_cpp/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "524eb4329e79eee932db5dc9e1954b4092c8e5755643bb018f8b8ec29b5445a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-assimp-vendor/default.nix
+++ b/distros/eloquent/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-assimp-vendor";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_assimp_vendor/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "a82670407cdd0d6e862f9f2176cf49d397ae23fb871656ef0f9b759587f334f5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_assimp_vendor/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "59c5f74d3fcafcaf88e43be858bcf84d3263a09517bc3f9ad990a3d43e809b8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-common/default.nix
+++ b/distros/eloquent/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-common";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_common/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "c1a38568b91cd4bb43b1a61546794e4b42d2c8e30cf09f9e081c26a871cb00fd";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_common/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "9616be831a5db30ff1e17ca4d1e9593cfdf29631208f129a982546c73c8166b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-default-plugins/default.nix
+++ b/distros/eloquent/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-default-plugins";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_default_plugins/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "3699a6211d157a8a7ba4f23065e5d63d5f66821911b224419a7f22c5547f98f9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_default_plugins/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "19941653be75f25e6018c7179722df79bea31f12845ab775a36c008cbc9d7c91";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-ogre-vendor/default.nix
+++ b/distros/eloquent/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-ogre-vendor";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_ogre_vendor/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "93036f39643946e6325533c7758160b87cce754464984c00aa1af01a258297cc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_ogre_vendor/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "f42ca396f8109f5f4e12f89cde74cd7d0740c7b422a61b59d509a972a2a8ab69";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-rendering-tests/default.nix
+++ b/distros/eloquent/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-rendering-tests";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering_tests/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "81702fbfbe3aea5b7f7ea0fba6c5518b8fbe3947ca6f899137ae4b050e491938";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering_tests/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "7a98124dba70ff427f478d07b0cc9c976a455c7fe08dc1a3e6fea9e67958ea7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-rendering/default.nix
+++ b/distros/eloquent/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-rendering";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "c7a44ab0fd6aa63bababcd640968d8308cd75383a69ef7a20ac1716096de9844";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "8cdb5ca39e6be9fc56f7e4474acc6001d43eab2291614909fce52679e487b6e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-visual-testing-framework/default.nix
+++ b/distros/eloquent/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-visual-testing-framework";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_visual_testing_framework/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "40251b0b1b1c0fdf7f294f5801b4e8c8f1fd552c4ead69776bbf7c5c5300b706";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_visual_testing_framework/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "fdfaaec05b257a318c12a775b313244379970dc1102ff42907376a661b980b00";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz2/default.nix
+++ b/distros/eloquent/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rviz2";
-  version = "7.0.3-r1";
+  version = "7.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz2/7.0.3-1.tar.gz";
-    name = "7.0.3-1.tar.gz";
-    sha256 = "bc01c3faa60d74d29b056a564d7202bde646ddbba48a13d74a6c38de676eabb5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz2/7.0.4-1.tar.gz";
+    name = "7.0.4-1.tar.gz";
+    sha256 = "9c58f88121f8c8812d464a6319b367cbf9a39484a360229aeb993ca597d0837a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-eigen/default.nix
+++ b/distros/eloquent/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-eigen";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_eigen/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "c0e7782becc5f1d4e00c4931ad9b86bac7016ae4c51e9132ab81e691d77c27ff";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_eigen/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "b4ead9a51274dc2ab0a8301c54b4333519f1b295b57d2fd0960862232c6b9b09";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-geometry-msgs/default.nix
+++ b/distros/eloquent/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-geometry-msgs";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_geometry_msgs/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "1ff60e34768d56630a407275e45fee398718208c6b7e98aa42977819c89fd466";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_geometry_msgs/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "467ea4e10953b36ff2ed4e1401e0f3b0f34ef93eadd3f535b30e78bee637b05f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-kdl/default.nix
+++ b/distros/eloquent/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-kdl";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_kdl/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "f78df24cb16a242bfe42106a1e4199862aa3b8fdce9ef0806827267f98b77b43";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_kdl/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "79cbe846f53f3fc42a9adb04d670eeadaed54e3c3b10e79f31060f618cc7556e";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-msgs/default.nix
+++ b/distros/eloquent/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-msgs";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_msgs/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "7c68fef9566f5d48f78f6e593288b6889dc5d9a66c901085fd7317151ce398c5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_msgs/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "526952f7d6ce253cb55a04eeb6910b059f99abc9d73d689a9d787588b8d383c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-py/default.nix
+++ b/distros/eloquent/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-py";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_py/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "1a0de98a0300bbf8f89806a7aece41c15938d9d704c62747360a4815e20a0518";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_py/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "a89f8bc4143650c6eea6ff94e6abe9d4f0cf53a8feba1d8cf14398edce3f77de";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-ros/default.nix
+++ b/distros/eloquent/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, geometry-msgs, message-filters, python-cmake-module, rclcpp, rclcpp-action, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-ros";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_ros/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "c43001ecbd393d53acb571ac03edf109b261bce50263fa05cb25b9b1127b6122";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_ros/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "c94fc5f2e2fcb03976fcb06698c359e0e798bffb559db0a98d757b4b2e86e937";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2-sensor-msgs/default.nix
+++ b/distros/eloquent/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-tf2-sensor-msgs";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_sensor_msgs/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "b28c11f83298d41fecc90260b31f4917cd9ada145efc67e3291422dede5c0db1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2_sensor_msgs/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "a75c527bf971f642ffa18ab5ff511f5957b4d10ea08db6e10ce7167eebe310a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/tf2/default.nix
+++ b/distros/eloquent/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-tf2";
-  version = "0.12.4-r1";
+  version = "0.12.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2/0.12.4-1.tar.gz";
-    name = "0.12.4-1.tar.gz";
-    sha256 = "0e8a360acb1d79d2909528b63680b33d50587846547332339cdb475a18e9b9a0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/eloquent/tf2/0.12.5-1.tar.gz";
+    name = "0.12.5-1.tar.gz";
+    sha256 = "4fde6f8cc51601b65c79fd13002c4262a890654941bee16bb837836ab32476b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/vision-opencv/default.nix
+++ b/distros/eloquent/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-geometry }:
 buildRosPackage {
   pname = "ros-eloquent-vision-opencv";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/vision_opencv/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "ffa2b7372b86cbb83a780c0d0c0c064537b8c82bc71265073c90ea9ae9ea1e33";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/eloquent/vision_opencv/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "75dbfadf38eef8d9b2c6d9c00cc32fd9d79751bdc608632dcf168b19eb265a9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/cloudwatch-metrics-collector/default.nix
+++ b/distros/kinetic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gmock, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-cloudwatch-metrics-collector";
-  version = "2.1.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/kinetic/cloudwatch_metrics_collector/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ad0dacd69d1bdc0b155d3d06dd5803ddd8ff8ac8dea22d9b6f61bc0a71170611";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/kinetic/cloudwatch_metrics_collector/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2d6819e4eac7ce7bc0b665a23942bc1e7a74155e017db04bf8adb0a8a0040bdd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "f018e2c886a9e1c5016f7b84854f2d073c668bef3b534a26ad6af9990466da15";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "41b8b16ee1dd78fa0066804f5691f80281f1233a2ad6ecfafd1bd8dd8c6ca72a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-msg-filters/default.nix
+++ b/distros/kinetic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-msg-filters";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "6015e319320d8aeab0fa5e15b9abcf98ed273876d12d16cf9b058ab52961b8a0";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "3c952d58aa9946fdd56606bcd96f68d4d21160056384b0505b6c67618f92e726";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-tools/default.nix
+++ b/distros/kinetic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-tools";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "14a74d0bb116451af43c73d98bb051dfcef22adb3d5a1998c84d02c9910e9bc1";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "1add1a92e88108a628f0760e7b4de9b0823c5ef803662980f3d7bf0069236083";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-usb/default.nix
+++ b/distros/kinetic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-usb";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "9c831ba342b4f9354f665ee45eb62f8b067b4a5a3c77e77a9b0262ba5ee161c7";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "dd8e538187735309aca85d346ea24b818f342782325c7f9a0ab57c593c62c3ec";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can/default.nix
+++ b/distros/kinetic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "b50f245fa693b0da4b11cf582ad696fd653573fb2e97aeb606d06f69bb190611";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "6a8f92d3c99c43f8f80119996e1fb438905b3dc9a3bbe6ebeba6e3dd438e989e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/earth-rover-localization/default.nix
+++ b/distros/kinetic/earth-rover-localization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographiclib, piksi-multi-rtk, piksi-rtk-msgs, robot-localization, roscpp, rospy, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-earth-rover-localization";
+  version = "1.2.0";
+
+  src = fetchurl {
+    url = "https://github.com/earthrover/earth_rover_localization-release/archive/release/kinetic/earth_rover_localization/1.2.0-0.tar.gz";
+    name = "1.2.0-0.tar.gz";
+    sha256 = "9e513c990da16d51f4c1b2c4f80097c9ec816509d8f03c65ab6329333a5bc3e6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geographiclib piksi-multi-rtk piksi-rtk-msgs robot-localization roscpp rospy std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Configuration for the EKF of the robot_localization package to use with the Earth Rover Open Agribot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -112,8 +112,6 @@ self: super: {
 
  arduino-daq = self.callPackage ./arduino-daq {};
 
- area-division = self.callPackage ./area-division {};
-
  arm-navigation-msgs = self.callPackage ./arm-navigation-msgs {};
 
  aruco = self.callPackage ./aruco {};
@@ -339,8 +337,6 @@ self: super: {
  cmake-modules = self.callPackage ./cmake-modules {};
 
  cmd-vel-smoother = self.callPackage ./cmd-vel-smoother {};
-
- cnn-bridge = self.callPackage ./cnn-bridge {};
 
  cob-3d-mapping-msgs = self.callPackage ./cob-3d-mapping-msgs {};
 
@@ -616,8 +612,6 @@ self: super: {
 
  cpr-multimaster-tools = self.callPackage ./cpr-multimaster-tools {};
 
- cpswarm-msgs = self.callPackage ./cpswarm-msgs {};
-
  create-dashboard = self.callPackage ./create-dashboard {};
 
  create-description = self.callPackage ./create-description {};
@@ -780,10 +774,6 @@ self: super: {
 
  dockeros = self.callPackage ./dockeros {};
 
- doosan-robot = self.callPackage ./doosan-robot {};
-
- doosan-robotics = self.callPackage ./doosan-robotics {};
-
  downward = self.callPackage ./downward {};
 
  dr-base = self.callPackage ./dr-base {};
@@ -796,11 +786,7 @@ self: super: {
 
  drone-wrapper = self.callPackage ./drone-wrapper {};
 
- dsr-control = self.callPackage ./dsr-control {};
-
  dsr-description = self.callPackage ./dsr-description {};
-
- dsr-example-cpp = self.callPackage ./dsr-example-cpp {};
 
  dsr-example-py = self.callPackage ./dsr-example-py {};
 
@@ -855,6 +841,8 @@ self: super: {
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
  dynpick-driver = self.callPackage ./dynpick-driver {};
+
+ earth-rover-localization = self.callPackage ./earth-rover-localization {};
 
  earth-rover-piksi = self.callPackage ./earth-rover-piksi {};
 
@@ -1426,8 +1414,6 @@ self: super: {
 
  hector-xacro-tools = self.callPackage ./hector-xacro-tools {};
 
- heron-control = self.callPackage ./heron-control {};
-
  heron-description = self.callPackage ./heron-description {};
 
  heron-desktop = self.callPackage ./heron-desktop {};
@@ -1704,6 +1690,8 @@ self: super: {
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
+ joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
  joint-states-settler = self.callPackage ./joint-states-settler {};
 
  joint-trajectory-action = self.callPackage ./joint-trajectory-action {};
@@ -1923,6 +1911,14 @@ self: super: {
  ksql-airport = self.callPackage ./ksql-airport {};
 
  kvh = self.callPackage ./kvh {};
+
+ kvh-geo-fog-3d = self.callPackage ./kvh-geo-fog-3d {};
+
+ kvh-geo-fog-3d-driver = self.callPackage ./kvh-geo-fog-3d-driver {};
+
+ kvh-geo-fog-3d-msgs = self.callPackage ./kvh-geo-fog-3d-msgs {};
+
+ kvh-geo-fog-3d-rviz = self.callPackage ./kvh-geo-fog-3d-rviz {};
 
  laptop-battery-monitor = self.callPackage ./laptop-battery-monitor {};
 
@@ -2188,6 +2184,8 @@ self: super: {
 
  mavlink = self.callPackage ./mavlink {};
 
+ mavros = self.callPackage ./mavros {};
+
  mavros-extras = self.callPackage ./mavros-extras {};
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
@@ -2324,8 +2322,6 @@ self: super: {
 
  moveit = self.callPackage ./moveit {};
 
- moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
-
  moveit-config-m0609 = self.callPackage ./moveit-config-m0609 {};
 
  moveit-config-m0617 = self.callPackage ./moveit-config-m0617 {};
@@ -2431,8 +2427,6 @@ self: super: {
  multi-jackal-base = self.callPackage ./multi-jackal-base {};
 
  multi-jackal-control = self.callPackage ./multi-jackal-control {};
-
- multi-jackal-description = self.callPackage ./multi-jackal-description {};
 
  multi-jackal-nav = self.callPackage ./multi-jackal-nav {};
 
@@ -2985,8 +2979,6 @@ self: super: {
  pointcloud-tools = self.callPackage ./pointcloud-tools {};
 
  pointgrey-camera-description = self.callPackage ./pointgrey-camera-description {};
-
- pointgrey-camera-driver = self.callPackage ./pointgrey-camera-driver {};
 
  polar-scan-matcher = self.callPackage ./polar-scan-matcher {};
 
@@ -4014,11 +4006,7 @@ self: super: {
 
  rr-openrover-basic = self.callPackage ./rr-openrover-basic {};
 
- rr-openrover-driver = self.callPackage ./rr-openrover-driver {};
-
  rr-openrover-driver-msgs = self.callPackage ./rr-openrover-driver-msgs {};
-
- rr-openrover-stack = self.callPackage ./rr-openrover-stack {};
 
  rr-swiftnav-piksi = self.callPackage ./rr-swiftnav-piksi {};
 
@@ -4071,10 +4059,6 @@ self: super: {
  rtt-kdl-conversions = self.callPackage ./rtt-kdl-conversions {};
 
  rtt-nav-msgs = self.callPackage ./rtt-nav-msgs {};
-
- rtt-pcl = self.callPackage ./rtt-pcl {};
-
- rtt-pcl-ros = self.callPackage ./rtt-pcl-ros {};
 
  rtt-ros = self.callPackage ./rtt-ros {};
 
@@ -4382,8 +4366,6 @@ self: super: {
 
  swarm-functions = self.callPackage ./swarm-functions {};
 
- swarmros = self.callPackage ./swarmros {};
-
  swri-console = self.callPackage ./swri-console {};
 
  swri-console-util = self.callPackage ./swri-console-util {};
@@ -4433,8 +4415,6 @@ self: super: {
  talos-description-inertial = self.callPackage ./talos-description-inertial {};
 
  tango-ros-messages = self.callPackage ./tango-ros-messages {};
-
- target-monitor = self.callPackage ./target-monitor {};
 
  task-allocation = self.callPackage ./task-allocation {};
 
@@ -4871,6 +4851,8 @@ self: super: {
  uuv-control-msgs = self.callPackage ./uuv-control-msgs {};
 
  uuv-control-utils = self.callPackage ./uuv-control-utils {};
+
+ uuv-cpc-sensor = self.callPackage ./uuv-cpc-sensor {};
 
  uuv-descriptions = self.callPackage ./uuv-descriptions {};
 

--- a/distros/kinetic/joint-state-publisher-gui/default.nix
+++ b/distros/kinetic/joint-state-publisher-gui/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
+buildRosPackage {
+  pname = "ros-kinetic-joint-state-publisher-gui";
+  version = "1.12.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher_gui/1.12.14-1.tar.gz";
+    name = "1.12.14-1.tar.gz";
+    sha256 = "9409f5c663a7ba11cf5f319c9459a7092fe29e1f18b3f9fabb9125246d2f7181";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher python-qt-binding rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a GUI tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/joint-state-publisher/default.nix
+++ b/distros/kinetic/joint-state-publisher/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, rospy, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-joint-state-publisher";
-  version = "1.12.13";
+  version = "1.12.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher/1.12.13-0.tar.gz";
-    name = "1.12.13-0.tar.gz";
-    sha256 = "cd9d0b495a0c98a0fc9f354a1d8c1895c04cfc3e33427e28b4b1c031c1ce1d71";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher/1.12.14-1.tar.gz";
+    name = "1.12.14-1.tar.gz";
+    sha256 = "6d3104ea5af5b2e187102eb6741c383b08c3bacee546eb1e54d48bbab63027e6";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ python-qt-binding rospy sensor-msgs ];
+  propagatedBuildInputs = [ rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "770e71b2407281590eb579f33a218920f957529ba637b4230309b09f00d5f8c7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e261a0b3130a08fd316a996741ce1351c5b07234360fd0ddc1c79356caa19368";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/kvh-geo-fog-3d-driver/default.nix
+++ b/distros/kinetic/kvh-geo-fog-3d-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, kvh-geo-fog-3d-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-kinetic-kvh-geo-fog-3d-driver";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/kinetic/kvh_geo_fog_3d_driver/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "634de4b086732a75c0cf67374c1d2473c0ae09dabcce7ef1e423b113fbde53e4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure geometry-msgs kvh-geo-fog-3d-msgs message-generation message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS driver for the KVH Geo Fog 3D INS family of systems.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/kvh-geo-fog-3d-msgs/default.nix
+++ b/distros/kinetic/kvh-geo-fog-3d-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-kvh-geo-fog-3d-msgs";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/kinetic/kvh_geo_fog_3d_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "edf792bd5f98e20b48ef0f065f45c0b735691760f69069347fa15b8e646e795e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin message-generation ];
+
+  meta = {
+    description = ''kvh_geo_fog_3d_msgs contains raw messages for the KVH GEO FOG 3D INS devices.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/kvh-geo-fog-3d-rviz/default.nix
+++ b/distros/kinetic/kvh-geo-fog-3d-rviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, kvh-geo-fog-3d-msgs, qt5, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-kinetic-kvh-geo-fog-3d-rviz";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/kinetic/kvh_geo_fog_3d_rviz/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "10121dd44b97bd8c939bea44be8a8cfda1035f193d8e168aebdbea4e32725444";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg roslint ];
+  propagatedBuildInputs = [ diagnostic-msgs kvh-geo-fog-3d-msgs rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The KVH GEO FOG 3D rviz plugin package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/kvh-geo-fog-3d/default.nix
+++ b/distros/kinetic/kvh-geo-fog-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kvh-geo-fog-3d-driver, kvh-geo-fog-3d-msgs, kvh-geo-fog-3d-rviz }:
+buildRosPackage {
+  pname = "ros-kinetic-kvh-geo-fog-3d";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/kinetic/kvh_geo_fog_3d/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "24ba7240b65125d53b3678655aadb5a371cb58b99927dc2e0fd2dbcd5a3a1dc0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ kvh-geo-fog-3d-driver kvh-geo-fog-3d-msgs kvh-geo-fog-3d-rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a driver node for KVH GEO FOG 3D INS sensors, messages, and rviz plugins.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/lex-common-msgs/default.nix
+++ b/distros/kinetic/lex-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-lex-common-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/kinetic/lex_common_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c0b17dece9e5e972eb566d7a92893ba405e66f38b11e6b6f3844e5876057aad2";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/kinetic/lex_common_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "06c01422063a3b321b1c8ac171c59f4a1bce7889d4cb8dc2eaf0d2c77f7403d4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/lex-node/default.nix
+++ b/distros/kinetic/lex-node/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, lex-common-msgs, roscpp, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-lex-node";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/kinetic/lex_node/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a99d4e508dce8223896a8d5d07db69e6f0803770bd9a50476727dc66cae876d5";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/kinetic/lex_node/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "dabda0eee28c7f38c38c7dc892b577af801136181d75a9fb7477dff7ee6856e7";
   };
 
   buildType = "catkin";
   checkInputs = [ gmock gtest rostest ];
-  propagatedBuildInputs = [ aws-common aws-ros1-common lex-common-msgs roscpp std-msgs ];
+  propagatedBuildInputs = [ aws-common aws-ros1-common lex-common lex-common-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/lms1xx/default.nix
+++ b/distros/kinetic/lms1xx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosconsole-bridge, roscpp, roscpp-serialization, roslaunch, roslint, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-lms1xx";
-  version = "0.1.6";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/lms1xx-release/archive/release/kinetic/lms1xx/0.1.6-0.tar.gz";
-    name = "0.1.6-0.tar.gz";
-    sha256 = "c14f2f6e88a9f791ec177ad64ea3a5013d52642ace02c6011c6a490652660abc";
+    url = "https://github.com/clearpath-gbp/lms1xx-release/archive/release/kinetic/lms1xx/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "79aa1e8c40c7b495c3c4ec71112d8e230e333985971d7ae5697c37fe577868b3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "e278c0d5e1e2d5324c9d0e58dbb0f4e81946c20ca9261cea2b796f6704ea4dad";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "17636a5b800223d6db33f1eca8a9280335a9920c8a9f82de6698895c810bd6fc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros/default.nix
+++ b/distros/kinetic/mavros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-mavros";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9774261f2a882ce0ff83d5ef9e1dd8bb2cf5de3c813897d0473bd7bba80aff1b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros-msgs message-runtime nav-msgs pluginlib rosconsole-bridge roscpp rospy sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MAVROS -- MAVLink extendable communication node for ROS
+    with proxy for Ground Control Station.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/kinetic/mcl-3dl-msgs/default.nix
+++ b/distros/kinetic/mcl-3dl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl-msgs";
-  version = "0.1.2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/kinetic/mcl_3dl_msgs/0.1.2-0.tar.gz";
-    name = "0.1.2-0.tar.gz";
-    sha256 = "9c81bd8e59eee4a8fd13e46a3f64c094f347d51256450363716ab873720d7526";
+    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/kinetic/mcl_3dl_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d6a213691f7fa4a1723ae1780d481d6fff067769d8765ffc145fbc903c07cec8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.1.7-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "cf9d7fbdfc1f04cabcd71bec364f2ea4026a34d5d684d34a5b70d1ffa41cc3f3";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "4f61dab68e34353ba9459010117a356d68f043c87ccab71943e61567c5fa0ab6";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ eigen geometry-msgs mcl-3dl-msgs nav-msgs pcl-ros roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs mcl-3dl-msgs nav-msgs pcl-ros roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d0fcb6a630e92ebd0ed05f2b5cb468c239a31cb0f457c7bd958f98c2bfc2615f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b0874ea47211cc46ff3711062bfe064a551c9e023fbf16ee29ed7aa6a673b8b0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "79997b6a14fd0ecd2d6b03930adddced48fa37c6a6124584180be218e8e27ecc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "298c40a7247ed4ad39eae32ea3e41b2e0b4ea89d545ada51f81ce2d70bb6a030";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d73d93b1089cc9fa0c4b9a791421e0e0ec98dec42a94c40a82e4e2dc1dd0cd27";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "bedde9b8a707f299605c7f5d430f78c574dfc337cbdd736d7d8677a0c90232d8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a661fbdaa03d7b702c59ba1706691bdd0eee5dc530ff2dd7e76a8fb1beaae649";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "855c42a01f4d816c95cee5b4a0b99f54affef169525044612f4ad69f1d41c176";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6e24b06bff42661b787af0327aa37c35ffca9d63815847327666d8cc8bb144c9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "df4acbef4a90fa9adc43059f8ae1d8672584e63c8bf69a4dea9ac5a3120cdfc9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "fbd74408bea457349ae76f3881be326f59bc566a5dc8e6c29100c6d781e9f576";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e618ae94739594bbcf7b48ec5550676a1988832d96e0092f302470d973e35afa";
   };
 
   buildType = "catkin";
-  checkInputs = [ nav-msgs roslint rostest ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/sbg-driver/default.nix
+++ b/distros/kinetic/sbg-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-sbg-driver";
-  version = "2.0.0-r1";
+  version = "1.1.7";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/kinetic/sbg_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2847883b08f3cbf6d6c1563ae00b3765dcc2a5a416e8e41d001cc03d452326de";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/kinetic/sbg_driver/1.1.7-0.tar.gz";
+    name = "1.1.7-0.tar.gz";
+    sha256 = "6ed1e97b68eef62f702922cbeb80dad354ae1fb1f173884be4b2bb427f8f054b";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules message-generation ];
+  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ geometry-msgs message-runtime roscpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/toposens-description/default.nix
+++ b/distros/kinetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "7514e02924b8b431b2a8bd54da65e63e3716ae8b2cb83a7ab2a019ef8a25168e";
+    sha256 = "08965d97b9d26caf879bad0fe9cc1ad6d99b333073ba68854fc5b2cdcb4c2292";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-driver/default.nix
+++ b/distros/kinetic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "48cbc6ef56b9f66da4344a0511aca4bd0b7764b9de7e5c5748ced40e5054504b";
+    sha256 = "e2e68162c95c18c83593438a36931cdd74345cd138d00b373bbe4a0a66c019e0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-markers/default.nix
+++ b/distros/kinetic/toposens-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-markers";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "122966fc03468f9ac3c96497700ba97223c53878e43c48187eb098d99b3d861d";
+    sha256 = "0e09e6b1620ffc93de23668504e4cc5209f9500d7206b7b77bdc5ba1813c125f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-msgs/default.nix
+++ b/distros/kinetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "913b7d55d0e40d501e64dee5a565c71652ece7e70cf18aa5c3e820c4cc03c3a1";
+    sha256 = "a02526831c6c1f0a91b1aaf589d923b48e4cf7d36edb16b4995ada9de6f810f4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-pointcloud/default.nix
+++ b/distros/kinetic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-pointcloud";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "974631470d3d0eb46536435f7afc2836e33e4b478449e38c69a00c8a676f5cea";
+    sha256 = "aa738820c18685d6f8c4e7f8074eb0ae8e5c867e2fde868ff755f5af4dc4bc69";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime pcl-ros roscpp rospy tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp rospy tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-sync/default.nix
+++ b/distros/kinetic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-sync";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "58b17fa7ab219312c0600a3b35279cd4abc7bc8fd712a0b4f75b7b2a6cb621d1";
+    sha256 = "a63d09817cca354422d86fffb7ff0e34364db714de6760977ad436f075d2ad9a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens/default.nix
+++ b/distros/kinetic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-kinetic-toposens";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "59d950c08bb50f93856a6a47b7a55293b5ea279990f8db39210dd16c793c068e";
+    sha256 = "51a4861b1b81bebe3f85138050ca1cdd3867b1c849b17d6f821b8c2390cee628";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "baa90c1ed834a5e980acebcf6af3abf713a2f446b7e78e48395512b6be0c9b1a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "58aedd635103fc5764f2383c1c1780f5afa5de46fab78cc1bb2ca4d347336ac1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "13cfb6efa609388eea9f1328b44d362321debc0a41ffad01735f73436f4c047a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "230e2313146f9e63d9672d4d29315c2921fab6cbcfbf3a76a689cb7a96b63b18";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/uuv-cpc-sensor/default.nix
+++ b/distros/kinetic/uuv-cpc-sensor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographiclib, geometry-msgs, nav-msgs, roscpp, sensor-msgs, std-msgs, tf2-ros, uuv-plume-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-uuv-cpc-sensor";
+  version = "0.3.1";
+
+  src = fetchurl {
+    url = "https://github.com/uuvsimulator/uuv_plume_simulator-release/archive/release/kinetic/uuv_cpc_sensor/0.3.1-0.tar.gz";
+    name = "0.3.1-0.tar.gz";
+    sha256 = "71e72a08872eccacb2d66d1a32c0523439362aa8bd8c511f7f792dc782ab2602";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ geographiclib roscpp tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs sensor-msgs std-msgs uuv-plume-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The uuv_cpc_sensor package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/uwsim-osgocean/default.nix
+++ b/distros/kinetic/uwsim-osgocean/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, fftw, libGL, libGLU, openscenegraph }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, fftw, fftwSinglePrec, libGL, libGLU, openscenegraph }:
 buildRosPackage {
   pname = "ros-kinetic-uwsim-osgocean";
   version = "1.0.3";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ boost catkin fftw libGL libGLU openscenegraph ];
+  propagatedBuildInputs = [ boost catkin fftw fftwSinglePrec libGL libGLU openscenegraph ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/astuff-sensor-msgs/default.nix
+++ b/distros/melodic/astuff-sensor-msgs/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-astuff-sensor-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/astuff_sensor_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "91f67f406cc09d6509d9639f61822a74c8ee42c17b423a06f21616576cd349ff";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/astuff_sensor_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "9e66ef493c6ad8152a2b2ac9f4d36f7d09f20ed5e83ee66f335e171bd27a93c8";
   };
 
   buildType = "catkin";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ delphi-esr-msgs delphi-srr-msgs derived-object-msgs ibeo-msgs kartech-linear-actuator-msgs mobileye-560-660-msgs neobotix-usboard-msgs pacmod-msgs radar-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/axis-camera/default.nix
+++ b/distros/melodic/axis-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager-py, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-axis-camera";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/axis_camera-release/archive/release/melodic/axis_camera/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "bfd2688c55b31c7c44318a4698f1de8bed6b5864367a9bb56d4c71ecfbdb5e0c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ camera-info-manager-py dynamic-reconfigure geometry-msgs message-runtime rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Python ROS drivers for accessing an Axis camera's MJPG
+    stream. Also provides control for PTZ cameras.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/cloudwatch-metrics-collector/default.nix
+++ b/distros/melodic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gmock, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-collector";
-  version = "2.1.1-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "765bfbb06471515deaa6dc40b39f426ef386774cf658a7b9afe356cfa75e2ca2";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e42cf30115b38b5976b736aaaa0e00e27c69ef6e6086e61eb1dc91f42630691a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "0e699602e776d38a98f69c67a28cde32d352ef5534272975c6355230daf0dfb7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "2d9fa6ea0715f39b983a46eb04511fa02027dc5a42e0bde950ed3a07edf4c5a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-msg-filters/default.nix
+++ b/distros/melodic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-msg-filters";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "042a76185f2ede3e557deb37f3dad0b56eaa8f7e25e5fa31c4d333e16c3ec082";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "2df46f943fa38c264b690f4594fb684e248d51211ec3ed2ae14136f0921ad755";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-tools/default.nix
+++ b/distros/melodic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-tools";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "164f92e63ab8188d83e4107e9cb19fdf9db3c96a44282ffb85833bc0c58bfb98";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "1c325db543acea3122c9bdafaa5fee0ce376e86745a8aad8e1dec77b80b601b9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-usb/default.nix
+++ b/distros/melodic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-usb";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "e664af652ae15f28732366c4ced5ee7d6cdb7e16183a5fec6d37c35856515013";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "a8ac02105c449255edbf91a2842f574db30ec2b83afbc5ee3dcccd04b63f336c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can/default.nix
+++ b/distros/melodic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can";
-  version = "1.0.12";
+  version = "1.0.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.12-0.tar.gz";
-    name = "1.0.12-0.tar.gz";
-    sha256 = "db45e27927b4142df69eb0748d76e39125e9c76bae491a84fc04f8aa9e7528aa";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.14-1.tar.gz";
+    name = "1.0.14-1.tar.gz";
+    sha256 = "8a966644b2a0f92d008f569b882aba5c266269f89a34ccaf4090507e071e65ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/delphi-esr-msgs/default.nix
+++ b/distros/melodic/delphi-esr-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-esr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_esr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "72672fb148635e3f817ca5ee1c5b6374ab20470bd9275a8de72a87da26c25888";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_esr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "92e4d1b61fe7b3658dcf55643dacbbf5594b53a51d5868a36776fcabd08f1704";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/delphi-mrr-msgs/default.nix
+++ b/distros/melodic/delphi-mrr-msgs/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-mrr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_mrr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "0f47230b42a53123e4f4a38eba9c775e8388bd3d04350273601fbe9988df40a6";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_mrr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e39cbf4c8107a205996d98997f167513c81f5b2f364875b033213c438523ab28";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''Message definitions for the Delphi MRR'';
-    license = with lib.licenses; [ gpl3 ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/delphi-srr-msgs/default.nix
+++ b/distros/melodic/delphi-srr-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-srr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_srr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "86a2a9e1e5dbdebd87011a95f0ae7b631a62638f0117a009a7f6159833a285e7";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_srr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d5848c18dad69762d5f942df492639043c6aa1347b87c4ff8d1348243db0334f";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/derived-object-msgs/default.nix
+++ b/distros/melodic/derived-object-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, radar-msgs, shape-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, radar-msgs, ros-environment, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-derived-object-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/derived_object_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "5b5450bf1c0968aa5b7f6190cb26b07b11563d0041e410d322ceff66567b5a23";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/derived_object_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "56782e3b607e2f56060747ae3328ca771620484e361386a58328aff21e97c420";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime radar-msgs shape-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-drone-wrapper";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7c159d672c49e7721c1c1f106741aaabddedd8ae8d47b7abb52b1ff22bef5f37";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge gazebo-ros geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The drone_wrapper package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -136,6 +136,8 @@ self: super: {
 
  aws-ros1-common = self.callPackage ./aws-ros1-common {};
 
+ axis-camera = self.callPackage ./axis-camera {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bagger = self.callPackage ./bagger {};
@@ -623,6 +625,8 @@ self: super: {
  driver-base = self.callPackage ./driver-base {};
 
  driver-common = self.callPackage ./driver-common {};
+
+ drone-wrapper = self.callPackage ./drone-wrapper {};
 
  dwa-local-planner = self.callPackage ./dwa-local-planner {};
 
@@ -1236,6 +1240,8 @@ self: super: {
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
+ joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
  joint-states-settler = self.callPackage ./joint-states-settler {};
 
  joint-trajectory-action = self.callPackage ./joint-trajectory-action {};
@@ -1517,6 +1523,8 @@ self: super: {
  mav-planning-msgs = self.callPackage ./mav-planning-msgs {};
 
  mavlink = self.callPackage ./mavlink {};
+
+ mavros = self.callPackage ./mavros {};
 
  mavros-extras = self.callPackage ./mavros-extras {};
 
@@ -2680,6 +2688,8 @@ self: super: {
 
  rqt-dep = self.callPackage ./rqt-dep {};
 
+ rqt-drone-teleop = self.callPackage ./rqt-drone-teleop {};
+
  rqt-ez-publisher = self.callPackage ./rqt-ez-publisher {};
 
  rqt-graph = self.callPackage ./rqt-graph {};
@@ -3014,6 +3024,8 @@ self: super: {
 
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
+ tf2-server = self.callPackage ./tf2-server {};
+
  tf2-tools = self.callPackage ./tf2-tools {};
 
  tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
@@ -3257,6 +3269,8 @@ self: super: {
  uuv-world-ros-plugins-msgs = self.callPackage ./uuv-world-ros-plugins-msgs {};
 
  uvc-camera = self.callPackage ./uvc-camera {};
+
+ uwsim = self.callPackage ./uwsim {};
 
  uwsim-bullet = self.callPackage ./uwsim-bullet {};
 

--- a/distros/melodic/geometry2/default.nix
+++ b/distros/melodic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-melodic-geometry2";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/geometry2/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "5374628e91d1625a9ee267b484d77b7672b3fa9ea1bd1e3ebb9660e0e1d4fcba";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/geometry2/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "077b18d3f1afdc72a99c3fb4e14168da26d82e4ae2e5b18ef90960e187209140";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ibeo-msgs/default.nix
+++ b/distros/melodic/ibeo-msgs/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ibeo-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/ibeo_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "dea8e5394662faf24cdc6a29a2d03de48952bf5000498f87110a5735c413e2f2";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/ibeo_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "6ac11a7e60287acc8f6840aed34b682da8a0b70e95a41e27b886fe50c3590f0b";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Package containing messages for Ibeo sensors.'';
+    description = ''The ibeo_msgs package'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/joint-state-publisher-gui/default.nix
+++ b/distros/melodic/joint-state-publisher-gui/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-joint-state-publisher-gui";
+  version = "1.12.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher_gui/1.12.14-1.tar.gz";
+    name = "1.12.14-1.tar.gz";
+    sha256 = "702d43d0986b4f6dca2ada79959c1781854bbba5935bc188c3fb581e3c0c210e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher python-qt-binding rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a GUI tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/joint-state-publisher/default.nix
+++ b/distros/melodic/joint-state-publisher/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, rospy, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-publisher";
-  version = "1.12.13";
+  version = "1.12.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher/1.12.13-0.tar.gz";
-    name = "1.12.13-0.tar.gz";
-    sha256 = "47bcd5c3c46ffd2d73ee0910bf584a3a23be56e2e423f3849b8771e55fe6fe8e";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher/1.12.14-1.tar.gz";
+    name = "1.12.14-1.tar.gz";
+    sha256 = "b2c30af5afd1e6796feb427ae60526e4485a3dfc565502814bed9bdf73a71e14";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ python-qt-binding rospy sensor-msgs ];
+  propagatedBuildInputs = [ rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "66286061ac94a61646f56437365cba42be0c1ff90be52db2d40c018024952689";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "c14055fa9c95d7c4d5215d97f0774b77d94d8f659903e9b738ef009142c04e6b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kartech-linear-actuator-msgs/default.nix
+++ b/distros/melodic/kartech-linear-actuator-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kartech-linear-actuator-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/kartech_linear_actuator_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "be518d78afb13fdaac8bdaf0da50fcafa371660bfe03e81c4e5e231d88732d5c";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/kartech_linear_actuator_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "33a0021ae7939c2452a3d4df3387a268b031676108a9f9bf2fe0b65b4938654d";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/lex-common-msgs/default.nix
+++ b/distros/melodic/lex-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-common-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "1379689a550b1cce87b3fb444add83140f2fcd085848da18b85dbc1f2ab772eb";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_common_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ca665d382b0694fc69c410c9b474bffebf278025ac46ac6554488870e94b23c8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lex-node/default.nix
+++ b/distros/melodic/lex-node/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, lex-common-msgs, roscpp, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-node";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "117cf4ce5de564b0b5bded63277f07ee0a9da28df13fb8750181640ccd1a358e";
+    url = "https://github.com/aws-gbp/lex_node-release/archive/release/melodic/lex_node/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "24375a02bbf5b57fa1fb9765d43c4cbcf76f7c14e3f250369a738f023ab773e6";
   };
 
   buildType = "catkin";
   checkInputs = [ gmock gtest rostest ];
-  propagatedBuildInputs = [ aws-common aws-ros1-common lex-common-msgs roscpp std-msgs ];
+  propagatedBuildInputs = [ aws-common aws-ros1-common lex-common lex-common-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "04ca1df9af7989f1947959e135da1066ae34049fea952ee80934c44ab602ccf4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e2a59ec8b52babf5970381d2e11827655a19aa1871ef4a7d1ba44d1243c2d4ed";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mavros";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "49bd5f9a85b659dd5d83af8c492a66393951adeca91f3d95884fb36cdf38976e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros-msgs message-runtime nav-msgs pluginlib rosconsole-bridge roscpp rospy sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MAVROS -- MAVLink extendable communication node for ROS
+    with proxy for Ground Control Station.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/melodic/mcl-3dl-msgs/default.nix
+++ b/distros/melodic/mcl-3dl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl-msgs";
-  version = "0.1.2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/melodic/mcl_3dl_msgs/0.1.2-0.tar.gz";
-    name = "0.1.2-0.tar.gz";
-    sha256 = "d946568df0327384e9e5e2304964454753889b4f703096a17d6d94795e64ce8a";
+    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/melodic/mcl_3dl_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ffce8cd5dfce7939118c69b6e47b65822d52589ad14a0a0de78be29b2d68badf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.1.7-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "e88356d9a2d3a1f2e3767277c860ab148053c3bf0203e61d55b8be136e887329";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d37d2a898ff0abb78d6804b27e866f061a9dedfe77ae39cdb9fd313274398817";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ eigen geometry-msgs mcl-3dl-msgs nav-msgs pcl-ros roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs mcl-3dl-msgs nav-msgs pcl-ros roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mobileye-560-660-msgs/default.nix
+++ b/distros/melodic/mobileye-560-660-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mobileye-560-660-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/mobileye_560_660_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "8b04f0cb7b653492bdffead10bf58a81273782d2c80128de999cad8a460c2f2e";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/mobileye_560_660_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "235c48b33b96b63d5bd8a8cb31ca5089759418df563d823390d2b6a963b160b9";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/neobotix-usboard-msgs/default.nix
+++ b/distros/melodic/neobotix-usboard-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-neobotix-usboard-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/neobotix_usboard_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "a85796618e8e9b7092aff7b93ed2c83becbf7f6ad4ba74fdd2afacdee2f800bf";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/neobotix_usboard_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "5d0e86a2a5dfeaf650ce7b3f799e9166ff9a7646b38fee46484bc430a31b6748";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "010ffaadf09621117a09475dff0c1c3b539e374d8525d45166e9189eba0d4a09";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "b1564cd915edd3d8ebe2e401008d6a42d7d6a0f4a99ac47d52142c342d09200b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "02a87a3a946c5f39bc38cf1262b245cb4cdfae695a028190b5334feb8986eb3f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fbbff504282b2619c6c850402ccbf3dcbc44c087068967fe1512b2d33b7b5450";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "9270e3492e52ce027cb051ba696e717387f5307c6ef9797568886d675eb5fb6c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ae7f64b299afde87337849bfa4b80050aa974c66fe8c7cfa6fa76feba89ceba4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "05e2b49e95d1c44b8a34c06ee580c24e9e8cfe82482ce740c6463ebddc08abab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "4eed7fb44c617182eb73057665fd41a0dcfaefe77982dcd9dbfcccf7cceee42e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pacmod-msgs/default.nix
+++ b/distros/melodic/pacmod-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pacmod-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/pacmod_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "cfdcb09b275da8304f367682c9d46fb3f02008e741a8634b67fd235f443c0a08";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/pacmod_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "3bf0ce0f3c1971b85a0af45522044352ea6f6e5b1baa313563cc8fc035536eb6";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "7c644d3731fe4d60d29eba882776481384dfa6087ae764d06dd025a156ef379c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e6ecc99d856c7f5ac4de1d873055f315e57516c3e5705e0fa992206a019b2b9b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan/default.nix
+++ b/distros/melodic/psen-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, roscpp, rostest, rosunit, rviz, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0dcd41292fa61e67b34cb9a059f344854be3deaedac08dfec6d3adc2ec8fc97d";
+    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f24ba5fd7ac6e48fc8c3127529b15b5f664d7d6db414c608ad628aaf9fb785fc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/radar-msgs/default.nix
+++ b/distros/melodic/radar-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-radar-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/radar_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "ef32eb400ff896750907c99abf7c31091f742b43a1bd011b35c15ee14deb5304";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/radar_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "637348f9732137f78066d3b40d49e04da010f5d928c12754157f4b9fb0364919";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rqt-drone-teleop";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9ab0e2bbfa0d684dda14e9becf829a7d7383f9264771a2223494ff5c5e27b068";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A common drone teleop interface for all drone exercises in the JdeRobot Robotics Academy'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "df80c0602a39659b9c41ae4b840a290d3f537e138f209d6a3872d30f5272244c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "14ff1dcbeee2ca5a68f9fcb968fd366ebd619f00b10b3c547c93454f3687b443";
   };
 
   buildType = "catkin";
-  checkInputs = [ nav-msgs roslint rostest ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/tf2-bullet/default.nix
+++ b/distros/melodic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-bullet";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_bullet/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "0cd02f568c25969428c38c409badfab9ab5b1a16598bc029f7de133b5938943b";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_bullet/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "2cb1d1e6d4ba180010c3f53ac138ba147ef4fb2c037d1b76be5cfb7d60ecd8e8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-eigen/default.nix
+++ b/distros/melodic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-eigen";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_eigen/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "635b0400d430496ff935616aba342c9d1481ff6c01689d8b07f4e8c7837ddddc";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_eigen/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "0097c690bd551d83154cc551b7d50439d86e8acda2bc4ebc307d1157cdf8c24d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-geometry-msgs/default.nix
+++ b/distros/melodic/tf2-geometry-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python-orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl, python-orocos-kdl, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-geometry-msgs";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_geometry_msgs/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "b660accdb1497e291e5bbfce2746f3da5da2b072acad53d40afb03fe6eb3d91c";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_geometry_msgs/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "f1516df538999a5fb7cb8eeaf71636c9572bba758adac8cdafbf5446918b7bbc";
   };
 
   buildType = "catkin";
-  checkInputs = [ ros-environment rostest ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ geometry-msgs orocos-kdl python-orocos-kdl tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/tf2-kdl/default.nix
+++ b/distros/melodic/tf2-kdl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, ros-environment, rostest, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, orocos-kdl, rostest, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-kdl";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_kdl/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "092567486d57feaad61f7b83432dcbd0b3450b189fcc74ec121d71cb57f1edbc";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_kdl/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "af0a21267f7ff0d435f5b54a3b55575e399daaf75ed8e01f09906e1b9af018cf";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  checkInputs = [ ros-environment rostest ];
+  checkInputs = [ rostest ];
   propagatedBuildInputs = [ eigen orocos-kdl tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/tf2-msgs/default.nix
+++ b/distros/melodic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
 buildRosPackage {
   pname = "ros-melodic-tf2-msgs";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_msgs/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "e688a6782f1f34bbd114c600c6cf3f569cebf04e0175981ce07546a5d3f1fc0e";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_msgs/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "27ecf00eef462615bab0dd0ff5232f6aaad8712e79bbf5912c008705f27c1d5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-py/default.nix
+++ b/distros/melodic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-tf2-py";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_py/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "949ec60f60bd8d454949978aa90e7358e18c5e89d4c5ba297162734f051097dd";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_py/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "24fc32a89eb1f6714d2f05c138c5d85741aabe819fc18475e63564aa0e2c388b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-ros/default.nix
+++ b/distros/melodic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-filters, roscpp, rosgraph, rospy, rostest, std-msgs, tf2, tf2-msgs, tf2-py, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-tf2-ros";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_ros/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "542cfe5dae5ea30237dedd044ed957a87fe9dc77b6a35600654a724c84adced2";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_ros/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "f5ea730b28e1668228c151fec493a768164843aa867770570c93ba3dcbda2d0f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-sensor-msgs/default.nix
+++ b/distros/melodic/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, python-orocos-kdl, rospy, rostest, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-sensor-msgs";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_sensor_msgs/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "f73e69b735c5c8b0bae8303e9f56ab887becb58c59d7a708eb4d5a8cf6ec8185";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_sensor_msgs/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "1a5247c2cfec650cb26758f587e6af12e90b0a99749eb861813ab39f83c7b2e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-server/default.nix
+++ b/distros/melodic/tf2-server/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-tf2-server";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c3d426d0010cb58736fe7bb5cca14fea50eea2dcb2e6e60d92218bb5f222689f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ gtest rostest tf ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime roscpp rospy tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TF2 server that can provide transforms over separate TF topics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tf2-tools/default.nix
+++ b/distros/melodic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-tools";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_tools/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "f38f0bd20aeeaf8a353fc1e76c511d1a0aa9973772412911f012c9c046cdbfcf";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2_tools/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "c474f792ecac52bec866f11bb705444141ea38f2e9f23fc1513307a4681ef724";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2/default.nix
+++ b/distros/melodic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, geometry-msgs, rostime, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-tf2";
-  version = "0.6.6-r1";
+  version = "0.6.5";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "dce6877a97b38551633d530e72b90ed18a3db6701e4e90ca93673c8e7336b16c";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/melodic/tf2/0.6.5-0.tar.gz";
+    name = "0.6.5-0.tar.gz";
+    sha256 = "f6776b600f397998cef387bfa57b6ad3e1e396f7a0015521ba7389ce2ca211c4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-description/default.nix
+++ b/distros/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "230a1079f3670501c9d1882cde91caed576760d81e0999f53cbcb9024c5184b4";
+    sha256 = "112ed1eba38d1bf762b10543732ab9d935d3186642dd5921e73f6fbb12431483";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-driver/default.nix
+++ b/distros/melodic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "2dde23232c45363f4323046520dfc7f4af273c3d55d2b8019853904b3842c3df";
+    sha256 = "350f81e9f95eb1cb3ae1d689dcf6223c7340ea12269eb5f14e0be8750cde254b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-markers/default.nix
+++ b/distros/melodic/toposens-markers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "29bc699a2f35279cd898997122cb404f6e362cf0cf3f1be6e046b7352a40c6ac";
+    sha256 = "482df6310904fd6516003072e431e0286427477b8725e1ed24b992b45929c29c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-msgs/default.nix
+++ b/distros/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "465af17d2a36bffa74b571fbb761ef3d33288398edd0676def469795c7ae5393";
+    sha256 = "5da086b2b490c2bf38c22991b34a36b7591e236967ee2110efe3818b11a7229d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-pointcloud/default.nix
+++ b/distros/melodic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rospy, rostest, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "4211f8fd0f4d0430de1ddf254337f0d3a1d6f33b6cf4764087db990dd2e20613";
+    sha256 = "011183a2f287c032f442e55d72f896fc89a0d29b2241ea2c982e3649033a71b1";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime pcl-ros roscpp rospy tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp rospy tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-sync/default.nix
+++ b/distros/melodic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "c4c06ac461a324ace265057eb911a34c301e4d207422cf4768ee27c76c4b0c02";
+    sha256 = "ba70fa2b4f8eacbd469632169a474161a9fed3b61ec9ce88796ca65376e748bb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens/default.nix
+++ b/distros/melodic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.1-1";
     name = "archive.tar.gz";
-    sha256 = "7a79d55f175374b8426cd02972c8830eef662b8bbf6bc9fb4fce4437c97f55a3";
+    sha256 = "466fd3be65d05e655636a384d183c04b0ad82a200c142e9e42fa4c38c34d3276";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "76782a69a652a1d29056580692484fd5d4aacea5ff424f5045d5ccf995c8f9d0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "8e3e1c8356df717c2abfa2b04c1e7829e2e9f6b03a85ce2ff1c9074a3b3e3a4f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.5.1-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "64e3766d747d5014e80b5a27345c1ea0b4c70dfeeb2fb7fb28aec459b27660dc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "44c324aca86ed578e712699f839f714a1c7465c8ae28dccfd1562a83efb748c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urdfdom-py/default.nix
+++ b/distros/melodic/urdfdom-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-urdfdom-py";
-  version = "0.4.1-r2";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.1-2.tar.gz";
-    name = "0.4.1-2.tar.gz";
-    sha256 = "c81a72fcf704300f049e61307f657235ae499bab71460f45d72fd54cacc53e40";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "c36e2459b2604566af7d5b9a212e156303a7a4094518dd62e2485d76a98b4db6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uwsim-osgocean/default.nix
+++ b/distros/melodic/uwsim-osgocean/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, fftw, libGL, libGLU, openscenegraph }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, fftw, fftwSinglePrec, libGL, libGLU, openscenegraph }:
 buildRosPackage {
   pname = "ros-melodic-uwsim-osgocean";
   version = "1.0.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ boost catkin fftw libGL libGLU openscenegraph ];
+  propagatedBuildInputs = [ boost catkin fftw fftwSinglePrec libGL libGLU openscenegraph ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/uwsim/default.nix
+++ b/distros/melodic/uwsim/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, dccomms-ros, fftw, fftwSinglePrec, geographiclib, geometry-msgs, image-transport, interactive-markers, kdl-parser, libGL, libGLU, libxmlxx, muparser, nav-msgs, openscenegraph, osg-interactive-markers, osg-markers, osg-utils, pcl-ros, pluginlib, resource-retriever, robot-state-publisher, roscpp, sensor-msgs, tf, underwater-sensor-msgs, urdf, uwsim-bullet, uwsim-osgbullet, uwsim-osgocean, uwsim-osgworks, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-uwsim";
+  version = "1.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/uwsim/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b10919106f1185052b450d190c70df712898a2d6902d3fe0d74e34a8e0065019";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost dccomms-ros fftw fftwSinglePrec geographiclib geometry-msgs image-transport interactive-markers kdl-parser libGL libGLU libxmlxx muparser nav-msgs openscenegraph osg-interactive-markers osg-markers osg-utils pcl-ros pluginlib resource-retriever robot-state-publisher roscpp sensor-msgs tf underwater-sensor-msgs urdf uwsim-bullet uwsim-osgbullet uwsim-osgocean uwsim-osgworks xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''UWSim is an UnderWater SIMulator for marine robotics research and development. UWSim visualizes an underwater virtual scenario that can be configured using standard modeling software. Controllable underwater vehicles, surface vessels and robotic manipulators, as well as simulated sensors, can be added to the scene and accessed externally through ROS interfaces. This allows to easily integrate the visualization tool with existing control architectures.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 444edcec26fe749682bc9e7bc8c8867d77eaf390.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *cv-bridge 2.1.3-r1 --> 2.1.4-r1*
* *image-geometry 2.1.3-r1 --> 2.1.4-r1*
* *vision-opencv 2.1.3-r1 --> 2.1.4-r1*

Eloquent Changes:
-----------------
* *ament-cmake-virtualenv 0.0.5-r6*
* *class-loader 1.4.0-r1 --> 1.4.1-r1*
* *cv-bridge 2.1.3-r1 --> 2.1.4-r1*
* *examples-tf2-py 0.12.4-r1 --> 0.12.5-r1*
* *geometry2 0.12.4-r1 --> 0.12.5-r1*
* *image-geometry 2.1.3-r1 --> 2.1.4-r1*
* *kobuki-ros 1.0.0-r2*
* *launch 0.9.5-r1 --> 0.9.6-r1*
* *launch-ros 0.9.4-r1 --> 0.9.5-r1*
* *launch-testing 0.9.5-r1 --> 0.9.6-r1*
* *launch-testing-ament-cmake 0.9.5-r1 --> 0.9.6-r1*
* *launch-testing-ros 0.9.4-r1 --> 0.9.5-r1*
* *launch-xml 0.9.5-r1 --> 0.9.6-r1*
* *launch-yaml 0.9.5-r1 --> 0.9.6-r1*
* *rcl 0.8.3-r1 --> 0.8.4-r1*
* *rcl-action 0.8.3-r1 --> 0.8.4-r1*
* *rcl-lifecycle 0.8.3-r1 --> 0.8.4-r1*
* *rcl-yaml-param-parser 0.8.3-r1 --> 0.8.4-r1*
* *rclcpp 0.8.3-r1 --> 0.8.4-r1*
* *rclcpp-action 0.8.3-r1 --> 0.8.4-r1*
* *rclcpp-components 0.8.3-r1 --> 0.8.4-r1*
* *rclcpp-lifecycle 0.8.3-r1 --> 0.8.4-r1*
* *rclpy 0.8.3-r1 --> 0.8.4-r1*
* *ros1-bridge 0.8.1-r4 --> 0.8.2-r1*
* *ros2action 0.8.6-r1 --> 0.8.7-r1*
* *ros2cli 0.8.6-r1 --> 0.8.7-r1*
* *ros2component 0.8.6-r1 --> 0.8.7-r1*
* *ros2interface 0.8.6-r1 --> 0.8.7-r1*
* *ros2launch 0.9.4-r1 --> 0.9.5-r1*
* *ros2lifecycle 0.8.6-r1 --> 0.8.7-r1*
* *ros2lifecycle-test-fixtures 0.8.6-r1 --> 0.8.7-r1*
* *ros2msg 0.8.6-r1 --> 0.8.7-r1*
* *ros2multicast 0.8.6-r1 --> 0.8.7-r1*
* *ros2node 0.8.6-r1 --> 0.8.7-r1*
* *ros2param 0.8.6-r1 --> 0.8.7-r1*
* *ros2pkg 0.8.6-r1 --> 0.8.7-r1*
* *ros2run 0.8.6-r1 --> 0.8.7-r1*
* *ros2service 0.8.6-r1 --> 0.8.7-r1*
* *ros2srv 0.8.6-r1 --> 0.8.7-r1*
* *ros2topic 0.8.6-r1 --> 0.8.7-r1*
* *rosidl-adapter 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-cmake 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-generator-c 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-generator-cpp 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-parser 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-typesupport-interface 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-typesupport-introspection-c 0.8.1-r1 --> 0.8.2-r1*
* *rosidl-typesupport-introspection-cpp 0.8.1-r1 --> 0.8.2-r1*
* *rviz-assimp-vendor 7.0.3-r1 --> 7.0.4-r1*
* *rviz-common 7.0.3-r1 --> 7.0.4-r1*
* *rviz-default-plugins 7.0.3-r1 --> 7.0.4-r1*
* *rviz-ogre-vendor 7.0.3-r1 --> 7.0.4-r1*
* *rviz-rendering 7.0.3-r1 --> 7.0.4-r1*
* *rviz-rendering-tests 7.0.3-r1 --> 7.0.4-r1*
* *rviz-visual-testing-framework 7.0.3-r1 --> 7.0.4-r1*
* *rviz2 7.0.3-r1 --> 7.0.4-r1*
* *tf2 0.12.4-r1 --> 0.12.5-r1*
* *tf2-eigen 0.12.4-r1 --> 0.12.5-r1*
* *tf2-geometry-msgs 0.12.4-r1 --> 0.12.5-r1*
* *tf2-kdl 0.12.4-r1 --> 0.12.5-r1*
* *tf2-msgs 0.12.4-r1 --> 0.12.5-r1*
* *tf2-py 0.12.4-r1 --> 0.12.5-r1*
* *tf2-ros 0.12.4-r1 --> 0.12.5-r1*
* *tf2-sensor-msgs 0.12.4-r1 --> 0.12.5-r1*
* *vision-opencv 2.1.3-r1 --> 2.1.4-r1*

Kinetic Changes:
----------------
* *cloudwatch-metrics-collector 2.1.1-r1 --> 2.2.0-r1*
* *costmap-cspace 0.5.1-r1 --> 0.6.0-r1*
* *dataspeed-can 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-msg-filters 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-tools 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-usb 1.0.12 --> 1.0.14-r1*
* *earth-rover-localization 1.2.0*
* *joint-state-publisher 1.12.13 --> 1.12.14-r1*
* *joint-state-publisher-gui 1.12.14-r1*
* *joystick-interrupt 0.5.1-r1 --> 0.6.0-r1*
* *kvh-geo-fog-3d 1.3.3-r1*
* *kvh-geo-fog-3d-driver 1.3.3-r1*
* *kvh-geo-fog-3d-msgs 1.3.3-r1*
* *kvh-geo-fog-3d-rviz 1.3.3-r1*
* *lex-common-msgs 2.0.1-r1 --> 2.0.2-r1*
* *lex-node 2.0.1-r1 --> 2.0.2-r1*
* *lms1xx 0.1.6 --> 0.1.7-r1*
* *map-organizer 0.5.1-r1 --> 0.6.0-r1*
* *mavros 1.0.0-r1*
* *mcl-3dl 0.1.7-r1 --> 0.2.0-r1*
* *mcl-3dl-msgs 0.1.2 --> 0.2.0-r1*
* *neonavigation 0.5.1-r1 --> 0.6.0-r1*
* *neonavigation-common 0.5.1-r1 --> 0.6.0-r1*
* *neonavigation-launch 0.5.1-r1 --> 0.6.0-r1*
* *obj-to-pointcloud 0.5.1-r1 --> 0.6.0-r1*
* *planner-cspace 0.5.1-r1 --> 0.6.0-r1*
* *safety-limiter 0.5.1-r1 --> 0.6.0-r1*
* *sbg-driver 2.0.0-r1 --> 1.1.7*
* *toposens 2.0.0-r1 --> 2.0.1-r1*
* *toposens-description 2.0.0-r1 --> 2.0.1-r1*
* *toposens-driver 2.0.0-r1 --> 2.0.1-r1*
* *toposens-markers 2.0.0-r1 --> 2.0.1-r1*
* *toposens-msgs 2.0.0-r1 --> 2.0.1-r1*
* *toposens-pointcloud 2.0.0-r1 --> 2.0.1-r1*
* *toposens-sync 2.0.0-r1 --> 2.0.1-r1*
* *track-odometry 0.5.1-r1 --> 0.6.0-r1*
* *trajectory-tracker 0.5.1-r1 --> 0.6.0-r1*
* *uuv-cpc-sensor 0.3.1*

Melodic Changes:
----------------
* *astuff-sensor-msgs 2.3.1 --> 3.0.1-r1*
* *axis-camera 0.3.0-r1*
* *cloudwatch-metrics-collector 2.1.1-r1 --> 2.2.0-r1*
* *costmap-cspace 0.5.1-r1 --> 0.6.0-r1*
* *dataspeed-can 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-msg-filters 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-tools 1.0.12 --> 1.0.14-r1*
* *dataspeed-can-usb 1.0.12 --> 1.0.14-r1*
* *delphi-esr-msgs 2.3.1 --> 3.0.1-r1*
* *delphi-mrr-msgs 2.3.1 --> 3.0.1-r1*
* *delphi-srr-msgs 2.3.1 --> 3.0.1-r1*
* *derived-object-msgs 2.3.1 --> 3.0.1-r1*
* *drone-wrapper 1.1.0-r1*
* *geometry2 0.6.6-r1 --> 0.6.5*
* *ibeo-msgs 2.3.1 --> 3.0.1-r1*
* *joint-state-publisher 1.12.13 --> 1.12.14-r1*
* *joint-state-publisher-gui 1.12.14-r1*
* *joystick-interrupt 0.5.1-r1 --> 0.6.0-r1*
* *kartech-linear-actuator-msgs 2.3.1 --> 3.0.1-r1*
* *lex-common-msgs 2.0.1-r1 --> 2.0.2-r1*
* *lex-node 2.0.1-r1 --> 2.0.2-r1*
* *map-organizer 0.5.1-r1 --> 0.6.0-r1*
* *mavros 1.0.0-r1*
* *mcl-3dl 0.1.7-r1 --> 0.2.0-r1*
* *mcl-3dl-msgs 0.1.2 --> 0.2.0-r1*
* *mobileye-560-660-msgs 2.3.1 --> 3.0.1-r1*
* *neobotix-usboard-msgs 2.3.1 --> 3.0.1-r1*
* *neonavigation 0.5.1-r1 --> 0.6.0-r1*
* *neonavigation-common 0.5.1-r1 --> 0.6.0-r1*
* *neonavigation-launch 0.5.1-r1 --> 0.6.0-r1*
* *obj-to-pointcloud 0.5.1-r1 --> 0.6.0-r1*
* *pacmod-msgs 2.3.1 --> 3.0.1-r1*
* *planner-cspace 0.5.1-r1 --> 0.6.0-r1*
* *psen-scan 1.0.2-r1 --> 1.0.3-r1*
* *radar-msgs 2.3.1 --> 3.0.1-r1*
* *rqt-drone-teleop 1.1.0-r1*
* *safety-limiter 0.5.1-r1 --> 0.6.0-r1*
* *tf2 0.6.6-r1 --> 0.6.5*
* *tf2-bullet 0.6.6-r1 --> 0.6.5*
* *tf2-eigen 0.6.6-r1 --> 0.6.5*
* *tf2-geometry-msgs 0.6.6-r1 --> 0.6.5*
* *tf2-kdl 0.6.6-r1 --> 0.6.5*
* *tf2-msgs 0.6.6-r1 --> 0.6.5*
* *tf2-py 0.6.6-r1 --> 0.6.5*
* *tf2-ros 0.6.6-r1 --> 0.6.5*
* *tf2-sensor-msgs 0.6.6-r1 --> 0.6.5*
* *tf2-server 1.0.3-r1*
* *tf2-tools 0.6.6-r1 --> 0.6.5*
* *toposens 2.0.0-r1 --> 2.0.1-r1*
* *toposens-description 2.0.0-r1 --> 2.0.1-r1*
* *toposens-driver 2.0.0-r1 --> 2.0.1-r1*
* *toposens-markers 2.0.0-r1 --> 2.0.1-r1*
* *toposens-msgs 2.0.0-r1 --> 2.0.1-r1*
* *toposens-pointcloud 2.0.0-r1 --> 2.0.1-r1*
* *toposens-sync 2.0.0-r1 --> 2.0.1-r1*
* *track-odometry 0.5.1-r1 --> 0.6.0-r1*
* *trajectory-tracker 0.5.1-r1 --> 0.6.0-r1*
* *urdfdom-py 0.4.1-r2 --> 0.4.2-r1*
* *uwsim 1.4.2-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] pointgrey_camera_driver
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] swarmros
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

