### PR TITLE
rosdistro sync, Fri Jan 31 12:38:34 2020

### DIFF
--- a/distros/dashing/astuff-sensor-msgs/default.nix
+++ b/distros/dashing/astuff-sensor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-dashing-astuff-sensor-msgs";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/astuff_sensor_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "622adf40fd95c3959705b66656cd620acca8a22231a35a1079face8311b5281a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment ];
+  propagatedBuildInputs = [ delphi-esr-msgs delphi-srr-msgs derived-object-msgs ibeo-msgs kartech-linear-actuator-msgs mobileye-560-660-msgs neobotix-usboard-msgs pacmod-msgs radar-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages specific to AStuff-provided sensors.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/dashing/costmap-converter-msgs/default.nix
+++ b/distros/dashing/costmap-converter-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-costmap-converter-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/costmap_converter-ros2-release/archive/release/dashing/costmap_converter_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "2abd489f2e371676dc61993cfd89930cd264df5bc0bf0d67aae908f74c475c0c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing message types for costmap conversion'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/costmap-converter/default.nix
+++ b/distros/dashing/costmap-converter/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, costmap-converter-msgs, cv-bridge, geometry-msgs, nav2-costmap-2d, pluginlib, rclcpp, tf2 }:
+buildRosPackage {
+  pname = "ros-dashing-costmap-converter";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/costmap_converter-ros2-release/archive/release/dashing/costmap_converter/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "32b0fc476708cbd34d0d01d75e36c43a6281d8d2880a56933b2c9148d2533e8c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ class-loader costmap-converter-msgs cv-bridge geometry-msgs nav2-costmap-2d pluginlib rclcpp tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A ros package that includes plugins and nodes to convert occupied costmap2d cells to primitive types.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/delphi-esr-msgs/default.nix
+++ b/distros/dashing/delphi-esr-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-delphi-esr-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_esr_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "c5fbeeae3284d8d4ca013b1dafd1579ddd24c85b1e938b81914d85c6a33e116c";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_esr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "1578811e78ecebdded1dbb09eda1259d1e20ca320964e3574e6d4299d0a5bb3d";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Message definitions for the Delphi ESR'';

--- a/distros/dashing/delphi-mrr-msgs/default.nix
+++ b/distros/dashing/delphi-mrr-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-delphi-mrr-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_mrr_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "f67852ebf501afcd7c44efe087e993aa2d8d2a935d9b0d6c65b646edf86dfcf1";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_mrr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "1f51086521a035c63399d7fb9e7ea0d5da9a2dc1fe15609ab8b17015ed8a0c37";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Message definitions for the Delphi MRR'';

--- a/distros/dashing/delphi-srr-msgs/default.nix
+++ b/distros/dashing/delphi-srr-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-delphi-srr-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_srr_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "4cef1816267d980d6b37d07c5f0f24e023e9ea686d78fb2c4daec16200b64a54";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/delphi_srr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "c6a4e3bd289113b51cc73fea0dc661f374eaf7dd8b7cce7de309844d0ba44165";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Message definitions for the Delphi SRR'';

--- a/distros/dashing/derived-object-msgs/default.nix
+++ b/distros/dashing/derived-object-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, radar-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, radar-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-derived-object-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/derived_object_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "712f19c204053eb543648508d1b827f93746346c1be10ed97945ad179ddb0ccb";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/derived_object_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7747a3dc69872f8129cafa20841b4299284602f6e179031dcabb1c8722017063";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs radar-msgs rosidl-default-runtime shape-msgs std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Abstracted Messages from Perception Modalities'';

--- a/distros/dashing/fmi-adapter-examples/default.nix
+++ b/distros/dashing/fmi-adapter-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmi-adapter, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-dashing-fmi-adapter-examples";
-  version = "0.1.5-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/dashing/fmi_adapter_examples/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "99fa8c81d94ca01518c54b89bac3592b76b0f88592b983ef57750409d8b59a44";
+    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/dashing/fmi_adapter_examples/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "a108d330b317cf8ae495245e3c0cfd79ccb92d30cf3a6efe294e4943882a9efd";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/fmi-adapter/default.nix
+++ b/distros/dashing/fmi-adapter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, fmilibrary-vendor, launch, launch-ros, launch-testing, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-fmi-adapter";
-  version = "0.1.5-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/dashing/fmi_adapter/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "b23081dda39b15640af630873356e1fd132983f9e710a44188357899768e98fb";
+    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/dashing/fmi_adapter/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "882c8da40eda002b618faf08fbd7e9122f5a5ca489288b3e7a3275a8a09857f8";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ fmilibrary-vendor ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing rcutils ];
   propagatedBuildInputs = [ launch launch-ros rcl-interfaces rclcpp rclcpp-components rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/dashing/fmilibrary-vendor/default.nix
+++ b/distros/dashing/fmilibrary-vendor/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, git }:
 buildRosPackage {
   pname = "ros-dashing-fmilibrary-vendor";
-  version = "0.1.0-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmilibrary_vendor-release/archive/release/dashing/fmilibrary_vendor/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f42c19d9641aa34e82fba8f8a737efa028f31aaa816afe7754f29eb4e278590e";
+    url = "https://github.com/boschresearch/fmilibrary_vendor-release/archive/release/dashing/fmilibrary_vendor/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "4de5e064258ae379d366cc8bf874f21b2d1f7bed1dc1d73b1f8c730b09ed55ef";
   };
 
   buildType = "catkin";
+  buildInputs = [ git ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -126,6 +126,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
+
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -193,6 +195,10 @@ self: super: {
  console-bridge-vendor = self.callPackage ./console-bridge-vendor {};
 
  control-msgs = self.callPackage ./control-msgs {};
+
+ costmap-converter = self.callPackage ./costmap-converter {};
+
+ costmap-converter-msgs = self.callPackage ./costmap-converter-msgs {};
 
  costmap-queue = self.callPackage ./costmap-queue {};
 
@@ -599,6 +605,8 @@ self: super: {
  osrf-testing-tools-cpp = self.callPackage ./osrf-testing-tools-cpp {};
 
  ouster-msgs = self.callPackage ./ouster-msgs {};
+
+ pacmod3 = self.callPackage ./pacmod3 {};
 
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 

--- a/distros/dashing/ibeo-msgs/default.nix
+++ b/distros/dashing/ibeo-msgs/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ibeo-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/ibeo_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "f3fc4ba83c4a42f47af165ba9f8d4df9bff547817358a1ce6126ca5490f18b52";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/ibeo_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "5bfb598dfc065b64788fc1af91fb167fcb882e7b5a0deff06d6c4013a6364e44";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Package containing messages for Ibeo sensors.'';
+    description = ''The ibeo_msgs package'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/dashing/kartech-linear-actuator-msgs/default.nix
+++ b/distros/dashing/kartech-linear-actuator-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-kartech-linear-actuator-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/kartech_linear_actuator_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "dadc3c49c1f47d24a1cfdd50323e5ac7a8b77eb982017485a9feb2f9487f0eee";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/kartech_linear_actuator_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d7b86425fcdda9eb906d4aa7a792b8da8a2be490723773254c4087255bfd9af4";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''The kartech_linear_actuator_msgs package'';

--- a/distros/dashing/mobileye-560-660-msgs/default.nix
+++ b/distros/dashing/mobileye-560-660-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-mobileye-560-660-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/mobileye_560_660_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "a79ff1bbbaa2429bf8d7745ee55aa0c42410fdaf31a3d05a37afd6d94be536ac";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/mobileye_560_660_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "5425246ee90b523b6ba6435851b0222aed375d50bf75eec47e0ac2a48de36ce9";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Message definitions for the Mobileye 560/660'';

--- a/distros/dashing/neobotix-usboard-msgs/default.nix
+++ b/distros/dashing/neobotix-usboard-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-neobotix-usboard-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/neobotix_usboard_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "8294ef1e6755b4619ab77dcf8a0f91ddbd7a4a297dbd3988756a651716eec199";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/neobotix_usboard_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "3d82b04442c0d35fdbe73206b5635bf7e457bba09bbb3e29e15f66c99150c8d9";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''neobotix_usboard package'';

--- a/distros/dashing/pacmod-msgs/default.nix
+++ b/distros/dashing/pacmod-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-pacmod-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/pacmod_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "8d3c53371755eb552b08cf5e4e80407b3279d5daf8d9a8d7eee0aaba7044150b";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/pacmod_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ef16cce219b65857d8229aed7d408dd618eee564867b133d1b0606b1bb0dcab3";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Message definition files for the PACMod driver'';

--- a/distros/dashing/pacmod3/default.nix
+++ b/distros/dashing/pacmod3/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, can-msgs, pacmod-msgs, rclcpp, rclcpp-components, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-pacmod3";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/pacmod3-release/archive/release/dashing/pacmod3/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "903fda537f50786c58a965a212b4519217a1679afbfd6a1cdd40928c05691719";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs pacmod-msgs rclcpp rclcpp-components std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''AutonomouStuff PACMod v3 Driver Package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/dashing/radar-msgs/default.nix
+++ b/distros/dashing/radar-msgs/default.nix
@@ -2,21 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-radar-msgs";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/radar_msgs/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "96fe2971bd3d43576f02e33ca8e0be13655249e207b228c255f0a01247f7a0de";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/dashing/radar_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "002f6d98435615ff68b95621e9b2851951d56d0b29ca7c567a5950318f768c8e";
   };
 
-  buildType = "ament_cmake";
-  checkInputs = [ ament-lint-common ];
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Generic Radar Messages'';

--- a/distros/dashing/tts-interfaces/default.nix
+++ b/distros/dashing/tts-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-dashing-tts-interfaces";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/tts-release/archive/release/dashing/tts_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ea2c475744c13bacdbcb227bec310950d235c971ba87c5330b64ac20cf49e1fa";
+    url = "https://github.com/aws-gbp/tts-release/archive/release/dashing/tts_interfaces/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "278759225665de9c9d1cc5e9aa2e9fc33b99ab78051590704ed3a0b13af532ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/costmap-converter-msgs/default.nix
+++ b/distros/eloquent/costmap-converter-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-costmap-converter-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/costmap_converter-ros2-release/archive/release/eloquent/costmap_converter_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "734517382100ace03f5109c3534687f1ca7a492beab2dfe1a413a08f6a1b51ed";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing message types for costmap conversion'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/costmap-converter/default.nix
+++ b/distros/eloquent/costmap-converter/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, costmap-converter-msgs, cv-bridge, geometry-msgs, nav2-costmap-2d, pluginlib, rclcpp, tf2 }:
+buildRosPackage {
+  pname = "ros-eloquent-costmap-converter";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/costmap_converter-ros2-release/archive/release/eloquent/costmap_converter/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "b7dd78631ee24fa0bd07f9fdc053bee9caab52e3422b313144b723a90e608698";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ class-loader costmap-converter-msgs cv-bridge geometry-msgs nav2-costmap-2d pluginlib rclcpp tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A ros package that includes plugins and nodes to convert occupied costmap2d cells to primitive types.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/fmi-adapter-examples/default.nix
+++ b/distros/eloquent/fmi-adapter-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmi-adapter, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-eloquent-fmi-adapter-examples";
-  version = "0.1.6-r1";
+  version = "0.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/eloquent/fmi_adapter_examples/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "0f333698c39e374f1f44c6746747a68cfe81a3201ef25ea21f0a656c757aeb72";
+    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/eloquent/fmi_adapter_examples/0.1.7-2.tar.gz";
+    name = "0.1.7-2.tar.gz";
+    sha256 = "1b7d09db16f2083ec7f5e5f9bbf44267d88f65a4e2f22fb38b63a3daf1f0d4b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/fmi-adapter/default.nix
+++ b/distros/eloquent/fmi-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, fmilibrary-vendor, launch, launch-ros, launch-testing, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-fmi-adapter";
-  version = "0.1.6-r1";
+  version = "0.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/eloquent/fmi_adapter/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "8d1de4e0a2eb1c8a82d574c31e75f72518aeb1febf1479839d192e1195fa12a4";
+    url = "https://github.com/boschresearch/fmi_adapter_ros2-release/archive/release/eloquent/fmi_adapter/0.1.7-2.tar.gz";
+    name = "0.1.7-2.tar.gz";
+    sha256 = "a5107a3807736f1460f26bc6f9f6836fd118e408af1db09d59a49e792026a7aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/fmilibrary-vendor/default.nix
+++ b/distros/eloquent/fmilibrary-vendor/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, git }:
 buildRosPackage {
   pname = "ros-eloquent-fmilibrary-vendor";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmilibrary_vendor-release/archive/release/eloquent/fmilibrary_vendor/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "3a6d01e743422b77756190a507e1f41e6133ebe591935cf97cbadf6cdd66b0bf";
+    url = "https://github.com/boschresearch/fmilibrary_vendor-release/archive/release/eloquent/fmilibrary_vendor/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "ca71005d9da2532676622d5194fbf8d1922458e9ce8677f17a57552ffc9d354f";
   };
 
   buildType = "catkin";
+  buildInputs = [ git ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -166,6 +166,10 @@ self: super: {
 
  control-msgs = self.callPackage ./control-msgs {};
 
+ costmap-converter = self.callPackage ./costmap-converter {};
+
+ costmap-converter-msgs = self.callPackage ./costmap-converter-msgs {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cross-compile = self.callPackage ./cross-compile {};
@@ -415,6 +419,8 @@ self: super: {
  launch-yaml = self.callPackage ./launch-yaml {};
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
+
+ libg2o = self.callPackage ./libg2o {};
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
@@ -923,6 +929,8 @@ self: super: {
  urdfdom-headers = self.callPackage ./urdfdom-headers {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
+
+ velocity-smoother = self.callPackage ./velocity-smoother {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/eloquent/libg2o/default.nix
+++ b/distros/eloquent/libg2o/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, libGL, libGLU, suitesparse }:
+buildRosPackage {
+  pname = "ros-eloquent-libg2o";
+  version = "2019.11.23-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/libg2o-release/archive/release/eloquent/libg2o/2019.11.23-4.tar.gz";
+    name = "2019.11.23-4.tar.gz";
+    sha256 = "f6f9b7c58d714f352fde9869161d54db868fa024adde88506eb0e74e6b4bcc11";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ eigen libGL libGLU suitesparse ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The libg2o library from http://openslam.org/g2o.html'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/py-trees-ros-interfaces/default.nix
+++ b/distros/eloquent/py-trees-ros-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-py-trees-ros-interfaces";
-  version = "2.0.2-r1";
+  version = "2.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros_interfaces-release/archive/release/eloquent/py_trees_ros_interfaces/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "4cc1b6e0379347b80c0ea3b086546122d86b4779dcb14dd207e557e9a1f6e8b5";
+    url = "https://github.com/stonier/py_trees_ros_interfaces-release/archive/release/eloquent/py_trees_ros_interfaces/2.0.3-2.tar.gz";
+    name = "2.0.3-2.tar.gz";
+    sha256 = "630bf9bf0d7ddeccb336026025b2b2080e3674108a9a8f1d78284532d9701356";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/velocity-smoother/default.nix
+++ b/distros/eloquent/velocity-smoother/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, geometry-msgs, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, ros2test }:
+buildRosPackage {
+  pname = "ros-eloquent-velocity-smoother";
+  version = "0.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/velocity_smoother-release/archive/release/eloquent/velocity_smoother/0.14.0-1.tar.gz";
+    name = "0.14.0-1.tar.gz";
+    sha256 = "6069d8a906a936bb642b1bc4bec812ac89afdff3ae7bc11e9f180324b40387ae";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.matplotlib ros2test ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rcl-interfaces rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Bound incoming velocity messages according to robot velocity and acceleration limits.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/astuff-sensor-msgs/default.nix
+++ b/distros/kinetic/astuff-sensor-msgs/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-kinetic-astuff-sensor-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/astuff_sensor_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "f537f00af14df34d02c8a67745a3ce7c39f50d0c862ba01d5a56fc9c37884846";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/astuff_sensor_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "be525b7f4483afa9ba544410ef3da5672ace83744cf27ce86ebc2d4de12a277d";
   };
 
   buildType = "catkin";
+  buildInputs = [ ros-environment ];
   propagatedBuildInputs = [ delphi-esr-msgs delphi-srr-msgs derived-object-msgs ibeo-msgs kartech-linear-actuator-msgs mobileye-560-660-msgs neobotix-usboard-msgs pacmod-msgs radar-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/chomp-motion-planner/default.nix
+++ b/distros/kinetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-chomp-motion-planner";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/chomp_motion_planner/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "0c24465ac6123e9c63cb9fb574bc129b798d5ba5d49b30cea45d87792f5785ff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/chomp_motion_planner/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "467b60dd67a5ed788fe3476b6b2b83ec4c2b5d99b2dff462d5b43139bf6a174a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-msg-filters/default.nix
+++ b/distros/kinetic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-msg-filters";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "3c952d58aa9946fdd56606bcd96f68d4d21160056384b0505b6c67618f92e726";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "a5c03ec73256b4998b53a84268e767a3d29e7798a9a87b87698b2cc02d6bf918";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-tools/default.nix
+++ b/distros/kinetic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-tools";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "1add1a92e88108a628f0760e7b4de9b0823c5ef803662980f3d7bf0069236083";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "2856ed287059e3419b3ce5f6cb58b7a4f37658ea40a7356625e245b345360c93";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-usb/default.nix
+++ b/distros/kinetic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-usb";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "dd8e538187735309aca85d346ea24b818f342782325c7f9a0ab57c593c62c3ec";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "81ee8019c72050458123c0491f199f42df0864668e76aa1a74733dacbd9ac647";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can/default.nix
+++ b/distros/kinetic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "6a8f92d3c99c43f8f80119996e1fb438905b3dc9a3bbe6ebeba6e3dd438e989e";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "d1b1c7623f4db15399b3f03f2ca32d14db310a088cc9bc21e08f32fba7cb218c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/delphi-esr-msgs/default.nix
+++ b/distros/kinetic/delphi-esr-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-delphi-esr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_esr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "261194c642ebc44637c0d1ea9b26ae1150810dfc5082d8be846def7e2d48b82d";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_esr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "46279eb24b29f88fe6187a980d8e637cef69661b7aede28b89a5ee89241b554f";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/delphi-mrr-msgs/default.nix
+++ b/distros/kinetic/delphi-mrr-msgs/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-delphi-mrr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_mrr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "8fb994bb02623ad2011740e1b929b4a935c6944ddaa18100ee09fb6d62e7624a";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_mrr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "75c20557775a574cca8d1ad41c9809ca723c6c2dc01e24d1ef6793fead27b89a";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''Message definitions for the Delphi MRR'';
-    license = with lib.licenses; [ gpl3 ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/kinetic/delphi-srr-msgs/default.nix
+++ b/distros/kinetic/delphi-srr-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-delphi-srr-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_srr_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "4a8aa34a1484075f13e2952ea936ebed5a2826b4865b2f698120464fb85eacea";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/delphi_srr_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "91d17a34349fc81e69ece5d46710ba08eaac822e3e28c16a5cf74efb089eb0a8";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/derived-object-msgs/default.nix
+++ b/distros/kinetic/derived-object-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, radar-msgs, shape-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, radar-msgs, ros-environment, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-derived-object-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/derived_object_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "2ba5578684d5935fd014c0fc4d933682117740f20acc62f7c8d5f00b398f20f2";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/derived_object_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7228dcfcda8eda5967f4f599c9318358952d068c2596bf71b8b7232de2bad8a2";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime radar-msgs shape-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -606,8 +606,6 @@ self: super: {
 
  costmap-queue = self.callPackage ./costmap-queue {};
 
- coverage-path = self.callPackage ./coverage-path {};
-
  cpp-common = self.callPackage ./cpp-common {};
 
  cpr-multimaster-tools = self.callPackage ./cpr-multimaster-tools {};
@@ -1330,6 +1328,14 @@ self: super: {
 
  gscam = self.callPackage ./gscam {};
 
+ gundam-robot = self.callPackage ./gundam-robot {};
+
+ gundam-rx78-control = self.callPackage ./gundam-rx78-control {};
+
+ gundam-rx78-description = self.callPackage ./gundam-rx78-description {};
+
+ gundam-rx78-gazebo = self.callPackage ./gundam-rx78-gazebo {};
+
  gx-sound = self.callPackage ./gx-sound {};
 
  gx-sound-msgs = self.callPackage ./gx-sound-msgs {};
@@ -1413,6 +1419,8 @@ self: super: {
  hector-worldmodel-msgs = self.callPackage ./hector-worldmodel-msgs {};
 
  hector-xacro-tools = self.callPackage ./hector-xacro-tools {};
+
+ heron-control = self.callPackage ./heron-control {};
 
  heron-description = self.callPackage ./heron-description {};
 
@@ -1845,8 +1853,6 @@ self: super: {
  khi-rs-gazebo = self.callPackage ./khi-rs-gazebo {};
 
  khi-rs-ikfast-plugin = self.callPackage ./khi-rs-ikfast-plugin {};
-
- kinematics-exchanger = self.callPackage ./kinematics-exchanger {};
 
  kinesis-manager = self.callPackage ./kinesis-manager {};
 
@@ -2322,6 +2328,8 @@ self: super: {
 
  moveit = self.callPackage ./moveit {};
 
+ moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
+
  moveit-config-m0609 = self.callPackage ./moveit-config-m0609 {};
 
  moveit-config-m0617 = self.callPackage ./moveit-config-m0617 {};
@@ -2423,14 +2431,6 @@ self: super: {
  msp = self.callPackage ./msp {};
 
  multi-interface-roam = self.callPackage ./multi-interface-roam {};
-
- multi-jackal-base = self.callPackage ./multi-jackal-base {};
-
- multi-jackal-control = self.callPackage ./multi-jackal-control {};
-
- multi-jackal-nav = self.callPackage ./multi-jackal-nav {};
-
- multi-jackal-tutorials = self.callPackage ./multi-jackal-tutorials {};
 
  multi-map-server = self.callPackage ./multi-map-server {};
 
@@ -4060,6 +4060,8 @@ self: super: {
 
  rtt-nav-msgs = self.callPackage ./rtt-nav-msgs {};
 
+ rtt-pcl = self.callPackage ./rtt-pcl {};
+
  rtt-ros = self.callPackage ./rtt-ros {};
 
  rtt-ros-comm = self.callPackage ./rtt-ros-comm {};
@@ -4288,8 +4290,6 @@ self: super: {
 
  stage-ros = self.callPackage ./stage-ros {};
 
- state-exchanger = self.callPackage ./state-exchanger {};
-
  static-tf = self.callPackage ./static-tf {};
 
  static-transform-mux = self.callPackage ./static-transform-mux {};
@@ -4358,14 +4358,6 @@ self: super: {
 
  summit-xl-sim-bringup = self.callPackage ./summit-xl-sim-bringup {};
 
- swarm-behaviors = self.callPackage ./swarm-behaviors {};
-
- swarm-behaviors-position = self.callPackage ./swarm-behaviors-position {};
-
- swarm-behaviors-velocity = self.callPackage ./swarm-behaviors-velocity {};
-
- swarm-functions = self.callPackage ./swarm-functions {};
-
  swri-console = self.callPackage ./swri-console {};
 
  swri-console-util = self.callPackage ./swri-console-util {};
@@ -4415,8 +4407,6 @@ self: super: {
  talos-description-inertial = self.callPackage ./talos-description-inertial {};
 
  tango-ros-messages = self.callPackage ./tango-ros-messages {};
-
- task-allocation = self.callPackage ./task-allocation {};
 
  task-compiler = self.callPackage ./task-compiler {};
 
@@ -4750,21 +4740,11 @@ self: super: {
 
  twistimu = self.callPackage ./twistimu {};
 
- uav-local-coverage = self.callPackage ./uav-local-coverage {};
-
- uav-optimal-coverage = self.callPackage ./uav-optimal-coverage {};
-
- uav-random-direction = self.callPackage ./uav-random-direction {};
-
- uav-simple-tracking = self.callPackage ./uav-simple-tracking {};
-
  ubiquity-motor = self.callPackage ./ubiquity-motor {};
 
  ueye = self.callPackage ./ueye {};
 
  ueye-cam = self.callPackage ./ueye-cam {};
-
- ugv-random-walk = self.callPackage ./ugv-random-walk {};
 
  um6 = self.callPackage ./um6 {};
 

--- a/distros/kinetic/gundam-robot/default.nix
+++ b/distros/kinetic/gundam-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gundam-rx78-control, gundam-rx78-description, gundam-rx78-gazebo }:
+buildRosPackage {
+  pname = "ros-kinetic-gundam-robot";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/kinetic/gundam_robot/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "e5441d28f483365fe1186988f60ee653fc8821b9255ddb485cf8539eb32d6a60";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gundam-rx78-control gundam-rx78-description gundam-rx78-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_robot is a meta package for GUNDAM RX-78 robot controller and simulator'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/gundam-rx78-control/default.nix
+++ b/distros/kinetic/gundam-rx78-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, joint-trajectory-controller, pluginlib, robot-state-publisher, ros-control, ros-controllers, roslaunch, roslint }:
+buildRosPackage {
+  pname = "ros-kinetic-gundam-rx78-control";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/kinetic/gundam_rx78_control/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "a091a2d331d48cf7387a3e3b542c64ca2a4ab0d6f09c344f9e5d5914a42504e3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-interface controller-manager joint-trajectory-controller pluginlib robot-state-publisher ros-control ros-controllers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_control contains launch and configuration scripts for the ros controller of the GUNDAM RX-78 robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/gundam-rx78-description/default.nix
+++ b/distros/kinetic/gundam-rx78-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, roslaunch, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-kinetic-gundam-rx78-description";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/kinetic/gundam_rx78_description/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "66964402687c54b3c58013ccd60ad418aa33786cc272e850c1183d3285f9d2c8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_description contains the ROS URDF file of the GUNDAM RX-78 robot'';
+    license = with lib.licenses; [ "TERMS OF USE FOR GUNDAM RESEARCH OPEN SIMULATOR Attribution-NonCommercial-ShareAlike" bsdOriginal ];
+  };
+}

--- a/distros/kinetic/gundam-rx78-gazebo/default.nix
+++ b/distros/kinetic/gundam-rx78-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fake-localization, gazebo-plugins, gazebo-ros, gazebo-ros-control, gundam-rx78-control, gundam-rx78-description, roslaunch, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-kinetic-gundam-rx78-gazebo";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/kinetic/gundam_rx78_gazebo/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "09e6982718bcd2aaccafd1fee6f8a6f53f41e41f26aa28c9c8ebb264221233b0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint rostest ];
+  propagatedBuildInputs = [ fake-localization gazebo-plugins gazebo-ros gazebo-ros-control gundam-rx78-control gundam-rx78-description ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_gazebo contains launch scripts for simulating the GUNDAM RX-78 robot in the gazebo simulation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/heron-control/default.nix
+++ b/distros/kinetic/heron-control/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-control";
-  version = "0.3.1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "d6c0ff6da42c06798880f29e435c7ce1b3705fa6cc77e39fb4a0e39e9083cecc";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a577a372b692460ec178d816731b46f89c3a34ac914b721a863bba1c272f26a8";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch ];
   propagatedBuildInputs = [ geometry-msgs pythonPackages.numpy robot-localization sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/heron-description/default.nix
+++ b/distros/kinetic/heron-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-description";
-  version = "0.3.1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "d566ac820693cbcce3ddf64a4ed8520f0f44dd31ac3491b565d5f39429e32269";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "819c01bc20489d1aa9f75516729f5aca7a34a52f53dced0f562c1fb676c8715e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-msgs/default.nix
+++ b/distros/kinetic/heron-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-msgs";
-  version = "0.3.1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "2ad5a2ee845261bde8492d547aa7738531de84181eb9a510d7e31d4be1b521d5";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "581f3578b85d11b73b7b8c62f42f6830b3827e5cfa2bcff4bec493f613e393e0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ibeo-msgs/default.nix
+++ b/distros/kinetic/ibeo-msgs/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ibeo-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/ibeo_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "d7a7ce5b115b598b1dcf4d4ac30d909de6db7e5577a770410d9629a0fe414f13";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/ibeo_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "4ec6a95ed8adf0c498b7b725bbc6c9e9a95b9153dd07b146a8e636c3ef615ec0";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Package containing messages for Ibeo sensors.'';
+    description = ''The ibeo_msgs package'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/kinetic/kartech-linear-actuator-msgs/default.nix
+++ b/distros/kinetic/kartech-linear-actuator-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-kartech-linear-actuator-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/kartech_linear_actuator_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "d6d6b78f353f2d0ac6f9a74038f2413f8afe9ed4b7977bd54280e933770eca62";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/kartech_linear_actuator_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ea77a8bfe9cdced1dfcf5ae1e3032ed508e9bcda11f1be85195a9b417dafd302";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/mobileye-560-660-msgs/default.nix
+++ b/distros/kinetic/mobileye-560-660-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mobileye-560-660-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/mobileye_560_660_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "2cf291c63246557cdaddd403354f584cc317b6d191bbadf616e6d4364bd0bdd5";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/mobileye_560_660_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "4ac2a256b2340a4d92444fa96067f233c6fb6fdaa2f23f862398943c3d2c7a31";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/kinetic/moveit-chomp-optimizer-adapter/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
+{ lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-chomp-optimizer-adapter";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_chomp_optimizer_adapter/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "a556ad4a3f8ef1ab4a68c2676f72832e7a80dfc421a79765c65000acd4e5a301";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_chomp_optimizer_adapter/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "76abba4678e67b320c5dffc74b5c350f2b982d6be9156430eab487f9508524e5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/moveit-controller-manager-example/default.nix
+++ b/distros/kinetic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-controller-manager-example";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_controller_manager_example/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "0c1fa391a1dd046f4b19a93362f23702c2ea92643483c7d4c96ff31d51bfb43a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_controller_manager_example/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "8e16220ba677f5b20906c97e7f097502cd1911cf3fb90557a655ac84bd4cf9c9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-experimental/default.nix
+++ b/distros/kinetic/moveit-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-experimental";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_experimental/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "efb3b0d7a04e28dda419582e8ec4ab046471ce7bba381613e0e3baafbe9b8ebc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_experimental/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "98059d942d39177b0ea180c292d68c1a4881c09d4c1613ccc906b8d1258443c8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-fake-controller-manager/default.nix
+++ b/distros/kinetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-fake-controller-manager";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_fake_controller_manager/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "4c60287aa3f6f31813f8871a824cff704aabebc273d85a8e734e720e714a6470";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_fake_controller_manager/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "2f84c631b400137fbb54f0781c38ddaacb0692f2a428c4ccf7a3a07c3bc944a3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-kinematics/default.nix
+++ b/distros/kinetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-ros-planning, pluginlib, roscpp, srdfdom, tf, tf-conversions, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-kinematics";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_kinematics/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "4b058191224030b597bc3e2a91b1838bf8ead80752e2e7057e9ea744592e998e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_kinematics/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "3abee7c37070e9e3517e20e6a9e21a61139ca51a2969cafdaed657217b1a565e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-planners-chomp/default.nix
+++ b/distros/kinetic/moveit-planners-chomp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-planners-chomp";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners_chomp/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "d529c21c02c92d071e9adf49d1a43f946a145a7ff06eff8602d92645a977aeac";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners_chomp/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "f292e1542ae3a727a0baf6382fe051d8a8d2570f51370a5590b0a7848e7a0350";
   };
 
   buildType = "catkin";
   checkInputs = [ moveit-ros-planning-interface rostest ];
-  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib roscpp ];
+  propagatedBuildInputs = [ chomp-motion-planner moveit-core pluginlib roscpp tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/moveit-planners-ompl/default.nix
+++ b/distros/kinetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen-conversions, moveit-core, moveit-resources, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-planners-ompl";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners_ompl/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "07ed7657b817fcdbc1f2c6937313d5c91dc794d9c315c276a2daeb01ab013bf1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners_ompl/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "b548684e53fe78fe80d3b5484cdc8c68acdf4b3e7f8cac64586f4c839308fad6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-planners/default.nix
+++ b/distros/kinetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-planners";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "8430a18ce5057b1cfbbe3ad2a468a537d7762671d28347be02e6f1589b3f0801";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_planners/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "9b9801ebee66f7a4127c00f25cabb077649473b00a6acbf5a50edcd2c69a974e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-plugins/default.nix
+++ b/distros/kinetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-plugins";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_plugins/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "97be072c552e9928d371e0e0794643f1c03d5a991ed473d4907152c216ad1b88";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_plugins/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "5bf14d48bd28fa081e5300166b10c18ef739b93a6900f716c06656d0daf8be9b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-benchmarks/default.nix
+++ b/distros/kinetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-benchmarks";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_benchmarks/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "447f9b82d349f39208c9e01ec4d9e21e5e31bddfb3ea0532327390871f452329";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_benchmarks/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "fd55873b6de0fbb02054516842f47c80ca02a962ad8665083be850a0e6337e52";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-control-interface/default.nix
+++ b/distros/kinetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-control-interface";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_control_interface/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "0592af36d9c8add86a1d73a18056616153244497d9b81e08b917e3d944d40baf";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_control_interface/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "180aed196b60704bebc39aa23b4917e7562dd17306dd09fd900651028bb9c440";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-manipulation/default.nix
+++ b/distros/kinetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-manipulation";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_manipulation/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "5a4e0ae3d9b8758c1a7d941f663f88d88b4beae9588e161388a65a6e99d58bff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_manipulation/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "611da2e957693dbd6e166b080b37b957966c02e57a6230215e1579139bef599b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-move-group/default.nix
+++ b/distros/kinetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-move-group";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_move_group/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "8e3485df31cdfd7300a2961a9976bcac6f9afc4a396be40370bbf5dcbd3bc5f3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_move_group/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "5e1258efb594bbe7de2983803c58c0204339217948d3cbe80fea5b05e87e26fe";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-perception/default.nix
+++ b/distros/kinetic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, message-filters, moveit-core, moveit-msgs, object-recognition-msgs, octomap, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf, tf-conversions, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-perception";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_perception/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "fa2c95f22921e83cf57f12c582307cb98ae169c8f65c77692fc3eef88e8273b6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_perception/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "d1982148b1a0bbd88dcffc4e712193ec96ada9e62b0f2b73c6ffc15636b6f14b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-planning-interface/default.nix
+++ b/distros/kinetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, moveit-msgs, moveit-resources, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-planning-interface";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_planning_interface/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "f87fa2d2113bc9deabc3fb3d8875ae52d2d63bbcbd6cd174980c956874253178";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_planning_interface/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "ccedbb78ed6b763555be0fb5f05b1711f85f4f2dcba5785c95b4883230e0062c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-planning/default.nix
+++ b/distros/kinetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, chomp-motion-planner, cmake-modules, dynamic-reconfigure, eigen, eigen-conversions, message-filters, moveit-core, moveit-msgs, moveit-ros-perception, pluginlib, roscpp, srdfdom, tf, tf-conversions, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-planning";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_planning/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "d048c85d344a24105ee4e4fa81ef0e12e325d96dbc94888a932ab869ee90794a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_planning/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "340ea962b6500af45eefec8c565926bbead74fbea972f0721241686701824cec";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/kinetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, interactive-markers, moveit-ros-planning, pluginlib, roscpp, rosunit, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-robot-interaction";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_robot_interaction/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "aa8380b917a9d5f8083ee45adb8545f6c40f90bb9ad84e9289c0a4903af6e7a7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_robot_interaction/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "cb09213ad4784da0ed290bda01e436fab3e7303deca1c1fbefe5ed37a6775671";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-visualization/default.nix
+++ b/distros/kinetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, eigen-conversions, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, pkg-config, pluginlib, rosconsole, roscpp, rospy, rostest, rviz, tf }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-visualization";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_visualization/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "93ebd24b176314a3e36d8c0b02aa97dc73f96022cf46d59a1823b848d9076bdb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_visualization/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "8e45cda205e236762679376a679b03d161415403c1b30298645d33d0df8121a6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros-warehouse/default.nix
+++ b/distros/kinetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf, warehouse-ros }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros-warehouse";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_warehouse/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "4a1d38a5d40c9e36a25ba8c802f69d4da95105bddfd33a90e1a0f77b88df0a7c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros_warehouse/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "e8c691c304cda2583d0c05f10f47e16886a0e446daf1e66114dd8c6e893a2993";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-ros/default.nix
+++ b/distros/kinetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-ros";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "2d0089b36f94a4d5bb49a803d0eccda09e1c14ec38ae909c1669b1b83521675d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_ros/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "8dd330e655b8936b8e5c55c614b47bcab013b53d55f1937180789ac9360f633e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-runtime/default.nix
+++ b/distros/kinetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-runtime";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_runtime/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "6004e647a10993c09e522a008bbfd44f9957b3c4d89ce7553d512599cb0fe9a1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_runtime/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "292cb8fe2e256f491ea2759a9b27f8d83d43a954132d5a161358196700a23502";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-setup-assistant/default.nix
+++ b/distros/kinetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources, moveit-ros-planning, moveit-ros-visualization, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-setup-assistant";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_setup_assistant/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "71cd748b0edaaca378bff6d6137ff8f974ebc41c9069ef5b9cb04a5eb3944f8b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_setup_assistant/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "b3c72ccf98ce085d7e62060603a540cf388472b7d984ac31a36545d685d109cf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-simple-controller-manager/default.nix
+++ b/distros/kinetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-simple-controller-manager";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_simple_controller_manager/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "f4a601efcc8e991e468324a46fc3ad702f95052f4cf01e64b077130b9c3cdee8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit_simple_controller_manager/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "62d318d64ec3d9a2163fa3843ed855d6f89cb8898abfcff6e2c585a2e6d56ef4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit/default.nix
+++ b/distros/kinetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-kinetic-moveit";
-  version = "0.9.17-r1";
+  version = "0.9.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit/0.9.17-1.tar.gz";
-    name = "0.9.17-1.tar.gz";
-    sha256 = "d8da29a3f6f60b04504ecfa565e219085a2b63cd52e91bcc378dc50b37677c4e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/kinetic/moveit/0.9.18-1.tar.gz";
+    name = "0.9.18-1.tar.gz";
+    sha256 = "60e6f741d8fb92bf1cbdc1af017b9d571c5fc500842dfa8ae27db7070a282b92";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neobotix-usboard-msgs/default.nix
+++ b/distros/kinetic/neobotix-usboard-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-neobotix-usboard-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/neobotix_usboard_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "ee1798c33b1876a8d936e8aead4a4960adffac76955c53bfda44647ad969116f";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/neobotix_usboard_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "136c1043955d35a99c3a89450db4dbf8c5f615ee34ff09b2ebbef24bcd701986";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/pacmod-msgs/default.nix
+++ b/distros/kinetic/pacmod-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-pacmod-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/pacmod_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "bd8431a073289ac9c954b7d39840bb1f51b1df67aa6df177a0c6ecb1726fe661";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/pacmod_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "79abf45c8c97dcbcc9d404cdfcce5e0942c355f80126e9d9148136d6418404b9";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/pacmod3/default.nix
+++ b/distros/kinetic/pacmod3/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-pacmod3";
-  version = "1.2.1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod3-release/archive/release/kinetic/pacmod3/1.2.1-0.tar.gz";
-    name = "1.2.1-0.tar.gz";
-    sha256 = "a79b95e60c750525f2418dc31c7d65ceb3ce1471bae80cea437458dad32ec0cb";
+    url = "https://github.com/astuff/pacmod3-release/archive/release/kinetic/pacmod3/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "f330d8b78709411340ed722b039469cef15c707656ffd843c9220e6462216a3f";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   propagatedBuildInputs = [ can-msgs pacmod-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/radar-msgs/default.nix
+++ b/distros/kinetic/radar-msgs/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-radar-msgs";
-  version = "2.3.1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/radar_msgs/2.3.1-0.tar.gz";
-    name = "2.3.1-0.tar.gz";
-    sha256 = "d97de686cb11d08039a4037888ba86301c60580fa4004e8d9864bd1856a20eb0";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/kinetic/radar_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "5b4f2510993ab45f1cfecae84d9684f05ea89942446d0ee92af6b81f46119b0a";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/rtt-pcl/default.nix
+++ b/distros/kinetic/rtt-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl, rtt }:
 buildRosPackage {
   pname = "ros-kinetic-rtt-pcl";
-  version = "0.1.0-r1";
+  version = "0.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/orocos-gbp/rtt_pcl-release/archive/release/kinetic/rtt_pcl/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "fd4698f20a681d6d37a6374b8c064046d2f6f07b898d146a1113c272f3cc0a84";
+    url = "https://github.com/orocos-gbp/rtt_pcl-release/archive/release/kinetic/rtt_pcl/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "036748c82878a644de891472964f2f5593cd0096017b3a5516d296219911d5d3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sbg-driver/default.nix
+++ b/distros/kinetic/sbg-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-sbg-driver";
-  version = "1.1.7";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/kinetic/sbg_driver/1.1.7-0.tar.gz";
-    name = "1.1.7-0.tar.gz";
-    sha256 = "6ed1e97b68eef62f702922cbeb80dad354ae1fb1f173884be4b2bb427f8f054b";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/kinetic/sbg_driver/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "bc497f55a096a2509cd28ebf1c6ef12a4901d64903df32a3692abe7593c1c7dd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-stamped/default.nix
+++ b/distros/kinetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-urg-stamped";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "fae0726c9ba44fbae6d2f2aa659edf7b010288e6bbe8310e86848356a7821dde";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "97f3b496fbcdc7e1f954d9f19e1549d00be21e5f7953541620b90effc04965a0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/combined-robot-hw-tests/default.nix
+++ b/distros/melodic/combined-robot-hw-tests/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-tests, hardware-interface, roscpp, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw-tests";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "df8e558ef4b707ba0691eabdd3dfbc72bfdb050c3e94c87e0cf69675ba2443ff";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "6bb759b482334bf889676c7425c2e27212648ab2bd5f62a6f52cbf3c05d557da";
   };
 
   buildType = "catkin";
-  checkInputs = [ rostest ];
-  propagatedBuildInputs = [ combined-robot-hw controller-manager controller-manager-tests hardware-interface roscpp ];
+  checkInputs = [ controller-manager-msgs controller-manager-tests rostest ];
+  propagatedBuildInputs = [ combined-robot-hw controller-manager hardware-interface pluginlib roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The combined_robot_hw_tests package'';
+    description = ''Tests for the combined Robot HW class.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/combined-robot-hw/default.nix
+++ b/distros/melodic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "aa5ba158529df1e934c5e0589dfd2c7f8af8f51820c86eb806494cc1613e0d01";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "c58087951a35c2e5dea7708ed6a8a05c6530bf01c274bfb4a02558470b4d9f23";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-interface/default.nix
+++ b/distros/melodic/controller-interface/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-controller-interface";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "6b4025c033f2785cdbf9c8246c7699e597de302f0651fd94e64d3b7746786350";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "21d6bf1b95666c974dadc6702dfdb451f6896b92a6e19ae34a15c75af233fdaf";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ hardware-interface pluginlib roscpp ];
+  propagatedBuildInputs = [ hardware-interface roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Interface base class for controllers'';
+    description = ''Interface base class for controllers.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/controller-manager-msgs/default.nix
+++ b/distros/melodic/controller-manager-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-msgs";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "4f4fcbac638d2fd81b823c7db44c3d0b7dfd41c961cc7360b301f16849ad6b79";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "2d253d226059c8ad5594e6ace21ea387dd58093114d56b6f0d618ea8ab86dc14";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  propagatedBuildInputs = [ message-runtime rospy rosservice std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/controller-manager-tests/default.nix
+++ b/distros/melodic/controller-manager-tests/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, rosbash, rosnode, rosservice, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-tests";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "b43edda9914e25875e06aaace29bf7c78afc68d0cc59da2b77dc7e5783a7b4af";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "fd2d50be7d5408d7162a87228cd9726e1b8d788afb56aa4f3bb833ad42efe9da";
   };
 
   buildType = "catkin";
-  checkInputs = [ rosbash rosnode rosservice rostest ];
-  propagatedBuildInputs = [ controller-interface controller-manager ];
+  checkInputs = [ rosbash rosnode rostest ];
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface pluginlib roscpp rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''controller_manager_tests'';
+    description = ''Tests for the controller manager.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/controller-manager/default.nix
+++ b/distros/melodic/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, rostest }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "23c70277cc132ceacb08eaea3ce9ff79d956458f817b9ab72bcf2713b12e7824";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "c143861db6d4ddee5b6a25d8ea10f733ec2bdde66ad20adf91b16881100dd90c";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ controller-interface controller-manager-msgs hardware-interface pluginlib ];
+  propagatedBuildInputs = [ boost controller-interface controller-manager-msgs hardware-interface pluginlib roscpp rosparam rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dataspeed-can-msg-filters/default.nix
+++ b/distros/melodic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-msg-filters";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "2df46f943fa38c264b690f4594fb684e248d51211ec3ed2ae14136f0921ad755";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "ac5059d8fc34cd27e9b5704f02766a36ed54e8ec48c4677fc85d1764fb7fb247";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-tools/default.nix
+++ b/distros/melodic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-tools";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "1c325db543acea3122c9bdafaa5fee0ce376e86745a8aad8e1dec77b80b601b9";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "60a79fceef9b5289c77cb08e01703866dca33f86e62bcf6deda2dc8b8b55571e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-usb/default.nix
+++ b/distros/melodic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-usb";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "a8ac02105c449255edbf91a2842f574db30ec2b83afbc5ee3dcccd04b63f336c";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "84de61b0d7e1579d062b53a275b6a0082e991245208db0f5791e50cf59c0ae3c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can/default.nix
+++ b/distros/melodic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can";
-  version = "1.0.14-r1";
+  version = "1.0.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.14-1.tar.gz";
-    name = "1.0.14-1.tar.gz";
-    sha256 = "8a966644b2a0f92d008f569b882aba5c266269f89a34ccaf4090507e071e65ef";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "2a5a118b55ac5200022941673a73e6e58bcaae063d379377fece35ebaa9b818f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fmi-adapter-examples/default.nix
+++ b/distros/melodic/fmi-adapter-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fmi-adapter, roscpp, rqt-plot }:
 buildRosPackage {
   pname = "ros-melodic-fmi-adapter-examples";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter-release/archive/release/melodic/fmi_adapter_examples/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "0cbc8b65bfcc5cd1c06eb8159dd090a7e4dd569e9f4d34a9de8e6258cee1514d";
+    url = "https://github.com/boschresearch/fmi_adapter-release/archive/release/melodic/fmi_adapter_examples/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6a5f6a686247cf80cc4b78249d75afbd8c9be2cf2891e7847824555c3e4d7966";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fmi-adapter/default.nix
+++ b/distros/melodic/fmi-adapter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, git, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fmi-adapter";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/boschresearch/fmi_adapter-release/archive/release/melodic/fmi_adapter/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "bfe24f7aa9671c953277071e419fc78de19d4ff33b5342fb7aef9e0b8f964f49";
+    url = "https://github.com/boschresearch/fmi_adapter-release/archive/release/melodic/fmi_adapter/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "560f868a23b5d96c3c97ec51af8053484e4ee418d69d650d0f1465d6900683b7";
   };
 
   buildType = "catkin";
+  buildInputs = [ git ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -252,8 +252,6 @@ self: super: {
 
  cmake-modules = self.callPackage ./cmake-modules {};
 
- cnn-bridge = self.callPackage ./cnn-bridge {};
-
  cob-3d-mapping-msgs = self.callPackage ./cob-3d-mapping-msgs {};
 
  cob-actions = self.callPackage ./cob-actions {};
@@ -1032,6 +1030,14 @@ self: super: {
 
  gscam = self.callPackage ./gscam {};
 
+ gundam-robot = self.callPackage ./gundam-robot {};
+
+ gundam-rx78-control = self.callPackage ./gundam-rx78-control {};
+
+ gundam-rx78-description = self.callPackage ./gundam-rx78-description {};
+
+ gundam-rx78-gazebo = self.callPackage ./gundam-rx78-gazebo {};
+
  h264-encoder-core = self.callPackage ./h264-encoder-core {};
 
  h264-video-encoder = self.callPackage ./h264-video-encoder {};
@@ -1234,6 +1240,8 @@ self: super: {
 
  jackal-viz = self.callPackage ./jackal-viz {};
 
+ jderobot-assets = self.callPackage ./jderobot-assets {};
+
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
 
  joint-state-controller = self.callPackage ./joint-state-controller {};
@@ -1349,6 +1357,14 @@ self: super: {
  kobuki-msgs = self.callPackage ./kobuki-msgs {};
 
  ksql-airport = self.callPackage ./ksql-airport {};
+
+ kvh-geo-fog-3d = self.callPackage ./kvh-geo-fog-3d {};
+
+ kvh-geo-fog-3d-driver = self.callPackage ./kvh-geo-fog-3d-driver {};
+
+ kvh-geo-fog-3d-msgs = self.callPackage ./kvh-geo-fog-3d-msgs {};
+
+ kvh-geo-fog-3d-rviz = self.callPackage ./kvh-geo-fog-3d-rviz {};
 
  laptop-battery-monitor = self.callPackage ./laptop-battery-monitor {};
 

--- a/distros/melodic/gundam-robot/default.nix
+++ b/distros/melodic/gundam-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gundam-rx78-control, gundam-rx78-description, gundam-rx78-gazebo }:
+buildRosPackage {
+  pname = "ros-melodic-gundam-robot";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/melodic/gundam_robot/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "104242639f58d31d81f2635f9a84db3e777dd60c82912fb774aff076719d8db9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gundam-rx78-control gundam-rx78-description gundam-rx78-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_robot is a meta package for GUNDAM RX-78 robot controller and simulator'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/gundam-rx78-control/default.nix
+++ b/distros/melodic/gundam-rx78-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, joint-trajectory-controller, pluginlib, robot-state-publisher, ros-control, ros-controllers, roslaunch, roslint }:
+buildRosPackage {
+  pname = "ros-melodic-gundam-rx78-control";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/melodic/gundam_rx78_control/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "aea11f0c98aced57ce60008763b2265d61130564f9a7be68085ea41662770f65";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-interface controller-manager joint-trajectory-controller pluginlib robot-state-publisher ros-control ros-controllers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_control contains launch and configuration scripts for the ros controller of the GUNDAM RX-78 robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/gundam-rx78-description/default.nix
+++ b/distros/melodic/gundam-rx78-description/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, roslaunch, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-gundam-rx78-description";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/melodic/gundam_rx78_description/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "4004070bbf315f396604e927dfe815feada9964aad421c3eb739706bb0705d18";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_description contains the ROS URDF file of the GUNDAM RX-78 robot'';
+    license = with lib.licenses; [ "TERMS OF USE FOR GUNDAM RESEARCH OPEN SIMULATOR Attribution-NonCommercial-ShareAlike" bsdOriginal ];
+  };
+}

--- a/distros/melodic/gundam-rx78-gazebo/default.nix
+++ b/distros/melodic/gundam-rx78-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fake-localization, gazebo-plugins, gazebo-ros, gazebo-ros-control, gundam-rx78-control, gundam-rx78-description, roslaunch, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-gundam-rx78-gazebo";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gundam-global-challenge/gundam_robot-release/archive/release/melodic/gundam_rx78_gazebo/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "0115b438aa2868aa547464ed22dfbedfd01b0c62a37d4d0b4fa3b7f3310e50c9";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint rostest ];
+  propagatedBuildInputs = [ fake-localization gazebo-plugins gazebo-ros gazebo-ros-control gundam-rx78-control gundam-rx78-description ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gundam_rx78_gazebo contains launch scripts for simulating the GUNDAM RX-78 robot in the gazebo simulation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/hardware-interface/default.nix
+++ b/distros/melodic/hardware-interface/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, rostest, rosunit }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-hardware-interface";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "32cf3ab34458a850b34cf14066562015d475f2c2e6edd49b16725c7f86e218c9";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "ad57d9e12500a21d1f4d3d9a63ab59c194de366b227d052e095cc50eb4fa190e";
   };
 
   buildType = "catkin";
-  checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ roscpp ];
+  propagatedBuildInputs = [ boost roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/jderobot-assets/default.nix
+++ b/distros/melodic/jderobot-assets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, turtlebot3-description, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-melodic-jderobot-assets";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1f0ed0051b66a63e5c616eea7354f3416125112f28e008b874bd1f2a5e2cecdd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros roscpp turtlebot3-description turtlebot3-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jderobot_assets package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/joint-limits-interface/default.nix
+++ b/distros/melodic/joint-limits-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-melodic-joint-limits-interface";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "c79c7fa6eaa2ccb35ed79b7dc6b125db16a98d298085a1fb1a2ed530e9817a64";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "08352d1fcd557e7fcb0a0d26340f6161c8a895798358bc3e2b6a40f603ee9e27";
   };
 
   buildType = "catkin";
-  checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ hardware-interface roscpp urdf urdfdom ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ hardware-interface roscpp urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/kvh-geo-fog-3d-driver/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, kvh-geo-fog-3d-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-kvh-geo-fog-3d-driver";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_driver/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "f52b0818c830b2b5d5e441e36374e801844fe9ba36a8880a94be6abf7e45e7ef";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure geometry-msgs kvh-geo-fog-3d-msgs message-generation message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS driver for the KVH Geo Fog 3D INS family of systems.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/kvh-geo-fog-3d-msgs/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-kvh-geo-fog-3d-msgs";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_msgs/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "0ea3ac9d0959826daed2ff9fe600c80939b2529744e74f1ebd0d96c6c24c1b37";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin message-generation ];
+
+  meta = {
+    description = ''kvh_geo_fog_3d_msgs contains raw messages for the KVH GEO FOG 3D INS devices.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/kvh-geo-fog-3d-rviz/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-rviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, kvh-geo-fog-3d-msgs, qt5, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-kvh-geo-fog-3d-rviz";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_rviz/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "e83f6fca4f5fea627273634cc6a32b1cd72f6afde9120ef2d57b319b4c9e7265";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg roslint ];
+  propagatedBuildInputs = [ diagnostic-msgs kvh-geo-fog-3d-msgs rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The KVH GEO FOG 3D rviz plugin package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/kvh-geo-fog-3d/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kvh-geo-fog-3d-driver, kvh-geo-fog-3d-msgs, kvh-geo-fog-3d-rviz }:
+buildRosPackage {
+  pname = "ros-melodic-kvh-geo-fog-3d";
+  version = "1.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "014ddc8b7bf8a2239353b8aa0b6bce023d2b809d407284eb8ef4de6e505149b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ kvh-geo-fog-3d-driver kvh-geo-fog-3d-msgs kvh-geo-fog-3d-rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a driver node for KVH GEO FOG 3D INS sensors, messages, and rviz plugins.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pacmod3/default.nix
+++ b/distros/melodic/pacmod3/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pacmod3";
-  version = "1.2.1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod3-release/archive/release/melodic/pacmod3/1.2.1-0.tar.gz";
-    name = "1.2.1-0.tar.gz";
-    sha256 = "daff58bf63c7d7e4d76b098f59076691ba3bb27401201eb39681d229ad256bf0";
+    url = "https://github.com/astuff/pacmod3-release/archive/release/melodic/pacmod3/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "5a48a3e0b845272836125c8065b81e777bc10bf088dbd2013431168ceda276be";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   propagatedBuildInputs = [ can-msgs pacmod-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/ros-control/default.nix
+++ b/distros/melodic/ros-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, combined-robot-hw-tests, controller-interface, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-ros-control";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "58bf82c63707b76b7d6752df3afd2b4fe369fc95260431e56a8cb7068a57f76a";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "93618cf09b18a69d63557b6230dca535cb0fce9d711abca706b6b66804a4693a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ combined-robot-hw combined-robot-hw-tests controller-interface controller-manager controller-manager-msgs controller-manager-tests hardware-interface joint-limits-interface realtime-tools transmission-interface ];
+  propagatedBuildInputs = [ combined-robot-hw controller-interface controller-manager controller-manager-msgs hardware-interface joint-limits-interface realtime-tools transmission-interface ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rqt-controller-manager/default.nix
+++ b/distros/melodic/rqt-controller-manager/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-manager, rqt-gui }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-controller-manager";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "d353d8ca83aa76818876e856d29fb0c5acebc9b55ef54085959a12af1224c8d7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "ce030aa56910c1c47fee4373ab83d90975a5ef946c46924417f349c60d10bed0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ controller-manager rqt-gui ];
+  propagatedBuildInputs = [ controller-manager-msgs rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The rqt_controller_manager package'';
+    description = ''Graphical frontend for interacting with the controller manager.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/sbg-driver/default.nix
+++ b/distros/melodic/sbg-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-sbg-driver";
-  version = "2.0.0-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "91fb4d9ecba6108f18023bda25c736a8ebf73dbf44588db2a2bdbb5462cbb129";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e4993f0efb6ad38028d9c4d521e40a631f6c66b844a91188790803620f59ac3c";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules message-generation ];
+  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ geometry-msgs message-runtime roscpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/transmission-interface/default.nix
+++ b/distros/melodic/transmission-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, rosunit, tinyxml }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-transmission-interface";
-  version = "0.15.1";
+  version = "0.16.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.15.1-0.tar.gz";
-    name = "0.15.1-0.tar.gz";
-    sha256 = "6b28074919478b6422588385850f0450d788ad06829adca29ae5cf2cac798692";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.16.0-1.tar.gz";
+    name = "0.16.0-1.tar.gz";
+    sha256 = "305fa23c79689242ab502dee48bb13aa479572d896d7e7024705c89b4cfe3513";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules hardware-interface ];
-  checkInputs = [ resource-retriever rosunit ];
-  propagatedBuildInputs = [ pluginlib roscpp tinyxml ];
+  buildInputs = [ cmake-modules ];
+  checkInputs = [ resource-retriever ];
+  propagatedBuildInputs = [ boost hardware-interface pluginlib roscpp tinyxml ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "39b46f6c170dee6ab94eca3fec1a364123d3efb290c5790219ca820ddccff739";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "77e73042c4c2e75125e3a70684ef9c95557092fac7e936c9b588d94f51f8d5da";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit edcc94051523487ed423b477d2ee5fd1332209d2.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *astuff-sensor-msgs 3.0.1-r1*
* *costmap-converter 0.1.0-r1*
* *costmap-converter-msgs 0.1.0-r1*
* *delphi-esr-msgs 3.0.0-r2 --> 3.0.1-r1*
* *delphi-mrr-msgs 3.0.0-r2 --> 3.0.1-r1*
* *delphi-srr-msgs 3.0.0-r2 --> 3.0.1-r1*
* *derived-object-msgs 3.0.0-r2 --> 3.0.1-r1*
* *fmi-adapter 0.1.5-r1 --> 0.1.7-r1*
* *fmi-adapter-examples 0.1.5-r1 --> 0.1.7-r1*
* *fmilibrary-vendor 0.1.0-r1 --> 0.2.0-r1*
* *ibeo-msgs 3.0.0-r2 --> 3.0.1-r1*
* *kartech-linear-actuator-msgs 3.0.0-r2 --> 3.0.1-r1*
* *mobileye-560-660-msgs 3.0.0-r2 --> 3.0.1-r1*
* *neobotix-usboard-msgs 3.0.0-r2 --> 3.0.1-r1*
* *pacmod-msgs 3.0.0-r2 --> 3.0.1-r1*
* *pacmod3 1.3.0-r1*
* *radar-msgs 3.0.0-r2 --> 3.0.1-r1*
* *tts-interfaces 2.0.1-r1 --> 2.0.2-r1*

Eloquent Changes:
-----------------
* *costmap-converter 0.1.1-r1*
* *costmap-converter-msgs 0.1.1-r1*
* *fmi-adapter 0.1.6-r1 --> 0.1.7-r2*
* *fmi-adapter-examples 0.1.6-r1 --> 0.1.7-r2*
* *fmilibrary-vendor 0.1.1-r1 --> 0.2.0-r1*
* *libg2o 2019.11.23-r4*
* *py-trees-ros-interfaces 2.0.2-r1 --> 2.0.3-r2*
* *velocity-smoother 0.14.0-r1*

Kinetic Changes:
----------------
* *astuff-sensor-msgs 2.3.1 --> 3.0.1-r1*
* *chomp-motion-planner 0.9.17-r1 --> 0.9.18-r1*
* *dataspeed-can 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-msg-filters 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-tools 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-usb 1.0.14-r1 --> 1.0.15-r1*
* *delphi-esr-msgs 2.3.1 --> 3.0.1-r1*
* *delphi-mrr-msgs 2.3.1 --> 3.0.1-r1*
* *delphi-srr-msgs 2.3.1 --> 3.0.1-r1*
* *derived-object-msgs 2.3.1 --> 3.0.1-r1*
* *gundam-robot 0.0.3-r1*
* *gundam-rx78-control 0.0.3-r1*
* *gundam-rx78-description 0.0.3-r1*
* *gundam-rx78-gazebo 0.0.3-r1*
* *heron-control 0.3.1 --> 0.3.2-r1*
* *heron-description 0.3.1 --> 0.3.2-r1*
* *heron-msgs 0.3.1 --> 0.3.2-r1*
* *ibeo-msgs 2.3.1 --> 3.0.1-r1*
* *kartech-linear-actuator-msgs 2.3.1 --> 3.0.1-r1*
* *mobileye-560-660-msgs 2.3.1 --> 3.0.1-r1*
* *moveit 0.9.17-r1 --> 0.9.18-r1*
* *moveit-chomp-optimizer-adapter 0.9.17-r1 --> 0.9.18-r1*
* *moveit-controller-manager-example 0.9.17-r1 --> 0.9.18-r1*
* *moveit-experimental 0.9.17-r1 --> 0.9.18-r1*
* *moveit-fake-controller-manager 0.9.17-r1 --> 0.9.18-r1*
* *moveit-kinematics 0.9.17-r1 --> 0.9.18-r1*
* *moveit-planners 0.9.17-r1 --> 0.9.18-r1*
* *moveit-planners-chomp 0.9.17-r1 --> 0.9.18-r1*
* *moveit-planners-ompl 0.9.17-r1 --> 0.9.18-r1*
* *moveit-plugins 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-benchmarks 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-control-interface 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-manipulation 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-move-group 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-perception 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-planning 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-planning-interface 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-robot-interaction 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-visualization 0.9.17-r1 --> 0.9.18-r1*
* *moveit-ros-warehouse 0.9.17-r1 --> 0.9.18-r1*
* *moveit-runtime 0.9.17-r1 --> 0.9.18-r1*
* *moveit-setup-assistant 0.9.17-r1 --> 0.9.18-r1*
* *moveit-simple-controller-manager 0.9.17-r1 --> 0.9.18-r1*
* *neobotix-usboard-msgs 2.3.1 --> 3.0.1-r1*
* *pacmod-msgs 2.3.1 --> 3.0.1-r1*
* *pacmod3 1.2.1 --> 1.3.0-r1*
* *radar-msgs 2.3.1 --> 3.0.1-r1*
* *rtt-pcl 0.1.0-r1 --> 0.1.0-r2*
* *sbg-driver 1.1.7 --> 2.0.2-r1*
* *urg-stamped 0.0.3-r1 --> 0.0.4-r1*

Melodic Changes:
----------------
* *combined-robot-hw 0.15.1 --> 0.16.0-r1*
* *combined-robot-hw-tests 0.15.1 --> 0.16.0-r1*
* *controller-interface 0.15.1 --> 0.16.0-r1*
* *controller-manager 0.15.1 --> 0.16.0-r1*
* *controller-manager-msgs 0.15.1 --> 0.16.0-r1*
* *controller-manager-tests 0.15.1 --> 0.16.0-r1*
* *dataspeed-can 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-msg-filters 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-tools 1.0.14-r1 --> 1.0.15-r1*
* *dataspeed-can-usb 1.0.14-r1 --> 1.0.15-r1*
* *fmi-adapter 1.0.2 --> 1.0.3-r1*
* *fmi-adapter-examples 1.0.2 --> 1.0.3-r1*
* *gundam-robot 0.0.3-r1*
* *gundam-rx78-control 0.0.3-r1*
* *gundam-rx78-description 0.0.3-r1*
* *gundam-rx78-gazebo 0.0.3-r1*
* *hardware-interface 0.15.1 --> 0.16.0-r1*
* *jderobot-assets 0.1.0-r1*
* *joint-limits-interface 0.15.1 --> 0.16.0-r1*
* *kvh-geo-fog-3d 1.3.3-r1*
* *kvh-geo-fog-3d-driver 1.3.3-r1*
* *kvh-geo-fog-3d-msgs 1.3.3-r1*
* *kvh-geo-fog-3d-rviz 1.3.3-r1*
* *pacmod3 1.2.1 --> 1.3.0-r1*
* *ros-control 0.15.1 --> 0.16.0-r1*
* *rqt-controller-manager 0.15.1 --> 0.16.0-r1*
* *sbg-driver 2.0.0-r1 --> 2.0.2-r1*
* *transmission-interface 0.15.1 --> 0.16.0-r1*
* *urg-stamped 0.0.3-r1 --> 0.0.4-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

