### PR TITLE
rosdistro sync, Fri Feb  7 12:39:54 2020

### DIFF
--- a/distros/dashing/controller-interface/default.nix
+++ b/distros/dashing/controller-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-dashing-controller-interface";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/controller_interface/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "6d306d244e7507a456811ba1a0fc86af5237401252c0ec9dfad1f84ae9d45df0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/controller-manager/default.nix
+++ b/distros/dashing/controller-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, controller-interface, hardware-interface, rclcpp, rcpputils, test-robot-hardware }:
+buildRosPackage {
+  pname = "ros-dashing-controller-manager";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/controller_manager/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "2aa8ff5581906136442c8e24c08ac643bb5023f413522947df93b77fe4ef3ea0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common test-robot-hardware ];
+  propagatedBuildInputs = [ ament-index-cpp class-loader controller-interface hardware-interface rclcpp rcpputils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_manager'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/controller-parameter-server/default.nix
+++ b/distros/dashing/controller-parameter-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-dashing-controller-parameter-server";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/controller_parameter_server/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "48351508ab523f5ea2240cb8fb57773d7c8919fd5ee32efddbe481663ff66547";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rcpputils rcutils yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''parameter server for loading specific controller configurations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -196,6 +196,12 @@ self: super: {
 
  control-msgs = self.callPackage ./control-msgs {};
 
+ controller-interface = self.callPackage ./controller-interface {};
+
+ controller-manager = self.callPackage ./controller-manager {};
+
+ controller-parameter-server = self.callPackage ./controller-parameter-server {};
+
  costmap-converter = self.callPackage ./costmap-converter {};
 
  costmap-converter-msgs = self.callPackage ./costmap-converter-msgs {};
@@ -421,6 +427,8 @@ self: super: {
  h264-encoder-core = self.callPackage ./h264-encoder-core {};
 
  h264-video-encoder = self.callPackage ./h264-video-encoder {};
+
+ hardware-interface = self.callPackage ./hardware-interface {};
 
  health-metric-collector = self.callPackage ./health-metric-collector {};
 
@@ -750,6 +758,8 @@ self: super: {
 
  ros1-rosbag-storage-vendor = self.callPackage ./ros1-rosbag-storage-vendor {};
 
+ ros2-control = self.callPackage ./ros2-control {};
+
  ros2-ouster = self.callPackage ./ros2-ouster {};
 
  ros2action = self.callPackage ./ros2action {};
@@ -789,6 +799,8 @@ self: super: {
  ros2trace-analysis = self.callPackage ./ros2trace-analysis {};
 
  ros-base = self.callPackage ./ros-base {};
+
+ ros-controllers = self.callPackage ./ros-controllers {};
 
  ros-core = self.callPackage ./ros-core {};
 
@@ -944,6 +956,8 @@ self: super: {
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
+ slide-show = self.callPackage ./slide-show {};
+
  sophus = self.callPackage ./sophus {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -1001,6 +1015,8 @@ self: super: {
  test-msgs = self.callPackage ./test-msgs {};
 
  test-osrf-testing-tools-cpp = self.callPackage ./test-osrf-testing-tools-cpp {};
+
+ test-robot-hardware = self.callPackage ./test-robot-hardware {};
 
  tf2 = self.callPackage ./tf2 {};
 

--- a/distros/dashing/hardware-interface/default.nix
+++ b/distros/dashing/hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rcutils }:
+buildRosPackage {
+  pname = "ros-dashing-hardware-interface";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/hardware_interface/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "6b6e74c8154f066becb6d60a99cc20aaafeec8d20e111a485a2e27c01ac49930";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rcutils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 ros_control hardware interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/pacmod3/default.nix
+++ b/distros/dashing/pacmod3/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, can-msgs, pacmod-msgs, rclcpp, rclcpp-components, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, can-msgs, pacmod-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-pacmod3";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod3-release/archive/release/dashing/pacmod3/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "903fda537f50786c58a965a212b4519217a1679afbfd6a1cdd40928c05691719";
+    url = "https://github.com/astuff/pacmod3-release/archive/release/dashing/pacmod3/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "1d3a8654ea4ac286c7c73ab55e50160c62745891683c27f582a2c00a49cd3a99";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs pacmod-msgs rclcpp rclcpp-components std-msgs ];
+  propagatedBuildInputs = [ can-msgs pacmod-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/ros-controllers/default.nix
+++ b/distros/dashing/ros-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, controller-parameter-server, hardware-interface, rclcpp-lifecycle, sensor-msgs, test-robot-hardware, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-ros-controllers";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/dashing/ros_controllers/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "a2108c76270ab10071d023d2700b09b16f3b91bf5b8a3bd474ebaa186ebb23ae";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-parameter-server test-robot-hardware ];
+  propagatedBuildInputs = [ controller-interface controller-manager controller-parameter-server hardware-interface rclcpp-lifecycle sensor-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of ros_controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/ros2-control/default.nix
+++ b/distros/dashing/ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-parameter-server, hardware-interface, test-robot-hardware }:
+buildRosPackage {
+  pname = "ros-dashing-ros2-control";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/ros2_control/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "be32aea241c99098b0b69d204f501dc400b7eb3227b2adc01adf62b42684b66d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ test-robot-hardware ];
+  propagatedBuildInputs = [ controller-interface controller-manager controller-parameter-server hardware-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for ROS2 control related packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/slide-show/default.nix
+++ b/distros/dashing/slide-show/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, python3Packages, pythonPackages, rcl-interfaces, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-slide-show";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/slide_show-release/archive/release/dashing/slide_show/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "aca5bee82b21f0a30b43c0b409ff7a45808bd3ce211024b6acc8bff0f01b5b5e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge python3Packages.opencv3 rcl-interfaces rclpy sensor-msgs ];
+
+  meta = {
+    description = ''Publishes images from the file system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/test-robot-hardware/default.nix
+++ b/distros/dashing/test-robot-hardware/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, hardware-interface, rcutils }:
+buildRosPackage {
+  pname = "ros-dashing-test-robot-hardware";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/dashing/test_robot_hardware/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "57f0dee22c810d9e65c9f1888e0e164fee8536b82b56c669bfd41ba4912154df";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface rcutils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of test_robot_hardware'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/eloquent/cartographer-ros-msgs/default.nix
+++ b/distros/eloquent/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-cartographer-ros-msgs";
-  version = "1.0.9000-r1";
+  version = "1.0.9001-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/eloquent/cartographer_ros_msgs/1.0.9000-1.tar.gz";
-    name = "1.0.9000-1.tar.gz";
-    sha256 = "56c121a252d5ca068edfc8cfd9ac8599f178c07399414f951970484cdb7d11fd";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/eloquent/cartographer_ros_msgs/1.0.9001-1.tar.gz";
+    name = "1.0.9001-1.tar.gz";
+    sha256 = "ff8c2cc070244499224f06ef178087fc8b2d02221218544fe895ad9f6cab274b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cartographer-ros/default.nix
+++ b/distros/eloquent/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-cartographer-ros";
-  version = "1.0.9000-r1";
+  version = "1.0.9001-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/eloquent/cartographer_ros/1.0.9000-1.tar.gz";
-    name = "1.0.9000-1.tar.gz";
-    sha256 = "ea1fe9fe0f851c817759dbc306e953af0f4cdf4488444b5a7ebdb67299a8cd3c";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/eloquent/cartographer_ros/1.0.9001-1.tar.gz";
+    name = "1.0.9001-1.tar.gz";
+    sha256 = "d4f1f7e844aef28e6fb2e31ec554d305913d20f2da1c5e741fd1de8e52cf3b8c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/costmap-queue/default.nix
+++ b/distros/eloquent/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-costmap-queue";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/costmap_queue/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "78553e7160a2d2135c15d9b0059c68e558f9c21e3a7e015addde2791f6309a26";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/costmap_queue/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "526b02487cd59d03b8aed62c84942b4afd867ddc84cfebbf180c4e407a24ea0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/dwb-core/default.nix
+++ b/distros/eloquent/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-dwb-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "9f3798ef66e5e563e980322c2b7357be45be3ceabe25db70c8fb64ba7dcda2ef";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "56f5fbf3bf39053069fadc291383d11aa7e69b0407f4d0b5575c230fc6c68cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/dwb-critics/default.nix
+++ b/distros/eloquent/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-dwb-critics";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_critics/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "68c72c3d998067769432e6b4e0af6a013af6e21493d57b6abcf59088834d564a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_critics/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "f1556f8ee64c7b2f7dd5f99f0a9f396a5f390ccb16efe9eddf2ef47c854e4562";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/dwb-msgs/default.nix
+++ b/distros/eloquent/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-dwb-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "2b8d655e24c089ba37e9c2554df80e91e885ee47653b4e2301c181b3f7388e10";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "53633b8afc64b03227e47ba681e7f699542e02ac962575f3c8242b43ea9a277d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/dwb-plugins/default.nix
+++ b/distros/eloquent/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-dwb-plugins";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_plugins/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "7aec81b8693b2d58fa5c9575385e9bca82a9d167b15434ad0a65ea5271335797";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/dwb_plugins/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "175b75223d4f83bd4bee608d287cd1b7806e0ad2cf57235c8801ea900d430e9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -840,6 +840,8 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ slide-show = self.callPackage ./slide-show {};
+
  sophus = self.callPackage ./sophus {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -931,6 +933,8 @@ self: super: {
  v4l2-camera = self.callPackage ./v4l2-camera {};
 
  velocity-smoother = self.callPackage ./velocity-smoother {};
+
+ vision-msgs = self.callPackage ./vision-msgs {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/eloquent/laser-geometry/default.nix
+++ b/distros/eloquent/laser-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, eigen, eigen3-cmake-module, rclcpp, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-laser-geometry";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/eloquent/laser_geometry/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "97c700bd336b2b196b478451c6d6b7222a3f77d4b614bc7e3596200bfa9b70e1";
+    url = "https://github.com/ros2-gbp/laser_geometry-release/archive/release/eloquent/laser_geometry/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5414b329a1eb442b33b63bcca255506c31797dd1961183e6a217abb8addf08e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav-2d-msgs/default.nix
+++ b/distros/eloquent/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav-2d-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav_2d_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "73429f1885e327d21741a4f224461b8d2872f78f1b5a0ee68f4a5bd2ae46bff3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav_2d_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "408253eba97744b149346ec898da9b8e33902fb177b6ac3538887dd5659f3803";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav-2d-utils/default.nix
+++ b/distros/eloquent/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav-2d-utils";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav_2d_utils/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c5c05a0dd16a8966e649242beb895781900c57644cce88e80ebe609937f003ff";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav_2d_utils/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "0311f5317d985a32fd0f8cfc6e2d7c107806162d654f2ffec8926e5abee3eedb";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-amcl/default.nix
+++ b/distros/eloquent/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-amcl";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_amcl/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "28b283f5d5b1208799f9530c023f367844d9d8778fccffbc2b55258abd760b96";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_amcl/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "fd9dcada83298705cf06b788267306879dd1ad700efbf8420eae4aeccb80c5a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-behavior-tree/default.nix
+++ b/distros/eloquent/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-behavior-tree";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_behavior_tree/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "8503481e389a133b07fae32fac92776ecd7d238a1c4a82c1d19eaba06c96ecc7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_behavior_tree/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "731db8482fdd00c8d4415c0a766734915c2a2c8f039543dd9a46e3e312d7ccfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-bringup/default.nix
+++ b/distros/eloquent/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2 }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-bringup";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_bringup/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d94ebe97f16b8fa4e155d2db4d942e60edcb576349b5a79c4eb7f59054bfb7c1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_bringup/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "4d3927070e6f7a8ea486ff8ebc0b5e1292cca62b58890d920d36a080efab2143";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-bt-navigator/default.nix
+++ b/distros/eloquent/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-bt-navigator";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_bt_navigator/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "03afcebbe873e09052ce8c03865a975133eb50e3e30c72cbd8761eebfd52e81d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_bt_navigator/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6e74ca9884e2cee9695a701bc8582828ae0f6c60b8974eedfe8d8622dd1d6afc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-common/default.nix
+++ b/distros/eloquent/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-common";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_common/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ada9db384d35d0c86a376834bca29c7ec7d3ca1216a5ddd6c90951e6c4f99f98";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_common/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "76549f364d7260fcdc72cc2c1d65832db2a1e02320e429276a48325ad50286b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-controller/default.nix
+++ b/distros/eloquent/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-controller";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_controller/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "3975a459858b09f901e507e4079151272e7a5314b829dd4b53260bfcf5bb39cc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_controller/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "3644735a1a92ac4793a2b18e9f9b9b93c6547965cc5f5d84d5641915ec1d71ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-core/default.nix
+++ b/distros/eloquent/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ca422da0bef24719425db07c4a5999e2a3ee18f4f7bc5046836e64d12fecdd31";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "2bc7987223cb083cb6c9d50786520e9814a739b032c92a1476d6e54a0fb5eb79";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-costmap-2d/default.nix
+++ b/distros/eloquent/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-costmap-2d";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_costmap_2d/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "64932ae3f94746f810c96f955320c66f276aa0db02d0560bcbbe764b83fb2efd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_costmap_2d/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "627333db4d9f2fd868ecb75d6fc0f177dde1aa2eb0cfc58040d7a016568250b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-dwb-controller/default.nix
+++ b/distros/eloquent/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-dwb-controller";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_dwb_controller/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ae0d2b62dbd858ab10e7ceb41e6c45357eee0d6ec2bef162f606c472039cf48f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_dwb_controller/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "db01235769b16ba75de5c940282261590479f4c4e6808a4dff1c994f7caa5e4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-gazebo-spawner/default.nix
+++ b/distros/eloquent/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-gazebo-spawner";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_gazebo_spawner/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c292e241c735a3520ee9038c2ca97748c37d78504007bb149e1b03f19bdaf303";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_gazebo_spawner/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e405c02184ca08edcce6e3d672312c6b572f8467ede0ee9bb5233ca3304d2fa1";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/nav2-lifecycle-manager/default.nix
+++ b/distros/eloquent/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-lifecycle-manager";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_lifecycle_manager/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "8d175b6b89ea06e26cc72c227845488d2f9ff11d800320ca977975856735de64";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_lifecycle_manager/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "2cd73f6b8c7af29ea972e95f55d5719cd02e578f2be57276ca1af38234daa54a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-map-server/default.nix
+++ b/distros/eloquent/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-map-server";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_map_server/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "97e41d0845c5f41342956949d7ea92c8ee154b0e97aca4c785ce9c53f1a594a6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_map_server/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "4e75e368dbcd3ab032675e4ddeab8b8d9d5d67289f403bfa7acfec7c2742c83a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-msgs/default.nix
+++ b/distros/eloquent/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "566f81f08243e98596698ea913a3b7b93fb1e9ed2d363e47c5b5c506872d3771";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "f03e3646603c890639910469e4c9f8739e394667fde0cbfe9b6ea9c416e368bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-navfn-planner/default.nix
+++ b/distros/eloquent/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-navfn-planner";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_navfn_planner/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "0bdc5fc459e5a8b56d7654f687027185308499d23afc6f974e5b0d23117456fd";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_navfn_planner/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "b14774e9ccaa09b80e3614e9d0c9bed09978fa783f6fea4871f9887227743190";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-planner/default.nix
+++ b/distros/eloquent/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-planner";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_planner/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c935addbffee5855ee023ef0ca5e43751e299338051d3c246ba769130ece506c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_planner/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "966aee1d02cab56cd60f653969688356ef42503d7ee0f6c76c8b8e7ef4ea4e75";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-recoveries/default.nix
+++ b/distros/eloquent/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-recoveries";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_recoveries/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "4133e84ed39083d0122ffa335548bdc995e66a2d6832899fdd1f195673103076";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_recoveries/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "ec917cef5bad09a79ec48c2db910307ad9e39e6b86a0db741dbdf2d728ee1722";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-rviz-plugins/default.nix
+++ b/distros/eloquent/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-rviz-plugins";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_rviz_plugins/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c3a3482fe5283883523d4cdee05d159ab27962cdc4c7b5dda8522a7317fa89cc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_rviz_plugins/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "101dc5ae08af3b8fdf1f1ccd78a4308206c7ea133eea52d1c4181f276ad67cd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-system-tests/default.nix
+++ b/distros/eloquent/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-system-tests";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_system_tests/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d7fe16ccf29cc65a5afb0248e1efb4d06bfbf1d96c3a1a154a6723a37a708733";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_system_tests/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "2285ee5df7eb3a13d90a420ec47198ad8128fc843ec4cad288d12f994377fde7";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-util/default.nix
+++ b/distros/eloquent/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL, SDL_image, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-util";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_util/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6fb04134977f4496711ee332794fd0b84e101267175c0906175a8d92ba83232d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_util/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "4927afb62b5cdf200293875970165ce0e46d62a815f12ae9a01dacfbf407612f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-voxel-grid/default.nix
+++ b/distros/eloquent/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-voxel-grid";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_voxel_grid/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d46ef75f83c7e90ccbcd161d4fd4f704db0c89586975d7f8e1292c88baa74d58";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_voxel_grid/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6d5fb02916a63c84c1f786eb009899c7066428d8e2df9e73d82d91874d828002";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/nav2-waypoint-follower/default.nix
+++ b/distros/eloquent/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-nav2-waypoint-follower";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_waypoint_follower/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "127a16cdf08e535205eb30ae72c3799a6678aa5d02934e4a2b94eca21a8c2fad";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/nav2_waypoint_follower/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6da076415d0c92735df2c3f71c95965a63581910759650db17eef1e0947933ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/navigation2/default.nix
+++ b/distros/eloquent/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-eloquent-navigation2";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/navigation2/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "5ebad03b9847e910ec64ceab9ba2bd12d3039388dc3022b26fb67ccb2f7a8b19";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/eloquent/navigation2/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "2678b4b9e7be98f8fb47f503d5d12074b3150212b6f4e6c7b3d7106ce466f9ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/py-trees-ros/default.nix
+++ b/distros/eloquent/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-py-trees-ros";
-  version = "2.0.4-r1";
+  version = "2.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "2986733a2084bbfcf595eae3c968cdf8ba11d085f05d81a808c8e623aaa88b85";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.6-2.tar.gz";
+    name = "2.0.6-2.tar.gz";
+    sha256 = "1205e3a498238974e4466607ec477026afcc713deae6a90679e6a1c3e5a441db";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/rqt-tf-tree/default.nix
+++ b/distros/eloquent/rqt-tf-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-dotgraph, rclpy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-rqt-tf-tree";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/eloquent/rqt_tf_tree/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "cca82385b50c00b8ea77549e413b507889f87bacba33fd77ac8e85f821da87c4";
+    url = "https://github.com/ros2-gbp/rqt_tf_tree-release/archive/release/eloquent/rqt_tf_tree/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "fa73a2983b7fd72d3db406030be982ac91dbbfea86880ef7997858b9a1b79e48";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/slide-show/default.nix
+++ b/distros/eloquent/slide-show/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, python3Packages, pythonPackages, rcl-interfaces, rclpy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-slide-show";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/slide_show-release/archive/release/eloquent/slide_show/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "efe7159897ece049a91bd1962d2a2ec7d3b17cb94d3aa6d8b4f4a03a482a689c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge python3Packages.opencv3 rcl-interfaces rclpy sensor-msgs ];
+
+  meta = {
+    description = ''Publishes images from the file system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/eloquent/vision-msgs/default.nix
+++ b/distros/eloquent/vision-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-vision-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/eloquent/vision_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "575cc9b20a60762e84bc5ec7c303e7120e4f5da6576edb21baa94569214780c5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for interfacing with various computer vision pipelines, such as
+    object detectors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/costmap-cspace-msgs/default.nix
+++ b/distros/kinetic/costmap-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/costmap_cspace_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "edcc47e537c5002239d74c64eefb9af640e45aa189997fd64ca1dd534b9ff8ee";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/costmap_cspace_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "6ff25482f4c30305b76729da59bbded0442381bbff3c297ff1dba460310d9bb9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "41b8b16ee1dd78fa0066804f5691f80281f1233a2ad6ecfafd1bd8dd8c6ca72a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a45ebbe610ff27a4dbbe36dd36342a462359ad8de52f1ee394a0280bb11a7ad1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e261a0b3130a08fd316a996741ce1351c5b07234360fd0ddc1c79356caa19368";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "25759be926372c6ce8fa63c6aff229f5e0b1e11cc170feb8184261f88a982f98";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer-msgs/default.nix
+++ b/distros/kinetic/map-organizer-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/map_organizer_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "8237f8589f0335ff71171ffd75e445b0ff7ea38e9e84d372b110f741fa75409a";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/map_organizer_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "f61eec12b587d91d10ddd9ec245963274942938529db8ea21c17ccbb281ffc55";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "17636a5b800223d6db33f1eca8a9280335a9920c8a9f82de6698895c810bd6fc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "599c542fa03f005b5f4737722a1ac58abc2ee4c7b9af75dc695f8c1ab81c9252";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2019.12.30-r1";
+  version = "2020.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2019.12.30-1.tar.gz";
-    name = "2019.12.30-1.tar.gz";
-    sha256 = "a7731b4fe968de88f8c2ce5f7d2062761ef1ddab55172aa0c57fb6da72979c11";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.2.2-1.tar.gz";
+    name = "2020.2.2-1.tar.gz";
+    sha256 = "dca55f1115e4fcdba811800fcc6bf06090ff9fdbb0b6ad663a387eeff0d804e7";
   };
 
   buildType = "cmake";
-  buildInputs = [ pythonPackages.future pythonPackages.lxml ];
-  propagatedBuildInputs = [ catkin python ];
+  buildInputs = [ python pythonPackages.future pythonPackages.lxml ];
+  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "4f61dab68e34353ba9459010117a356d68f043c87ccab71943e61567c5fa0ab6";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "5ac1d2caf2b59158e501da90e376eff9ef97d4f52498e1ff6d5e7a76cf7dad67";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "b0874ea47211cc46ff3711062bfe064a551c9e023fbf16ee29ed7aa6a673b8b0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "89265f3853999da94c2f8d9c034c77ce890d79c7b63ab5645f5b8059f65f0157";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "298c40a7247ed4ad39eae32ea3e41b2e0b4ea89d545ada51f81ce2d70bb6a030";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "1ac29d4aba766556fa8585abd4b0fbe32c7213048e6c64333c2301392a87c5a5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-msgs/default.nix
+++ b/distros/kinetic/neonavigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, map-organizer-msgs, planner-cspace-msgs, safety-limiter-msgs, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/neonavigation_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "7ecdbe2667c57f1119d3b1cb9da7ee48eaecd961bd3638f2a18107bf91200437";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/neonavigation_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a6f019a962f5d63e5ba0d6221b3e1b4c9785a1f6359d7094a40db9a3d5e40716";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "bedde9b8a707f299605c7f5d430f78c574dfc337cbdd736d7d8677a0c90232d8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "d5c932c59909cecd8b78bfd9c256271b5033d0253959c50d69a56245186aecba";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "855c42a01f4d816c95cee5b4a0b99f54affef169525044612f4ad69f1d41c176";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "e948ad370b0bac793475c5af72feab6736f20554e176dc75ec38dafb9c104dbf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pacmod-game-control/default.nix
+++ b/distros/kinetic/pacmod-game-control/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joy, pacmod-msgs, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, joy, pacmod-msgs, roscpp, roslint, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-pacmod-game-control";
-  version = "2.3.0";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod_game_control-release/archive/release/kinetic/pacmod_game_control/2.3.0-0.tar.gz";
-    name = "2.3.0-0.tar.gz";
-    sha256 = "4bf23d9a203f9d2a26a4222a8f2a7e3f5c21b269569c346264af867219e6a375";
+    url = "https://github.com/astuff/pacmod_game_control-release/archive/release/kinetic/pacmod_game_control/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d5d6e476b8f0ba42a1eeef98c5a7fafccd3fc7c5eaa5157a5fcf6cc4fb823dfc";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   propagatedBuildInputs = [ joy pacmod-msgs roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/planner-cspace-msgs/default.nix
+++ b/distros/kinetic/planner-cspace-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/planner_cspace_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "23e1473ae485eb7f5b0f72793a7a16dbbe4f6217865c8ef593f72e27b4320424";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/planner_cspace_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "21e140b60ec140a95d6ebe2b8a13e1ade2043dcdbe66228388ee3c969752a9e9";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "df4acbef4a90fa9adc43059f8ae1d8672584e63c8bf69a4dea9ac5a3120cdfc9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "24b201ba1b35106da63ece52c5cce84218ab642faa444a43f2549a1c02ee1a71";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rcdiscover/default.nix
+++ b/distros/kinetic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-kinetic-rcdiscover";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/kinetic/rcdiscover/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b2209e39f2944eadd36d0aece80cbc376c8073b2f6cf8431464291c12bd280b6";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/kinetic/rcdiscover/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "749bb27b2f58cf8a281b590ec23df315090f46fc98764ad2c765bf3b1196b0fa";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/safety-limiter-msgs/default.nix
+++ b/distros/kinetic/safety-limiter-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/safety_limiter_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "7fd6d9e2dc6e62adc379623d9d67d2ce1105a19b5fe00fba59732831d38d187f";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/safety_limiter_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "3179a2920dc315a44587a1a5b30fb97cfe5d650701b7fb35b0ce3d066b46616c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e618ae94739594bbcf7b48ec5550676a1988832d96e0092f302470d973e35afa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "8d91861285b31b1bdd274065f9e699ba9f3a45e0a1c9f1d9f52207bf7930c774";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "58aedd635103fc5764f2383c1c1780f5afa5de46fab78cc1bb2ca4d347336ac1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "43fb5611616558f4bafd35384a3a3486b0ef7c5a325fcae31b39b1652f702fb4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker-msgs/default.nix
+++ b/distros/kinetic/trajectory-tracker-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/trajectory_tracker_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "fc27910c3d5c5391976d1d76ba51ad4333646a0bd9d68839ef1a527068331a56";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/kinetic/trajectory_tracker_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "954c926e8c36651789cdcdd6a4bf99ee68a406fdc61105d5309006d1c10e70ee";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "230e2313146f9e63d9672d4d29315c2921fab6cbcfbf3a76a689cb7a96b63b18";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "8273955702e83af61dd82a77cf0a4fb4b343985f0847e9f3afd68d4ccec7629f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-drivers/default.nix
+++ b/distros/melodic/ainstein-radar-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, can-msgs, catkin, nodelet, pcl-ros, roscpp, socketcan-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-drivers";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "de0bffb6af0b60b2508065ca674f88aa04f332107cfd6d96b6725017afb8fda1";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "5dfb5737907fd231491d05a5c871243e3869cde93146a2d28c5185eaef5d2cb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-filters/default.nix
+++ b/distros/melodic/ainstein-radar-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-filters";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6924545d6ca9563ea3035d935a4614287718e1989ff412f1f09656e30e18abbd";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "53a831c1b7e0b011a093bbafb87d18e42a4fddeb0bc5986edb3596dcd508de97";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, gazebo-plugins, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-gazebo-plugins";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "a9b7e22b72584d76cf0e62c37ea5f3723f3e36faaf81151d27ddc38e7b4b64a8";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "dd2a4a646e14ce84ea9b08f7d52e3807b514079b555e8ad2704eb83d9926bb13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-msgs/default.nix
+++ b/distros/melodic/ainstein-radar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-msgs";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "0b7dcd915b866597f9457ac0f1e15188bcb4309b7043f932378d041830f261d5";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "4f1489ed65070103851d5ea569cffee0d73fbd8156090bea184478d18ae4c432";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-rviz-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, pcl, qt5, rviz }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-rviz-plugins";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e55ca73701363e257bdd186d2d355076015b7e3832ec9b1ac4a49088774b4a8a";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "925bfeea971400c6668acbd62007ca50d96ad4e1636bd79b870926cf0787e652";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-tools/default.nix
+++ b/distros/melodic/ainstein-radar-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-filters, ainstein-radar-msgs, catkin, cv-bridge, image-geometry, image-transport, pcl-ros, roscpp, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-tools";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "edd663b4d4fccb71e7ed6e87fe55f0847752f09e5923b6f89551d5b944223626";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "dab485d2d37654886e080b9e037ec78897ce64b4212418a23c5bf23a7e60783b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar/default.nix
+++ b/distros/melodic/ainstein-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-drivers, ainstein-radar-filters, ainstein-radar-gazebo-plugins, ainstein-radar-msgs, ainstein-radar-rviz-plugins, ainstein-radar-tools, catkin }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "8f47d68abd970c72ed9de890d8e1dc78cc89a6403493420ebd102fa18a577d11";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "f85a42304fa9e9bde722ac15182b9a2f92789a658873a1a1afaa1306fd2881ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace-msgs/default.nix
+++ b/distros/melodic/costmap-cspace-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/costmap_cspace_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "6d0286a8b36a35142db9e2c78857e2423fbbe9dd87ff350487dd1b07c8759e7a";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/costmap_cspace_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "e6524cf78fe5a9feacaeced8de9c2f82699bf1f9bc74c6483a2356c9dd9c8573";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "2d9fa6ea0715f39b983a46eb04511fa02027dc5a42e0bde950ed3a07edf4c5a4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b1891926f477fce3fa0501e2a3eaeeda6d7dbea6241349bec67c4fdbee518b07";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "9c25ea0be3ab138229ba6c7dd74b518c2b317a642168a6f277e46092b9eeae35";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "fd9d5e9f071ac3cb9c545b59a1409c53cfc2b92e0844cd2c847fdb1d05c6732a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-cartpole-dynamics-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "8ab241a34a764ef7f6d76e98c22da15aa1b4f7bf83ed276259640cbe60eec516";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartpole dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "3272a80421da42c672c81733bc649c88783104d945c886f589acf5fd90d97294";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "b78f6882b598153128b9a3eeb8c26359a3e136b0412bb9f169c37b72be044d60";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -2,18 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "3a3613b62c0ad3be115ad5c6214e3ed1d8b55280d5bd7b20555ad4585d3b0b49";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "69ad78f397ed4ca35cf13e7b06e5672e4dc537a4325c4313953fa2b36ca42180";
   };
 
   buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen-conversions, geometry-msgs, kdl-parser, message-runtime, moveit-core, moveit-msgs, moveit-ros-planning, pluginlib, roscpp, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2, zeromq }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "c5f91ca156ad37a8357e9b650c39fab45ea4327bf1a4a645f1bdc2bcde2e59fc";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "5960220f06734e58b4299790facba37df5aedf03ddb8ea53d62805b62f25380e";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ eigen-conversions geometry-msgs kdl-parser message-runtime moveit-core moveit-msgs moveit-ros-planning pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  buildInputs = [ cmake-modules cppzmq ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 zeromq ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-ddp-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "e1f666bb01595a4c0cc01ea7c10d184361d00c44b22e443d2141a902597514c1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various DDP Solvers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "5e363275f4f6d3416e8c3f70120f2ab929b1e93d1111dd20326f6377ce940f24";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Double integrator dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-dynamics-solvers";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "5ba5e9ea76413d2d21231057e962346b48d0c558a98cf5c6f544141095600839";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-cartpole-dynamics-solver exotica-double-integrator-dynamics-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-quadrotor-dynamics-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for all dynamics solvers bundled with core EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "29b1331e8e4ea4183064803a44e6e438b638c4d5c1c4927ea3d93d79dd29c325";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "f87ecd743478ba8b878497fee3baaef7baf679825c12931e6adf159f6975bf20";
   };
 
   buildType = "catkin";
-  checkInputs = [ exotica-val-description rostest ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-core exotica-core-task-maps exotica-ik-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  checkInputs = [ exotica-val-description rostest rosunit ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "6f5acb6bf7625497c93ce8204bd5bb8eb05441eb32973da328e34bd0cbfa27f5";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "0cc069f206bd5685839b49f2adff4d9d6406e7546f02da5748168c91c57cbcac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-ilqg-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "3d98d36aeaff9b7ff1e6e7cb813d260694e201d9664d0068a7346150b092488f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQG Solver (Todorov and Li, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-ilqr-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "6d30e8519eca9e69e1e5391a4431a174053f1302a623fba77840a4d8fe97d437";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQR Solver (Li and Todorov, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "8de5b8fb856c5ca84c37447698c4635251f39b39db82d323f6b788aea4b1d93f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "c8524e36a7fff41f67d6363facaa3226f41c88fd3c5e8b8b01da6189b7c13e50";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-ompl-control-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "f7bd90a177fa3c7c75385bd4fafe681b084e7d99964fcff748a17d0f7be88f30";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Kinodynamic Control Solvers from OMPL'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "07851ceb7d6c1cae605a7ba07157219995fcb3e1358f65c62daf96e73012ff26";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "704142289766a06eefd6bc3a02ba414919c80bd0fc28e948fef60975cdc0046d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-pendulum-dynamics-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "b386143058490db3d4bbfdb2bb1f5d5e2e1820b267ed48260228a74d74ffa8ef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Pendulum dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "d46aae22af5c04244ca6bc6268a32644a8de5f11a52c5d4e10297fefdc7694dd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Dynamics solver plug-in using Pinocchio for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "9ae4a89c165c5669eba0b7a5a89d9a55101879d06afd4e27995ad280be094c0e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Quadrotor dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
+buildRosPackage {
+  pname = "ros-melodic-exotica-scipy-solver";
+  version = "5.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "fb1f96bc8288ad7251f4b411316150ad3f8d863b94f6cd4f70d0aa4de67f2a4d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pythonPackages.numpy pythonPackages.scipy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''SciPy-based Python solvers for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "e5b831d55d98996965fed4fcdd67e9c99bc140caa7b0273227c9805a193565ec";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "4041b3d2fd8a3e4a6c3b6ca75d3731a25f4150b8922c3711d335d1d008fb81d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "5.0.0";
+  version = "5.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "c765e57dd0796114cc5b4bdaaeb8f8f55dd9311bbcc7320273be1fc4d6dc0d52";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.1.0-1.tar.gz";
+    name = "5.1.0-1.tar.gz";
+    sha256 = "e921c0149d23d8f74fa0f68dec4086bd7afed803e6b0481df84edbc2cf28d92d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -776,19 +776,41 @@ self: super: {
 
  exotica-aico-solver = self.callPackage ./exotica-aico-solver {};
 
+ exotica-cartpole-dynamics-solver = self.callPackage ./exotica-cartpole-dynamics-solver {};
+
  exotica-collision-scene-fcl-latest = self.callPackage ./exotica-collision-scene-fcl-latest {};
 
  exotica-core = self.callPackage ./exotica-core {};
 
  exotica-core-task-maps = self.callPackage ./exotica-core-task-maps {};
 
+ exotica-ddp-solver = self.callPackage ./exotica-ddp-solver {};
+
+ exotica-double-integrator-dynamics-solver = self.callPackage ./exotica-double-integrator-dynamics-solver {};
+
+ exotica-dynamics-solvers = self.callPackage ./exotica-dynamics-solvers {};
+
  exotica-examples = self.callPackage ./exotica-examples {};
 
  exotica-ik-solver = self.callPackage ./exotica-ik-solver {};
 
+ exotica-ilqg-solver = self.callPackage ./exotica-ilqg-solver {};
+
+ exotica-ilqr-solver = self.callPackage ./exotica-ilqr-solver {};
+
  exotica-levenberg-marquardt-solver = self.callPackage ./exotica-levenberg-marquardt-solver {};
 
+ exotica-ompl-control-solver = self.callPackage ./exotica-ompl-control-solver {};
+
  exotica-ompl-solver = self.callPackage ./exotica-ompl-solver {};
+
+ exotica-pendulum-dynamics-solver = self.callPackage ./exotica-pendulum-dynamics-solver {};
+
+ exotica-pinocchio-dynamics-solver = self.callPackage ./exotica-pinocchio-dynamics-solver {};
+
+ exotica-quadrotor-dynamics-solver = self.callPackage ./exotica-quadrotor-dynamics-solver {};
+
+ exotica-scipy-solver = self.callPackage ./exotica-scipy-solver {};
 
  exotica-time-indexed-rrt-connect-solver = self.callPackage ./exotica-time-indexed-rrt-connect-solver {};
 

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "c14055fa9c95d7c4d5215d97f0774b77d94d8f659903e9b738ef009142c04e6b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "fb3ca36b097e6fc5788e7c59e8187d0f4a369f3d51710c1e9211b0cf2f61d0d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer-msgs/default.nix
+++ b/distros/melodic/map-organizer-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/map_organizer_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "1320445d272efde8b0dfa97594007ffd520c73e18c53e30bb451e52ace2c5aea";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/map_organizer_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "4b94fc9da69ca5e9e2fd79d10543a61e46f05abfffc0059759f69e93547ceaff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e2a59ec8b52babf5970381d2e11827655a19aa1871ef4a7d1ba44d1243c2d4ed";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "de4c7bb476791b76c31d2f7388a481f19e376d6a2e707b7f747ac827350256d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2019.12.30-r1";
+  version = "2020.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2019.12.30-1.tar.gz";
-    name = "2019.12.30-1.tar.gz";
-    sha256 = "0476baf1a1238c4b914c1a0c98d7c69ff95ed6f28a8665528fa2b3c74e302c5a";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.2.2-1.tar.gz";
+    name = "2020.2.2-1.tar.gz";
+    sha256 = "c639292ab1ec51eaea462ac4d82dc10780ba90e8586a4249366a7476cc434178";
   };
 
   buildType = "cmake";
-  buildInputs = [ pythonPackages.future pythonPackages.lxml ];
-  propagatedBuildInputs = [ catkin python ];
+  buildInputs = [ python pythonPackages.future pythonPackages.lxml ];
+  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d37d2a898ff0abb78d6804b27e866f061a9dedfe77ae39cdb9fd313274398817";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "cbc4b7bc153ea1c011045c4b0a8a1f20c699fabfe052290162e0b5a54c1f76c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "b1564cd915edd3d8ebe2e401008d6a42d7d6a0f4a99ac47d52142c342d09200b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a89435984d4e63220d2aeebb09cb9664b5552c8760a6f7b5957bf4a278aafd4b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "fbbff504282b2619c6c850402ccbf3dcbc44c087068967fe1512b2d33b7b5450";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "29cb34de13a0c550f4c6fa2eb0821ce2cbb13f3f278e43c5d94031b7fad6dad7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-msgs/default.nix
+++ b/distros/melodic/neonavigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, map-organizer-msgs, planner-cspace-msgs, safety-limiter-msgs, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/neonavigation_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "72cf1e5ef7e9b0431705b47be4bfd14dfd9775b208ff62f1e98ba75c86b7551c";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/neonavigation_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "207fe349d6848b4c96c6d6408114767cb38f92e7535a4be0d607d515b70df7db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "ae7f64b299afde87337849bfa4b80050aa974c66fe8c7cfa6fa76feba89ceba4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "93ec5df21ff9d32b8fa204a0cfb245eafb407fc090f16140328476b152cd3cb8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "4eed7fb44c617182eb73057665fd41a0dcfaefe77982dcd9dbfcccf7cceee42e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "99bc4dedb4bc848608a3466fa2122b5438d14ff5447c9ccd1e90ee3db10113bd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pacmod-game-control/default.nix
+++ b/distros/melodic/pacmod-game-control/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joy, pacmod-msgs, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, joy, pacmod-msgs, roscpp, roslint, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pacmod-game-control";
-  version = "2.3.0";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod_game_control-release/archive/release/melodic/pacmod_game_control/2.3.0-0.tar.gz";
-    name = "2.3.0-0.tar.gz";
-    sha256 = "279a95661041ef6f88cf7ba26f5f61af4010fac0ca579a38eddad0088f6dcabb";
+    url = "https://github.com/astuff/pacmod_game_control-release/archive/release/melodic/pacmod_game_control/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d6dcf815bd4eeb07f8f36532359eb8dd0bb5bae2942df2a54a36eb2bad16611f";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   propagatedBuildInputs = [ joy pacmod-msgs roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/planner-cspace-msgs/default.nix
+++ b/distros/melodic/planner-cspace-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/planner_cspace_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "97391d287ee4f03c83fd7d6c715039d25da350f32b26b01168b91ff04337c38c";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/planner_cspace_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "10c72f46c6a0d1e05208afa278a50ce5265acbdf97b2599e211f011d0d149d09";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "e6ecc99d856c7f5ac4de1d873055f315e57516c3e5705e0fa992206a019b2b9b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "125391e741659360317517db9b16e4e1e16c7ff86b633a697b4fafd566463b31";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rcdiscover/default.nix
+++ b/distros/melodic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-rcdiscover";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "43fdfa6280e76ad07d45bf32e7e1e08ee91f161bfef9605765758ef8a51e5b13";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ce3eec02147055dfd98d8e5cf830b634ce6c72bef9ac06c1310bcb46b0fa86a2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/realtime-tools/default.nix
+++ b/distros/melodic/realtime-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-realtime-tools";
-  version = "1.15.0-r1";
+  version = "1.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/melodic/realtime_tools/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "7f931948bd7454781ba1f93a1dd3642a561c97ce7668d8c4b8e862a1616bcb5d";
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/melodic/realtime_tools/1.15.1-1.tar.gz";
+    name = "1.15.1-1.tar.gz";
+    sha256 = "acf2cb7827b85a846c7fb3f01879260c2eae38576856e0059ce983521eda99d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter-msgs/default.nix
+++ b/distros/melodic/safety-limiter-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/safety_limiter_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "ce604a0c0ea91871e7e2a7949b792e751fadde6e2570ab4091eb5c63806e9703";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/safety_limiter_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "407f671b4c31ccc36c54b5957ad6069ffbb385bf0e4a6284f6bd87ec69cd875c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "14ff1dcbeee2ca5a68f9fcb968fd366ebd619f00b10b3c547c93454f3687b443";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "76cb673579086ab54bf5434d96d2f10d56982874d909a24b3783ba00bdb3197b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sparse-bundle-adjustment/default.nix
+++ b/distros/melodic/sparse-bundle-adjustment/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, blas, catkin, eigen, liblapack, suitesparse }:
+{ lib, buildRosPackage, fetchurl, blas, catkin, eigen, liblapack, roscpp, suitesparse }:
 buildRosPackage {
   pname = "ros-melodic-sparse-bundle-adjustment";
-  version = "0.4.2";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/melodic/sparse_bundle_adjustment/0.4.2-0.tar.gz";
-    name = "0.4.2-0.tar.gz";
-    sha256 = "ab87c65d8f8d392258c9d733edf76c417488f78b564a7ce7000bd67ed5bd26fd";
+    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/melodic/sparse_bundle_adjustment/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "01999d93ad1a1991f5e80606f43a52dd27906b2da58c9f3296af6868f497aa1e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ blas eigen liblapack suitesparse ];
+  propagatedBuildInputs = [ blas eigen liblapack roscpp suitesparse ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/tf2-server/default.nix
+++ b/distros/melodic/tf2-server/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, nodelet, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-server";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "c3d426d0010cb58736fe7bb5cca14fea50eea2dcb2e6e60d92218bb5f222689f";
+    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d0e1148870bc96da2119d39390871602142aa7afa20ebf73d54fb89561d27c64";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ gtest rostest tf ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime roscpp rospy tf2-msgs tf2-ros ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nodelet roscpp rospy tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "8e3e1c8356df717c2abfa2b04c1e7829e2e9f6b03a85ce2ff1c9074a3b3e3a4f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "ab22bf90ff720d085883d9111a38cb89684d24b8c1a0a5db01a2a5052bfa9778";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker-msgs/default.nix
+++ b/distros/melodic/trajectory-tracker-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker-msgs";
-  version = "0.5.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/trajectory_tracker_msgs/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "16e5defe9dc4296864c7920fcc8249c3b6b261cdf7f66511d12f1a3a8a51e725";
+    url = "https://github.com/at-wat/neonavigation_msgs-release/archive/release/melodic/trajectory_tracker_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "e9fca011f593164e1e4a51d34ad294ef1d9f28f59867990bf314e313b5b07761";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "44c324aca86ed578e712699f839f714a1c7465c8ae28dccfd1562a83efb748c1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c08569c73047c01677257c0706f1375a243b3e3af2178f8eb46c7e82be390038";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit b601aa155530002d554e0f4a22930099d47648cd.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *controller-interface 0.0.1-r1*
* *controller-manager 0.0.1-r1*
* *controller-parameter-server 0.0.1-r1*
* *hardware-interface 0.0.1-r1*
* *pacmod3 1.3.0-r1 --> 1.3.1-r1*
* *ros-controllers 0.0.1-r2*
* *ros2-control 0.0.1-r1*
* *slide-show 0.1.0-r1*
* *test-robot-hardware 0.0.1-r1*

Eloquent Changes:
-----------------
* *cartographer-ros 1.0.9000-r1 --> 1.0.9001-r1*
* *cartographer-ros-msgs 1.0.9000-r1 --> 1.0.9001-r1*
* *costmap-queue 0.3.2-r1 --> 0.3.3-r1*
* *dwb-core 0.3.2-r1 --> 0.3.3-r1*
* *dwb-critics 0.3.2-r1 --> 0.3.3-r1*
* *dwb-msgs 0.3.2-r1 --> 0.3.3-r1*
* *dwb-plugins 0.3.2-r1 --> 0.3.3-r1*
* *laser-geometry 2.1.0-r1 --> 2.1.1-r1*
* *nav-2d-msgs 0.3.2-r1 --> 0.3.3-r1*
* *nav-2d-utils 0.3.2-r1 --> 0.3.3-r1*
* *nav2-amcl 0.3.2-r1 --> 0.3.3-r1*
* *nav2-behavior-tree 0.3.2-r1 --> 0.3.3-r1*
* *nav2-bringup 0.3.2-r1 --> 0.3.3-r1*
* *nav2-bt-navigator 0.3.2-r1 --> 0.3.3-r1*
* *nav2-common 0.3.2-r1 --> 0.3.3-r1*
* *nav2-controller 0.3.2-r1 --> 0.3.3-r1*
* *nav2-core 0.3.2-r1 --> 0.3.3-r1*
* *nav2-costmap-2d 0.3.2-r1 --> 0.3.3-r1*
* *nav2-dwb-controller 0.3.2-r1 --> 0.3.3-r1*
* *nav2-gazebo-spawner 0.3.2-r1 --> 0.3.3-r1*
* *nav2-lifecycle-manager 0.3.2-r1 --> 0.3.3-r1*
* *nav2-map-server 0.3.2-r1 --> 0.3.3-r1*
* *nav2-msgs 0.3.2-r1 --> 0.3.3-r1*
* *nav2-navfn-planner 0.3.2-r1 --> 0.3.3-r1*
* *nav2-planner 0.3.2-r1 --> 0.3.3-r1*
* *nav2-recoveries 0.3.2-r1 --> 0.3.3-r1*
* *nav2-rviz-plugins 0.3.2-r1 --> 0.3.3-r1*
* *nav2-system-tests 0.3.2-r1 --> 0.3.3-r1*
* *nav2-util 0.3.2-r1 --> 0.3.3-r1*
* *nav2-voxel-grid 0.3.2-r1 --> 0.3.3-r1*
* *nav2-waypoint-follower 0.3.2-r1 --> 0.3.3-r1*
* *navigation2 0.3.2-r1 --> 0.3.3-r1*
* *py-trees-ros 2.0.4-r1 --> 2.0.6-r2*
* *rqt-tf-tree 1.0.1-r1 --> 1.0.2-r1*
* *slide-show 0.1.0-r1*
* *vision-msgs 1.0.0-r1*

Kinetic Changes:
----------------
* *costmap-cspace 0.6.0-r1 --> 0.7.0-r1*
* *costmap-cspace-msgs 0.5.0-r1 --> 0.7.0-r1*
* *joystick-interrupt 0.6.0-r1 --> 0.7.0-r1*
* *map-organizer 0.6.0-r1 --> 0.7.0-r1*
* *map-organizer-msgs 0.5.0-r1 --> 0.7.0-r1*
* *mavlink 2019.12.30-r1 --> 2020.2.2-r1*
* *mcl-3dl 0.2.0-r1 --> 0.2.1-r1*
* *neonavigation 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-common 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-launch 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-msgs 0.5.0-r1 --> 0.7.0-r1*
* *obj-to-pointcloud 0.6.0-r1 --> 0.7.0-r1*
* *pacmod-game-control 2.3.0 --> 3.0.1-r1*
* *planner-cspace 0.6.0-r1 --> 0.7.0-r1*
* *planner-cspace-msgs 0.5.0-r1 --> 0.7.0-r1*
* *rcdiscover 1.0.0-r1 --> 1.0.2-r1*
* *safety-limiter 0.6.0-r1 --> 0.7.0-r1*
* *safety-limiter-msgs 0.5.0-r1 --> 0.7.0-r1*
* *track-odometry 0.6.0-r1 --> 0.7.0-r1*
* *trajectory-tracker 0.6.0-r1 --> 0.7.0-r1*
* *trajectory-tracker-msgs 0.5.0-r1 --> 0.7.0-r1*

Melodic Changes:
----------------
* *ainstein-radar 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-drivers 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-filters 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-gazebo-plugins 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-msgs 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-rviz-plugins 2.0.2-r1 --> 3.0.0-r1*
* *ainstein-radar-tools 2.0.2-r1 --> 3.0.0-r1*
* *costmap-cspace 0.6.0-r1 --> 0.7.0-r1*
* *costmap-cspace-msgs 0.5.0-r1 --> 0.7.0-r1*
* *exotica 5.0.0 --> 5.1.0-r1*
* *exotica-aico-solver 5.0.0 --> 5.1.0-r1*
* *exotica-cartpole-dynamics-solver 5.1.0-r1*
* *exotica-collision-scene-fcl-latest 5.0.0 --> 5.1.0-r1*
* *exotica-core 5.0.0 --> 5.1.0-r1*
* *exotica-core-task-maps 5.0.0 --> 5.1.0-r1*
* *exotica-ddp-solver 5.1.0-r1*
* *exotica-double-integrator-dynamics-solver 5.1.0-r1*
* *exotica-dynamics-solvers 5.1.0-r1*
* *exotica-examples 5.0.0 --> 5.1.0-r1*
* *exotica-ik-solver 5.0.0 --> 5.1.0-r1*
* *exotica-ilqg-solver 5.1.0-r1*
* *exotica-ilqr-solver 5.1.0-r1*
* *exotica-levenberg-marquardt-solver 5.0.0 --> 5.1.0-r1*
* *exotica-ompl-control-solver 5.1.0-r1*
* *exotica-ompl-solver 5.0.0 --> 5.1.0-r1*
* *exotica-pendulum-dynamics-solver 5.1.0-r1*
* *exotica-pinocchio-dynamics-solver 5.1.0-r1*
* *exotica-quadrotor-dynamics-solver 5.1.0-r1*
* *exotica-scipy-solver 5.1.0-r1*
* *exotica-time-indexed-rrt-connect-solver 5.0.0 --> 5.1.0-r1*
* *joystick-interrupt 0.6.0-r1 --> 0.7.0-r1*
* *map-organizer 0.6.0-r1 --> 0.7.0-r1*
* *map-organizer-msgs 0.5.0-r1 --> 0.7.0-r1*
* *mavlink 2019.12.30-r1 --> 2020.2.2-r1*
* *mcl-3dl 0.2.0-r1 --> 0.2.1-r1*
* *neonavigation 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-common 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-launch 0.6.0-r1 --> 0.7.0-r1*
* *neonavigation-msgs 0.5.0-r1 --> 0.7.0-r1*
* *obj-to-pointcloud 0.6.0-r1 --> 0.7.0-r1*
* *pacmod-game-control 2.3.0 --> 3.0.1-r1*
* *planner-cspace 0.6.0-r1 --> 0.7.0-r1*
* *planner-cspace-msgs 0.5.0-r1 --> 0.7.0-r1*
* *rcdiscover 1.0.0-r1 --> 1.0.2-r1*
* *realtime-tools 1.15.0-r1 --> 1.15.1-r1*
* *safety-limiter 0.6.0-r1 --> 0.7.0-r1*
* *safety-limiter-msgs 0.5.0-r1 --> 0.7.0-r1*
* *sparse-bundle-adjustment 0.4.2 --> 0.4.3-r1*
* *tf2-server 1.0.3-r1 --> 1.0.4-r1*
* *track-odometry 0.6.0-r1 --> 0.7.0-r1*
* *trajectory-tracker 0.6.0-r1 --> 0.7.0-r1*
* *trajectory-tracker-msgs 0.5.0-r1 --> 0.7.0-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

