### PR TITLE
rosdistro sync, Fri Feb 14 12:40:25 2020

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -752,6 +752,8 @@ self: super: {
 
  rmw-opensplice-cpp = self.callPackage ./rmw-opensplice-cpp {};
 
+ robot-localization = self.callPackage ./robot-localization {};
+
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
  ros1-bridge = self.callPackage ./ros1-bridge {};

--- a/distros/dashing/joy-teleop/default.nix
+++ b/distros/dashing/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, rclpy, sensor-msgs, teleop-tools-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-dashing-joy-teleop";
-  version = "1.0.1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/joy_teleop/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "e6a6750721cacab7e348bc219676b6007b1abba1cdbbd6181bb185284b3bea5a";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/joy_teleop/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ae20e98e28091af8ad97150e4b84f1626195f0b30ef97ada9244294be390d5e6";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/key-teleop/default.nix
+++ b/distros/dashing/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-key-teleop";
-  version = "1.0.1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/key_teleop/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "801499b37a29a2ff26955ecfa912aa902db98a6ffb5df9166e1e6710ea0274d7";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/key_teleop/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "45f8e4c06f88eaceac3f7d60a9094294a524d5f8085f5121f58cc5569df57977";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/mouse-teleop/default.nix
+++ b/distros/dashing/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-mouse-teleop";
-  version = "1.0.1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/mouse_teleop/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "9230fff0302bc592e4091435c1bd49a5f7ae38d3fa363a1c1acd5ed5127f7674";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/mouse_teleop/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "babea784bc146a28073dbea6b81db017798770ff11791fa8d777a2bd31ee8013";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/robot-localization/default.nix
+++ b/distros/dashing/robot-localization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geometry-msgs, launch-testing-ament-cmake, libyamlcpp, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-robot-localization";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/dashing/robot_localization/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "0977a96d2e5d4e501a7f9178dd23eee8e66e45f95431303c46d79ff3b136568c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common builtin-interfaces launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen geographic-msgs geometry-msgs libyamlcpp nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides nonlinear state estimation through sensor fusion of an abritrary number of sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/system-modes-examples/default.nix
+++ b/distros/dashing/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-dashing-system-modes-examples";
-  version = "0.1.4-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "a77739b39f240f7158a9a4650f5cd1fac2103a193b2222e9b51e861763f75e5d";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "821afe20643a4d3f645a637ed8e52f10adc6a9c84bde3521d26ed750c8bccc21";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/system-modes/default.nix
+++ b/distros/dashing/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-system-modes";
-  version = "0.1.4-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b2eb0ff85a3f98c18d0b23c8599579e2e3a200d891a2a1de36d356cce9ecce60";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "9e7670f69f1cdf63fdaa042c7423b59731f2e34390567fdb0fbdde7399b770c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/teleop-tools-msgs/default.nix
+++ b/distros/dashing/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-dashing-teleop-tools-msgs";
-  version = "1.0.1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools_msgs/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "525574e5ad6dc449341d69a948dc2006ec2e42a0a87780ba98f832962adefbf9";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6a16f3d22cd21a42dfe0c8261d0a6b192aa7471e418f973df28b4a22723f0248";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/teleop-tools/default.nix
+++ b/distros/dashing/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-dashing-teleop-tools";
-  version = "1.0.1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "ded3fce86b0df35113d84809762af3fe0ace5a3cd9035e32fe36511e85b0108a";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2ff018eb2e76415e08eab89f9b0a973a58213cbfde24e2d2d8c778956c7cd12b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -572,6 +572,8 @@ self: super: {
 
  poco-vendor = self.callPackage ./poco-vendor {};
 
+ pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
+
  px4-msgs = self.callPackage ./px4-msgs {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};

--- a/distros/eloquent/pointcloud-to-laserscan/default.nix
+++ b/distros/eloquent/pointcloud-to-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, laser-geometry, launch, launch-ros, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-pointcloud-to-laserscan";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/eloquent/pointcloud_to_laserscan/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "da985ec21e84208b66a3e9bb3084e78aba5ed01d505de35e89c04d727adefc1a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ laser-geometry launch launch-ros message-filters rclcpp rclcpp-components sensor-msgs tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts a 3D Point Cloud into a 2D laser scan. This is useful for making devices like the Kinect appear like a laser scanner for 2D-based algorithms (e.g. laser-based SLAM).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/py-trees-ros/default.nix
+++ b/distros/eloquent/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-py-trees-ros";
-  version = "2.0.6-r2";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.6-2.tar.gz";
-    name = "2.0.6-2.tar.gz";
-    sha256 = "1205e3a498238974e4466607ec477026afcc713deae6a90679e6a1c3e5a441db";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "1077877920d104ca6d6be08bb89dcbde36b78da735da5c347d2f172584664c9c";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/system-modes-examples/default.nix
+++ b/distros/eloquent/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-eloquent-system-modes-examples";
-  version = "0.1.5-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes_examples/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "a5b8ba166e181e91f6c9a6dc869e13c847449864960baa872998ceb5ab78aa78";
+    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes_examples/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "ea38bacfa97d0c748694d4e341e01e95598d86c415110a91617580a24bf8c4a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/system-modes/default.nix
+++ b/distros/eloquent/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-system-modes";
-  version = "0.1.5-r1";
+  version = "0.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "f328cbd28c04a2179b20f79e02a5c3bba588ca7bf33a3e53704b57e682baefe0";
+    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "b91e592ec1286276b05e8a618578dadacc25b9ae598c46d1aa9b6b03538681ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/ainstein-radar-drivers/default.nix
+++ b/distros/kinetic/ainstein-radar-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, can-msgs, catkin, nodelet, pcl-ros, roscpp, socketcan-bridge }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-drivers";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_drivers/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "96a66a4cefb59faed8193b670db22077e6df3d66f26fe80e0f064e3c3cd8bd89";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_drivers/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "864f7950a9dd927671cb137d913738395656b7a4bbd1577bc2a473f1dd1dd0f9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ainstein-radar-filters/default.nix
+++ b/distros/kinetic/ainstein-radar-filters/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-filters";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_filters/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "779da5a6c95af8b75eba3d941d2649f70af4742fe371759153d2a2de888228f2";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_filters/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "681d99f0bbe1decc0aa2bc0170c45b866fd194365c8a4e795e802ca18547523b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen ];
+  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen tf2-sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/ainstein-radar-gazebo-plugins/default.nix
+++ b/distros/kinetic/ainstein-radar-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, gazebo-plugins, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-gazebo-plugins";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_gazebo_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "96594cfda92b5032a9b37f1ae3ec8c017c61f4d67fa05e57bf115c2e508ed606";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_gazebo_plugins/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "f2856f3b88625364c548b3f160a63126e1c55bcbf5886a79ff29f9b6ad13586a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ainstein-radar-msgs/default.nix
+++ b/distros/kinetic/ainstein-radar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-msgs";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_msgs/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "6389a87f6ef5a4de37d9bf8e242f4f8105c550191ad5342a58d64c122c2d6210";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "09906428586f54f4790a47d51d41014ef410001ea78b5e31d1aa0f903e452c39";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ainstein-radar-rviz-plugins/default.nix
+++ b/distros/kinetic/ainstein-radar-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, pcl, qt5, rviz }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-rviz-plugins";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_rviz_plugins/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "cb85b1326a0ea194aeb4ccf005c010becb1774ad64dfd035a766abf953e649bb";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_rviz_plugins/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "93d55af3cc6dddb8778692cc4c5cb9171da6344c64f8788b50db3bef7aa1ba61";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ainstein-radar-tools/default.nix
+++ b/distros/kinetic/ainstein-radar-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-filters, ainstein-radar-msgs, catkin, cv-bridge, image-geometry, image-transport, pcl-ros, roscpp, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar-tools";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_tools/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "78a6c18b25c77cea7d706d10a09555f1872261576fff9e0834aba09a61b86760";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar_tools/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "3bbfb7e1c2ef0fd3f0fe0c15f221af655b21909cb500ca92991b73e909fd31af";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ainstein-radar/default.nix
+++ b/distros/kinetic/ainstein-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-drivers, ainstein-radar-filters, ainstein-radar-gazebo-plugins, ainstein-radar-msgs, ainstein-radar-rviz-plugins, ainstein-radar-tools, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-ainstein-radar";
-  version = "2.0.2-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e58ad4a1f7a07b24d62a33d9d64e5d8c229ac86bdd8b1b769e0b847544ecab3d";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/kinetic/ainstein_radar/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "071300d08b705ac987d189ec37d2298667d90fa009482b6a63ecfd0b7841eb5a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/combined-robot-hw-tests/default.nix
+++ b/distros/kinetic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-tests, hardware-interface, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-combined-robot-hw-tests";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw_tests/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "062bc3b2a7136efa85a876a91e4d6136d84ee05a97eba7f52e5c0f728227852a";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw_tests/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "28215de86afa095dd2ec4e1535c594664b63e3d8b3d131b42b6b0e5906314ed2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/combined-robot-hw/default.nix
+++ b/distros/kinetic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-combined-robot-hw";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "7e38dbeef1b656cd09fe29ed945315fde50cd4593ab867364a0fa6142b7499eb";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/combined_robot_hw/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "7808de7107a8a5b9dce0b9c5cef08cc3a9b216d93f513aef27ebabdf6f53a877";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/controller-interface/default.nix
+++ b/distros/kinetic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-controller-interface";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_interface/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "f18d88901d6e04e1001f85041f93aaafb8f3b569a1b666b060bb37753b15f7a3";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_interface/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "30eba6cf7866a83292b67ea5b82f21b62a428de5577078b278474063ea3f3739";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/controller-manager-msgs/default.nix
+++ b/distros/kinetic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager-msgs";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_msgs/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "8f7c8b12ccfb1134afd671f78a6769070e3a33e5d308d3234513c841acc731ac";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_msgs/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "3b5867ec736565dae667ef70e6d3976e6934b1b65c8f3728d566906c012b333e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/controller-manager-tests/default.nix
+++ b/distros/kinetic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, rosbash, rosnode, rosservice, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager-tests";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_tests/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "98db7d491de2f2ffa7d08866f6c276920ff5ce7ed6da6412b46267e24230c60a";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager_tests/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "15b9230f00066024310438a7438ada24ecc30dd952323f5ea4f43d31ea3c494b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/controller-manager/default.nix
+++ b/distros/kinetic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-controller-manager";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "e2e4d37d8f4b682b825caca7fe740e8991e9a7d1db3d2103235ab04f19946d75";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/controller_manager/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "50fe6cfc05ab3de17340660ead08a660343e33e75fef8433e1d0acd387af1df9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -3664,6 +3664,8 @@ self: super: {
 
  ros-core = self.callPackage ./ros-core {};
 
+ ros-cvb-camera-driver = self.callPackage ./ros-cvb-camera-driver {};
+
  ros-emacs-utils = self.callPackage ./ros-emacs-utils {};
 
  ros-environment = self.callPackage ./ros-environment {};
@@ -4357,6 +4359,8 @@ self: super: {
  summit-xl-sim = self.callPackage ./summit-xl-sim {};
 
  summit-xl-sim-bringup = self.callPackage ./summit-xl-sim-bringup {};
+
+ swarmros = self.callPackage ./swarmros {};
 
  swri-console = self.callPackage ./swri-console {};
 

--- a/distros/kinetic/hardware-interface/default.nix
+++ b/distros/kinetic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-hardware-interface";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/hardware_interface/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "575a20e649c9b44fbad6362ed6f2acb2810a738b778ff520ba70c8e67e70bd1b";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/hardware_interface/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "9b33ac5a19c6f1a926e39922bd4ffadbc9ed1d49ec54390a6df9198569c7becb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ira-laser-tools/default.nix
+++ b/distros/kinetic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
 buildRosPackage {
   pname = "ros-kinetic-ira-laser-tools";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "d1394e4f4f8dc23d9fe38bcc54ba8e04762e58a5e527bf5643ebb1600f38b09b";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "68a56b260c6b1063c03305d2cea284da424d86f7d30b970a77ae735f57813bde";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joint-limits-interface/default.nix
+++ b/distros/kinetic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, rosunit, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-kinetic-joint-limits-interface";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/joint_limits_interface/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "42c1a2cfc42f096eb00dc5af396c03733a814dcf1d2c41248166a898019d905d";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/joint_limits_interface/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "101a22a1703ef8efd2d5455f36ee5cc0a28a338b0037c04bb578d9e9f5f80afb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joy-teleop/default.nix
+++ b/distros/kinetic/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, rospy, rostopic, sensor-msgs, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-joy-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/joy_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "fb103a3378b8dd99bc396dbf2ba0d3cd0fd222739c4f6266aef50f82259b1335";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/joy_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "b2088e4af99b40191b47073d8192147731d6514289128551011a89173fc518c2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/key-teleop/default.nix
+++ b/distros/kinetic/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-key-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/key_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "eca757cd4e4ed2427b8c8b00b1827eec8fdfdfe01f5d9b05c82aeb8e2e7f21db";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/key_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "86db7fa7f0390f4eef0baf57a011e55860aac0dbe8159e45b6df45be1861c530";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mouse-teleop/default.nix
+++ b/distros/kinetic/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-mouse-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/mouse_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "6b265a935613e2d806be914cf4088be249e58f7abb5c55317111e97892e092d7";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/mouse_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6b86a8f1377a67cc0c65b18205f8441d9f118b76cab79a403203f60eecbc7365";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pacmod/default.nix
+++ b/distros/kinetic/pacmod/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-pacmod";
-  version = "2.0.2";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/pacmod-release/archive/release/kinetic/pacmod/2.0.2-0.tar.gz";
-    name = "2.0.2-0.tar.gz";
-    sha256 = "8c6f53699c4548da8a76cde1e431bb4f64c95d82b2201453160568b0780c6e14";
+    url = "https://github.com/astuff/pacmod-release/archive/release/kinetic/pacmod/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "10c2c90882a3d735231d711a024825e8413d8cff60d66c34d0a241389ef36513";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, ros-type-introspection, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.5.0-r1";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "4cbac0de83143ecb3bf3f129783a75cb8f9baa735106fa2dbd21cabfac54b3b9";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "a5152333f0d3519502bf09d9c4b11128a56cd2bae03b76be7f3de9bae2933e67";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-control/default.nix
+++ b/distros/kinetic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, combined-robot-hw-tests, controller-interface, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-kinetic-ros-control";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/ros_control/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "77df478bf9b1d047065ae307a396ee325143bd260ce89011c90e0faf86c2fcf7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/ros_control/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "eaa5804551a2d127a5c6275cbbd84db6fe566b5a1ca4e47e3264732d5de4e10b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-cvb-camera-driver/default.nix
+++ b/distros/kinetic/ros-cvb-camera-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, roscpp, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-ros-cvb-camera-driver";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/gleichaufjo/ros_cvb_camera_driver_release/archive/release/kinetic/ros_cvb_camera_driver/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "87079d005ec32d021929e2a66b8e20b56b8893d654bc7445362ed9e754729250";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-info-manager roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros_cvb_camera_driver package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/rqt-controller-manager/default.nix
+++ b/distros/kinetic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, rqt-gui }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-controller-manager";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/rqt_controller_manager/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "cff3814b9b0010aa55c60b1dc2b773dc71bffbf91c9df9ef2892f1f7178e49b4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/rqt_controller_manager/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "55d4a3447b12e9f36ca350b07cd018bb88f93f43728c4aa9fb4385779c15f240";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swarmros/default.nix
+++ b/distros/kinetic/swarmros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosconsole, roscpp, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-swarmros";
-  version = "0.3.1-r2";
+  version = "0.3.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/amilankovich-slab/swarmros-release/archive/release/kinetic/swarmros/0.3.1-2.tar.gz";
-    name = "0.3.1-2.tar.gz";
-    sha256 = "a1e94dfe9d1f24d4e0e69dbb3707ff9294d1f522ba0e50c71a13ba60f91e538c";
+    url = "https://github.com/amilankovich-slab/swarmros-release/archive/release/kinetic/swarmros/0.3.1-4.tar.gz";
+    name = "0.3.1-4.tar.gz";
+    sha256 = "31cac1fff0c41da3450230da45bbc752d537e0b4917991e1a46ff9def1453ae9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/teleop-tools-msgs/default.nix
+++ b/distros/kinetic/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, control-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-teleop-tools-msgs";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/teleop_tools_msgs/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "3ef2838d7479e42fc83ac6737bc0df2fd33809dc3c4f87fc8022c1b7545bcbb1";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/teleop_tools_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "bff68979e77c5765181dc380bd501b32bc91fb2e98c5bc236278f8cf604ca8e1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/teleop-tools/default.nix
+++ b/distros/kinetic/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-teleop-tools";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/teleop_tools/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "27f8c579a75432b85a5331b72f83a5ae9699bcc5bfdbcd3feedbd02be49c41d7";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/kinetic/teleop_tools/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "36f6aedb61970f9634660a25cb33c482860fafb9583087cbc7caabccf09d54a4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/transmission-interface/default.nix
+++ b/distros/kinetic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, rosunit, tinyxml }:
 buildRosPackage {
   pname = "ros-kinetic-transmission-interface";
-  version = "0.13.4-r1";
+  version = "0.13.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/transmission_interface/0.13.4-1.tar.gz";
-    name = "0.13.4-1.tar.gz";
-    sha256 = "9239320500fa34cf57b3e8319af7b10c31245272c7a8ce388bec031e7c1c0039";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/kinetic/transmission_interface/0.13.5-1.tar.gz";
+    name = "0.13.5-1.tar.gz";
+    sha256 = "e295f962ca5dbe619937d038170dd10de07f23413fddc089d49243affdede803";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-drivers/default.nix
+++ b/distros/melodic/ainstein-radar-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, can-msgs, catkin, nodelet, pcl-ros, roscpp, socketcan-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-drivers";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "5dfb5737907fd231491d05a5c871243e3869cde93146a2d28c5185eaef5d2cb9";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "50ab65173d2825aebc4cd3f988ec172e811aafef86c6fdb813c58d66873e2622";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-filters/default.nix
+++ b/distros/melodic/ainstein-radar-filters/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen, tf2-sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-filters";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "53a831c1b7e0b011a093bbafb87d18e42a4fddeb0bc5986edb3596dcd508de97";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e347805bf17c73a04c4d02e4323c0c7c8e9b9fa7ade5307095f7d83d423f7be2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen ];
+  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen tf2-sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, gazebo-plugins, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-gazebo-plugins";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "dd2a4a646e14ce84ea9b08f7d52e3807b514079b555e8ad2704eb83d9926bb13";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "795dc969d70f86385cdc9260cf5e54055fb6e686c54609c3d7f62fdf3471f776";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-msgs/default.nix
+++ b/distros/melodic/ainstein-radar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-msgs";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "4f1489ed65070103851d5ea569cffee0d73fbd8156090bea184478d18ae4c432";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "a47be6bd84665d7ca28b60f6eff5ba62c04414592b50be47e1d796887d1695a3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-rviz-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, pcl, qt5, rviz }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-rviz-plugins";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "925bfeea971400c6668acbd62007ca50d96ad4e1636bd79b870926cf0787e652";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d293cc93d7f1b1e31e93eda9de9cf260b065feb034c5ad24df3f18ee979079a6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-tools/default.nix
+++ b/distros/melodic/ainstein-radar-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-filters, ainstein-radar-msgs, catkin, cv-bridge, image-geometry, image-transport, pcl-ros, roscpp, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-tools";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "dab485d2d37654886e080b9e037ec78897ce64b4212418a23c5bf23a7e60783b";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "fbb4ccb20a888ce31f3a19e97e8ee05fb71f791f3cab227b9befeea211aed91e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar/default.nix
+++ b/distros/melodic/ainstein-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-drivers, ainstein-radar-filters, ainstein-radar-gazebo-plugins, ainstein-radar-msgs, ainstein-radar-rviz-plugins, ainstein-radar-tools, catkin }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "f85a42304fa9e9bde722ac15182b9a2f92789a658873a1a1afaa1306fd2881ea";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "9d8c48044d1fe25bee4f8e6ab8954377d7d76b088b09a2abd8f3d74784366c90";
   };
 
   buildType = "catkin";

--- a/distros/melodic/catkin-virtualenv/default.nix
+++ b/distros/melodic/catkin-virtualenv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3, python3Packages, pythonPackages, rosbash, roslint }:
 buildRosPackage {
   pname = "ros-melodic-catkin-virtualenv";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/locusrobotics/catkin_virtualenv-release/archive/release/melodic/catkin_virtualenv/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "af870d6acef78e77b5703742a94ac73334e81a0ef916b5a41d2e0c9fba263d7c";
+    url = "https://github.com/locusrobotics/catkin_virtualenv-release/archive/release/melodic/catkin_virtualenv/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "a2deb0b6f5fa198765c367ae19f3caf5503a0a4710642adbc7e04e0d5a768f2d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "7c159d672c49e7721c1c1f106741aaabddedd8ae8d47b7abb52b1ff22bef5f37";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "eefc23a804dccfef4f52dc80a88e651a8951456d534d523ec11075f2eb72e6b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "fd9d5e9f071ac3cb9c545b59a1409c53cfc2b92e0844cd2c847fdb1d05c6732a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "39cfa431d55b8d9852dfd0d2e3d4eea53e439fa95cb0f092a7458f747fba2632";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "8ab241a34a764ef7f6d76e98c22da15aa1b4f7bf83ed276259640cbe60eec516";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "b6782b0e0cde5a78e3cf468e40a70e95136db336ab2a89f154288362d93fb25c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "b78f6882b598153128b9a3eeb8c26359a3e136b0412bb9f169c37b72be044d60";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "d3b03d6778e8ab4e509245977fd1703bc9ffaddb66f5ffc2c5e6e23b6d172b3f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "69ad78f397ed4ca35cf13e7b06e5672e4dc537a4325c4313953fa2b36ca42180";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "cb9230100c4a7a2f0ccb68b713bc5cecf570beb887025b18943353fac54515db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2, zeromq }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "5960220f06734e58b4299790facba37df5aedf03ddb8ea53d62805b62f25380e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "3df8d716a7d34a58746962a1c7229bce9455bebd0246de0e9a49be628d28303f";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules cppzmq ];
+  buildInputs = [ cmake-modules ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 zeromq ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "e1f666bb01595a4c0cc01ea7c10d184361d00c44b22e443d2141a902597514c1";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "1fcf2a9fb9871aaf86e29a4cf1ba2981a780d3ba9cdb6cb1406f29e12ead952a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "5e363275f4f6d3416e8c3f70120f2ab929b1e93d1111dd20326f6377ce940f24";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "78ca9fe0345fbb35ebd6a2d5579c9c8ab518d58d2f92ba0ee4d779c887f30f01";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "5ba5e9ea76413d2d21231057e962346b48d0c558a98cf5c6f544141095600839";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "9df5028b2245caf4045ae4f1da68b3eaf2582b6df67417a1b6f0226290814b4a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "f87ecd743478ba8b878497fee3baaef7baf679825c12931e6adf159f6975bf20";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "d9d221cafa1290cde1c8d9e285cd7a1793d7fcd23eff5b59a074907c033ee295";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "0cc069f206bd5685839b49f2adff4d9d6406e7546f02da5748168c91c57cbcac";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "8999b2bcbb97a6cc6ebc5b0e3b5ff8b28d154a11d86d79cefad8512a9bc97a1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "3d98d36aeaff9b7ff1e6e7cb813d260694e201d9664d0068a7346150b092488f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "15d310fba58eb7eb7d766585210654a94c08282b723489e1c8867c8b7750075e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "6d30e8519eca9e69e1e5391a4431a174053f1302a623fba77840a4d8fe97d437";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "e5a0298a4a186bbe0d60b03c6dd7412457061955e9265c1c85b5d680079d6859";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "c8524e36a7fff41f67d6363facaa3226f41c88fd3c5e8b8b01da6189b7c13e50";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "2782ec425a5659acb31d3492e8999a765fd7654e35b2fd41361018e0e58587c6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "f7bd90a177fa3c7c75385bd4fafe681b084e7d99964fcff748a17d0f7be88f30";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "93d0a10086b45bb8a3d761b09408eb1b3428c68c9c5e9ced735df3e34b67fc27";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core ];
+  propagatedBuildInputs = [ exotica-core ompl ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "704142289766a06eefd6bc3a02ba414919c80bd0fc28e948fef60975cdc0046d";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "692432ad32c66690874b48d3fbb721c192e87664f38ce20263e17a593703190c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "b386143058490db3d4bbfdb2bb1f5d5e2e1820b267ed48260228a74d74ffa8ef";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "8203597e8d8b34785c89db31621d949d964a1a4692c85a7c0aac39b89c089186";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "d46aae22af5c04244ca6bc6268a32644a8de5f11a52c5d4e10297fefdc7694dd";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "9a7ec88e3788da0ea147ce0d7eb2ee4c4bbd7fd3de6eaf9ac3796f18fb6dc5c9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "9ae4a89c165c5669eba0b7a5a89d9a55101879d06afd4e27995ad280be094c0e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "542fde5cde5a4465137774f6cf527950109d670672971d690e89fbf4e65ccf9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "fb1f96bc8288ad7251f4b411316150ad3f8d863b94f6cd4f70d0aa4de67f2a4d";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "8fb8a94b7adea8edc0f68b6574abb48089fed5b02551a040fa7dc0d1cab585c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "4041b3d2fd8a3e4a6c3b6ca75d3731a25f4150b8922c3711d335d1d008fb81d6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "738b1d76c6ace5a5385eef6bddcf758f58a1c7d066e9dd2daca20d35687c59f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "5.1.0-r1";
+  version = "5.1.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.1.0-1.tar.gz";
-    name = "5.1.0-1.tar.gz";
-    sha256 = "e921c0149d23d8f74fa0f68dec4086bd7afed803e6b0481df84edbc2cf28d92d";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.1.3-3.tar.gz";
+    name = "5.1.3-3.tar.gz";
+    sha256 = "a743c4a29edc8eb2f269cf4f39b7a0795998a58ba971e512610ea87c0a3b5efa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1242,6 +1242,8 @@ self: super: {
 
  ipr-extern = self.callPackage ./ipr-extern {};
 
+ ira-laser-tools = self.callPackage ./ira-laser-tools {};
+
  ivcon = self.callPackage ./ivcon {};
 
  jackal-control = self.callPackage ./jackal-control {};
@@ -1609,6 +1611,8 @@ self: super: {
  microstrain-3dmgx2-imu = self.callPackage ./microstrain-3dmgx2-imu {};
 
  microstrain-mips = self.callPackage ./microstrain-mips {};
+
+ mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};
 
  mini-maxwell = self.callPackage ./mini-maxwell {};
 
@@ -2001,6 +2005,8 @@ self: super: {
  p2os-teleop = self.callPackage ./p2os-teleop {};
 
  p2os-urdf = self.callPackage ./p2os-urdf {};
+
+ pacmod = self.callPackage ./pacmod {};
 
  pacmod3 = self.callPackage ./pacmod3 {};
 
@@ -2731,6 +2737,8 @@ self: super: {
  rqt-ez-publisher = self.callPackage ./rqt-ez-publisher {};
 
  rqt-graph = self.callPackage ./rqt-graph {};
+
+ rqt-ground-robot-teleop = self.callPackage ./rqt-ground-robot-teleop {};
 
  rqt-gui = self.callPackage ./rqt-gui {};
 

--- a/distros/melodic/ira-laser-tools/default.nix
+++ b/distros/melodic/ira-laser-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
+buildRosPackage {
+  pname = "ros-melodic-ira-laser-tools";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "68a56b260c6b1063c03305d2cea284da424d86f7d30b970a77ae735f57813bde";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt4 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ira_laser_tools package. These nodes are meant to provide some utils for lasers, like listen to different laser scan sources and merge them in a single scan or generate virtual laser scans from a pointcloud.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/joy-teleop/default.nix
+++ b/distros/melodic/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, rospy, rostopic, sensor-msgs, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joy-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/joy_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "36f191ff3945af0b25a599fecf08a999b1d7bdf91e0f387775a3e6adda9be052";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/joy_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "9b40cbf56d2384f70de1281d1e6269131dab98a92f7c84036212e5f216c08ea0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/key-teleop/default.nix
+++ b/distros/melodic/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-key-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/key_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "06f164a11e5deeab452048a9d404d302ac6b82f351df562da48abaf604019286";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/key_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "798313243d19edcf979363cd0a1d3e28d4a4a93393ece7c5148924021adb067e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mikrotik-swos-tools/default.nix
+++ b/distros/melodic/mikrotik-swos-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mikrotik-swos-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/mikrotik_swos_tools-release/archive/release/melodic/mikrotik_swos_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "59c6ba7bda87a782a15c2513cd298bfd84cc6ad3ca8d2f7c88e2d139d5171087";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime pythonPackages.requests rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Integration between ROS (Robot Operating System) and Mikrotik SwOS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mouse-teleop/default.nix
+++ b/distros/melodic/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-mouse-teleop";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/mouse_teleop/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "ccf8af493ba91d2a7dee432444454286025cc9bafb30105a1e5ec46ab744cb05";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/mouse_teleop/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "c87ffb687d83e3ac8b63d82ec3ff641b77b085e2f6379d2bc0a01c7cd8607e20";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pacmod/default.nix
+++ b/distros/melodic/pacmod/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, pacmod-msgs, roscpp, roslint, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pacmod";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/pacmod-release/archive/release/melodic/pacmod/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "e8047a0dfa0788b2a4180a40ce209fd71798d039924e920fc0b4c96e79ba0470";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ can-msgs pacmod-msgs roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AutonomouStuff PACMod driver package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, ros-type-introspection, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.5.0-r1";
+  version = "2.5.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0ca20598fffdf4b6148c9099e058959326e9f5a504b5b530927b03773cf68bd9";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.5.1-2.tar.gz";
+    name = "2.5.1-2.tar.gz";
+    sha256 = "3f0f2f5fa1cf4a0b9fe8c25779b5f0a93a5afac2fec96e649f06cd5e91f67303";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.5-r1";
+  version = "2.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.5-1.tar.gz";
-    name = "2.6.5-1.tar.gz";
-    sha256 = "971bcda9b4564009674b21d1a344a14ef6d7458f3156b9110ed36b02d933b189";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.6-1.tar.gz";
+    name = "2.6.6-1.tar.gz";
+    sha256 = "8ebb61da8246a0ed2dd7b5cdbc7b917e29b6d654f1209f21ad58b5126fc9b411";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9ab0e2bbfa0d684dda14e9becf829a7d7383f9264771a2223494ff5c5e27b068";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "15282c4b6711a6e296c0e346efac97e08802d51c2b0c69da964cad9df062d470";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rqt-ground-robot-teleop";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fd7cc9f6fffca226ee07c9d246053443317c9b81ec90cd9831914be433d985d1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A common ground robot teleop interface for all ground robot exercises in the JdeRobot Robotics Academy'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/teleop-tools-msgs/default.nix
+++ b/distros/melodic/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, control-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-teleop-tools-msgs";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/teleop_tools_msgs/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "6a087baf64271603f7708582a440c2fe47f15f2da8be3996b115ad707ee05366";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/teleop_tools_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "8e09cf4ead3f0f1f98917472c6c2286a6fc33b2b707978d8919132a70cb3244c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/teleop-tools/default.nix
+++ b/distros/melodic/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-melodic-teleop-tools";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/teleop_tools/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "13fa3947b654ea8548445a755c14e39bd83c9aa2e5df261d75febda38d013594";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/melodic/teleop_tools/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "d45ea282f8d899d5213a3f616d5c09e37779e81bc5f8b5a9a2fa53896a039ff8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-server/default.nix
+++ b/distros/melodic/tf2-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, nodelet, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-server";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d0e1148870bc96da2119d39390871602142aa7afa20ebf73d54fb89561d27c64";
+    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "c3d98a499738325ecbf1dbfbaa21efdcdb20b8387387df3de7af09657088e402";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit f3ad1bc0068777aaff8680f183da3e149223fa00.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *joy-teleop 1.0.1 --> 1.0.2-r1*
* *key-teleop 1.0.1 --> 1.0.2-r1*
* *mouse-teleop 1.0.1 --> 1.0.2-r1*
* *robot-localization 3.0.1-r1*
* *system-modes 0.1.4-r1 --> 0.2.0-r2*
* *system-modes-examples 0.1.4-r1 --> 0.2.0-r2*
* *teleop-tools 1.0.1 --> 1.0.2-r1*
* *teleop-tools-msgs 1.0.1 --> 1.0.2-r1*

Eloquent Changes:
-----------------
* *pointcloud-to-laserscan 2.0.0-r1*
* *py-trees-ros 2.0.6-r2 --> 2.0.7-r1*
* *system-modes 0.1.5-r1 --> 0.2.0-r2*
* *system-modes-examples 0.1.5-r1 --> 0.2.0-r2*

Kinetic Changes:
----------------
* *ainstein-radar 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-drivers 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-filters 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-gazebo-plugins 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-msgs 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-rviz-plugins 2.0.2-r1 --> 3.0.1-r1*
* *ainstein-radar-tools 2.0.2-r1 --> 3.0.1-r1*
* *combined-robot-hw 0.13.4-r1 --> 0.13.5-r1*
* *combined-robot-hw-tests 0.13.4-r1 --> 0.13.5-r1*
* *controller-interface 0.13.4-r1 --> 0.13.5-r1*
* *controller-manager 0.13.4-r1 --> 0.13.5-r1*
* *controller-manager-msgs 0.13.4-r1 --> 0.13.5-r1*
* *controller-manager-tests 0.13.4-r1 --> 0.13.5-r1*
* *hardware-interface 0.13.4-r1 --> 0.13.5-r1*
* *ira-laser-tools 1.0.2 --> 1.0.3-r1*
* *joint-limits-interface 0.13.4-r1 --> 0.13.5-r1*
* *joy-teleop 0.3.0 --> 0.3.1-r1*
* *key-teleop 0.3.0 --> 0.3.1-r1*
* *mouse-teleop 0.3.0 --> 0.3.1-r1*
* *pacmod 2.0.2 --> 2.1.0-r1*
* *plotjuggler 2.5.0-r1 --> 2.5.1-r2*
* *ros-control 0.13.4-r1 --> 0.13.5-r1*
* *ros-cvb-camera-driver 0.0.1-r2*
* *rqt-controller-manager 0.13.4-r1 --> 0.13.5-r1*
* *swarmros 0.3.1-r2 --> 0.3.1-r4*
* *teleop-tools 0.3.0 --> 0.3.1-r1*
* *teleop-tools-msgs 0.3.0 --> 0.3.1-r1*
* *transmission-interface 0.13.4-r1 --> 0.13.5-r1*

Melodic Changes:
----------------
* *ainstein-radar 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-drivers 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-filters 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-gazebo-plugins 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-msgs 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-rviz-plugins 3.0.0-r1 --> 3.0.1-r1*
* *ainstein-radar-tools 3.0.0-r1 --> 3.0.1-r1*
* *catkin-virtualenv 0.5.1-r1 --> 0.5.2-r1*
* *drone-wrapper 1.1.0-r1 --> 1.2.0-r1*
* *exotica 5.1.0-r1 --> 5.1.3-r3*
* *exotica-aico-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-cartpole-dynamics-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-collision-scene-fcl-latest 5.1.0-r1 --> 5.1.3-r3*
* *exotica-core 5.1.0-r1 --> 5.1.3-r3*
* *exotica-core-task-maps 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ddp-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-double-integrator-dynamics-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-dynamics-solvers 5.1.0-r1 --> 5.1.3-r3*
* *exotica-examples 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ik-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ilqg-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ilqr-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-levenberg-marquardt-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ompl-control-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-ompl-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-pendulum-dynamics-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-pinocchio-dynamics-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-quadrotor-dynamics-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-scipy-solver 5.1.0-r1 --> 5.1.3-r3*
* *exotica-time-indexed-rrt-connect-solver 5.1.0-r1 --> 5.1.3-r3*
* *ira-laser-tools 1.0.3-r1*
* *joy-teleop 0.3.0 --> 0.3.1-r1*
* *key-teleop 0.3.0 --> 0.3.1-r1*
* *mikrotik-swos-tools 1.0.1-r1*
* *mouse-teleop 0.3.0 --> 0.3.1-r1*
* *pacmod 2.1.0-r1*
* *plotjuggler 2.5.0-r1 --> 2.5.1-r2*
* *robot-localization 2.6.5-r1 --> 2.6.6-r1*
* *rqt-drone-teleop 1.1.0-r1 --> 1.2.0-r1*
* *rqt-ground-robot-teleop 1.2.0-r1*
* *teleop-tools 0.3.0 --> 0.3.1-r1*
* *teleop-tools-msgs 0.3.0 --> 0.3.1-r1*
* *tf2-server 1.0.4-r1 --> 1.0.5-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

