### PR TITLE
rosdistro sync, Fri Feb 21 12:40:47 2020

### DIFF
--- a/distros/dashing/robot-localization/default.nix
+++ b/distros/dashing/robot-localization/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geometry-msgs, launch-testing-ament-cmake, libyamlcpp, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, libyamlcpp, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-dashing-robot-localization";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/dashing/robot_localization/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "0977a96d2e5d4e501a7f9178dd23eee8e66e45f95431303c46d79ff3b136568c";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/dashing/robot_localization/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "a6f38b7b1f2dad61db87b55d50b3e372552e4403b4d2aeba03ec05568dcd37ba";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common builtin-interfaces launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen geographic-msgs geometry-msgs libyamlcpp nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eigen geographic-msgs geometry-msgs launch-ros libyamlcpp nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
 
   meta = {

--- a/distros/dashing/system-modes-examples/default.nix
+++ b/distros/dashing/system-modes-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-dashing-system-modes-examples";
-  version = "0.2.0-r2";
+  version = "0.2.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.2.0-2.tar.gz";
-    name = "0.2.0-2.tar.gz";
-    sha256 = "821afe20643a4d3f645a637ed8e52f10adc6a9c84bde3521d26ed750c8bccc21";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.2.0-3.tar.gz";
+    name = "0.2.0-3.tar.gz";
+    sha256 = "893e4b0099bb12a4a07528199f7f1d4f29892a2faf1e0a2ca1769963786ab074";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake ];
   propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle system-modes ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = ''Simple example system for system_modes package.'';

--- a/distros/dashing/system-modes/default.nix
+++ b/distros/dashing/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-system-modes";
-  version = "0.2.0-r2";
+  version = "0.2.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.2.0-2.tar.gz";
-    name = "0.2.0-2.tar.gz";
-    sha256 = "9e7670f69f1cdf63fdaa042c7423b59731f2e34390567fdb0fbdde7399b770c2";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.2.0-3.tar.gz";
+    name = "0.2.0-3.tar.gz";
+    sha256 = "5474cb959ac3bf8df018dc5bd6a9ab73d3ef73e28e7eae58275755bfdb61496d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/fastrtps/default.nix
+++ b/distros/eloquent/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-eloquent-fastrtps";
-  version = "1.9.3-r1";
+  version = "1.9.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/eloquent/fastrtps/1.9.3-1.tar.gz";
-    name = "1.9.3-1.tar.gz";
-    sha256 = "b16b1f0223f73d7dea2219235f8d9de66549c7a5fdd59db39878a679fc2bf861";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/eloquent/fastrtps/1.9.3-2.tar.gz";
+    name = "1.9.3-2.tar.gz";
+    sha256 = "467fc5509c30ff9c1328ef57f9a582008e3cf5d8a4c5bf77949609fb47e722cb";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/gazebo-dev/default.nix
+++ b/distros/eloquent/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazeboSimulator }:
 buildRosPackage {
   pname = "ros-eloquent-gazebo-dev";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_dev/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "6d0de02f381a3707ef91d26f9b3af3fb0a322a3377e67c30116099d78e8b9a29";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_dev/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "2627ac82737d8946709d5769a3832f450055d89b7b13a5176fc30fee9255a84e";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/gazebo-msgs/default.nix
+++ b/distros/eloquent/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-gazebo-msgs";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_msgs/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "895aba35c630b534926125fc29275f0797bc826f67d174a5618f244605d57340";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_msgs/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "1920efaf9e80724e8e6e720f5d76a4fb6e01080f4238a37e56c31ed06f3cfc9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/gazebo-plugins/default.nix
+++ b/distros/eloquent/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-gazebo-plugins";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_plugins/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "f3b0e5462cfe13f3ce34a9d3bc45a20d404318b326fb84a4d43a962908bd2e8b";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_plugins/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "b0d3ef22be8fe86c92e0608f4231b1a2499b42c0ad93244222b57cfd9e180b80";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/gazebo-ros-pkgs/default.nix
+++ b/distros/eloquent/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-eloquent-gazebo-ros-pkgs";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_ros_pkgs/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "1e7fa96f8fbb9d74c4f5ff4d6b5bfa85a0944c16ed22cd575122e193c16bd9f9";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_ros_pkgs/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "26b6dfa58679dcb64b798211d15259d0cc6f16c6683b155c3585420c331c0913";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/gazebo-ros/default.nix
+++ b/distros/eloquent/gazebo-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, gazebo-dev, gazebo-msgs, geometry-msgs, launch-ros, rcl, rclcpp, rclpy, sensor-msgs, std-msgs, std-srvs, tinyxml-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, gazebo-dev, gazebo-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, rcl, rclcpp, rclpy, ros2run, sensor-msgs, std-msgs, std-srvs, tinyxml-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-gazebo-ros";
-  version = "3.4.2-r1";
+  version = "3.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_ros/3.4.2-1.tar.gz";
-    name = "3.4.2-1.tar.gz";
-    sha256 = "3df6258906354085a75725d07865002b7e2e5690fb8faf50115c5b90ef3b44d4";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/eloquent/gazebo_ros/3.4.3-1.tar.gz";
+    name = "3.4.3-1.tar.gz";
+    sha256 = "61d9c061fa7dcb8ebc27e11675bbcb6452f60a23295debfbc9a8a8cc321d134f";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs sensor-msgs std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs launch-testing-ament-cmake ros2run sensor-msgs std-msgs ];
   propagatedBuildInputs = [ builtin-interfaces gazebo-dev gazebo-msgs geometry-msgs launch-ros rcl rclcpp rclpy sensor-msgs std-srvs tinyxml-vendor ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -842,6 +842,8 @@ self: super: {
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
+ sick-scan2 = self.callPackage ./sick-scan2 {};
+
  slide-show = self.callPackage ./slide-show {};
 
  sophus = self.callPackage ./sophus {};

--- a/distros/eloquent/sick-scan2/default.nix
+++ b/distros/eloquent/sick-scan2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, diagnostic-updater, rclcpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-sick-scan2";
+  version = "0.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_scan2-release/archive/release/eloquent/sick_scan2/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "6033e4d2569c53fb3f1c14dc45069a60b6c89ba39188dd36c2dbbce49d28f6bf";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost diagnostic-updater rclcpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A ROS2 driver for the SICK TiM series of laser scanners.
+    This package is based on the sick_scan-Repository.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/system-modes-examples/default.nix
+++ b/distros/eloquent/system-modes-examples/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-eloquent-system-modes-examples";
-  version = "0.2.0-r2";
+  version = "0.2.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes_examples/0.2.0-2.tar.gz";
-    name = "0.2.0-2.tar.gz";
-    sha256 = "ea38bacfa97d0c748694d4e341e01e95598d86c415110a91617580a24bf8c4a9";
+    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes_examples/0.2.0-3.tar.gz";
+    name = "0.2.0-3.tar.gz";
+    sha256 = "1dbb35fd6f71838d2bd9b5d9946cfcc635c4ff25ad850db157dd355301b96cd7";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake ];
   propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle system-modes ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {
     description = ''Simple example system for system_modes package.'';

--- a/distros/eloquent/system-modes/default.nix
+++ b/distros/eloquent/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-system-modes";
-  version = "0.2.0-r2";
+  version = "0.2.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes/0.2.0-2.tar.gz";
-    name = "0.2.0-2.tar.gz";
-    sha256 = "b91e592ec1286276b05e8a618578dadacc25b9ae598c46d1aa9b6b03538681ac";
+    url = "https://github.com/microROS/system_modes-release/archive/release/eloquent/system_modes/0.2.0-3.tar.gz";
+    name = "0.2.0-3.tar.gz";
+    sha256 = "bcb0096786248d9f3bbc3aa604dcb85929e7da1cc80e143e12e6854241c3206d";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/dbw-fca-can/default.nix
+++ b/distros/kinetic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-fca-can";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_can/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "53bd2a513e1af517bf5c2226484896c1717304cd27d0b1e1ee031e1b3ed72eb0";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_can/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "98c86465d7d44089a11a2b3743d6b4fc8066c684fdb4637131a89ed944496678";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-fca-description/default.nix
+++ b/distros/kinetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-fca-description";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_description/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "b14ced68b05aaca8520ed8ffc546e23725e677d21e661ba5ab842e92f49370ca";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_description/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5ae0a063ff6adda7f5f5a518c02f6b5717cdcb119b1e71818f97168a636e1c5f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/kinetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-fca-joystick-demo";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_joystick_demo/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "3a6e6b9c5f9b77c01ae848304e44026c01ed3ea2c66e4c8e525c22a3ef9184e6";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_joystick_demo/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "3d16451bd8b8d241a4a46e41fe77a5161203849e2c5660b10b7babc70b8a0c28";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-fca-msgs/default.nix
+++ b/distros/kinetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-fca-msgs";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "bfcf7f9628f8ca6424cf203eb706a8a07dd509c7c5a45e86d4c96d25ac79a840";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "590d29a69e5e51b3ab6d4b0f0be40a528e45caed5f93a5ec2fcb0991e2b4d3eb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-fca/default.nix
+++ b/distros/kinetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-fca";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "ae3b5d94da017f7fc4de9e01f06a52d852a61146cd0fc881144a07bf4ed74af3";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/kinetic/dbw_fca/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "23bc125fdbc5ac35d013dcfa9a5424983a23f10f5dc376d68e090b76a7b5570e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-mkz-can/default.nix
+++ b/distros/kinetic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-mkz-can";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_can/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "2c3aafbd5ac4b620bb5fb476ea6ad33fa785b29422f0a12bc836c9af70df5124";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_can/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "a4e3ff1d8e742fdadbc2ddd6fdfc929c77aa99ef03bf6fbcd393038765706045";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-mkz-description/default.nix
+++ b/distros/kinetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-mkz-description";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_description/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "cd0f675c467b304c7371668de296aa3b05821d5875989ecdd175bd04bb3649b5";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_description/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "b1b941bcc0085e666229d5d35654c9c54e0ad078c7e4137620575ffe466a27b5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/kinetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-mkz-joystick-demo";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_joystick_demo/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "c785c74e35df4ec5d357c6b9c8687064b249e82aca3d557e89561141e3c21d26";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_joystick_demo/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "6300ac3ee56acf50756cb25ca3f19be9de17a12367d0874a33e96a3fcde5983a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-mkz-msgs/default.nix
+++ b/distros/kinetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-mkz-msgs";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_msgs/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "44a4bee6d1dc7242f7fc5fcfbf4508de3c5f80f1008e4df05243a2a33791252c";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "426cb3a3b8a9b498defb4f103da5a844964c9eded8b6a1e59e6fd799e96e4a40";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dbw-mkz/default.nix
+++ b/distros/kinetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dbw-mkz";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "86eec437e5acf5a125a5a31f7178fcecb09a9a2e4812c72249add0a6f48556ad";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/kinetic/dbw_mkz/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "4a681a78ac71283ed638589ab75ac5957dd50128afa4347c4f0abe09583db2bc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/eband-local-planner/default.nix
+++ b/distros/kinetic/eband-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, control-toolbox, costmap-2d, geometry-msgs, nav-core, nav-msgs, pluginlib, roscpp, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-kinetic-eband-local-planner";
-  version = "0.3.1";
+  version = "0.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/utexas-bwi-gbp/eband_local_planner-release/archive/release/kinetic/eband_local_planner/0.3.1-0.tar.gz";
-    name = "0.3.1-0.tar.gz";
-    sha256 = "28af2a7ee8fa4ef4b4bf938fd8314d9ccd334315caf5aa6eccc492230a0a3fe6";
+    url = "https://github.com/utexas-bwi-gbp/eband_local_planner-release/archive/release/kinetic/eband_local_planner/0.3.1-2.tar.gz";
+    name = "0.3.1-2.tar.gz";
+    sha256 = "f6b59fdb1a752463feb105a2b9722bbb207817654fc11ef72ed9fef70fe1ac7c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/euslisp/default.nix
+++ b/distros/kinetic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-kinetic-euslisp";
-  version = "9.26.0-r1";
+  version = "9.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/kinetic/euslisp/9.26.0-1.tar.gz";
-    name = "9.26.0-1.tar.gz";
-    sha256 = "9344f724cc7072808a06697ae1401ce338e37153e9bc41c29508f39a9ae90f90";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/kinetic/euslisp/9.27.0-1.tar.gz";
+    name = "9.27.0-1.tar.gz";
+    sha256 = "010d088f47b03f875d773a61304bbe0da401a3ddacea2adec37359970795a660";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/exotica-aico-solver/default.nix
+++ b/distros/kinetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-aico-solver";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "045c7102c2b9756890ea7def52b0072ec44f1432850ef02f05ada35d2e855e20";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "708cf024f510d19ecaec42229977c8c0287c85ef2027e47086504cde469c8f57";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-cartpole-dynamics-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_cartpole_dynamics_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "1ecf2db3f075a814ac8479fbca225e4308f131e8877c5249f7204449ac5e798c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartpole dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-collision-scene-fcl-latest";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "00c141c2716d048f8ecefaa8e85c5157c708050db7164de8deb697a62b04c216";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "0ee03e0d1f0571c797c13629e4f15b4aba9de9592cd2ded98a0efc0afbab7897";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-core-task-maps/default.nix
+++ b/distros/kinetic/exotica-core-task-maps/default.nix
@@ -2,18 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, geometry-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core-task-maps";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "a418a7fbc9f792628c166a655fcdcac930857f7e39b973cf01516e74e87b43a0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "7907f65456f3e72ae98dd38c4169696aea15c8ea453d2220f102b244d522862a";
   };
 
   buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/exotica-core/default.nix
+++ b/distros/kinetic/exotica-core/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen-conversions, geometry-msgs, kdl-parser, message-runtime, moveit-core, moveit-msgs, moveit-ros-planning, pluginlib, roscpp, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "15d7411d8b64ca107e002fd726ac71522f2e1e8efb3e01e22d828998180317bc";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "a93f1c3b11b39fefbe92c4817c7bc8463546359ebcde0ae8c5daf1b2c3a6147f";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ eigen-conversions geometry-msgs kdl-parser message-runtime moveit-core moveit-msgs moveit-ros-planning pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ddp-solver/default.nix
+++ b/distros/kinetic/exotica-ddp-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-ddp-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ddp_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "66b54fb007dd3d00a302b0569b7514722c8fb8e8c6e6bc36563790fdad1cd117";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various DDP Solvers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-double-integrator-dynamics-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_double_integrator_dynamics_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "41d25fff9a399fe3108f099096adcbc29a1e29e9d002c0e4d63deaee765cc01c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Double integrator dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-dynamics-solvers/default.nix
+++ b/distros/kinetic/exotica-dynamics-solvers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-dynamics-solvers";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_dynamics_solvers/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "440c181e1317367a34ca3c637f38473de77c641f30b0b1ff401e2d5527844128";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-cartpole-dynamics-solver exotica-double-integrator-dynamics-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-quadrotor-dynamics-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for all dynamics solvers bundled with core EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-examples/default.nix
+++ b/distros/kinetic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-examples";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "30a9b871c1d2de18ddca98f1f18b469d42c7d2eaa865b98eb201d691eebd012c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "029538f988c913bb1975ec8b93158583500199ca91cf7288cc0a8900c0d339d8";
   };
 
   buildType = "catkin";
-  checkInputs = [ exotica-val-description rostest ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-core exotica-core-task-maps exotica-ik-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  checkInputs = [ exotica-val-description rostest rosunit ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ik-solver/default.nix
+++ b/distros/kinetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ik-solver";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "535f0ae4bc0843b65e146336560747815b88c846aa1e4a98b24022e78372c1b3";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "6c98b087038486b89e7c314bac2bd996a5aea42be7cd547d833d511a6274e305";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ilqg-solver/default.nix
+++ b/distros/kinetic/exotica-ilqg-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-ilqg-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqg_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "a39a0be4c5369350fe70be43e897016107e3eeb0289def87a714b566313d95f3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQG Solver (Todorov and Li, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-ilqr-solver/default.nix
+++ b/distros/kinetic/exotica-ilqr-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-ilqr-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqr_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "9f35aef66cd7bbb30a10ee3602d2d45c7a8b88f05c27eae242485acb769a658c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQR Solver (Li and Todorov, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-levenberg-marquardt-solver";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "49f2a5535759894ad4b2a8a8d3442cd8aa7f90b914bc8f867cda0fd2d962d4a7";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "bf2bb3264c9845bb92067b62c24dd38006c65dca697c550c3b921ace9721349f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ompl-control-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-control-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-ompl-control-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_control_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "aa8804ff9e628307967c4ba20f7f51827732ebce76da472c215c7968e8f595fb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Kinodynamic Control Solvers from OMPL'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-ompl-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ompl-solver";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "31f73a27db8af3a3f662b5fba756411e41397a2e5c51b9260f4e868416a688fe";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "37c5e45f430e8b6fb18a18cdf91931cc6c2d75e629011499187bdb0a47887826";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-pendulum-dynamics-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pendulum_dynamics_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "24148169f2a720e75792fb2627b2a2f843a3bd6b934476a2ec09c804ab51985e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Pendulum dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-pinocchio-dynamics-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pinocchio_dynamics_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "23b1028add47a816c472fd051c9e950f968488c3c8b601263166a81be1ed2731";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Dynamics solver plug-in using Pinocchio for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-quadrotor-dynamics-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_quadrotor_dynamics_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "27fd9a8655b8ba1a0890a483f6ae5899fbcbacd6abadef083813e6c795e35995";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Quadrotor dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-scipy-solver/default.nix
+++ b/distros/kinetic/exotica-scipy-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
+buildRosPackage {
+  pname = "ros-kinetic-exotica-scipy-solver";
+  version = "5.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_scipy_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "16aefbee63612dcae3bf9f777d50ff9aa94983289a9eec850b3072e572ab8096";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pythonPackages.numpy pythonPackages.scipy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''SciPy-based Python solvers for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "723f365f55eb060e8f1fd2a38996f8ea2f9c075a9b8185b015819bc325c42e0f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "3a767882cb81ee4def7f1ba2b485efbb62cde4f68591c3a0ac7c0e76308a8b82";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica/default.nix
+++ b/distros/kinetic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-kinetic-exotica";
-  version = "5.0.0";
+  version = "5.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/5.0.0-0.tar.gz";
-    name = "5.0.0-0.tar.gz";
-    sha256 = "154e8c189a3d75ee7bc4f6f463478fc4eb620a555bf10d644c901c913c756771";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/5.1.3-1.tar.gz";
+    name = "5.1.3-1.tar.gz";
+    sha256 = "e1f0b657a45fdc9f1eafb26655f0445ac3bdaec9f884d24f5e5e7f4076e14af0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -674,8 +674,6 @@ self: super: {
 
  dbw-mkz-msgs = self.callPackage ./dbw-mkz-msgs {};
 
- dbw-mkz-twist-controller = self.callPackage ./dbw-mkz-twist-controller {};
-
  ddwrt-access-point = self.callPackage ./ddwrt-access-point {};
 
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
@@ -982,19 +980,41 @@ self: super: {
 
  exotica-aico-solver = self.callPackage ./exotica-aico-solver {};
 
+ exotica-cartpole-dynamics-solver = self.callPackage ./exotica-cartpole-dynamics-solver {};
+
  exotica-collision-scene-fcl-latest = self.callPackage ./exotica-collision-scene-fcl-latest {};
 
  exotica-core = self.callPackage ./exotica-core {};
 
  exotica-core-task-maps = self.callPackage ./exotica-core-task-maps {};
 
+ exotica-ddp-solver = self.callPackage ./exotica-ddp-solver {};
+
+ exotica-double-integrator-dynamics-solver = self.callPackage ./exotica-double-integrator-dynamics-solver {};
+
+ exotica-dynamics-solvers = self.callPackage ./exotica-dynamics-solvers {};
+
  exotica-examples = self.callPackage ./exotica-examples {};
 
  exotica-ik-solver = self.callPackage ./exotica-ik-solver {};
 
+ exotica-ilqg-solver = self.callPackage ./exotica-ilqg-solver {};
+
+ exotica-ilqr-solver = self.callPackage ./exotica-ilqr-solver {};
+
  exotica-levenberg-marquardt-solver = self.callPackage ./exotica-levenberg-marquardt-solver {};
 
+ exotica-ompl-control-solver = self.callPackage ./exotica-ompl-control-solver {};
+
  exotica-ompl-solver = self.callPackage ./exotica-ompl-solver {};
+
+ exotica-pendulum-dynamics-solver = self.callPackage ./exotica-pendulum-dynamics-solver {};
+
+ exotica-pinocchio-dynamics-solver = self.callPackage ./exotica-pinocchio-dynamics-solver {};
+
+ exotica-quadrotor-dynamics-solver = self.callPackage ./exotica-quadrotor-dynamics-solver {};
+
+ exotica-scipy-solver = self.callPackage ./exotica-scipy-solver {};
 
  exotica-time-indexed-rrt-connect-solver = self.callPackage ./exotica-time-indexed-rrt-connect-solver {};
 
@@ -4008,7 +4028,13 @@ self: super: {
 
  rr-openrover-basic = self.callPackage ./rr-openrover-basic {};
 
+ rr-openrover-description = self.callPackage ./rr-openrover-description {};
+
+ rr-openrover-driver = self.callPackage ./rr-openrover-driver {};
+
  rr-openrover-driver-msgs = self.callPackage ./rr-openrover-driver-msgs {};
+
+ rr-openrover-stack = self.callPackage ./rr-openrover-stack {};
 
  rr-swiftnav-piksi = self.callPackage ./rr-swiftnav-piksi {};
 

--- a/distros/kinetic/iirob-filters/default.nix
+++ b/distros/kinetic/iirob-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen-conversions, filters, geometry-msgs, pluginlib, roscpp, rosparam-handler, rostest, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-iirob-filters";
-  version = "0.8.1-r3";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/kinetic/iirob_filters/0.8.1-3.tar.gz";
-    name = "0.8.1-3.tar.gz";
-    sha256 = "f083c70688f848452c3c68ac030b5ecf36bd7899a36331eadf1f6132954dca79";
+    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/kinetic/iirob_filters/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "49b6825ee4eb633d00d726efcad2378d28b58befc09408c68a58f424ea78e4af";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ira-laser-tools/default.nix
+++ b/distros/kinetic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
 buildRosPackage {
   pname = "ros-kinetic-ira-laser-tools";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "68a56b260c6b1063c03305d2cea284da424d86f7d30b970a77ae735f57813bde";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "0ee756f6f202edc1a82a439a0e0fff65e610f0e9631e19685591acf393f8bf77";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moveit-resources/default.nix
+++ b/distros/kinetic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-kinetic-moveit-resources";
-  version = "0.6.4";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/kinetic/moveit_resources/0.6.4-0.tar.gz";
-    name = "0.6.4-0.tar.gz";
-    sha256 = "d8792f991f74dd06a2aa700eee464c1d7a560547e15523c0e0d20de700cd85f7";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/kinetic/moveit_resources/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "331af4bef80688c6b9cb201ab3a6c1eab5cd345fa28ee3a7ba697ec643473222";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pinocchio/default.nix
+++ b/distros/kinetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-kinetic-pinocchio";
-  version = "2.2.1-r2";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/kinetic/pinocchio/2.2.1-2.tar.gz";
-    name = "2.2.1-2.tar.gz";
-    sha256 = "08351666c19195fd8e41675249787ab7fe920dee30f973e8ab9a098ce7c89be9";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/kinetic/pinocchio/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "440f8326ce3ed76af6e18e04670748349654190e0245aa121e3cbc459407ab2a";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/resource-retriever/default.nix
+++ b/distros/kinetic/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, pythonPackages, rosconsole, roslib }:
 buildRosPackage {
   pname = "ros-kinetic-resource-retriever";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/kinetic/resource_retriever/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "16a6290bd8670c961329a737c8a992385ff8557eec9ef546feb31c942a1928e7";
+    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/kinetic/resource_retriever/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "20fa51672b8c050c6054e49b081cfacd270f58683705bde6cd6f8edb82d5974c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosapi/default.nix
+++ b/distros/kinetic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosapi";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "a1738bb4afa1a408df592b8d99b010386d1ff9ee41d6fd1c31334238a0b728fb";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "3d2ec2a3490c28a56dd778a84ad7ee83ac89bfd5230e3da3b147883e46df2af5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-msgs/default.nix
+++ b/distros/kinetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-msgs";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "0c8a2b2f26be501abba8e6afc43a61dc770ba8e18134becb3d0ccc426b125be4";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "a6888aca127473f4ba2cb2c580bd487f767b69fbd35d626e589dca6977719370";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-server/default.nix
+++ b/distros/kinetic/rosbridge-server/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-server";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "2cfe8c0047ca4c87629b47fb25429aba6b6fe718d49209f5c168fd3af88049a6";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "993ca3aa0c7d0c94718e9063c8706a8df323a48c8859e76ebc7f1693f7237f3c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rosbridge-suite/default.nix
+++ b/distros/kinetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-suite";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "626b4080bcfb8523d8a1472b1ae09a11898a82ad9c512d85161d91cb794db548";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "4adecf14b696f7e8fbb0b41362053ed9c7d5ed92b3791937543b0348f454976f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslisp/default.nix
+++ b/distros/kinetic/roslisp/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosgraph-msgs, roslang, rospack, sbcl, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment, rosgraph-msgs, roslang, rospack, sbcl, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-roslisp";
-  version = "1.9.21";
+  version = "1.9.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp-release/archive/release/kinetic/roslisp/1.9.21-0.tar.gz";
-    name = "1.9.21-0.tar.gz";
-    sha256 = "7c1461d993cfbadccec208f5d806d10c146c9387ebfa15c5d8427b89261b92c7";
+    url = "https://github.com/ros-gbp/roslisp-release/archive/release/kinetic/roslisp/1.9.23-1.tar.gz";
+    name = "1.9.23-1.tar.gz";
+    sha256 = "e87b1ece09a86e140c6a4f65df89589c4535f97f1b52975dfca36638513a8b9f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rosgraph-msgs roslang rospack sbcl std-srvs ];
+  propagatedBuildInputs = [ ros-environment rosgraph-msgs roslang rospack sbcl std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rr-control-input-manager/default.nix
+++ b/distros/kinetic/rr-control-input-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-control-input-manager";
-  version = "0.7.3-r2";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/0.7.3-2.tar.gz";
-    name = "0.7.3-2.tar.gz";
-    sha256 = "e7a1593e799125997c0d35e0755d842fc72fca548e18bd3dc3f1eb26544bbb18";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "5e046b6a18847e64a548dae54ea8aca94cbd72159ed04790f291465d4f4f3c0a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-description/default.nix
+++ b/distros/kinetic/rr-openrover-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rr-openrover-description";
+  version = "0.7.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_description/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "a0933fb1627cac569d42f08502ab53a1da391f222ee9659df7dea1e1a6f2e506";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rr_openrover_description package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/kinetic/rr-openrover-driver-msgs/default.nix
+++ b/distros/kinetic/rr-openrover-driver-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver-msgs";
-  version = "0.7.3-r2";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/0.7.3-2.tar.gz";
-    name = "0.7.3-2.tar.gz";
-    sha256 = "b6ff3e6465f484a087dd50cc62b84b57880f35a59f5fcfc9220c1e9bcb1fdeb2";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "f61fd27dc07ab8e8549756a430555fc2a0f6b20bcbdbd254c4fd6808331d7fa1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-driver/default.nix
+++ b/distros/kinetic/rr-openrover-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf, twist-mux }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver";
-  version = "0.7.3-r2";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/0.7.3-2.tar.gz";
-    name = "0.7.3-2.tar.gz";
-    sha256 = "cacceb53b3813b6df1251993d67ef64cefd1a1bf06ebb1fa106541d8a0d53b0b";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "a2dc76133f845df10ded914283e65d1c5c9d578a52577d3fba1e719f4b60707a";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs joy message-runtime nav-msgs roscpp rospy rr-openrover-driver-msgs sensor-msgs std-msgs tf twist-mux ];
+  buildInputs = [ message-generation tf2-geometry-msgs ];
+  propagatedBuildInputs = [ geometry-msgs joy message-runtime nav-msgs roscpp rospy rr-openrover-driver-msgs sensor-msgs std-msgs tf2 twist-mux ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rr-openrover-stack/default.nix
+++ b/distros/kinetic/rr-openrover-stack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-driver, rr-openrover-driver-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-stack";
-  version = "0.7.3-r2";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/0.7.3-2.tar.gz";
-    name = "0.7.3-2.tar.gz";
-    sha256 = "6505d3323fdba14cdc6caf56d06a3e02ddb5ff43662d6eff70a14c9bbb3966a8";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "abcd679c276a7d78b15b29471cce7426298adcd3f6cbe2f7094615ae055aa66b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-can/default.nix
+++ b/distros/melodic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-can";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "af20f55d7125879bc0b6728be7a12e1c0927d91c947d3722d2753b526201915d";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "96509722dd038c74b0905b89b8e5ee940190446cf61b9d4f63bd6c191a9d5b3d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-description/default.nix
+++ b/distros/melodic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-description";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "9ceafbf5bdce281b0423fdb9a4c50810fd443490315897c8f789cc0be28c86ee";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "6ba589ca001f5f73c2479525cbadb50c8a17d045e526d4d4481c104028c6b87f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-joystick-demo/default.nix
+++ b/distros/melodic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-joystick-demo";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "0e76c63bbc9bde6a5d6348a3f0656001284ba66c589e6df91211bc9365f3f5c7";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "5be5b5800bcae7a6667789cd54e34f95bdccbf0f118932369e74d0912a7a3e78";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-msgs/default.nix
+++ b/distros/melodic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-msgs";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "1d6724bac0b0d14312065b87d7ae4ec4bc2645ec563eef12570af9e2317b0f53";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "2307d4b9754ca3be66c3df4dd763cc49e715260ddaf78c90d07594b963d98737";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca/default.nix
+++ b/distros/melodic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca";
-  version = "1.0.6-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "688c0c01e19c4499df112a404081a453bf81aab02905c4b567d7b3d0968be36a";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "bd90d2ef8a5cd91d8021389e8114203d531f400b2d1df44ccd34066c8d61f09a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-can/default.nix
+++ b/distros/melodic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-can";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "c9bfcc4af61c81906db7436009f9620e4db8e92397e964c85f99cfd00519ec24";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "b701e37fa696038ddb838dacbf36f419129256f315e743989d0aa38640030544";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-description/default.nix
+++ b/distros/melodic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-description";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "342433ddcb9d4f194348334c952eb39a39f0d6d6290ed9c8e8ef97665860b095";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "f4192a596f917c67b5ee6b3114e3b10291e09eb373f185917a9cca546a965d71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/melodic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-joystick-demo";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "b758a37133992a0725348cc96d5abe0d462f7083892bed279a18d8751bcccf02";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "0c3270baaa8cdf5487c144cddc68547edc375229fd5419dd3de2b24b7798cf7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-msgs/default.nix
+++ b/distros/melodic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-msgs";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "12caef99ae83fc9711e4422b4c4a86adf5ba988789ec470dea553f650976e4aa";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "cc04b3d632a06e82df37106a80638f4ab6929c85eda101694a874c8b12a5975b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz/default.nix
+++ b/distros/melodic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz";
-  version = "1.2.3-r1";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "dd8b1ff2c326f66b1106449e1ae429badff6740c2d744c88d653092fa58f7aa3";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "17df7b95f4ecf3354709c705ade105120af4775cbb2afa6fe9dce16ad67e6667";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.2.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "eefc23a804dccfef4f52dc80a88e651a8951456d534d523ec11075f2eb72e6b7";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "d86c729dcfeb36890fe7bd4f7825e856e77dda955452debffdd1468a32cef4c8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eband-local-planner/default.nix
+++ b/distros/melodic/eband-local-planner/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, control-toolbox, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-core, nav-msgs, pluginlib, roscpp, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-eband-local-planner";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/utexas-bwi-gbp/eband_local_planner-release/archive/release/melodic/eband_local_planner/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "5c4fcdfb8e5d7fa63ba539b3cb4017a9d1f315a4133fad4277f7df4c53254a92";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ base-local-planner control-toolbox costmap-2d dynamic-reconfigure geometry-msgs nav-core nav-msgs pluginlib roscpp tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''eband_local_planner implements a plugin to the
+    base_local_planner. It implements the Elastic Band method on the
+    SE2 manifold.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/euslisp/default.nix
+++ b/distros/melodic/euslisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libGL, libGLU, libjpeg, libpng, mk, postgresql, xorg }:
 buildRosPackage {
   pname = "ros-melodic-euslisp";
-  version = "9.26.0-r1";
+  version = "9.27.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.26.0-1.tar.gz";
-    name = "9.26.0-1.tar.gz";
-    sha256 = "267e9150e430c87ed26dd58e103e1db0ef56dfe6580f16bf3352ebb23f5f374a";
+    url = "https://github.com/tork-a/euslisp-release/archive/release/melodic/euslisp/9.27.0-1.tar.gz";
+    name = "9.27.0-1.tar.gz";
+    sha256 = "6afe4048c28c7c5d1b94a85be4c774797eac4f43835fa20511e841eac47f5907";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -544,8 +544,6 @@ self: super: {
 
  dbw-mkz-msgs = self.callPackage ./dbw-mkz-msgs {};
 
- dbw-mkz-twist-controller = self.callPackage ./dbw-mkz-twist-controller {};
-
  dccomms-ros = self.callPackage ./dccomms-ros {};
 
  dccomms-ros-msgs = self.callPackage ./dccomms-ros-msgs {};
@@ -661,6 +659,8 @@ self: super: {
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
  easy-markers = self.callPackage ./easy-markers {};
+
+ eband-local-planner = self.callPackage ./eband-local-planner {};
 
  eca-a9-control = self.callPackage ./eca-a9-control {};
 
@@ -1265,6 +1265,8 @@ self: super: {
  jackal-viz = self.callPackage ./jackal-viz {};
 
  jderobot-assets = self.callPackage ./jderobot-assets {};
+
+ jderobot-drones = self.callPackage ./jderobot-drones {};
 
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
 
@@ -3229,6 +3231,8 @@ self: super: {
  ublox-msgs = self.callPackage ./ublox-msgs {};
 
  ublox-serialization = self.callPackage ./ublox-serialization {};
+
+ ubnt-airos-tools = self.callPackage ./ubnt-airos-tools {};
 
  um6 = self.callPackage ./um6 {};
 

--- a/distros/melodic/iirob-filters/default.nix
+++ b/distros/melodic/iirob-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen-conversions, filters, geometry-msgs, pluginlib, roscpp, rosparam-handler, rostest, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-iirob-filters";
-  version = "0.8.1-r2";
+  version = "0.8.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/melodic/iirob_filters/0.8.1-2.tar.gz";
-    name = "0.8.1-2.tar.gz";
-    sha256 = "6629c570ce81b0181753951b2c3376bfe2c81ba9d8819f32380e8a5e668c3494";
+    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/melodic/iirob_filters/0.8.3-2.tar.gz";
+    name = "0.8.3-2.tar.gz";
+    sha256 = "90eafcd1b7a8ea55473788276d8e62b8721028dfcb286c0c09b2c39f4cb24a21";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ira-laser-tools/default.nix
+++ b/distros/melodic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
 buildRosPackage {
   pname = "ros-melodic-ira-laser-tools";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/kinetic/ira_laser_tools/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "68a56b260c6b1063c03305d2cea284da424d86f7d30b970a77ae735f57813bde";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/melodic/ira_laser_tools/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "6973e29fd04073a94af1a7d7d1eb03395ef024786672f7c97317f55cacdaad34";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-assets/default.nix
+++ b/distros/melodic/jderobot-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, turtlebot3-description, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-assets";
-  version = "0.1.0-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1f0ed0051b66a63e5c616eea7354f3416125112f28e008b874bd1f2a5e2cecdd";
+    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b9ab9560902ce44eff68f2b917a964d6b9e34a627924ba34d099d4b06d27fea3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
+buildRosPackage {
+  pname = "ros-melodic-jderobot-drones";
+  version = "1.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "3fb47b09572914f7c0cdadf589845476dbde4661bb67fa3b950f82aafb744cd1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ drone-wrapper rqt-drone-teleop rqt-ground-robot-teleop ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jderobot_drones stack'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/moveit-resources/default.nix
+++ b/distros/melodic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources";
-  version = "0.6.4";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.6.4-0.tar.gz";
-    name = "0.6.4-0.tar.gz";
-    sha256 = "ae728a1d284591ce8080f4cad69bcb5d143211ba07ef05055585541a3fe94915";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "64c9130100b43f8eefd7aa006c4d7d82d8a5e936c3f8082ab8421f83962862f9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.2.1-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "f12b7e165d1ff99706aaa1d75d329c58227b06c85c5d806d2d1ad9e70c32e7b3";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "7b7935e8fcab51283582505aee0b17a367bdacb90fbf0529c8ae4c2efac6a2fd";
   };
 
   buildType = "cmake";

--- a/distros/melodic/resource-retriever/default.nix
+++ b/distros/melodic/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, pythonPackages, rosconsole, roslib }:
 buildRosPackage {
   pname = "ros-melodic-resource-retriever";
-  version = "1.12.5-r1";
+  version = "1.12.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/melodic/resource_retriever/1.12.5-1.tar.gz";
-    name = "1.12.5-1.tar.gz";
-    sha256 = "4a1ac42150b348eed92838078929e4ac8ea5123c9d16c39e88412a3724640cce";
+    url = "https://github.com/ros-gbp/resource_retriever-release/archive/release/melodic/resource_retriever/1.12.6-1.tar.gz";
+    name = "1.12.6-1.tar.gz";
+    sha256 = "083fd42894f66c1d08379c5ed963d6cf008c326709bfb70f21690560df17fc67";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosapi/default.nix
+++ b/distros/melodic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosapi";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "52cf4c91178e2a736bba78bf73454a377eabccc48621baa9445e04c6431c11f9";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "b262637ca1cd5796c78c1a25d1ebfa54bbaba9ac78b6ec19b8f8c7cc68cc4c1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-msgs/default.nix
+++ b/distros/melodic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-msgs";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "04bed1531b62ac7ee3e3ef8bdb39469e22d6422c805a0db6bce0eff7527042db";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "ae1ffa13591790fcb804bf7a1c8e87b673e046c6d530539a5c3a376c6beb46ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-server/default.nix
+++ b/distros/melodic/rosbridge-server/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-server";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "a684e9312df285ca883597f446427e9c6955a790ada9b97f67c40e2ccc0cc5f8";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "997c78e4fb51f1346e2c542ef3dba2392ace94c3bef01ee828168ced2364cbb8";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbridge-suite/default.nix
+++ b/distros/melodic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-suite";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "2d3f7f7cc800d54dabde409e9f6caf4a9dee6b4901ba5639d060f0c91ea0bcb1";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "3201e11ff7f28d25df138c113691804c093ba4470064d999862671c6ca081b5a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslisp/default.nix
+++ b/distros/melodic/roslisp/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosgraph-msgs, roslang, rospack, sbcl, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, ros-environment, rosgraph-msgs, roslang, rospack, sbcl, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-roslisp";
-  version = "1.9.22";
+  version = "1.9.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp-release/archive/release/melodic/roslisp/1.9.22-0.tar.gz";
-    name = "1.9.22-0.tar.gz";
-    sha256 = "83844af11c1d8a5baf84efcef5a107629966d66b14973723446cd8803fc9781a";
+    url = "https://github.com/ros-gbp/roslisp-release/archive/release/melodic/roslisp/1.9.24-1.tar.gz";
+    name = "1.9.24-1.tar.gz";
+    sha256 = "86906499473238efd1de66d1cb4749973e1b5fc2965b3d6b6096fabc0bc601b7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rosgraph-msgs roslang rospack sbcl std-srvs ];
+  propagatedBuildInputs = [ ros-environment rosgraph-msgs roslang rospack sbcl std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.2.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "15282c4b6711a6e296c0e346efac97e08802d51c2b0c69da964cad9df062d470";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "7790a97effdd08d073ff9bf2565e8a8352eca540b181d0b8c3197d5cb91842ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.2.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fd7cc9f6fffca226ee07c9d246053443317c9b81ec90cd9831914be433d985d1";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "e24d28aacaff383d7e8c51fe4e26dba42991d6903b3e7ab15452eca86f596eb0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ubnt-airos-tools/default.nix
+++ b/distros/melodic/ubnt-airos-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-ubnt-airos-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/ubnt_airos_tools-release/archive/release/melodic/ubnt_airos_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "93160bad92af03db3438a1e00b4d3bd41305408b221400eb3c2193690c249369";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime pythonPackages.requests rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Ubiquiti AirOS tools for extracting AP information to ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit c56358999def307d68478f8a7786c6352c5794a5.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *robot-localization 3.0.1-r1 --> 3.0.2-r1*
* *system-modes 0.2.0-r2 --> 0.2.0-r3*
* *system-modes-examples 0.2.0-r2 --> 0.2.0-r3*

Eloquent Changes:
-----------------
* *fastrtps 1.9.3-r1 --> 1.9.3-r2*
* *gazebo-dev 3.4.2-r1 --> 3.4.3-r1*
* *gazebo-msgs 3.4.2-r1 --> 3.4.3-r1*
* *gazebo-plugins 3.4.2-r1 --> 3.4.3-r1*
* *gazebo-ros 3.4.2-r1 --> 3.4.3-r1*
* *gazebo-ros-pkgs 3.4.2-r1 --> 3.4.3-r1*
* *sick-scan2 0.1.5-r1*
* *system-modes 0.2.0-r2 --> 0.2.0-r3*
* *system-modes-examples 0.2.0-r2 --> 0.2.0-r3*

Kinetic Changes:
----------------
* *dbw-fca 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-can 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-description 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-joystick-demo 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-msgs 1.0.6-r1 --> 1.0.9-r1*
* *dbw-mkz 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-can 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-description 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-joystick-demo 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-msgs 1.2.3-r1 --> 1.2.7-r1*
* *eband-local-planner 0.3.1 --> 0.3.1-r2*
* *euslisp 9.26.0-r1 --> 9.27.0-r1*
* *exotica 5.0.0 --> 5.1.3-r1*
* *exotica-aico-solver 5.0.0 --> 5.1.3-r1*
* *exotica-cartpole-dynamics-solver 5.1.3-r1*
* *exotica-collision-scene-fcl-latest 5.0.0 --> 5.1.3-r1*
* *exotica-core 5.0.0 --> 5.1.3-r1*
* *exotica-core-task-maps 5.0.0 --> 5.1.3-r1*
* *exotica-ddp-solver 5.1.3-r1*
* *exotica-double-integrator-dynamics-solver 5.1.3-r1*
* *exotica-dynamics-solvers 5.1.3-r1*
* *exotica-examples 5.0.0 --> 5.1.3-r1*
* *exotica-ik-solver 5.0.0 --> 5.1.3-r1*
* *exotica-ilqg-solver 5.1.3-r1*
* *exotica-ilqr-solver 5.1.3-r1*
* *exotica-levenberg-marquardt-solver 5.0.0 --> 5.1.3-r1*
* *exotica-ompl-control-solver 5.1.3-r1*
* *exotica-ompl-solver 5.0.0 --> 5.1.3-r1*
* *exotica-pendulum-dynamics-solver 5.1.3-r1*
* *exotica-pinocchio-dynamics-solver 5.1.3-r1*
* *exotica-quadrotor-dynamics-solver 5.1.3-r1*
* *exotica-scipy-solver 5.1.3-r1*
* *exotica-time-indexed-rrt-connect-solver 5.0.0 --> 5.1.3-r1*
* *iirob-filters 0.8.1-r3 --> 0.8.4-r1*
* *ira-laser-tools 1.0.3-r1 --> 1.0.4-r1*
* *moveit-resources 0.6.4 --> 0.6.5-r1*
* *pinocchio 2.2.1-r2 --> 2.3.1-r1*
* *resource-retriever 1.12.5-r1 --> 1.12.6-r1*
* *rosapi 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-msgs 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-server 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-suite 0.11.3-r1 --> 0.11.4-r1*
* *roslisp 1.9.21 --> 1.9.23-r1*
* *rr-control-input-manager 0.7.3-r2 --> 0.7.4-r1*
* *rr-openrover-description 0.7.4-r1*
* *rr-openrover-driver 0.7.3-r2 --> 0.7.4-r1*
* *rr-openrover-driver-msgs 0.7.3-r2 --> 0.7.4-r1*
* *rr-openrover-stack 0.7.3-r2 --> 0.7.4-r1*

Melodic Changes:
----------------
* *dbw-fca 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-can 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-description 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-joystick-demo 1.0.6-r1 --> 1.0.9-r1*
* *dbw-fca-msgs 1.0.6-r1 --> 1.0.9-r1*
* *dbw-mkz 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-can 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-description 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-joystick-demo 1.2.3-r1 --> 1.2.7-r1*
* *dbw-mkz-msgs 1.2.3-r1 --> 1.2.7-r1*
* *drone-wrapper 1.2.0-r1 --> 1.3.1-r1*
* *eband-local-planner 0.4.0-r1*
* *euslisp 9.26.0-r1 --> 9.27.0-r1*
* *iirob-filters 0.8.1-r2 --> 0.8.3-r2*
* *ira-laser-tools 1.0.3-r1 --> 1.0.4-r1*
* *jderobot-assets 0.1.0-r1 --> 1.0.0-r1*
* *jderobot-drones 1.3.1-r1*
* *moveit-resources 0.6.4 --> 0.6.5-r1*
* *pinocchio 2.2.1-r1 --> 2.3.1-r1*
* *resource-retriever 1.12.5-r1 --> 1.12.6-r1*
* *rosapi 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-msgs 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-server 0.11.3-r1 --> 0.11.4-r1*
* *rosbridge-suite 0.11.3-r1 --> 0.11.4-r1*
* *roslisp 1.9.22 --> 1.9.24-r1*
* *rqt-drone-teleop 1.2.0-r1 --> 1.3.1-r1*
* *rqt-ground-robot-teleop 1.2.0-r1 --> 1.3.1-r1*
* *ubnt-airos-tools 1.0.1-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

