### PR TITLE
rosdistro sync, Fri Feb 28 12:55:03 2020

### DIFF
--- a/distros/dashing/apex-containers/default.nix
+++ b/distros/dashing/apex-containers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, foonathan-memory-vendor, osrf-testing-tools-cpp }:
+buildRosPackage {
+  pname = "ros-dashing-apex-containers";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/apex_containers-release/repository/archive.tar.gz?ref=release/dashing/apex_containers/0.0.1-1";
+    name = "archive.tar.gz";
+    sha256 = "d1f23e197e82dc94aa7f34d45420363e507338ddf6bc5a86b3ddbaf40f849a3e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ osrf-testing-tools-cpp ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ foonathan-memory-vendor ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''Containers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/apex-test-tools/default.nix
+++ b/distros/dashing/apex-test-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-cmake-pclint, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp }:
+buildRosPackage {
+  pname = "ros-dashing-apex-test-tools";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/dashing/apex_test_tools/0.0.1-1";
+    name = "archive.tar.gz";
+    sha256 = "b6b2e089f91c2599d15173c41729109d70a03fc1e41823ffa1b293c9fdb461d4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pclint ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-gtest osrf-testing-tools-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''The package Apex.OS Test Tools contains test helpers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -120,6 +120,10 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
+ apex-containers = self.callPackage ./apex-containers {};
+
+ apex-test-tools = self.callPackage ./apex-test-tools {};
+
  apriltag = self.callPackage ./apriltag {};
 
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
@@ -1011,6 +1015,8 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
+
+ test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/dashing/test-apex-test-tools/default.nix
+++ b/distros/dashing/test-apex-test-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, apex-test-tools }:
+buildRosPackage {
+  pname = "ros-dashing-test-apex-test-tools";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/dashing/test_apex_test_tools/0.0.1-1";
+    name = "archive.tar.gz";
+    sha256 = "006c6431dda12ec1af3791f8cea08a963e537219e1cdc2f2942f57829dcd93f8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ apex-test-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Test package, which uses things exported by apex_test_tools'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/eloquent/apex-test-tools/default.nix
+++ b/distros/eloquent/apex-test-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-cmake-pclint, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp }:
+buildRosPackage {
+  pname = "ros-eloquent-apex-test-tools";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/eloquent/apex_test_tools/0.0.1-1";
+    name = "archive.tar.gz";
+    sha256 = "668c01ed5f982f36b97cfd95d93351e4b5f68fbd0bed50b106ab485af7048ef7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pclint ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-gtest osrf-testing-tools-cpp ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''The package Apex.OS Test Tools contains test helpers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -126,6 +126,8 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
+ apex-test-tools = self.callPackage ./apex-test-tools {};
+
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -489,6 +491,8 @@ self: super: {
  nav-msgs = self.callPackage ./nav-msgs {};
 
  navigation2 = self.callPackage ./navigation2 {};
+
+ nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
@@ -875,6 +879,8 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
+
+ test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/eloquent/nmea-msgs/default.nix
+++ b/distros/eloquent/nmea-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-nmea-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nmea_msgs-release/archive/release/eloquent/nmea_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d6bb7bab34c9458efe792fcbb201a0143ff7d7862d7fc9ac680bea12fefd7f4d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The nmea_msgs package contains messages related to data in the NMEA format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/nonpersistent-voxel-layer/default.nix
+++ b/distros/eloquent/nonpersistent-voxel-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, geometry-msgs, laser-geometry, map-msgs, nav-msgs, nav2-costmap-2d, nav2-msgs, nav2-voxel-grid, pcl, pcl-conversions, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-nonpersistent-voxel-layer";
-  version = "2.1.0-r2";
+  version = "2.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/eloquent/nonpersistent_voxel_layer/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "35298293b1514e3e4365905f951ccffb4fe63bd0c5d879c6a8b26d0596d34f0a";
+    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/eloquent/nonpersistent_voxel_layer/2.1.1-2.tar.gz";
+    name = "2.1.1-2.tar.gz";
+    sha256 = "0ff37107693cfad069c80e424c8c4a3e21738886378182a94fb05d28bbc7b940";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/spatio-temporal-voxel-layer/default.nix
+++ b/distros/eloquent/spatio-temporal-voxel-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, builtin-interfaces, geometry-msgs, laser-geometry, message-filters, nav2-costmap-2d, openexr, openvdb, pcl, pcl-conversions, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tbb, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-spatio-temporal-voxel-layer";
-  version = "2.1.2-r2";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/eloquent/spatio_temporal_voxel_layer/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "0be31caba7e291f424b112cdf26f1fff711a952a6836c1457a080c6ac1664860";
+    url = "https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release/archive/release/eloquent/spatio_temporal_voxel_layer/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "acfbd3487c3703f84bc49ca0361234d834312ca0a1e723d32c7010968c045116";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/test-apex-test-tools/default.nix
+++ b/distros/eloquent/test-apex-test-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, apex-test-tools }:
+buildRosPackage {
+  pname = "ros-eloquent-test-apex-test-tools";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/eloquent/test_apex_test_tools/0.0.1-1";
+    name = "archive.tar.gz";
+    sha256 = "9ad467a779b5ddcf557dd10c4142e9ee9b49e172bd0a5702108e651e0d985db2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ apex-test-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Test package, which uses things exported by apex_test_tools'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -1538,6 +1538,8 @@ self: super: {
 
  ieee80211-channels = self.callPackage ./ieee80211-channels {};
 
+ ifm3d = self.callPackage ./ifm3d {};
+
  ifm-o3mxxx = self.callPackage ./ifm-o3mxxx {};
 
  igvc-self-drive-description = self.callPackage ./igvc-self-drive-description {};

--- a/distros/kinetic/ifm3d/default.nix
+++ b/distros/kinetic/ifm3d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ifm3d-core, image-transport, message-generation, nodelet, pcl-ros, roscpp, rospy, rostest, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-ifm3d";
+  version = "0.6.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-ros-release/archive/release/kinetic/ifm3d/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "00f12ec49d8d480b19b46b5c4d5ef8cc8246b5f347d6220ed3f265fe0ee30de4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ cv-bridge ifm3d-core image-transport message-generation nodelet pcl-ros roscpp rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ifm pmd-based 3D ToF Camera ROS package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/nerian-stereo/default.nix
+++ b/distros/kinetic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-nerian-stereo";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/kinetic/nerian_stereo/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "6989933355e16b6f44e3ab24d105c36dba12ef0b5f70684b563d69cc96082915";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/kinetic/nerian_stereo/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "9fe08f5e7bd220a41c55676a2de00c2d1b4e0dd3f4063a1687a6be982969b750";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, ros-type-introspection, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.5.1-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.5.1-2.tar.gz";
-    name = "2.5.1-2.tar.gz";
-    sha256 = "a5152333f0d3519502bf09d9c4b11128a56cd2bae03b76be7f3de9bae2933e67";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "b07fc355d97f2948b1150c15dad003e551836e1af9ae4f100e88b439d5600e03";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-drivers/default.nix
+++ b/distros/melodic/ainstein-radar-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, can-msgs, catkin, nodelet, pcl-ros, roscpp, socketcan-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-drivers";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "50ab65173d2825aebc4cd3f988ec172e811aafef86c6fdb813c58d66873e2622";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_drivers/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "de0bffb6af0b60b2508065ca674f88aa04f332107cfd6d96b6725017afb8fda1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-filters/default.nix
+++ b/distros/melodic/ainstein-radar-filters/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen, tf2-sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, jsk-recognition-msgs, nodelet, pcl-ros, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-filters";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "e347805bf17c73a04c4d02e4323c0c7c8e9b9fa7ade5307095f7d83d423f7be2";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_filters/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6924545d6ca9563ea3035d935a4614287718e1989ff412f1f09656e30e18abbd";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen tf2-sensor-msgs ];
+  propagatedBuildInputs = [ ainstein-radar-msgs jsk-recognition-msgs nodelet pcl-ros roscpp tf2-eigen ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, gazebo-plugins, gazebo-ros, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-gazebo-plugins";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "795dc969d70f86385cdc9260cf5e54055fb6e686c54609c3d7f62fdf3471f776";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_gazebo_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "a9b7e22b72584d76cf0e62c37ea5f3723f3e36faaf81151d27ddc38e7b4b64a8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-msgs/default.nix
+++ b/distros/melodic/ainstein-radar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-msgs";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "a47be6bd84665d7ca28b60f6eff5ba62c04414592b50be47e1d796887d1695a3";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "0b7dcd915b866597f9457ac0f1e15188bcb4309b7043f932378d041830f261d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-rviz-plugins/default.nix
+++ b/distros/melodic/ainstein-radar-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-msgs, catkin, pcl, qt5, rviz }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-rviz-plugins";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "d293cc93d7f1b1e31e93eda9de9cf260b065feb034c5ad24df3f18ee979079a6";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_rviz_plugins/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e55ca73701363e257bdd186d2d355076015b7e3832ec9b1ac4a49088774b4a8a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar-tools/default.nix
+++ b/distros/melodic/ainstein-radar-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-filters, ainstein-radar-msgs, catkin, cv-bridge, image-geometry, image-transport, pcl-ros, roscpp, sensor-msgs, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar-tools";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "fbb4ccb20a888ce31f3a19e97e8ee05fb71f791f3cab227b9befeea211aed91e";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar_tools/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "edd663b4d4fccb71e7ed6e87fe55f0847752f09e5923b6f89551d5b944223626";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ainstein-radar/default.nix
+++ b/distros/melodic/ainstein-radar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ainstein-radar-drivers, ainstein-radar-filters, ainstein-radar-gazebo-plugins, ainstein-radar-msgs, ainstein-radar-rviz-plugins, ainstein-radar-tools, catkin }:
 buildRosPackage {
   pname = "ros-melodic-ainstein-radar";
-  version = "3.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "9d8c48044d1fe25bee4f8e6ab8954377d7d76b088b09a2abd8f3d74784366c90";
+    url = "https://github.com/AinsteinAI/ainstein_radar-release/archive/release/melodic/ainstein_radar/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8f47d68abd970c72ed9de890d8e1dc78cc89a6403493420ebd102fa18a577d11";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ati-force-torque/default.nix
+++ b/distros/melodic/ati-force-torque/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cob-generic-can, filters, force-torque-sensor, gazebo-ros, geometry-msgs, hardware-interface, iirob-filters, libmodbus, message-generation, message-runtime, pluginlib, realtime-tools, robot-state-publisher, roscpp, roslaunch, rosparam-handler, rospy, rostopic, std-msgs, std-srvs, teleop-twist-joy, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, visualization-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-ati-force-torque";
+  version = "1.1.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/KITrobotics/ati_force_torque-release/archive/release/melodic/ati_force_torque/1.1.1-3.tar.gz";
+    name = "1.1.1-3.tar.gz";
+    sha256 = "ab56ef07e73679565c0e42290e449c0c3fd2531b8c77eb99e290c8b88c65717d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules message-generation ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ cob-generic-can filters force-torque-sensor gazebo-ros geometry-msgs hardware-interface iirob-filters libmodbus message-runtime pluginlib realtime-tools robot-state-publisher roscpp roslaunch rosparam-handler rospy rostopic std-msgs std-srvs teleop-twist-joy tf2 tf2-geometry-msgs tf2-ros trajectory-msgs visualization-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package implements driver for ATI force torque sensors up to firmware 3.x. Char and Net CAN devices are supported through cob_generic_can package. The code if based on cob_forcetorque package.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/melodic/combined-robot-hw-tests/default.nix
+++ b/distros/melodic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw-tests";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "6bb759b482334bf889676c7425c2e27212648ab2bd5f62a6f52cbf3c05d557da";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "d7cfa399b2ae7788af8fe287d3bef7370e78e9f400789c4364f087d4735d5c20";
   };
 
   buildType = "catkin";

--- a/distros/melodic/combined-robot-hw/default.nix
+++ b/distros/melodic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "c58087951a35c2e5dea7708ed6a8a05c6530bf01c274bfb4a02558470b4d9f23";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "6227a48754f5d70d1fbca5d568b1789f2c6d4ad23d4e962d7585d961b2eb2644";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-interface/default.nix
+++ b/distros/melodic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-controller-interface";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "21d6bf1b95666c974dadc6702dfdb451f6896b92a6e19ae34a15c75af233fdaf";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "35521842178e0dfb433dd86ebbbc8973d7bac33ba6640cb7b04fd21555c12f0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-msgs/default.nix
+++ b/distros/melodic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-msgs";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "2d253d226059c8ad5594e6ace21ea387dd58093114d56b6f0d618ea8ab86dc14";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "dee778480bccb9523fd82cd35184717238fd0631047379955b105bccb897a51b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-tests/default.nix
+++ b/distros/melodic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-tests";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "fd2d50be7d5408d7162a87228cd9726e1b8d788afb56aa4f3bb833ad42efe9da";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "c08a0bf1018f093ba45c5fa87c01428327d1a9076151259a1249cd1dabb8315f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager/default.nix
+++ b/distros/melodic/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, roscpp, rosparam, rospy, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "c143861db6d4ddee5b6a25d8ea10f733ec2bdde66ad20adf91b16881100dd90c";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "e84634dd7609b4cded9e9e78c8b0087d36dd48e2421bf109fc9add7f6abf0248";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ boost controller-interface controller-manager-msgs hardware-interface pluginlib roscpp rosparam rospy std-msgs ];
+  propagatedBuildInputs = [ controller-interface controller-manager-msgs hardware-interface pluginlib roscpp rosparam rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/force-torque-sensor/default.nix
+++ b/distros/melodic/force-torque-sensor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, geometry-msgs, hardware-interface, iirob-filters, message-runtime, pluginlib, realtime-tools, roscpp, rosparam-handler, rospy, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-force-torque-sensor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KITrobotics/force_torque_sensor-release/archive/release/melodic/force_torque_sensor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "187d9649a0604ed6f13a57c41bd0893c659ac73908c925c4a8eba7ef50837770";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules dynamic-reconfigure geometry-msgs hardware-interface iirob-filters message-runtime pluginlib realtime-tools roscpp rosparam-handler rospy std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The force_torque_sensor package'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -110,6 +110,8 @@ self: super: {
 
  async-web-server-cpp = self.callPackage ./async-web-server-cpp {};
 
+ ati-force-torque = self.callPackage ./ati-force-torque {};
+
  audibot = self.callPackage ./audibot {};
 
  audibot-description = self.callPackage ./audibot-description {};
@@ -912,6 +914,8 @@ self: super: {
 
  fmi-adapter-examples = self.callPackage ./fmi-adapter-examples {};
 
+ force-torque-sensor = self.callPackage ./force-torque-sensor {};
+
  force-torque-sensor-controller = self.callPackage ./force-torque-sensor-controller {};
 
  forward-command-controller = self.callPackage ./forward-command-controller {};
@@ -1155,6 +1159,8 @@ self: super: {
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
 
  ieee80211-channels = self.callPackage ./ieee80211-channels {};
+
+ ifm3d = self.callPackage ./ifm3d {};
 
  igvc-self-drive-description = self.callPackage ./igvc-self-drive-description {};
 
@@ -1715,6 +1721,12 @@ self: super: {
  moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
  movie-publisher = self.callPackage ./movie-publisher {};
+
+ mpc-local-planner = self.callPackage ./mpc-local-planner {};
+
+ mpc-local-planner-examples = self.callPackage ./mpc-local-planner-examples {};
+
+ mpc-local-planner-msgs = self.callPackage ./mpc-local-planner-msgs {};
 
  mrpt1 = self.callPackage ./mrpt1 {};
 

--- a/distros/melodic/hardware-interface/default.nix
+++ b/distros/melodic/hardware-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-hardware-interface";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "ad57d9e12500a21d1f4d3d9a63ab59c194de366b227d052e095cc50eb4fa190e";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "68e96e4c41c7d733e4680b424b7bed6efeb695b077f4225edc3c8d92a45c2a3a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost roscpp ];
+  propagatedBuildInputs = [ roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ifm3d/default.nix
+++ b/distros/melodic/ifm3d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ifm3d-core, image-transport, message-generation, nodelet, pcl-ros, roscpp, rospy, rostest, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-ifm3d";
+  version = "0.6.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-ros-release/archive/release/melodic/ifm3d/0.6.2-2.tar.gz";
+    name = "0.6.2-2.tar.gz";
+    sha256 = "71bf4886c74200afc466308abfadec6ff8c44a22c77f7d82603642e613d74b23";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ cv-bridge ifm3d-core image-transport message-generation nodelet pcl-ros roscpp rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ifm pmd-based 3D ToF Camera ROS package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/iirob-filters/default.nix
+++ b/distros/melodic/iirob-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen-conversions, filters, geometry-msgs, pluginlib, roscpp, rosparam-handler, rostest, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-iirob-filters";
-  version = "0.8.3-r2";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/melodic/iirob_filters/0.8.3-2.tar.gz";
-    name = "0.8.3-2.tar.gz";
-    sha256 = "90eafcd1b7a8ea55473788276d8e62b8721028dfcb286c0c09b2c39f4cb24a21";
+    url = "https://github.com/KITrobotics/iirob_filters-release/archive/release/melodic/iirob_filters/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "7ed0549cbc54b49b2462c34e0597f9c7d3758b30ea0942450ba8c6027b2bcfbb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-limits-interface/default.nix
+++ b/distros/melodic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-melodic-joint-limits-interface";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "08352d1fcd557e7fcb0a0d26340f6161c8a895798358bc3e2b6a40f603ee9e27";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "2d70e266bc085fdd5824db3d43efa49baf6c23ecdbb2dd6dad4a9b98c4435bdc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mpc-local-planner-examples/default.nix
+++ b/distros/melodic/mpc-local-planner-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, map-server, move-base, mpc-local-planner, stage-ros }:
+buildRosPackage {
+  pname = "ros-melodic-mpc-local-planner-examples";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_examples/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "b9f4eac97f3a645144e828e8e1f7fd8a3c127562b1f9ab4320dfa25dec8fab2f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl map-server move-base mpc-local-planner stage-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mpc_local_planner_examples package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mpc-local-planner-msgs/default.nix
+++ b/distros/melodic/mpc-local-planner-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mpc-local-planner-msgs";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_msgs/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "2589b79d0482d0214b7fa7d90f191f554a11a120319588ac8c875b678890a85c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides message types that are used by the package mpc_local_planner'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/melodic/mpc-local-planner/default.nix
+++ b/distros/melodic/mpc-local-planner/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, control-box-rst, costmap-2d, costmap-converter, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, mbf-costmap-core, mbf-msgs, mpc-local-planner-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, teb-local-planner, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mpc-local-planner";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "412bcbb02d2232ba66f7a7049196f8f9c2f31356c6e4282b5f72535edf5066ba";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ base-local-planner control-box-rst costmap-2d costmap-converter dynamic-reconfigure eigen geometry-msgs interactive-markers mbf-costmap-core mbf-msgs mpc-local-planner-msgs nav-core nav-msgs pluginlib roscpp std-msgs teb-local-planner tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mpc_local_planner package implements a plugin
+    to the base_local_planner of the 2D navigation stack.
+    It provides a generic and versatile model predictive control implementation
+    with minimum-time and quadratic-form receding-horizon configurations.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/melodic/nerian-stereo/default.nix
+++ b/distros/melodic/nerian-stereo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-nerian-stereo";
-  version = "3.6.0-r1";
+  version = "3.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.6.0-1.tar.gz";
-    name = "3.6.0-1.tar.gz";
-    sha256 = "80f089c8d22cb880e1653dccedf1f29eafd1a68819b6efe0bd32f4bf568f6acf";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.7.0-1.tar.gz";
+    name = "3.7.0-1.tar.gz";
+    sha256 = "e37bd3fc3b998e1a17a3d7a1c21b210f68bbc1544b95886dd7daa07d1884ef80";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nmea-navsat-driver/default.nix
+++ b/distros/melodic/nmea-navsat-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nmea-msgs, pythonPackages, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-nmea-navsat-driver";
-  version = "0.5.1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/nmea_navsat_driver-release/archive/release/melodic/nmea_navsat_driver/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "c502e261f11dee9d169b96c13eec505a7251157364aeac7201a6518740559557";
+    url = "https://github.com/ros-drivers-gbp/nmea_navsat_driver-release/archive/release/melodic/nmea_navsat_driver/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "4bb6d7fbaf5d6d3d334c0ce1b21997c6c303d10ded2bb87c72b9dd609fbc18ba";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Package to parse NMEA strings and publish a very simple GPS message. Does not 
+    description = ''Package to parse NMEA strings and publish a very simple GPS message. Does not
     require or use the GPSD deamon.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, ros-type-introspection, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.5.1-r2";
+  version = "2.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.5.1-2.tar.gz";
-    name = "2.5.1-2.tar.gz";
-    sha256 = "3f0f2f5fa1cf4a0b9fe8c25779b5f0a93a5afac2fec96e649f06cd5e91f67303";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.6.2-1.tar.gz";
+    name = "2.6.2-1.tar.gz";
+    sha256 = "5a912c34f996f1e378249f713bc7fc6ebce018c250798dd3b8040e77e1dd3b11";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-control/default.nix
+++ b/distros/melodic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-ros-control";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "93618cf09b18a69d63557b6230dca535cb0fce9d711abca706b6b66804a4693a";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "25afad4a8408aa2251004a3f157b08c82babf5ff58779ca67be4530932d0b9ec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-controller-manager/default.nix
+++ b/distros/melodic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-controller-manager";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "ce030aa56910c1c47fee4373ab83d90975a5ef946c46924417f349c60d10bed0";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "3206e0571c8fa50478a0bfe79532698ab449f0c0aaaf1c6c3c1742d6f38f9a29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/transmission-interface/default.nix
+++ b/distros/melodic/transmission-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-transmission-interface";
-  version = "0.16.0-r1";
+  version = "0.17.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.16.0-1.tar.gz";
-    name = "0.16.0-1.tar.gz";
-    sha256 = "305fa23c79689242ab502dee48bb13aa479572d896d7e7024705c89b4cfe3513";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.17.0-1.tar.gz";
+    name = "0.17.0-1.tar.gz";
+    sha256 = "533f757e589d9f94198898c02c92dc7b1ef7b77b5981b3d14b22b3e07af6e252";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ resource-retriever ];
-  propagatedBuildInputs = [ boost hardware-interface pluginlib roscpp tinyxml ];
+  propagatedBuildInputs = [ hardware-interface pluginlib roscpp tinyxml ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit d093a9377975cce7dcadeb40a0339acea400a545.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *apex-containers 0.0.1-r1*
* *apex-test-tools 0.0.1-r1*
* *test-apex-test-tools 0.0.1-r1*

Eloquent Changes:
-----------------
* *apex-test-tools 0.0.1-r1*
* *nmea-msgs 2.0.0-r1*
* *nonpersistent-voxel-layer 2.1.0-r2 --> 2.1.1-r2*
* *spatio-temporal-voxel-layer 2.1.2-r2 --> 2.1.3-r1*
* *test-apex-test-tools 0.0.1-r1*

Kinetic Changes:
----------------
* *ifm3d 0.6.2-r1*
* *nerian-stereo 3.6.0-r1 --> 3.7.0-r1*
* *plotjuggler 2.5.1-r2 --> 2.6.1-r1*

Melodic Changes:
----------------
* *ainstein-radar 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-drivers 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-filters 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-gazebo-plugins 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-msgs 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-rviz-plugins 3.0.1-r1 --> 2.0.2-r1*
* *ainstein-radar-tools 3.0.1-r1 --> 2.0.2-r1*
* *ati-force-torque 1.1.1-r3*
* *combined-robot-hw 0.16.0-r1 --> 0.17.0-r1*
* *combined-robot-hw-tests 0.16.0-r1 --> 0.17.0-r1*
* *controller-interface 0.16.0-r1 --> 0.17.0-r1*
* *controller-manager 0.16.0-r1 --> 0.17.0-r1*
* *controller-manager-msgs 0.16.0-r1 --> 0.17.0-r1*
* *controller-manager-tests 0.16.0-r1 --> 0.17.0-r1*
* *force-torque-sensor 1.0.0-r1*
* *hardware-interface 0.16.0-r1 --> 0.17.0-r1*
* *ifm3d 0.6.2-r2*
* *iirob-filters 0.8.3-r2 --> 0.9.1-r1*
* *joint-limits-interface 0.16.0-r1 --> 0.17.0-r1*
* *mpc-local-planner 0.0.1-r2*
* *mpc-local-planner-examples 0.0.1-r2*
* *mpc-local-planner-msgs 0.0.1-r2*
* *nerian-stereo 3.6.0-r1 --> 3.7.0-r1*
* *nmea-navsat-driver 0.5.1 --> 0.5.2-r1*
* *plotjuggler 2.5.1-r2 --> 2.6.2-r1*
* *ros-control 0.16.0-r1 --> 0.17.0-r1*
* *rqt-controller-manager 0.16.0-r1 --> 0.17.0-r1*
* *transmission-interface 0.16.0-r1 --> 0.17.0-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-packaging
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

