### PR TITLE
rosdistro sync, Fri Mar 13 12:45:42 2020

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -434,6 +434,10 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ joint-state-publisher = self.callPackage ./joint-state-publisher {};
+
+ joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
  joy = self.callPackage ./joy {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
@@ -1059,6 +1063,8 @@ self: super: {
  urdfdom = self.callPackage ./urdfdom {};
 
  urdfdom-headers = self.callPackage ./urdfdom-headers {};
+
+ urdfdom-py = self.callPackage ./urdfdom-py {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
 

--- a/distros/dashing/joint-state-publisher-gui/default.nix
+++ b/distros/dashing/joint-state-publisher-gui/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+buildRosPackage {
+  pname = "ros-dashing-joint-state-publisher-gui";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher_gui/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "fdc9c350e4bc32ecf23b87f1c6231e5eb90b6884f6a635fdb0abe6883e2b1af1";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
+
+  meta = {
+    description = ''This package contains a GUI tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/joint-state-publisher/default.nix
+++ b/distros/dashing/joint-state-publisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-joint-state-publisher";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a6954e9cc7c42c8dfb42f5f2dbae8071f247de380c8e66f6ef008f16c5213d34";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-xmllint launch-testing launch-testing-ros pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy sensor-msgs std-msgs ];
+
+  meta = {
+    description = ''This package contains a tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/novatel-gps-driver/default.nix
+++ b/distros/dashing/novatel-gps-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-dashing-novatel-gps-driver";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_driver/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "bec8812154087cc0d76383a58e50cb5d24688fc817aea4b7c223c4f6c7eb1a39";
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_driver/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "4d66783e1e12b139b4f958c934d115df285552ac316cc812291c0209d357b3f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/novatel-gps-msgs/default.nix
+++ b/distros/dashing/novatel-gps-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-novatel-gps-msgs";
-  version = "4.0.2-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_msgs/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "055a89dababf0cd077bfc3ea1a761051fe80b979dad06bf64bf9bbbd1da388b1";
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/dashing/novatel_gps_msgs/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "a45e2dff554df37d445daaabc241eb6afa33007828527f19240c80cb959ad2fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/pcl-conversions/default.nix
+++ b/distros/dashing/pcl-conversions/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
-    sha256 = "1dee570593be56530a89248cd15ba13a1eb72daad1c1a4d452ed7b396db8a134";
+    sha256 = "7e5a799ac5e1a196d385a9247cffabe2b8589c554b22a4a1cb10896ff3bfcb07";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-action/default.nix
+++ b/distros/dashing/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcl-action, rclcpp, rosidl-generator-c, rosidl-generator-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-action";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "a22b2889a613dd67bd9631ff569a2319cb1bf0f3c4fb5ebdc3ccba135ced5149";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "5ab26070f9a706bf9721ea272daba10d5282d689394b19f733d3c44fde4ba026";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-components/default.nix
+++ b/distros/dashing/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-components";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "0070b66875b9ab3fbc1bcdc5121c5fdafcc26a5c7b281ba0b779540799e113aa";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "f3dc76e4f8011c2a76baea0d7732f57cd53cf488f79ca34cccb932fdac96d70d";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-lifecycle/default.nix
+++ b/distros/dashing/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, rcl-lifecycle, rclcpp, rmw-implementation, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-lifecycle";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "9e8f20a28fa9c757bc5d7a1ba64c884d074a1e248283d4fe7654f13cbde63b31";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "db0e9ed504d776ca7d5af19f7446b247c41f61f924c36b3fabb564c892de93eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp/default.nix
+++ b/distros/dashing/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rcl-yaml-param-parser, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp";
-  version = "0.7.12-r1";
+  version = "0.7.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.12-1.tar.gz";
-    name = "0.7.12-1.tar.gz";
-    sha256 = "d5ff4aa3dfd5a5c8f408d0f082a5214859bb349c4f7acbbca6868f00f5a35d49";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.13-1.tar.gz";
+    name = "0.7.13-1.tar.gz";
+    sha256 = "50be58a8aca9bcfe3831e39f98c21da456be63b03e88578583e1cf6ad7473c12";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-assimp-vendor/default.nix
+++ b/distros/dashing/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-dashing-rviz-assimp-vendor";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_assimp_vendor/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "16e30c0eac1bfee1ce1550b0eb1545efa151a01d0049e8e65a68c4411a8e51e1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_assimp_vendor/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "c10458ca563f1fac5784cf32a16fc941d0e8eaf58651012b7510593a90098937";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-common/default.nix
+++ b/distros/dashing/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rviz-common";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_common/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "18c0f221ac4ebc600d52df42864aefa6d05220d54f41f4c9cfa013ee9f43cc2d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_common/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "c0dd3bc6f3a3303fb7c8fd38f24be59f5d9e062d8b1adb87b9bc830b3992311d";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-default-plugins/default.nix
+++ b/distros/dashing/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rviz-default-plugins";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_default_plugins/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "58fa0a7a0f99c53fcfbf05c11f4d29a040e41f4f190aa22aafe6f5a797979eeb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_default_plugins/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "eaff175387959833dc3b78e962134a19064b58650e6c7a835dd70b695bee0036";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-ogre-vendor/default.nix
+++ b/distros/dashing/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-dashing-rviz-ogre-vendor";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_ogre_vendor/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "4c5f6855267c89c348087aa95a50c8f5abd27947194f8c7b79582d4d726a79f9";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_ogre_vendor/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "b60cc9018effb2e6bf18fac6b8e20aa17d46eed3248c1e0c7b95de074474f5b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-rendering-tests/default.nix
+++ b/distros/dashing/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-dashing-rviz-rendering-tests";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering_tests/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "89b580a8005ee307108d7dc29d02cd3fddf018ccddafec53dc286731382a349a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering_tests/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "4378ba090743abc192a5a3121365e4cd0552877e78e456717d609c8964f2a52b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-rendering/default.nix
+++ b/distros/dashing/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rviz-rendering";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "f4d2ccdbcd2124d6357870375fb859aac8c4c34a0d255fc5cd3a15cdeff08bee";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_rendering/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "d8b2e265c2eac4d119f60270edd93fb7e232f0cb74726364c8893164a12f203e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz-visual-testing-framework/default.nix
+++ b/distros/dashing/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-dashing-rviz-visual-testing-framework";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_visual_testing_framework/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "f42359c9869ba7d26ef732be855d801a9eac100ce3c3c9bad833b586fd73bc5c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz_visual_testing_framework/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "b6ac3827f3b791fe4e15dbe1dcbd28de43d050f26321192fd4290deb8e1f653f";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rviz2/default.nix
+++ b/distros/dashing/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rviz2";
-  version = "6.1.5-r1";
+  version = "6.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz2/6.1.5-1.tar.gz";
-    name = "6.1.5-1.tar.gz";
-    sha256 = "377500f6ea8558a149975e30e1ede7b874458b2cfbc4938116977a3c5b2fbc2f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/dashing/rviz2/6.1.6-1.tar.gz";
+    name = "6.1.6-1.tar.gz";
+    sha256 = "cd3ad8a85be34b45cd40346dd529d93a4d9100c9f189b4c847b77de53f1f7a96";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-console-util/default.nix
+++ b/distros/dashing/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-console-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "6142cc9246f94e547bdadfa4caba870ffbbee81799554fe13773be7682f8d60a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "cfbc0c6cdfd5bab294fbd579b026011c22820b648690330e58e5de7ca9dae754";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-dbw-interface/default.nix
+++ b/distros/dashing/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-swri-dbw-interface";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8ae48576888e81ba3ad2d62d075462ffc847069cbf7332afaeb73edb9195477e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "fae8828419a7a45b97df0f7605adf9cb94c0cec06edf6877b43f7b029bef7320";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-geometry-util/default.nix
+++ b/distros/dashing/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-geometry-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4a1338a7ec6543c4e6282cb1a50eadf9ab3c2c7affeb90974d5d3bbb28c2b35c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "9dd5099da1c066daafc55a6aff174a37accbfc4a27dadfac6adc8ad717c4517b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-image-util/default.nix
+++ b/distros/dashing/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-image-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "efa42cb49dfea66b874a82ba27bc4e0c24779b10d23653f9bbcb0d54440b0db4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "13383b5325aac6f8ec818ae1a50bd0991e963d35c78cea098cd0b112237d885e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-math-util/default.nix
+++ b/distros/dashing/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-math-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "873b92d99bb026adfad728416d63cbf92d316b39ea5a0f594b67163298797bfc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "96b2f85c86acca733b8c10c872bc27dae369b29fd776c1a6b4eb81294836fb78";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-opencv-util/default.nix
+++ b/distros/dashing/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-dashing-swri-opencv-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "1ddc25b6ccce5ae943d951613cde3db07aa6223a3bd9c17406c202b006c6707c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "738818b73a162c155749aa73c72a49d0542e0c0773add32a186633d75641d9d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-prefix-tools/default.nix
+++ b/distros/dashing/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-swri-prefix-tools";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "d6f1383cbd3173a4a6c5499ecc0946b29176291dfa86001ac291b15048b1f1b2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "f351dc7353b8f1f7db6f6be25306148136ac6ec842c21934f33b6a88de9e0afc";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-roscpp/default.nix
+++ b/distros/dashing/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-swri-roscpp";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "23d0e9ee6ab78e21212aa8bf39f00eb78a385f73558fde9e29c60711e4578d6a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "aa69852446a9718f1e667b8842470eaae14ef1783fffa1eb5b42b27dfd5ed93a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-route-util/default.nix
+++ b/distros/dashing/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-swri-route-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "7a7f1f03e7312d3ca8d08bbaf727ad68842d180f0383d052b6240948f8d10d93";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "5330ea2c8509c8aa64b02ed68d8ef61c9b31ae1fca5890e97ea95d2b44a10edd";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-serial-util/default.nix
+++ b/distros/dashing/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-dashing-swri-serial-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4597d0be4428e18f2061619ebdea4ae36fe0eb24d9726ce70b746eb0470a34ab";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "31c6b1c337648d7bf51b49baf6d9e2dba9bfc81c5c91da3621ba00cc5f0c7d4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-system-util/default.nix
+++ b/distros/dashing/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-system-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "48359f72cb2deae5d6cfcb58280c77690dea11ea1cce8665b19c0af81fa35039";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "d5502493ffb2819b7ff7c46005b213b57d9cc34635f1497c20dcfbdf4dd6efe6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-transform-util/default.nix
+++ b/distros/dashing/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-dashing-swri-transform-util";
-  version = "3.0.4-r1";
+  version = "3.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "859b4df313187c93fdef49a5bf89cb6c7a4b7ff85ba983872d18f4085ff6ce6e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.0.5-2.tar.gz";
+    name = "3.0.5-2.tar.gz";
+    sha256 = "316d4b56c77b7bb86c37f241a8048c466d93458acde86224175ec7b475bb9e68";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/urdfdom-py/default.nix
+++ b/distros/dashing/urdfdom-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-dashing-urdfdom-py";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urdfdom_py-release/archive/release/dashing/urdfdom_py/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2f4ce85f6a4fa0b42b44e8bc5920f1e4d6e53b5e4be32a8818d23991f8e0e6aa";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ python3Packages.lxml python3Packages.pyyaml rclpy ];
+
+  meta = {
+    description = ''Python implementation of the URDF parser.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -396,6 +396,10 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ joint-state-publisher = self.callPackage ./joint-state-publisher {};
+
+ joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
  joy = self.callPackage ./joy {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
@@ -896,6 +900,30 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ swri-console-util = self.callPackage ./swri-console-util {};
+
+ swri-dbw-interface = self.callPackage ./swri-dbw-interface {};
+
+ swri-geometry-util = self.callPackage ./swri-geometry-util {};
+
+ swri-image-util = self.callPackage ./swri-image-util {};
+
+ swri-math-util = self.callPackage ./swri-math-util {};
+
+ swri-opencv-util = self.callPackage ./swri-opencv-util {};
+
+ swri-prefix-tools = self.callPackage ./swri-prefix-tools {};
+
+ swri-roscpp = self.callPackage ./swri-roscpp {};
+
+ swri-route-util = self.callPackage ./swri-route-util {};
+
+ swri-serial-util = self.callPackage ./swri-serial-util {};
+
+ swri-system-util = self.callPackage ./swri-system-util {};
+
+ swri-transform-util = self.callPackage ./swri-transform-util {};
+
  system-modes = self.callPackage ./system-modes {};
 
  system-modes-examples = self.callPackage ./system-modes-examples {};
@@ -967,6 +995,8 @@ self: super: {
  urdfdom = self.callPackage ./urdfdom {};
 
  urdfdom-headers = self.callPackage ./urdfdom-headers {};
+
+ urdfdom-py = self.callPackage ./urdfdom-py {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
 

--- a/distros/eloquent/joint-state-publisher-gui/default.nix
+++ b/distros/eloquent/joint-state-publisher-gui/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
+buildRosPackage {
+  pname = "ros-eloquent-joint-state-publisher-gui";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher_gui/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "887ebb72a58819414bac54372188c1740038abb40791c586bfd83230d2082540";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ joint-state-publisher python-qt-binding rclpy ];
+
+  meta = {
+    description = ''This package contains a GUI tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/joint-state-publisher/default.nix
+++ b/distros/eloquent/joint-state-publisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-joint-state-publisher";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bef59b518cb96eafbf5d9aeffe2b3edcfc18532489e44da9c9e5717d47fd1148";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-xmllint launch-testing launch-testing-ros pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy sensor-msgs std-msgs ];
+
+  meta = {
+    description = ''This package contains a tool for setting and publishing joint state values for a given URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/py-trees-ros/default.nix
+++ b/distros/eloquent/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-py-trees-ros";
-  version = "2.0.9-r1";
+  version = "2.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.9-1.tar.gz";
-    name = "2.0.9-1.tar.gz";
-    sha256 = "40cc4048935dab5ccf355020e7e69496deaf5be51c658ebeac38105731563414";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/eloquent/py_trees_ros/2.0.10-1.tar.gz";
+    name = "2.0.10-1.tar.gz";
+    sha256 = "cff566a2461d3e4385855e0afb9b50fe52145b1e78b1d0e71e1e77f330ec7a23";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/swri-console-util/default.nix
+++ b/distros/eloquent/swri-console-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-console-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_console_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d00789e4702b243bed9c2deb70db746aec0aa720cb4f8d4ca56b03d7ffdb5877";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_console_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-dbw-interface/default.nix
+++ b/distros/eloquent/swri-dbw-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-dbw-interface";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_dbw_interface/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "14a08b22551407eb582ef32f48265aa8232b68fd462931beb4300102e060219f";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides documentation on common interface conventions for
+    drive-by-wire systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-geometry-util/default.nix
+++ b/distros/eloquent/swri-geometry-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-geometry-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_geometry_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ce3fbf8fef81e533e994635f2fdb010984c799d86c43df3c164533902fce9756";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ cv-bridge eigen geos rclcpp tf2 ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = ''swri_geometry_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-image-util/default.nix
+++ b/distros/eloquent/swri-image-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-image-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_image_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "5930e396244ba7095b7a0a0e7895973dc3ef297ff5e46582cc6df5878ddeca03";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ ament-index-cpp boost camera-calibration-parsers cv-bridge eigen geometry-msgs image-geometry image-transport message-filters nav-msgs rclcpp rclcpp-components rclpy std-msgs swri-geometry-util swri-math-util swri-opencv-util swri-roscpp tf2 ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = ''swri_image_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-math-util/default.nix
+++ b/distros/eloquent/swri-math-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-math-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_math_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b8ef28a941d94832e13c2ae949d27e3e6a7794f2b90c17e9bfdbb185d885afdc";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ boost rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_math_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-opencv-util/default.nix
+++ b/distros/eloquent/swri-opencv-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-opencv-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_opencv_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d0845e09c2896a59a4528085c68c22a8660ac301281c4d881d315b1c2596aedd";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost cv-bridge swri-math-util ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_opencv_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-prefix-tools/default.nix
+++ b/distros/eloquent/swri-prefix-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-prefix-tools";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_prefix_tools/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "9a1465d6cd9fd94aeadf9508e6f6d35e02abaf35ac00a5f098f51b419a5da117";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ pythonPackages.psutil ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains scripts that are useful as prefix commands for nodes
+    started by roslaunch.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-roscpp/default.nix
+++ b/distros/eloquent/swri-roscpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-roscpp";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_roscpp/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "03e23bb4dc7aa91387a5287f74d89796c2b5695782fed0ba53fde4b760aaf224";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-cmake ];
+  checkInputs = [ ament-cmake-gtest gtest ];
+  propagatedBuildInputs = [ boost diagnostic-updater marti-common-msgs nav-msgs rclcpp rosidl-default-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''swri_roscpp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-route-util/default.nix
+++ b/distros/eloquent/swri-route-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-route-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_route_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "940b43f9a9edb41b2cf8dbf4e2b8cdcf11f7a872dcac1ad4a22002f65dd50354";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost marti-common-msgs marti-nav-msgs rclcpp swri-geometry-util swri-math-util swri-roscpp swri-transform-util visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This library provides functionality to simplify working with the
+    navigation messages defined in marti_nav_msgs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-serial-util/default.nix
+++ b/distros/eloquent/swri-serial-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-serial-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_serial_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "909797a777c2b5413776218672beb52cef2368f3a6bce902a3a3ce83cff1dc1c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_serial_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-system-util/default.nix
+++ b/distros/eloquent/swri-system-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-system-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_system_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "869469b0bf65d9035f262c41ff5b29ea56120c49195a4039dcb3b5a7c70f4b9a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ];
+  propagatedBuildInputs = [ boost rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''swri_system_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-transform-util/default.nix
+++ b/distros/eloquent/swri-transform-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-transform-util";
+  version = "3.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_transform_util/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "efd1e50a943795722e98ba1c4970a720d12b4e3dee552fc438efcfec16538ff7";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
+
+  meta = {
+    description = ''The swri_transform_util package contains utility functions and classes for
+     transforming between coordinate frames.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/urdfdom-py/default.nix
+++ b/distros/eloquent/urdfdom-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, rclpy }:
+buildRosPackage {
+  pname = "ros-eloquent-urdfdom-py";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urdfdom_py-release/archive/release/eloquent/urdfdom_py/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "fb24c4eb4d4f8f43fd6cc66bc895a56b049e5d1d18a51e965c5455c4d165dd24";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ python3Packages.lxml python3Packages.pyyaml rclpy ];
+
+  meta = {
+    description = ''Python implementation of the URDF parser.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/amcl/default.nix
+++ b/distros/kinetic/amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, map-server, message-filters, nav-msgs, rosbag, roscpp, rostest, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-amcl";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/amcl/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "0657fe6cc0c2c31c59edab28305e53991f9db8b72ac333c0e5ed4abfb62200fe";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/amcl/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "126fc4299e663c1c8e38f73dc27ce4245a96e3d9dd2336abdbb300067b3bfa70";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/base-local-planner/default.nix
+++ b/distros/kinetic/base-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pcl-conversions, pcl-ros, pluginlib, roscpp, rospy, rosunit, std-msgs, tf, voxel-grid }:
 buildRosPackage {
   pname = "ros-kinetic-base-local-planner";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/base_local_planner/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "728390ded2b54d2846e65a72c557be950be1997963d814ac3052e0d206cd584b";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/base_local_planner/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "f7a1bf9314897b51031490aeb7ff6e2ff28e356591e58494e88f91d87399b31e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/carla-msgs/default.nix
+++ b/distros/kinetic/carla-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-carla-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/kinetic/carla_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c287805a87b147fd52c225ae811c6f935ae2600d2ff21bd14ae799b8402ac0aa";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The carla_msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/carrot-planner/default.nix
+++ b/distros/kinetic/carrot-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, eigen, nav-core, pluginlib, roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-carrot-planner";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/carrot_planner/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "be83e77b7f193cd2af491d7f90a2697f9d5f72101fa2b44eb2b85752607f114b";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/carrot_planner/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "b6ab22cd97eb038e683cd9de9504bc8adf27ca1060afee18ecef7e4c20cf5f2a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/clear-costmap-recovery/default.nix
+++ b/distros/kinetic/clear-costmap-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, eigen, nav-core, pluginlib, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-clear-costmap-recovery";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/clear_costmap_recovery/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "3ccd7ef37ee61777a13c993cfedb1ae8f209cb8ff746e108dd2b156e69672915";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/clear_costmap_recovery/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "36d2e725d81f31a5668508e387011f17c460a492eaa33f3139bcf5accd675909";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-2d/default.nix
+++ b/distros/kinetic/costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, map-server, message-filters, message-generation, message-runtime, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rosbag, rosconsole, roscpp, rostest, rosunit, sensor-msgs, std-msgs, tf, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-2d";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/costmap_2d/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "b8bda9750d1c8117468d802b0a18c598beb46f4b12418d93c052dc05397eb454";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/costmap_2d/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "f819d5d8f5a9541ece4125b5e77f854fb38dacd6791c8e1022eb6af89f294147";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a45ebbe610ff27a4dbbe36dd36342a462359ad8de52f1ee394a0280bb11a7ad1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "1f9d261f577a6da07a9744a72d5df0f39f661fa0155d95aeda9fa01077547f1d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dwa-local-planner/default.nix
+++ b/distros/kinetic/dwa-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, nav-core, nav-msgs, pcl-conversions, pluginlib, roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-dwa-local-planner";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/dwa_local_planner/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "7f86aa2ffc55815d90a68c88001f515917ea3e95d33b57ab278051e28f8db12e";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/dwa_local_planner/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "454f2fb9179db45dfda1b492f6427b8df66ff4b960034b03eb197af7ecaa6ab7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/fake-localization/default.nix
+++ b/distros/kinetic/fake-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, message-filters, nav-msgs, rosconsole, roscpp, rospy, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-fake-localization";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/fake_localization/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "5285fddec54294a69954d90e5ec8f716c26eed2b6cb8f573e0bcda7bfd4b4e40";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/fake_localization/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "7759409db122c4a8726fbbc5599617293d3eca3442581d789c21b27825a1b98c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -276,6 +276,8 @@ self: super: {
 
  care-o-bot-simulation = self.callPackage ./care-o-bot-simulation {};
 
+ carla-msgs = self.callPackage ./carla-msgs {};
+
  carrot-planner = self.callPackage ./carrot-planner {};
 
  cartesian-msgs = self.callPackage ./cartesian-msgs {};
@@ -3215,6 +3217,8 @@ self: super: {
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
 
  pyclearsilver = self.callPackage ./pyclearsilver {};
+
+ pyquaternion = self.callPackage ./pyquaternion {};
 
  pyros = self.callPackage ./pyros {};
 

--- a/distros/kinetic/global-planner/default.nix
+++ b/distros/kinetic/global-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-global-planner";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/global_planner/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "74d043e7c676b27c046324f1549fbdf644c75e5087cdc63f81891ea3cf988026";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/global_planner/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "c91be57e508c657412ed72ffde77b1b5382d4012d90ed709883e5c778b191ace";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ifm3d/default.nix
+++ b/distros/kinetic/ifm3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ifm3d-core, image-transport, message-generation, nodelet, pcl-ros, roscpp, rospy, rostest, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-ifm3d";
-  version = "0.6.2-r1";
+  version = "0.6.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ifm/ifm3d-ros-release/archive/release/kinetic/ifm3d/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "00f12ec49d8d480b19b46b5c4d5ef8cc8246b5f347d6220ed3f265fe0ee30de4";
+    url = "https://github.com/ifm/ifm3d-ros-release/archive/release/kinetic/ifm3d/0.6.2-2.tar.gz";
+    name = "0.6.2-2.tar.gz";
+    sha256 = "267cdb74a0407c2b0e27a4ff91d596023579fa2d241ef2bdb04e294d88fa8f82";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ipr-extern/default.nix
+++ b/distros/kinetic/ipr-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libmodbus, libreflexxestype2, ros-reflexxes }:
 buildRosPackage {
   pname = "ros-kinetic-ipr-extern";
-  version = "0.8.8";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ipr_extern/0.8.8-0.tar.gz";
-    name = "0.8.8-0.tar.gz";
-    sha256 = "d7e37fb86212a48bfdfba21e29cca5541aaf7e1e950e4415fbf1a08191079b6a";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ipr_extern/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d9a11c9df9a4577801f4d3e061b54ed192f349e4b72663dc9db2fca4f3dba67c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-control/default.nix
+++ b/distros/kinetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-control";
-  version = "0.6.2";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.2-0.tar.gz";
-    name = "0.6.2-0.tar.gz";
-    sha256 = "f300d2f001da3ecde426697f54571d830e51c3f06b68dfe1d7865eebca5f7355";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "6c80fb7642b9a3495a36c883a76cc891ae8473a81ab02df3acc89d7ac849b872";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-description/default.nix
+++ b/distros/kinetic/jackal-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-description";
-  version = "0.6.2";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.2-0.tar.gz";
-    name = "0.6.2-0.tar.gz";
-    sha256 = "4c2d0cbf6fd755476a1a7872639929c7d5277a3e4f258091df26e5c959f8f70c";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "5038df4c1b634582d9334b8ce74e9f2c255ec298765286d2362c43234a30ab91";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ lms1xx robot-state-publisher urdf xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/jackal-msgs/default.nix
+++ b/distros/kinetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-msgs";
-  version = "0.6.2";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.2-0.tar.gz";
-    name = "0.6.2-0.tar.gz";
-    sha256 = "14c8deb7808dd63e2120074d75f7ea8a2ff277805ee93ffbd951fb9d27c2b5c7";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "473913df23930c85c13b3a7bb666997de48ddad7ef629dea96f9581858d9a943";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-navigation/default.nix
+++ b/distros/kinetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-navigation";
-  version = "0.6.2";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.2-0.tar.gz";
-    name = "0.6.2-0.tar.gz";
-    sha256 = "d42cf86af4666a1802fb3782112f26641a231ad5cddc30e11e75e21e8cf9fda1";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "c53313a7ac2c40a6dca6d763332c9c4828994603b47dc12d2b07b0b6bfb9360b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-tutorials/default.nix
+++ b/distros/kinetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-tutorials";
-  version = "0.6.2";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.2-0.tar.gz";
-    name = "0.6.2-0.tar.gz";
-    sha256 = "ef9f89d86c226f61f8ef0b52650f584944da093cab755dd931133aff8ecd3c53";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "593bb5d76d07caad934a721f6ee62da170a83d2f8104723394f5dc89347e4a44";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joint-state-publisher-gui/default.nix
+++ b/distros/kinetic/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-joint-state-publisher-gui";
-  version = "1.12.14-r1";
+  version = "1.12.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher_gui/1.12.14-1.tar.gz";
-    name = "1.12.14-1.tar.gz";
-    sha256 = "9409f5c663a7ba11cf5f319c9459a7092fe29e1f18b3f9fabb9125246d2f7181";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher_gui/1.12.15-1.tar.gz";
+    name = "1.12.15-1.tar.gz";
+    sha256 = "ef8e3abcb28222b108de0d7a099bc4840ff770324b4020ae18443c496dbec409";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joint-state-publisher/default.nix
+++ b/distros/kinetic/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-joint-state-publisher";
-  version = "1.12.14-r1";
+  version = "1.12.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher/1.12.14-1.tar.gz";
-    name = "1.12.14-1.tar.gz";
-    sha256 = "6d3104ea5af5b2e187102eb6741c383b08c3bacee546eb1e54d48bbab63027e6";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/kinetic/joint_state_publisher/1.12.15-1.tar.gz";
+    name = "1.12.15-1.tar.gz";
+    sha256 = "14d612952ea45f7f1910f77a96707066862953d83f3c35a6841cb2a635a80a0b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "25759be926372c6ce8fa63c6aff229f5e0b1e11cc170feb8184261f88a982f98";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "afbcf8048fc6c42cb26bab0d5fb309507d249a7b86b7cb4b7c07f16399a1652b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/lgsvl-msgs/default.nix
+++ b/distros/kinetic/lgsvl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-lgsvl-msgs";
-  version = "0.0.1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/kinetic/lgsvl_msgs/0.0.1-0.tar.gz";
-    name = "0.0.1-0.tar.gz";
-    sha256 = "f46ae4bd92dcb6c432f1f23cc583adf3febfe04f478a15e63b790c003e9c4aa5";
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/kinetic/lgsvl_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "7adfcbaad0a60937c98b32d07fbf2e6fcc27656fbde4f460079bb4d2f825d870";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libmodbus/default.nix
+++ b/distros/kinetic/libmodbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules }:
 buildRosPackage {
   pname = "ros-kinetic-libmodbus";
-  version = "0.8.8";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libmodbus/0.8.8-0.tar.gz";
-    name = "0.8.8-0.tar.gz";
-    sha256 = "2ba6a63a88bb1809ef7743a25530875678171c980b46071933297d91540fe3f4";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libmodbus/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "bb7a3a59a7b9a186565922f4eb3dfbaa82beeee2668f7408717ed7c2a0d28184";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, linuxHeaders, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.31.0-r1";
+  version = "2.33.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.31.0-1.tar.gz";
-    name = "2.31.0-1.tar.gz";
-    sha256 = "9ed23359080d8219f5f705812298eadd68e807085438dc2222c34db6c3ff0544";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.33.1-2.tar.gz";
+    name = "2.33.1-2.tar.gz";
+    sha256 = "9c755cf1d0f4301d48d86f67ec1a7d159c513471f06b8f95de7bb4c5a4b304e4";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/libreflexxestype2/default.nix
+++ b/distros/kinetic/libreflexxestype2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-libreflexxestype2";
-  version = "0.8.8";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libreflexxestype2/0.8.8-0.tar.gz";
-    name = "0.8.8-0.tar.gz";
-    sha256 = "e19f5d03525f6c8998061a81b632443960778dc6769bb830ac178a6d69cfbe69";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libreflexxestype2/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f35455983c902ec35fcbf2a01bdc95c5147284d8c2dbbd14f03ac08b5b87ad0b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "599c542fa03f005b5f4737722a1ac58abc2ee4c7b9af75dc695f8c1ab81c9252";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "288d6d9dbb2484fde20cd5a0938696e8e97282636248a84d51fc2f9f65a57a95";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-server/default.nix
+++ b/distros/kinetic/map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, libyamlcpp, nav-msgs, roscpp, rospy, rostest, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-kinetic-map-server";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/map_server/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "e5fb03609a0fdc9f72eda300b47fc2acc5497c3a96d5524667f9154d9bfd6cd7";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/map_server/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "10572b096dc4c4a9a799869593eaa8fb475020b9b883d69e2a9d756f70dae089";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/media-export/default.nix
+++ b/distros/kinetic/media-export/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-media-export";
-  version = "0.2.0";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/media_export-release/archive/release/kinetic/media_export/0.2.0-0.tar.gz";
-    name = "0.2.0-0.tar.gz";
-    sha256 = "5e0eb9f4064277d11d28778f9b50391a6330c0716ee21a6bf30dac94fd8d165a";
+    url = "https://github.com/ros-gbp/media_export-release/archive/release/kinetic/media_export/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "9cbc287753601f38919984b84ebeed52c9e69e4614d2e5a861e05f8ef6a08d13";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base/default.nix
+++ b/distros/kinetic/move-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, base-local-planner, catkin, clear-costmap-recovery, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, rospy, rotate-recovery, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-move-base";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/move_base/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "42e5d6a18400f4eb4253f2616d09de15705e60a31cc8f6cb92cc2033c7409114";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/move_base/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "d42486eb340811edaac1ef1df4b3daf49d9b36dfd59f5e450ee36030bdacee90";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-slow-and-clear/default.nix
+++ b/distros/kinetic/move-slow-and-clear/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-move-slow-and-clear";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/move_slow_and_clear/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "0095dfefff660fcf940441ed5ef62952ff939c0ecb4d6dd4ac67e6a4b3feaf0f";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/move_slow_and_clear/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "0a2e9e5d13ec5dc7229380eab292aa452912897b52b88bdcff7e65fecac3f9fd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/nav-core/default.nix
+++ b/distros/kinetic/nav-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-nav-core";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/nav_core/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "c6a171d4573c9c71a1faf98534a9dfbc4392e1ccec244667b9138dfcd3f021fd";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/nav_core/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "d5f07cdc88c4b865a48dd6c5d3bfd0f3cb8f29fac37e26bc714a59022f660a75";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/navfn/default.nix
+++ b/distros/kinetic/navfn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, netpbm, pcl-conversions, pcl-ros, pluginlib, rosconsole, roscpp, rosunit, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-navfn";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/navfn/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "8f607f68d59f3f3639d85c5f28aeda8d49eee123c3da42ef0d91d35a2c6bbb32";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/navfn/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "578ac9c4199111b36c901acdf713ed687b0bcab49e71038970ae0c10196f3bfd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/navigation/default.nix
+++ b/distros/kinetic/navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, carrot-planner, catkin, clear-costmap-recovery, costmap-2d, dwa-local-planner, fake-localization, global-planner, map-server, move-base, move-base-msgs, move-slow-and-clear, nav-core, navfn, robot-pose-ekf, rotate-recovery, voxel-grid }:
 buildRosPackage {
   pname = "ros-kinetic-navigation";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/navigation/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "6dec46f3b86fd05858e9672cf49203cfb7a8e491fd1a40e628f997f3d1bc333d";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/navigation/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "b2dc970e5d8e0131fb691b9fcfd64a90981ef30ef0d9ae4b106678fe5f4b315f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "89265f3853999da94c2f8d9c034c77ce890d79c7b63ab5645f5b8059f65f0157";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "d2c80ebf5a18f80b51b0053810be3887af5bf6397611b64ba2c900472933f867";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "1ac29d4aba766556fa8585abd4b0fbe32c7213048e6c64333c2301392a87c5a5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "842d73fe030513c72f4b7aab44dc04da3a988601e876bb651071596b21538aa8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "d5c932c59909cecd8b78bfd9c256271b5033d0253959c50d69a56245186aecba";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "99d157c7d8f6b2ad3a1d435fd209dd219549419fd4c291b1ebc0b89d30292694";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "e948ad370b0bac793475c5af72feab6736f20554e176dc75ec38dafb9c104dbf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "44d3aa8dcb4ae8233b34b5e5d7815c0837dd349c1c4d3b86c36e722092a8a416";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "24b201ba1b35106da63ece52c5cce84218ab642faa444a43f2549a1c02ee1a71";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "437acd4b3d9b397ff001e0f8dd15a11d3d9cd97fec28bf272b2817f346c08684";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pyquaternion/default.nix
+++ b/distros/kinetic/pyquaternion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-kinetic-pyquaternion";
+  version = "0.9.6-r4";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/pyquaternion-release/archive/release/kinetic/pyquaternion/0.9.6-4.tar.gz";
+    name = "0.9.6-4.tar.gz";
+    sha256 = "a7403ccdc0e3b902817dc17aebac4becfdb46cd79348d42dfb5ccdd8aebce4be";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.numpy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''quaternion operations'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/rc-common-msgs/default.nix
+++ b/distros/kinetic/rc-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-common-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/kinetic/rc_common_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "975f3b0da23dccb4ec540f45dead33605b4a26f85d976ae7f13e27f8098ccb61";
+    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/kinetic/rc_common_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "396a499a59bef9bd7a45960ca7258f934c6e908cf41248965321fbb079d45fee";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-genicam-api/default.nix
+++ b/distros/kinetic/rc-genicam-api/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, libusb }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-kinetic-rc-genicam-api";
-  version = "2.2.3-r1";
+  version = "2.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/kinetic/rc_genicam_api/2.2.3-1.tar.gz";
-    name = "2.2.3-1.tar.gz";
-    sha256 = "122f4c42b5a0e84d0c2560388a9c494456cf082fab861a3065a51a8a625adecd";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/kinetic/rc_genicam_api/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "8f84ab4363271afc4a164a9327ce64d2429b03561a75c77c262f607fc4d2c758";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin libusb ];
+  propagatedBuildInputs = [ catkin libpng libusb ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.11-r1";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.11-1.tar.gz";
-    name = "2.2.11-1.tar.gz";
-    sha256 = "ea1563ddeb76a9f9ef5c14fccc86ef1440e6ed91b7e82d8bf34ec6777783ce5f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "14b8c6820854fee2cb4a07dc24100efe7f6bd2ff0b9c6008759bd74b3f999512";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.11-r1";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.11-1.tar.gz";
-    name = "2.2.11-1.tar.gz";
-    sha256 = "4d41ebfd6bc8ebb8b1b39392cfafd564d959559e05de891cd53625a22b0c84d7";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "21b79cfad078f38eba241dba892b47890e4b1976a2493065fbffa378aa18efd6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ridgeback-control/default.nix
+++ b/distros/kinetic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-ridgeback-control";
-  version = "0.2.2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_control/0.2.2-0.tar.gz";
-    name = "0.2.2-0.tar.gz";
-    sha256 = "48adc4b082c2fbd306b49077d3b04a8a84b25ffc2a2da7e807a1d114ef209ca8";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_control/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "c01c96c3c7ab0012c30aa1f3f0db81c0de158e2bdf27d357f130ccf2df7184a5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ridgeback-description/default.nix
+++ b/distros/kinetic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-ridgeback-description";
-  version = "0.2.2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_description/0.2.2-0.tar.gz";
-    name = "0.2.2-0.tar.gz";
-    sha256 = "a37e75af1544fc229b6fce54be8e4916f275b7863909d03d66f1037fdf226f93";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_description/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "8ef0d000ef23e350b0a50674f7c6cfa5b76d2ac4e2c356ff9d98f809f718cd4c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ridgeback-msgs/default.nix
+++ b/distros/kinetic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ridgeback-msgs";
-  version = "0.2.2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_msgs/0.2.2-0.tar.gz";
-    name = "0.2.2-0.tar.gz";
-    sha256 = "e30d8dcac64fa38e60f4eaee72284d4e606b92b288da28df2c2db8832930f2c5";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_msgs/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "c90eb2f23a2805380991a2562e374cd0984beca67cec570c41efe0e9a7e615fb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ridgeback-navigation/default.nix
+++ b/distros/kinetic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-ridgeback-navigation";
-  version = "0.2.2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_navigation/0.2.2-0.tar.gz";
-    name = "0.2.2-0.tar.gz";
-    sha256 = "2f8b096bdb890d3ebe3b4dc31039075bd226a65530ba3f0b83c49192ddf8dbf3";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/kinetic/ridgeback_navigation/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "18273e840f81adf57ee604a903ad385130ce4fdc4fa0683fad54e50659f8092a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robot-pose-ekf/default.nix
+++ b/distros/kinetic/robot-pose-ekf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, rosbag, roscpp, rostest, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-robot-pose-ekf";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/robot_pose_ekf/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "96ef6f117ab3673bf9599ca80d84be55d13c1601d4a84afed38b6bd908bbd4bd";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/robot_pose_ekf/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "79f958634e65f3f2a6b039dc63ad89945d3585e2c0cadb97a4763e5a6af7166f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-reflexxes/default.nix
+++ b/distros/kinetic/ros-reflexxes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-ros-reflexxes";
-  version = "0.8.8";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ros_reflexxes/0.8.8-0.tar.gz";
-    name = "0.8.8-0.tar.gz";
-    sha256 = "6fffe8bdbc4b262e0c0c806be94310d9429959403af9a3fea107d4612d6dc858";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ros_reflexxes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b676048654ee5d484a00965b86059a8127498f44f69fba40ab7a8e77e469ab41";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ libreflexxestype2 roscpp ];
+  propagatedBuildInputs = [ libreflexxestype2 pluginlib roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rotate-recovery/default.nix
+++ b/distros/kinetic/rotate-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, costmap-2d, eigen, nav-core, pluginlib, roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-rotate-recovery";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/rotate_recovery/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "8b4ddb512e196bc183a004f70d77563be6e9d3856831d3bfe4cad0e54e3939a6";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/rotate_recovery/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "c0219e79493989f85c51f58f6a69a129c9c740ebe58fb51a40da59473db36308";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "8d91861285b31b1bdd274065f9e699ba9f3a45e0a1c9f1d9f52207bf7930c774";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "7d810cc21c4bdda1d25c50cfc415df283806c8e14f4a829a8ae748d1b13f1a2e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/tracetools/default.nix
+++ b/distros/kinetic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/kinetic/tracetools/0.2.1-0.tar.gz";
     name = "0.2.1-0.tar.gz";
-    sha256 = "59ed304f0ac9078e5b0875444b5594170921f29d35ba304a7f60f17eadd54f57";
+    sha256 = "0c51e131b0461a9aeb8822e368147433d331bbf9c972062f775d9f4e73a0636e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "43fb5611616558f4bafd35384a3a3486b0ef7c5a325fcae31b39b1652f702fb4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "8d53be7885e51317a6848ad75235c5252e57eea20bbf7c68be468a2d5e202b04";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.7.0-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "8273955702e83af61dd82a77cf0a4fb4b343985f0847e9f3afd68d4ccec7629f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "0224381b3802d35eb36394345bfb51a136272da6ee73bcc7dfdd6ebfb010b3ad";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/voxel-grid/default.nix
+++ b/distros/kinetic/voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-voxel-grid";
-  version = "1.14.5-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/voxel_grid/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "7fb2bb109e7d90a4ea87e5b06a0f4b5ea4bcd24ced4889bf6dda890256ec1f4f";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/kinetic/voxel_grid/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "196d4dd37ddc4324010f8421244edaf619626843a0e70b967c8a84a0fa785b51";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ackermann-steering-controller/default.nix
+++ b/distros/melodic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, diff-drive-controller, gazebo-ros, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, rosunit, std-msgs, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ackermann-steering-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "d6de33231e9dfdcb67a15c0c397f77d3e3e656823cabd02eb2464ba4a617b83a";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "322a175e8e262849f1159517354c0bd1713a08577465dc0f789068b1d11bc674";
   };
 
   buildType = "catkin";

--- a/distros/melodic/carla-msgs/default.nix
+++ b/distros/melodic/carla-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-carla-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/melodic/carla_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "4123c5d7911ca7264472746f09382668b65a0267466919e6d115b99787e85ae1";
+    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/melodic/carla_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0b66cc070a8c1950429f5fa6975bdcfbe1b47508cfcf6b5fc18c8f5b6ac4f3ed";
   };
 
   buildType = "catkin";

--- a/distros/melodic/diff-drive-controller/default.nix
+++ b/distros/melodic/diff-drive-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, nav-msgs, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-diff-drive-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "bc06277c71ef12ba835e78b38e48a3f39886aaf0a03d779c99689f1ebea02ff0";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "bba19fbf9898f70fcbcad93bbb0594073bd1385f49e6a5767603077f2b4e61e6";
   };
 
   buildType = "catkin";
   checkInputs = [ controller-manager rosgraph-msgs rostest std-srvs xacro ];
-  propagatedBuildInputs = [ control-msgs controller-interface dynamic-reconfigure nav-msgs realtime-tools tf urdf ];
+  propagatedBuildInputs = [ control-msgs controller-interface dynamic-reconfigure nav-msgs pluginlib realtime-tools tf urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/effort-controllers/default.nix
+++ b/distros/melodic/effort-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, realtime-tools, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, pluginlib, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-effort-controllers";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "52db667f0de73f3ceff16dc3ec2d5e5c3b4a1d67ede0c58c89a53883f194821e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "08a47328c88cab240dd5e07e72ca7f615bf47758907c7a380f4a56bf808fc37b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface forward-command-controller realtime-tools urdf ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface forward-command-controller pluginlib realtime-tools urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/eigen-conversions/default.nix
+++ b/distros/melodic/eigen-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, orocos-kdl, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-eigen-conversions";
-  version = "1.12.0";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/eigen_conversions/1.12.0-0.tar.gz";
-    name = "1.12.0-0.tar.gz";
-    sha256 = "6485f64dd54db8430e4aacfa15b0d09b575aff8cfcf4ad24f946e090004521ad";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/eigen_conversions/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "ba111914a7e79c176c8eafa732201d0aeca1dd0ffc481f4b83038384b2e44261";
   };
 
   buildType = "catkin";

--- a/distros/melodic/force-torque-sensor-controller/default.nix
+++ b/distros/melodic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-force-torque-sensor-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "5d2aede75983ca4789ab54a5b688500a58decd441e38582bc0d80999ee595786";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "0d79ee174d2afda41b87f1a13683d7d1b31c1e6671162cdc351d381f19d74414";
   };
 
   buildType = "catkin";

--- a/distros/melodic/forward-command-controller/default.nix
+++ b/distros/melodic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-forward-command-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "811c1ec365f2d1e20a0c2269f4b678683e6b71788a4adc5c64379e3e523c2ab0";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "b04daaf8ae46594040fe7ab857d20706190b65c273ad76ff91cdc851e5ef4c98";
   };
 
   buildType = "catkin";

--- a/distros/melodic/four-wheel-steering-controller/default.nix
+++ b/distros/melodic/four-wheel-steering-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, nav-msgs, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf-geometry-parser }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf-geometry-parser }:
 buildRosPackage {
   pname = "ros-melodic-four-wheel-steering-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "bd529d3a98a4ca99a6965a27d09a019ab15fbb247be61246e4c949bed5ae9fcb";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "471f11668627322bb06fabb1d59fce96de3d40f7d6dd4f548ca20b7141e19473";
   };
 
   buildType = "catkin";
   checkInputs = [ controller-manager rosgraph-msgs rostest std-srvs ];
-  propagatedBuildInputs = [ controller-interface four-wheel-steering-msgs nav-msgs realtime-tools tf urdf-geometry-parser ];
+  propagatedBuildInputs = [ controller-interface four-wheel-steering-msgs nav-msgs pluginlib realtime-tools tf urdf-geometry-parser ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2096,6 +2096,8 @@ self: super: {
 
  pilz-robots = self.callPackage ./pilz-robots {};
 
+ pilz-status-indicator-rqt = self.callPackage ./pilz-status-indicator-rqt {};
+
  pilz-testutils = self.callPackage ./pilz-testutils {};
 
  pilz-trajectory-generation = self.callPackage ./pilz-trajectory-generation {};
@@ -2322,6 +2324,10 @@ self: super: {
 
  qpmad = self.callPackage ./qpmad {};
 
+ qt-build = self.callPackage ./qt-build {};
+
+ qt-create = self.callPackage ./qt-create {};
+
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
  qt-gui = self.callPackage ./qt-gui {};
@@ -2335,6 +2341,10 @@ self: super: {
  qt-gui-py-common = self.callPackage ./qt-gui-py-common {};
 
  qt-qmake = self.callPackage ./qt-qmake {};
+
+ qt-ros = self.callPackage ./qt-ros {};
+
+ qt-tutorials = self.callPackage ./qt-tutorials {};
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
@@ -2777,6 +2787,8 @@ self: super: {
  rqt-image-view = self.callPackage ./rqt-image-view {};
 
  rqt-joint-trajectory-controller = self.callPackage ./rqt-joint-trajectory-controller {};
+
+ rqt-joint-trajectory-plot = self.callPackage ./rqt-joint-trajectory-plot {};
 
  rqt-launch = self.callPackage ./rqt-launch {};
 

--- a/distros/melodic/geometry/default.nix
+++ b/distros/melodic/geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, eigen-conversions, kdl-conversions, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-geometry";
-  version = "1.12.0";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/geometry/1.12.0-0.tar.gz";
-    name = "1.12.0-0.tar.gz";
-    sha256 = "6e5e79d8157d16ce6c27bc7b8f1e8411f0fea3a01698f69962746ec4af80e44d";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/geometry/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "6c8b032a8095842fb79e21e2c07aa440e71193130702a637dd46ea02e34166a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gripper-action-controller/default.nix
+++ b/distros/melodic/gripper-action-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, realtime-tools, roscpp, trajectory-msgs, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-gripper-action-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "7b15202e7175d3352a3855ee222ddbd4db8a5221425436f4637a80e600907ce2";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "2337e0adb4170e7b59a23577e3ad6be54e451df5bc51d840a859e33460ea68ed";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib angles cmake-modules control-msgs control-toolbox controller-interface controller-manager hardware-interface realtime-tools roscpp trajectory-msgs urdf xacro ];
+  propagatedBuildInputs = [ actionlib angles cmake-modules control-msgs control-toolbox controller-interface controller-manager hardware-interface pluginlib realtime-tools roscpp trajectory-msgs urdf xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/imu-sensor-controller/default.nix
+++ b/distros/melodic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-imu-sensor-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "9e5a18ddf716a8a9edd539104025b9d6828acb17b690b660780b56f05c2f0948";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "79b75d3618a15c1ae465aa3cf30a0054426298e2175144d77a8dd23f7a225927";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ipr-extern/default.nix
+++ b/distros/melodic/ipr-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libmodbus, libreflexxestype2, ros-reflexxes }:
 buildRosPackage {
   pname = "ros-melodic-ipr-extern";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ipr_extern/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "a117475704fac421bb5f283eb775ab4339944f6ea148c2c996c0fb7642bb0fe8";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ipr_extern/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e3884879277729178b8a6de7ff1de7916eaec4f6489a1adbad72568bce0de1fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-state-controller/default.nix
+++ b/distros/melodic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "97c1c877b5f1f3fd9377c0c1e8a8fb5ef9b2ab05957d3469d25300bb088e937e";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "368aeb4a599f094d510015612695922a46f8e0690a2d39ae054c4fcd7c5297f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-trajectory-controller/default.nix
+++ b/distros/melodic/joint-trajectory-controller/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-joint-trajectory-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "d7624bbbca732b5e17524908ec9e6214c448aa9cc33ffddb3538e9269c6bd313";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "206fd84efd527fa25f341effcfcdec8aeba5cc81d1373ee9c36d128909eb7d14";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ controller-manager rostest xacro ];
-  propagatedBuildInputs = [ actionlib angles control-msgs control-toolbox controller-interface hardware-interface realtime-tools roscpp trajectory-msgs urdf ];
+  propagatedBuildInputs = [ actionlib angles control-msgs control-toolbox controller-interface hardware-interface pluginlib realtime-tools roscpp trajectory-msgs urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/kdl-conversions/default.nix
+++ b/distros/melodic/kdl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, orocos-kdl }:
 buildRosPackage {
   pname = "ros-melodic-kdl-conversions";
-  version = "1.12.0";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/kdl_conversions/1.12.0-0.tar.gz";
-    name = "1.12.0-0.tar.gz";
-    sha256 = "2a82a8648b7c47cdf7ee46f7bf331202c2d8e6a6d25c058d944f78283452994f";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/kdl_conversions/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "617dd8beae97409400b106c6a3f5a2e76afab2d6c2ea1fca6b740aca3a4e6ee6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmodbus/default.nix
+++ b/distros/melodic/libmodbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules }:
 buildRosPackage {
   pname = "ros-melodic-libmodbus";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libmodbus/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "f5b0b1453abb1f1950ad1ca3378b061979259515d0d5bdc5958dd46a5c6b3c36";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libmodbus/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "383dfdd6819424090d457f987f790dfb026cdfe768ab5e00dd7d5fb2e602312d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, linuxHeaders, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.31.0-r3";
+  version = "2.33.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.31.0-3.tar.gz";
-    name = "2.31.0-3.tar.gz";
-    sha256 = "8ca69f229adffd59eeb549d761107dcf188cc1c8ce001dfde1701f860259823b";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.33.1-2.tar.gz";
+    name = "2.33.1-2.tar.gz";
+    sha256 = "d68e4e9abc03a53eafba043b0cda4a945a677daa021bda28442d79d01d62574b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libreflexxestype2/default.nix
+++ b/distros/melodic/libreflexxestype2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libreflexxestype2";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libreflexxestype2/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "ff69ec96c35d48bc4b768dc25812ea2dbece052f25a8d3de96f5460296eb0ccf";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libreflexxestype2/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "feda77d853652f9dff5e1e0e2df972c45916ade312570696cf789d1c6ec02a6c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/media-export/default.nix
+++ b/distros/melodic/media-export/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-media-export";
-  version = "0.2.0";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/media_export-release/archive/release/melodic/media_export/0.2.0-0.tar.gz";
-    name = "0.2.0-0.tar.gz";
-    sha256 = "dba5a590101d4f4969a5f963f8fba90fff5a095e0c19770166787d22bdb799e3";
+    url = "https://github.com/ros-gbp/media_export-release/archive/release/melodic/media_export/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "36831d912cd432fa1c4dcf0b50898c9cf579eaf33ee76f88e049c76bee08fff6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mpc-local-planner-examples/default.nix
+++ b/distros/melodic/mpc-local-planner-examples/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, catkin, map-server, move-base, mpc-local-planner, stage-ros }:
+{ lib, buildRosPackage, fetchurl, amcl, catkin, map-server, move-base, mpc-local-planner, mpc-local-planner-msgs, stage-ros }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner-examples";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_examples/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "b9f4eac97f3a645144e828e8e1f7fd8a3c127562b1f9ab4320dfa25dec8fab2f";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_examples/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "cd714dbefccd4740cc76657dc09776e1a243664df04c01f46b7434f4abc5aaaf";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ amcl map-server move-base mpc-local-planner stage-ros ];
+  propagatedBuildInputs = [ amcl map-server move-base mpc-local-planner mpc-local-planner-msgs stage-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mpc-local-planner-msgs/default.nix
+++ b/distros/melodic/mpc-local-planner-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner-msgs";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_msgs/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "2589b79d0482d0214b7fa7d90f191f554a11a120319588ac8c875b678890a85c";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "ee9966e8bd7b011c4f2f44d7aaf71bb61cf781fcb76b04b694c95b8063758823";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mpc-local-planner/default.nix
+++ b/distros/melodic/mpc-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, control-box-rst, costmap-2d, costmap-converter, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, mbf-costmap-core, mbf-msgs, mpc-local-planner-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, teb-local-planner, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner";
-  version = "0.0.1-r2";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner/0.0.1-2.tar.gz";
-    name = "0.0.1-2.tar.gz";
-    sha256 = "412bcbb02d2232ba66f7a7049196f8f9c2f31356c6e4282b5f72535edf5066ba";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3bd8496e1c349125dbdc73f1db4c3003d2d294f3387cc369944f502ed6621e45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mrt-cmake-modules/default.nix
+++ b/distros/melodic/mrt-cmake-modules/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mrt-cmake-modules";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/melodic/mrt_cmake_modules/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "88ba3da8cec2fd431c069862b927ac1e01ba8bdda5728fce09e46f1b68db0c38";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/melodic/mrt_cmake_modules/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d3e5d808d767175c5ca3a0a2ee80af6a35306fe670dd6860be6b8483b1e750cf";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ python pythonPackages.pyyaml ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pilz-control/default.nix
+++ b/distros/melodic/pilz-control/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, joint-trajectory-controller, roscpp, roslint, rostest, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, joint-trajectory-controller, pilz-utils, roscpp, roslint, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-control";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "40dcf2a7df405b67e00744e0126579b9039d327de55401f69e2448649e3021b9";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "d6c277a94b8bd6a12f2b867829cdaaebc8bf177bc5cb5f019e93ba6aae2bafa7";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules roslint ];
   checkInputs = [ code-coverage rostest ];
-  propagatedBuildInputs = [ controller-interface controller-manager joint-trajectory-controller roscpp std-srvs ];
+  propagatedBuildInputs = [ controller-interface controller-manager joint-trajectory-controller pilz-utils roscpp std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pilz-robots/default.nix
+++ b/distros/melodic/pilz-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-control, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robots";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "60aaa3937e626e0b48324a8680c265048639a236ac8e89f8c68ff6fd26079698";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "5b5e6734dd3ac62c99843a9cb477b0dba8fc801ca003b5c4482ff510bb2f8c79";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-status-indicator-rqt/default.nix
+++ b/distros/melodic/pilz-status-indicator-rqt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, prbt-hardware-support, pythonPackages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pilz-status-indicator-rqt";
+  version = "0.5.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "b539a5240ba8d28f28179faa26b73162876a46dd45d29d797871f95e79b0e5fc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ pythonPackages.mock rostest rosunit ];
+  propagatedBuildInputs = [ prbt-hardware-support rospy rqt-gui rqt-gui-py std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Showing information about operation mode, status and speed override of the robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pilz-testutils/default.nix
+++ b/distros/melodic/pilz-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pilz-testutils";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "b7dfcbbc918dbe876c8f1d59a3014dd553a4be60a231f8c64a7b5b6b8a33157a";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "c67d04bf22b08aee5f9d8932bd3372d4ee7630daea6b721995ddbbea6718cda4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-utils/default.nix
+++ b/distros/melodic/pilz-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clang, cmake-modules, code-coverage, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pilz-utils";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "d9e0690cec48d88e597c46572a54db6385598f0b8f2882bdb4cd86dee3e71d8b";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "1bcefccc449f970dafccbd1f504fa64253a52514b6eda0d930b5577bfa850715";
   };
 
   buildType = "catkin";

--- a/distros/melodic/position-controllers/default.nix
+++ b/distros/melodic/position-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-position-controllers";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "4fc2790e75f82b2a202e46c7c851f61348aaf1f355f69cb940ead157d5e43368";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "f0d988dc23a38324ae43c88ef559e459a93a36df418ce2d6242f25f7a7d14554";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ controller-interface forward-command-controller ];
+  propagatedBuildInputs = [ controller-interface forward-command-controller pluginlib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/prbt-gazebo/default.nix
+++ b/distros/melodic/prbt-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-gazebo";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "96c5b2d363f9fafa623e0b21e7eda59d8188152c8d1f20324c2031b036d7c9d6";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "41617b657b2eaef709aebcf6244968d8cb40d0419a41cc32f8e1afead2084645";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-hardware-support/default.nix
+++ b/distros/melodic/prbt-hardware-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-prbt-hardware-support";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "bb949d904d7bd6ec6a352b6db288d598f49ad60dd7d1a2ae3bf061df5c53518b";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "d726c347c6a26e1fd16d2a1518f19daf16779b15faf21a277d9f09aec3ad013f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, eigen-conversions, moveit-core, moveit-ros-planning, pluginlib, roscpp, rostest, rosunit, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-prbt-ikfast-manipulator-plugin";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "d978a30e0d5a3bb3ca8e2f7e251085bb0ff37cc97fb3f5a7bd031605ed50b1c7";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "dfd8dbab410bf1a26f89085d3bc843e0bf910ca8c4c97a226f16bce72a6a7f5a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-moveit-config/default.nix
+++ b/distros/melodic/prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roslaunch, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-moveit-config";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "1a3ce66aeaa0cec88057ee254278cfdf5729b2f4afc651141939596d0beab868";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "3f70afb6ae76e4d0d8927f9e93f6ed1963626fb933445212ed2bea0627d187ca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-support/default.nix
+++ b/distros/melodic/prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, rosservice, rostest, rviz, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-support";
-  version = "0.5.13-r1";
+  version = "0.5.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.13-1.tar.gz";
-    name = "0.5.13-1.tar.gz";
-    sha256 = "305cf3ea3a6a9856a99632a748208366fc9dfc44be087f2019cded8354711030";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.14-1.tar.gz";
+    name = "0.5.14-1.tar.gz";
+    sha256 = "b86814f440ed26ec5b466d056ca7680f43f2e4db489a515fb91b66bf70bc3b47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qt-build/default.nix
+++ b/distros/melodic/qt-build/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-qt-build";
+  version = "0.2.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/qt_ros-release/archive/release/melodic/qt_build/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "8efbd3e986cd99b3cd997e6dc4bd94babe0885f4bcc5c4571b5558ad5273c98e";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Currently just maintains a cmake api for simplifying the building
+    of qt apps within the ros framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qt-create/default.nix
+++ b/distros/melodic/qt-create/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt-build }:
+buildRosPackage {
+  pname = "ros-melodic-qt-create";
+  version = "0.2.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/qt_ros-release/archive/release/melodic/qt_create/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "cec2e88476fc8894e4baa333e77479cd10b8c21938d751914127f3fdd20a2dea";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt-build ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides templates and scripts for creating qt-ros packages
+     (similar to roscreate-pkg).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qt-ros/default.nix
+++ b/distros/melodic/qt-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt-build, qt-create, qt-tutorials }:
+buildRosPackage {
+  pname = "ros-melodic-qt-ros";
+  version = "0.2.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/qt_ros-release/archive/release/melodic/qt_ros/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "40bab49c3f46bf6a0e3f0585e58e195ade2251fc3d69ca4c231157cef5b9ee09";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt-build qt-create qt-tutorials ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple qt cmake build tools and master-chooser style application template.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qt-tutorials/default.nix
+++ b/distros/melodic/qt-tutorials/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qt-build, qt4, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-qt-tutorials";
+  version = "0.2.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/qt_ros-release/archive/release/melodic/qt_tutorials/0.2.10-1.tar.gz";
+    name = "0.2.10-1.tar.gz";
+    sha256 = "95d2b5fca0298fc52e2c506d08e83c4a43b055058e2a9166ec1606c4058238be";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime qt-build qt4 roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Example qt programs, generated from code similar to that used by the 
+     roscreate-qt-pkg script and styled on roscpp_tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rc-common-msgs/default.nix
+++ b/distros/melodic/rc-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-common-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/melodic/rc_common_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b9ac40ea5d7627deaa9b8b1b12214fddf4a2a3f33e53c49c49205e90000e8e6d";
+    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/melodic/rc_common_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "785d4e3a8db937b4daa35e2214e0afafa6c091c71f3937e977f848c32c7b7421";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.12-r1";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.12-1.tar.gz";
-    name = "2.2.12-1.tar.gz";
-    sha256 = "5d7c51ae9754aef43318a19fd0e638b190969557b830fc74be812488661c209a";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "efe764720fb1a8e3b7aac3d22de94434c8487131bc3611c3a6e312184f6379ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.12-r1";
+  version = "2.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.12-1.tar.gz";
-    name = "2.2.12-1.tar.gz";
-    sha256 = "9acfcae0896e5a49f694c7d786be8654b176318d27137b6619739091dc7114af";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.13-1.tar.gz";
+    name = "2.2.13-1.tar.gz";
+    sha256 = "ff4ecc35a08bc221862e0f7b5b46353adb03d914d25a79f85a24460db6183114";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers/default.nix
+++ b/distros/melodic/ros-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, rqt-joint-trajectory-controller, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-ros-controllers";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "829aba95b33c273faf7fe6e06f26abc2660fe9bb61e784751da72646c8fd0c06";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "cccce233d5580224c90c3c77bde2c9229855d9b85595cd3a0edb1b24812ba739";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ ackermann-steering-controller diff-drive-controller effort-controllers force-torque-sensor-controller forward-command-controller gripper-action-controller imu-sensor-controller joint-state-controller joint-trajectory-controller position-controllers rqt-joint-trajectory-controller velocity-controllers ];
+  propagatedBuildInputs = [ ackermann-steering-controller diff-drive-controller effort-controllers force-torque-sensor-controller forward-command-controller gripper-action-controller imu-sensor-controller joint-state-controller joint-trajectory-controller position-controllers velocity-controllers ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-reflexxes/default.nix
+++ b/distros/melodic/ros-reflexxes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-ros-reflexxes";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ros_reflexxes/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "76626c036fcf97fd86efb214887ddffe715d343b660a6117eddd0f833ef11fda";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ros_reflexxes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c06bc668e6c5108f1b2bfb8b0422144ba633892237ed063350579b25b53d3e72";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ libreflexxestype2 roscpp ];
+  propagatedBuildInputs = [ libreflexxestype2 pluginlib roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rqt-gui-cpp/default.nix
+++ b/distros/melodic/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, qt-gui, qt-gui-cpp, qt5, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-rqt-gui-cpp";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_cpp/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "29dd122311b73050bde2957210a6523688298a3c1993833b78ef18b80a671603";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_cpp/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "87b9fca3c031833debaa4a04e27c2470d34e242ff919198a34956ba5810052d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-gui-py/default.nix
+++ b/distros/melodic/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-gui, rospy, rqt-gui }:
 buildRosPackage {
   pname = "ros-melodic-rqt-gui-py";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_py/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "0ff83fecf2965173c22e185ba5388c38645c281a5aa89dbe3baac46c431eece6";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_py/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "309447f09365e68cf299ddea67675149cba9d277ac06dd92d128814ee2172414";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-gui/default.nix
+++ b/distros/melodic/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-gui }:
 buildRosPackage {
   pname = "ros-melodic-rqt-gui";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "d6a9306b14facf26f432b32e9946daa1aa3c10c6f6d053e3a701bfab10e3200a";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "e0e4e6b5c7d8778d50b0ebd32859e22667a8be4b44be41e93c46baaa18391b13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/melodic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-joint-trajectory-controller";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "469f85d30f031dece7a2077959de20084d813282ce05d007ba6296f991e68763";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "45a2846b2dd5700ada8d6505e4018f5e6ad7c07f14e8ce4b9d744f6220d6c178";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-joint-trajectory-plot/default.nix
+++ b/distros/melodic/rqt-joint-trajectory-plot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, moveit-msgs, roslaunch, roslint, rospy, rostest, rqt-gui, rqt-gui-py, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rqt-joint-trajectory-plot";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rqt_joint_trajectory_plot-release/archive/release/melodic/rqt_joint_trajectory_plot/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "8ed2a8dd2ebbbaf91dceb82134c324f5efb676ddc2767175967f96361357c77e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch roslint rostest ];
+  propagatedBuildInputs = [ control-msgs moveit-msgs rospy rqt-gui rqt-gui-py trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rqt_joint_trajectory_plot package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/rqt-py-common/default.nix
+++ b/distros/melodic/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, genmsg, genpy, python-qt-binding, qt-gui, rosbag, roslib, rospy, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-py-common";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_py_common/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "54fd2fa913483ae10a05f07b58c91b78b3f3cf79f0dfd53544adb1ca1e576123";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_py_common/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "d352ab8dc677872b068374d52888a61c2896e38252df659c1f61a789f30b3aa8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt/default.nix
+++ b/distros/melodic/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rqt-gui, rqt-gui-cpp, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "0838063390001fcb552096bd5a6827aae9bb3105855cbdf0c2a3105a25851e67";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "1ed513439e34e85c1e1753637fcf442f9a9b605dc307f6655815246afbe64cb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf-conversions/default.nix
+++ b/distros/melodic/tf-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, kdl-conversions, orocos-kdl, python-orocos-kdl, tf }:
 buildRosPackage {
   pname = "ros-melodic-tf-conversions";
-  version = "1.12.0";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/tf_conversions/1.12.0-0.tar.gz";
-    name = "1.12.0-0.tar.gz";
-    sha256 = "eec87e068f5106c1835fb093d5995ca8c6972e3a5e127038d94c68701ad2029e";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/tf_conversions/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "e2e457c4d59951b3ed07f72d6e013905184e5de1458c3a57b9e3b35ee4355580";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf/default.nix
+++ b/distros/melodic/tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, graphviz, message-filters, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, roswtf, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf";
-  version = "1.12.0";
+  version = "1.12.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/tf/1.12.0-0.tar.gz";
-    name = "1.12.0-0.tar.gz";
-    sha256 = "00d706fa94be4c4348556e8985dae8be407e76aae3f767e92dbd35e206f5ab03";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/melodic/tf/1.12.1-1.tar.gz";
+    name = "1.12.1-1.tar.gz";
+    sha256 = "49b7cc26908b03a7d035a88b238b11a86d31648559e488fbfae09d3a0696efbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tracetools/default.nix
+++ b/distros/melodic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/melodic/tracetools/0.2.1-1.tar.gz";
     name = "0.2.1-1.tar.gz";
-    sha256 = "1c5114e1acce416cfb16dfca419508fd9dfcfd682ffdd63eafbe7a609d5f14f7";
+    sha256 = "1432003c36ab6c12cd03dc132dba1e8dd87986ae2fbf3bb4537001369bd47fc4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-gps/default.nix
+++ b/distros/melodic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-gps";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "ef380666fecf4c3b12c7ac0b2c7e8f59548898a8774616eadb03b42b171859ef";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "7b213073545194fc7cb4d1cefb3057536b99643f0c3566d20625f799a7dd47ee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-msgs/default.nix
+++ b/distros/melodic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "512c2afd61e324fb5dc06e9e90ee3403389a9d6ba4b0f858217b3a0a8ba575e6";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "20c42f29aeaa71e8e64de505e4c409757f22a96ff00e0c36814d8f0d5090787a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-serialization/default.nix
+++ b/distros/melodic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-serialization";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "237e337629963a1222b01e068886f5b69fd6a507844555ee14df1b7d4e266c77";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "9d1b442a0d36838ab40081565a45e9ad4e736691bee01fe271a457c58601eff8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox/default.nix
+++ b/distros/melodic/ublox/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "b51feba373e616f8bb6f28d93cc61aa6738645d5587d671e6911ed19ade5bbf6";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "cdf68577cfb07dd68049c6c8b924420a1c2c9d68feb3ca773e0a922dfea43ec1";
   };
 
   buildType = "catkin";
+  propagatedBuildInputs = [ ublox-gps ublox-msgs ublox-serialization ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/urdf-parser-plugin/default.nix
+++ b/distros/melodic/urdf-parser-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-melodic-urdf-parser-plugin";
-  version = "1.13.1";
+  version = "1.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdf-release/archive/release/melodic/urdf_parser_plugin/1.13.1-0.tar.gz";
-    name = "1.13.1-0.tar.gz";
-    sha256 = "7031baf19ed479dcc35455fc5090a740ccc28592c8fd565154ea6556aa80f747";
+    url = "https://github.com/ros-gbp/urdf-release/archive/release/melodic/urdf_parser_plugin/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "292e3a8dd2aa7672ef77ca49f1ef9ebc753f521c524f5fa6b4cfea324a2be13f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urdf/default.nix
+++ b/distros/melodic/urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pluginlib, rosconsole-bridge, roscpp, rostest, tinyxml, tinyxml-2, urdf-parser-plugin, urdfdom, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-melodic-urdf";
-  version = "1.13.1";
+  version = "1.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdf-release/archive/release/melodic/urdf/1.13.1-0.tar.gz";
-    name = "1.13.1-0.tar.gz";
-    sha256 = "2d16536bc8a59e01339b034539828f411245a3b170abc65d8e1f99f1305ae4f0";
+    url = "https://github.com/ros-gbp/urdf-release/archive/release/melodic/urdf/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "476b4598a2a6d84da0a60fe3436d7f0b7fc8270c977b70eca24201f37529dbc3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velocity-controllers/default.nix
+++ b/distros/melodic/velocity-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, realtime-tools, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, pluginlib, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-velocity-controllers";
-  version = "0.15.0";
+  version = "0.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.15.0-0.tar.gz";
-    name = "0.15.0-0.tar.gz";
-    sha256 = "7a2b419156bb96923bd97e0ffe3ffda525f2fdc4027868c461590c749c379cbb";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.15.1-1.tar.gz";
+    name = "0.15.1-1.tar.gz";
+    sha256 = "9a3fc8815f8747560c40fbb82154b9780a1180822f65f40608f4e8c31631eacb";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface forward-command-controller realtime-tools urdf ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface forward-command-controller pluginlib realtime-tools urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 2fc907db39bdb4e0a4aca83d8c5b091884d215d2.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *joint-state-publisher 2.0.0-r1*
* *joint-state-publisher-gui 2.0.0-r1*
* *novatel-gps-driver 4.0.2-r1 --> 4.0.3-r1*
* *novatel-gps-msgs 4.0.2-r1 --> 4.0.3-r1*
* *rclcpp 0.7.12-r1 --> 0.7.13-r1*
* *rclcpp-action 0.7.12-r1 --> 0.7.13-r1*
* *rclcpp-components 0.7.12-r1 --> 0.7.13-r1*
* *rclcpp-lifecycle 0.7.12-r1 --> 0.7.13-r1*
* *rviz-assimp-vendor 6.1.5-r1 --> 6.1.6-r1*
* *rviz-common 6.1.5-r1 --> 6.1.6-r1*
* *rviz-default-plugins 6.1.5-r1 --> 6.1.6-r1*
* *rviz-ogre-vendor 6.1.5-r1 --> 6.1.6-r1*
* *rviz-rendering 6.1.5-r1 --> 6.1.6-r1*
* *rviz-rendering-tests 6.1.5-r1 --> 6.1.6-r1*
* *rviz-visual-testing-framework 6.1.5-r1 --> 6.1.6-r1*
* *rviz2 6.1.5-r1 --> 6.1.6-r1*
* *swri-console-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-dbw-interface 3.0.4-r1 --> 3.0.5-r2*
* *swri-geometry-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-image-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-math-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-opencv-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-prefix-tools 3.0.4-r1 --> 3.0.5-r2*
* *swri-roscpp 3.0.4-r1 --> 3.0.5-r2*
* *swri-route-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-serial-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-system-util 3.0.4-r1 --> 3.0.5-r2*
* *swri-transform-util 3.0.4-r1 --> 3.0.5-r2*
* *urdfdom-py 1.0.0-r1*

Eloquent Changes:
-----------------
* *joint-state-publisher 2.0.0-r1*
* *joint-state-publisher-gui 2.0.0-r1*
* *py-trees-ros 2.0.9-r1 --> 2.0.10-r1*
* *swri-console-util 3.0.5-r1*
* *swri-dbw-interface 3.0.5-r1*
* *swri-geometry-util 3.0.5-r1*
* *swri-image-util 3.0.5-r1*
* *swri-math-util 3.0.5-r1*
* *swri-opencv-util 3.0.5-r1*
* *swri-prefix-tools 3.0.5-r1*
* *swri-roscpp 3.0.5-r1*
* *swri-route-util 3.0.5-r1*
* *swri-serial-util 3.0.5-r1*
* *swri-system-util 3.0.5-r1*
* *swri-transform-util 3.0.5-r1*
* *urdfdom-py 1.0.0-r1*

Kinetic Changes:
----------------
* *amcl 1.14.5-r1 --> 1.14.7-r1*
* *base-local-planner 1.14.5-r1 --> 1.14.7-r1*
* *carla-msgs 1.0.1-r1*
* *carrot-planner 1.14.5-r1 --> 1.14.7-r1*
* *clear-costmap-recovery 1.14.5-r1 --> 1.14.7-r1*
* *costmap-2d 1.14.5-r1 --> 1.14.7-r1*
* *costmap-cspace 0.7.0-r1 --> 0.8.0-r1*
* *dwa-local-planner 1.14.5-r1 --> 1.14.7-r1*
* *fake-localization 1.14.5-r1 --> 1.14.7-r1*
* *global-planner 1.14.5-r1 --> 1.14.7-r1*
* *ifm3d 0.6.2-r1 --> 0.6.2-r2*
* *ipr-extern 0.8.8 --> 0.9.0-r1*
* *jackal-control 0.6.2 --> 0.6.4-r1*
* *jackal-description 0.6.2 --> 0.6.4-r1*
* *jackal-msgs 0.6.2 --> 0.6.4-r1*
* *jackal-navigation 0.6.2 --> 0.6.4-r1*
* *jackal-tutorials 0.6.2 --> 0.6.4-r1*
* *joint-state-publisher 1.12.14-r1 --> 1.12.15-r1*
* *joint-state-publisher-gui 1.12.14-r1 --> 1.12.15-r1*
* *joystick-interrupt 0.7.0-r1 --> 0.8.0-r1*
* *lgsvl-msgs 0.0.1 --> 0.0.2-r1*
* *libmodbus 0.8.8 --> 0.9.0-r1*
* *librealsense2 2.31.0-r1 --> 2.33.1-r2*
* *libreflexxestype2 0.8.8 --> 0.9.0-r1*
* *map-organizer 0.7.0-r1 --> 0.8.0-r1*
* *map-server 1.14.5-r1 --> 1.14.7-r1*
* *media-export 0.2.0 --> 0.3.0-r1*
* *move-base 1.14.5-r1 --> 1.14.7-r1*
* *move-slow-and-clear 1.14.5-r1 --> 1.14.7-r1*
* *nav-core 1.14.5-r1 --> 1.14.7-r1*
* *navfn 1.14.5-r1 --> 1.14.7-r1*
* *navigation 1.14.5-r1 --> 1.14.7-r1*
* *neonavigation 0.7.0-r1 --> 0.8.0-r1*
* *neonavigation-common 0.7.0-r1 --> 0.8.0-r1*
* *neonavigation-launch 0.7.0-r1 --> 0.8.0-r1*
* *obj-to-pointcloud 0.7.0-r1 --> 0.8.0-r1*
* *planner-cspace 0.7.0-r1 --> 0.8.0-r1*
* *pyquaternion 0.9.6-r4*
* *rc-common-msgs 0.4.0-r1 --> 0.4.1-r1*
* *rc-genicam-api 2.2.3-r1 --> 2.3.3-r1*
* *realsense2-camera 2.2.11-r1 --> 2.2.13-r1*
* *realsense2-description 2.2.11-r1 --> 2.2.13-r1*
* *ridgeback-control 0.2.2 --> 0.2.3-r1*
* *ridgeback-description 0.2.2 --> 0.2.3-r1*
* *ridgeback-msgs 0.2.2 --> 0.2.3-r1*
* *ridgeback-navigation 0.2.2 --> 0.2.3-r1*
* *robot-pose-ekf 1.14.5-r1 --> 1.14.7-r1*
* *ros-reflexxes 0.8.8 --> 0.9.0-r1*
* *rotate-recovery 1.14.5-r1 --> 1.14.7-r1*
* *safety-limiter 0.7.0-r1 --> 0.8.0-r1*
* *track-odometry 0.7.0-r1 --> 0.8.0-r1*
* *trajectory-tracker 0.7.0-r1 --> 0.8.0-r1*
* *voxel-grid 1.14.5-r1 --> 1.14.7-r1*

Melodic Changes:
----------------
* *ackermann-steering-controller 0.15.0 --> 0.15.1-r1*
* *carla-msgs 1.0.0-r1 --> 1.0.1-r1*
* *diff-drive-controller 0.15.0 --> 0.15.1-r1*
* *effort-controllers 0.15.0 --> 0.15.1-r1*
* *eigen-conversions 1.12.0 --> 1.12.1-r1*
* *force-torque-sensor-controller 0.15.0 --> 0.15.1-r1*
* *forward-command-controller 0.15.0 --> 0.15.1-r1*
* *four-wheel-steering-controller 0.15.0 --> 0.15.1-r1*
* *geometry 1.12.0 --> 1.12.1-r1*
* *gripper-action-controller 0.15.0 --> 0.15.1-r1*
* *imu-sensor-controller 0.15.0 --> 0.15.1-r1*
* *ipr-extern 0.8.8-r1 --> 0.9.0-r1*
* *joint-state-controller 0.15.0 --> 0.15.1-r1*
* *joint-trajectory-controller 0.15.0 --> 0.15.1-r1*
* *kdl-conversions 1.12.0 --> 1.12.1-r1*
* *libmodbus 0.8.8-r1 --> 0.9.0-r1*
* *librealsense2 2.31.0-r3 --> 2.33.1-r2*
* *libreflexxestype2 0.8.8-r1 --> 0.9.0-r1*
* *media-export 0.2.0 --> 0.3.0-r1*
* *mpc-local-planner 0.0.1-r2 --> 0.0.2-r1*
* *mpc-local-planner-examples 0.0.1-r2 --> 0.0.2-r1*
* *mpc-local-planner-msgs 0.0.1-r2 --> 0.0.2-r1*
* *mrt-cmake-modules 1.0.0-r1 --> 1.0.1-r1*
* *pilz-control 0.5.13-r1 --> 0.5.14-r1*
* *pilz-robots 0.5.13-r1 --> 0.5.14-r1*
* *pilz-status-indicator-rqt 0.5.14-r1*
* *pilz-testutils 0.5.13-r1 --> 0.5.14-r1*
* *pilz-utils 0.5.13-r1 --> 0.5.14-r1*
* *position-controllers 0.15.0 --> 0.15.1-r1*
* *prbt-gazebo 0.5.13-r1 --> 0.5.14-r1*
* *prbt-hardware-support 0.5.13-r1 --> 0.5.14-r1*
* *prbt-ikfast-manipulator-plugin 0.5.13-r1 --> 0.5.14-r1*
* *prbt-moveit-config 0.5.13-r1 --> 0.5.14-r1*
* *prbt-support 0.5.13-r1 --> 0.5.14-r1*
* *qt-build 0.2.10-r1*
* *qt-create 0.2.10-r1*
* *qt-ros 0.2.10-r1*
* *qt-tutorials 0.2.10-r1*
* *rc-common-msgs 0.4.0-r1 --> 0.4.1-r1*
* *realsense2-camera 2.2.12-r1 --> 2.2.13-r1*
* *realsense2-description 2.2.12-r1 --> 2.2.13-r1*
* *ros-controllers 0.15.0 --> 0.15.1-r1*
* *ros-reflexxes 0.8.8-r1 --> 0.9.0-r1*
* *rqt 0.5.0 --> 0.5.1-r1*
* *rqt-gui 0.5.0 --> 0.5.1-r1*
* *rqt-gui-cpp 0.5.0 --> 0.5.1-r1*
* *rqt-gui-py 0.5.0 --> 0.5.1-r1*
* *rqt-joint-trajectory-controller 0.15.0 --> 0.15.1-r1*
* *rqt-joint-trajectory-plot 0.0.5-r1*
* *rqt-py-common 0.5.0 --> 0.5.1-r1*
* *tf 1.12.0 --> 1.12.1-r1*
* *tf-conversions 1.12.0 --> 1.12.1-r1*
* *ublox 1.3.0-r1 --> 1.3.1-r1*
* *ublox-gps 1.3.0-r1 --> 1.3.1-r1*
* *ublox-msgs 1.3.0-r1 --> 1.3.1-r1*
* *ublox-serialization 1.3.0-r1 --> 1.3.1-r1*
* *urdf 1.13.1 --> 1.13.2-r1*
* *urdf-parser-plugin 1.13.1 --> 1.13.2-r1*
* *velocity-controllers 0.15.0 --> 0.15.1-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-rosdistro-modules
 * [ ] python3-rospkg-modules
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

