### PR TITLE
rosdistro sync, Fri Mar 20 12:40:08 2020

### DIFF
--- a/distros/dashing/class-loader/default.nix
+++ b/distros/dashing/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, poco, poco-vendor }:
 buildRosPackage {
   pname = "ros-dashing-class-loader";
-  version = "1.3.2-r1";
+  version = "1.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/dashing/class_loader/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "548cefc198d57f9d46e471c195ef961d8513a8e57caed0ded81806f1d3ab43f5";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/dashing/class_loader/1.3.3-1.tar.gz";
+    name = "1.3.3-1.tar.gz";
+    sha256 = "64ca57310bf7a5786199773f61d8ffe55c11bccf03ea0569681f34891d9d53f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/launch-ros/default.nix
+++ b/distros/dashing/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-launch-ros";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/launch_ros/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "06de5fd5c0cb74f314214f08763f7f0e417c8b06c7625caf43eae853308085ce";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/launch_ros/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "163067d8987f1561cf0fba0c9340a1fd5c6b6adf24e9d1caf16eee80982ffb06";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/launch-testing-ros/default.nix
+++ b/distros/dashing/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, demo-nodes-py, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-launch-testing-ros";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/launch_testing_ros/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "16acb0261e74aaaedddb08268d9cc835f8b48c5690cb6eddc16edc225de79f2a";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/launch_testing_ros/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "0169adf84658014cd51ed3fd6bb05cac99266e707ae309826e72ebf262ec1edd";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/osrf-testing-tools-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-dashing-osrf-testing-tools-cpp";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/osrf_testing_tools_cpp/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "fa05588eb92e0f73a87bce1ab9129703553f4bf6e9c8192b6f0da1e8929d9456";
+    url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "185f904f6e12b39cd031144ba279c08540bb5337960ecc2d9446e282281bcaa3";
   };
 
   buildType = "cmake";

--- a/distros/dashing/rmw-fastrtps-cpp/default.nix
+++ b/distros/dashing/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcutils, rmw, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-fastrtps-cpp";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_cpp/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "7d1cd50cd401524f95ed5a9461ef765dd2d1ee51de855e39502258c3e763f265";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_cpp/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "b4e1e9b9ca34cafc5a01f35811eb0bbbbd449659adab7c9eb935ba3cc66a44f6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/dashing/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcpputils, rcutils, rmw, rmw-fastrtps-shared-cpp, rosidl-generator-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-fastrtps-dynamic-cpp";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_dynamic_cpp/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "b26142e34a61c6030a0ad8e412a955623b324c73b4892a565f04b1861f06f907";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_dynamic_cpp/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "6815a3f23852c633c58f1c12f7f2908d7815c7de59f04091042c9f5dcd2533e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/dashing/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcpputils, rcutils, rmw }:
 buildRosPackage {
   pname = "ros-dashing-rmw-fastrtps-shared-cpp";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_shared_cpp/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "1aae2bed65ab79759edd67f5763f0a9d4e6bf06ebc656214006588da49336ddf";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/dashing/rmw_fastrtps_shared_cpp/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "edf4ab7586c5ec6d70dd8fa70aa8eaef5bbb217dd8ef1621b57b120f24ffd4e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros1-bridge/default.nix
+++ b/distros/dashing/ros1-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, actionlib-msgs, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, demo-nodes-cpp, diagnostic-msgs, example-interfaces, gazebo-msgs, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, pkg-config, python3Packages, rclcpp, rcutils, rmw-implementation-cmake, ros2run, rosidl-cmake, rosidl-parser, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ros1-bridge";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "50da1aae9709becf1fd1a2db4fe646b9351320dd731fdaae96d103ceb4de6b63";
+    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "8922a36968861339b30c56ac8a57d9f5105ddc9fedd027b8f4c19e3613c69f7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros2action/default.nix
+++ b/distros/dashing/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ros2action";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "3d76762fc41d3aeb3a11e579fcd516623427d61f43e05ee4b13890ab157d0c98";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "dea7b7a2578c5f9f0df501264f97d0f700a0e2ce8e2f9f17d2602978c771253a";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2cli/default.nix
+++ b/distros/dashing/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-ros2cli";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "67e38bf73d5287d664e4c2200a7d640376469dc14045d57923b730bc831aa700";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "2c93d9207eb1463bc80d3f8e3990077370f667c1589f99442be0fa5eb190d731";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2component/default.nix
+++ b/distros/dashing/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-dashing-ros2component";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "5a46c00a9c7ed0f4f04b50c207d56347033576229ce4477a39cbe48208a25d28";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "4ecd9c7c490d2f2684f5d54a421d6ecfe3270e2e67db2f6f20dcce75cc29400a";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2launch/default.nix
+++ b/distros/dashing/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-dashing-ros2launch";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/ros2launch/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "4be10039d8d58089d589011c14583de306686c5c1b21123ca335283ac508a9d8";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/dashing/ros2launch/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "88206e3a3713e82764a53484b7aebbca8c137daf2bdc968d5cd70e6d35059875";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2lifecycle/default.nix
+++ b/distros/dashing/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-dashing-ros2lifecycle";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "acb86a11c4db2d3664ec3dd619179c35f29c2e65679b353fe0df892b73698cc8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "7337e5aa79511e6fe056e61d63d3de41130cd2b85b0615e4d34426e3cbe4f4b9";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2msg/default.nix
+++ b/distros/dashing/ros2msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-ros2msg";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "be9517679ff27f944efe3e20bc90a6e6914dd3843c5780fee554692486f242be";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "674ffd4c65a7ebe6b6f76d0b59b87eff7371b42b66a3a281f1fd5e811b5eff5e";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2multicast/default.nix
+++ b/distros/dashing/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2multicast";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "9e2a33956ae6dbe428faebf7f39f2739e2ef5f9b33c514a96e29cb5610d034be";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "ffdf72d272a19e9233dc26529d3d88b0edc994062c0dd6a928a65e13e9e973bd";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2node/default.nix
+++ b/distros/dashing/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2node";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "0a816063c33aa9d6de80091d6549f1e6f4f78410de46a0d080a6988396458faf";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "86341fa400424abfbe4059211bc3369306b4e6ff7b4cc634df42ef1bfa01bb00";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2param/default.nix
+++ b/distros/dashing/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-dashing-ros2param";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "0ec236992a0559de9a9d29fbe4e959e118fd9684db5694e32a7b952ed2782b9e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1099bd3e66e97cd6cf7738165e93b00500730201013ed4e3cfb7f21b5f755d25";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2pkg/default.nix
+++ b/distros/dashing/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2pkg";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "89ab52df66265e32af512b998989d231afe98bf7f2c899f3d766d91cc09b52f8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "80a9aa72cef1048b9825510b5b012b401352a60ecc20f36b2a8f0eeac093aa95";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2run/default.nix
+++ b/distros/dashing/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-dashing-ros2run";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "ad32899334d8f1732500ad9a13854891db06fd2b3a0d1efb0d2afb058571b54b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "8867efcea5c4a0ce700d149601ebf18a5bf3e5e148bf2e4ace026f57a3c3fba6";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2service/default.nix
+++ b/distros/dashing/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros2cli, ros2srv, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-dashing-ros2service";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "9f77faf09fc5f78f4937f2ade6fde9d05a21ba199a1bde0c71b3feb65233b520";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1c01e9ad32981920f2931db93b9936e9d1a99679bb91f5a138f8560eef044053";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2srv/default.nix
+++ b/distros/dashing/ros2srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-ros2srv";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "51cf1feb9c87d8c7079d622cb7dfebca2f31f517b972dc6b0cdd7cd0c5c7264d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "d8e660143245f78987a5981261b63bddb246aa9bd4f41ed0937f393bbbb5e260";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2topic/default.nix
+++ b/distros/dashing/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros2cli, ros2msg, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-dashing-ros2topic";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "43e8621002238c52b75e7e3cfa86ceda25b902e10a7de33835960d5b115895eb";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "65e6b8b3634b05646bd07e5aa9d28720f06876b7a5c394ebc3d9c7c6316d2d4b";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/ros2trace/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "64237813f80593f21dffe7f61ba91f290111e8a994449bc55800e9d42acf29c5";
+    sha256 = "be0044a3cd8924c54627d963ea29c6987aec28afa21b3d875f0ea34bed8ad7ff";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/rosidl-adapter/default.nix
+++ b/distros/dashing/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-adapter";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_adapter/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "adb7550016f0abcfc0e2d01c04373bab25884fbe441ec4ccc798c4ec92cb2ad3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_adapter/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "c44f076deb033afa3505af7bb4aafec6653cd694e3eea61cf48cd1dda825af08";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-cmake/default.nix
+++ b/distros/dashing/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-cmake";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_cmake/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "90754adaacb0883fba1a37ea6412e29f520214f050664a0338906c02f7ad1cd7";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_cmake/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "4487d4f50642cd260d17b0c84807ca1fe9ce48f756e2277e833786983332e806";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-generator-c/default.nix
+++ b/distros/dashing/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-parser, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-generator-c";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_c/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "d962db1e0542e342cae1de57e75bff407173fd22efca8ddc83c6297de594faaa";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_c/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "4a651b0626e46e88a353ad7a98b9b4757ed4c65eefe11c5289bd98e178286615";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-generator-cpp/default.nix
+++ b/distros/dashing/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-parser }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-generator-cpp";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_cpp/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "de780f9561333d09e10f328f75ece3b391cd27e9377001ea866003742764c58c";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_generator_cpp/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "261c07c539a46171c157aba8104b2e69db274b2cd9527261f34e59a4c8b4d75a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-parser/default.nix
+++ b/distros/dashing/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-parser";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_parser/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "5599d67dccabbbd079d7f929f9364fdcd05809b0dc527517a4049b25854b5114";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_parser/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "b455e209b3fd64b368dd1856d1ecfb4c810b2ce301c83aa3991926a36b074ec8";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-typesupport-interface/default.nix
+++ b/distros/dashing/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-interface";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_interface/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "d5eb326572080faa965bf6cee6caaf9d1e4efdce3fad56e74279bd32cfa679b5";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_interface/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "6b6ccc9078fa381c710eb49231bb7ca7efd9f83be36877e0f5fe114d1271257e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/dashing/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-parser }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-introspection-c";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_c/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "417a32362cecedea22f15c8c50f2a05d36a73082f091e066fb70b87bc3c8a1e3";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_c/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "c8f7c61f1de4217778fb24e43bf29d361c3848d4c43ebbf0d0eea2b895e27b95";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/dashing/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-dashing-rosidl-typesupport-introspection-cpp";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_cpp/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "526226529a953bb61270f96a4be65ce203af3d2fb95060e8e0e31458a509d390";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/dashing/rosidl_typesupport_introspection_cpp/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "0f73273d4f6ca5d51bccdb83c7777c919d2b092161d7e030cd456115bf9e9b55";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/test-osrf-testing-tools-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-dashing-test-osrf-testing-tools-cpp";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/test_osrf_testing_tools_cpp/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "c915c2c8f93288002afff83a2d50b2ce77121657a25fb39ff94988480a795a9a";
+    url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "b5168ed927afbbeb3f17be5913baf27b4f34a3aed3a4c3f199012f2a68d44031";
   };
 
   buildType = "cmake";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/tracetools/default.nix
+++ b/distros/dashing/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "5ccad4d10ecd2ebe25e0d1d8f1de0aae46d6285b2fef0cc7e7a32a4c354d8724";
+    sha256 = "41d143bfa711fd0099511994140865377d0951df75711d5a22e409d5427c2ecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -998,6 +998,8 @@ self: super: {
 
  urdfdom-py = self.callPackage ./urdfdom-py {};
 
+ urg-node-msgs = self.callPackage ./urg-node-msgs {};
+
  v4l2-camera = self.callPackage ./v4l2-camera {};
 
  velocity-smoother = self.callPackage ./velocity-smoother {};

--- a/distros/eloquent/urg-node-msgs/default.nix
+++ b/distros/eloquent/urg-node-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-urg-node-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/urg_node_msgs-release/archive/release/eloquent/urg_node_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d39088376083e5e6052edec5984a997f6b4615e5d0a8c2dcaceefee2ff51a8f2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''urg_node_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/async-comm/default.nix
+++ b/distros/kinetic/async-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
 buildRosPackage {
   pname = "ros-kinetic-async-comm";
-  version = "0.1.1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/dpkoch/async_comm-release/archive/release/kinetic/async_comm/0.1.1-0.tar.gz";
-    name = "0.1.1-0.tar.gz";
-    sha256 = "2178321d845dac075d6f96084f02438f8a60cbf7ef119ca7988fad78bc18c244";
+    url = "https://github.com/dpkoch/async_comm-release/archive/release/kinetic/async_comm/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "83a1e27066268408f24d54f213701b538c1f722c2c5f6b36c7e6addbddbbd21a";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "1f9d261f577a6da07a9744a72d5df0f39f661fa0155d95aeda9fa01077547f1d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "bb608060d9e7cb4bfaf2741d8669b64c56e09381e0cdf01c9d4dff52490eb145";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -3490,6 +3490,8 @@ self: super: {
 
  robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
 
+ robot-indicator = self.callPackage ./robot-indicator {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-mechanism-controllers = self.callPackage ./robot-mechanism-controllers {};

--- a/distros/kinetic/ipr-extern/default.nix
+++ b/distros/kinetic/ipr-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libmodbus, libreflexxestype2, ros-reflexxes }:
 buildRosPackage {
   pname = "ros-kinetic-ipr-extern";
-  version = "0.9.0-r1";
+  version = "0.8.8";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ipr_extern/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "d9a11c9df9a4577801f4d3e061b54ed192f349e4b72663dc9db2fca4f3dba67c";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ipr_extern/0.8.8-0.tar.gz";
+    name = "0.8.8-0.tar.gz";
+    sha256 = "d7e37fb86212a48bfdfba21e29cca5541aaf7e1e950e4415fbf1a08191079b6a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "afbcf8048fc6c42cb26bab0d5fb309507d249a7b86b7cb4b7c07f16399a1652b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "bd4f662c3abd8c4e38419dab55d4724384437706719f703e80c978f3256b5c76";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libmodbus/default.nix
+++ b/distros/kinetic/libmodbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules }:
 buildRosPackage {
   pname = "ros-kinetic-libmodbus";
-  version = "0.9.0-r1";
+  version = "0.8.8";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libmodbus/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "bb7a3a59a7b9a186565922f4eb3dfbaa82beeee2668f7408717ed7c2a0d28184";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libmodbus/0.8.8-0.tar.gz";
+    name = "0.8.8-0.tar.gz";
+    sha256 = "2ba6a63a88bb1809ef7743a25530875678171c980b46071933297d91540fe3f4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libreflexxestype2/default.nix
+++ b/distros/kinetic/libreflexxestype2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-libreflexxestype2";
-  version = "0.9.0-r1";
+  version = "0.8.8";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libreflexxestype2/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "f35455983c902ec35fcbf2a01bdc95c5147284d8c2dbbd14f03ac08b5b87ad0b";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/libreflexxestype2/0.8.8-0.tar.gz";
+    name = "0.8.8-0.tar.gz";
+    sha256 = "e19f5d03525f6c8998061a81b632443960778dc6769bb830ac178a6d69cfbe69";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "288d6d9dbb2484fde20cd5a0938696e8e97282636248a84d51fc2f9f65a57a95";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "c3e9952efc1c2184aba0917af4d1d9a4d95ef0e3de39e7d0294f733f3d5a1696";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "d2c80ebf5a18f80b51b0053810be3887af5bf6397611b64ba2c900472933f867";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "308079108ed2857fe1d6959f689955b5d1be6c19c39129442b19e1ae9ef7bca0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "842d73fe030513c72f4b7aab44dc04da3a988601e876bb651071596b21538aa8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "861e20f83e375a452dd650e988b50e516f2df779754872c6eee68d9587ec43f5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "99d157c7d8f6b2ad3a1d435fd209dd219549419fd4c291b1ebc0b89d30292694";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "5eaff64eb21012df8d259d193c5c16b63f2486b1606195b413cf6b124a6c852f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "44d3aa8dcb4ae8233b34b5e5d7815c0837dd349c1c4d3b86c36e722092a8a416";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b0ca8782274166c6ff81205d74b59753ef022439bae5e4779baf108a056d51ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "437acd4b3d9b397ff001e0f8dd15a11d3d9cd97fec28bf272b2817f346c08684";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "6c79b30b4dce525d1def8d5c00ee78a17cf1d2b509168812c8048dc3df631aa9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robot-indicator/default.nix
+++ b/distros/kinetic/robot-indicator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-kinetic-robot-indicator";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LucidOne-release/robot_indicator/archive/release/kinetic/robot_indicator/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "c8a5274a5f343b7822cbf77a2f77a293d89041d971092ce5fe0dc27671db510c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.rospkg ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS Robot Status Indicator'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/kinetic/ros-reflexxes/default.nix
+++ b/distros/kinetic/ros-reflexxes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, pluginlib, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-ros-reflexxes";
-  version = "0.9.0-r1";
+  version = "0.8.8";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ros_reflexxes/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "b676048654ee5d484a00965b86059a8127498f44f69fba40ab7a8e77e469ab41";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/kinetic/ros_reflexxes/0.8.8-0.tar.gz";
+    name = "0.8.8-0.tar.gz";
+    sha256 = "6fffe8bdbc4b262e0c0c806be94310d9429959403af9a3fea107d4612d6dc858";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ libreflexxestype2 pluginlib roscpp ];
+  propagatedBuildInputs = [ libreflexxestype2 roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7d810cc21c4bdda1d25c50cfc415df283806c8e14f4a829a8ae748d1b13f1a2e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "49fe087d5ed1b8012baa832282939e984386af864738f18550ecaabd3a0f24a9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "8d53be7885e51317a6848ad75235c5252e57eea20bbf7c68be468a2d5e202b04";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "d49a22eac956646edb53b3118efb701308f8fd44160d91f42e3fa677d8bcde83";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "0224381b3802d35eb36394345bfb51a136272da6ee73bcc7dfdd6ebfb010b3ad";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "d6d2097c8f5495896152644ca267798487ab6fe6de51b7d0e6996e054fecce20";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.11";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.11-0.tar.gz";
-    name = "0.1.11-0.tar.gz";
-    sha256 = "8e3154c0e0e1c02a4aa54733d79a4bc78c74108b258de57b2908bd3c976464b0";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "7e8b6fa6f623347a42fc45c34cd36bc12b41998dbcdbc1753e1dabc52c8e4c04";
   };
 
   buildType = "catkin";

--- a/distros/melodic/amcl/default.nix
+++ b/distros/melodic/amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, message-filters, nav-msgs, python-orocos-kdl, rosbag, roscpp, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-amcl";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/amcl/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "d03da5a74803e6f6c7968e1358074891637da8946e2208898097bdec44a19b37";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/amcl/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "31ed6f2fa24e842e9db6d4860e5cfa280d86466c3eb429462b9b361ca0e3c6a6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/async-comm/default.nix
+++ b/distros/melodic/async-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-async-comm";
-  version = "0.1.1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/dpkoch/async_comm-release/archive/release/melodic/async_comm/0.1.1-0.tar.gz";
-    name = "0.1.1-0.tar.gz";
-    sha256 = "9a87d3e8db68cf7c7fc3c318f1d31d6660dd5ca39172d0f78efdf6330de49bcc";
+    url = "https://github.com/dpkoch/async_comm-release/archive/release/melodic/async_comm/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "657753a9f478d51187d61862ab11deea0eaa38b107bc599084c6a2d49addfb2f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/base-local-planner/default.nix
+++ b/distros/melodic/base-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, rosconsole, roscpp, rospy, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-melodic-base-local-planner";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/base_local_planner/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "a43ba1eb77a1b56b98ff1c6686a0482315aa49f7cb7fc8312ed9f1c7dbcb6632";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/base_local_planner/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "878aa47bac54ee37bd25a27362270bb75e1418060f9db990190b8afece4f3db4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/carrot-planner/default.nix
+++ b/distros/melodic/carrot-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, eigen, nav-core, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-carrot-planner";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/carrot_planner/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "46bd430ab5278ca20b0da0b68e29af2d0307392270ca5508627c7098be6f2786";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/carrot_planner/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "0cb3855aaeea49d521ad11e14d48b1f0d2c0a91778e1438f2f0b1f987ef24b7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/clear-costmap-recovery/default.nix
+++ b/distros/melodic/clear-costmap-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, eigen, nav-core, pluginlib, roscpp, rostest, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-clear-costmap-recovery";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/clear_costmap_recovery/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "4132cb3ed50b823bed0bc38f7dd7bef039123c4f3c2556be019f76ddd98de031";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/clear_costmap_recovery/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "841bb672c01a4e164842b3d55e81eb5a186aa76244917647e3a7ce808662f7ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-3d-mapping-msgs/default.nix
+++ b/distros/melodic/cob-3d-mapping-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-object-detection-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-3d-mapping-msgs";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_3d_mapping_msgs/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "8efeb75129ad677ff76f1f42626d9fbc6cfa16b8854d349707765936e97e2d43";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_3d_mapping_msgs/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "263177d023bf7be849cc0cf2aae30dcd68dfe852e33271bf393f7881dd5194ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-actions/default.nix
+++ b/distros/melodic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-cob-actions";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_actions/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "4d88715a20c1d162791421cf834761a2a5bcd1370e0a67087c6802f9932ee010";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_actions/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "c8f2442b4430c3a1289c871bf3671c22c1fd44f525e10c568d43844ba595eee5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-android-msgs/default.nix
+++ b/distros/melodic/cob-android-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-cob-android-msgs";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_msgs/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "506bb55d787b9cfc23d15fbf27abbe8bfa6d5c57e24b137e47e80c7dbe4287db";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_msgs/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "433dceb954125d4eae4fdf222e7886305b3690946e647c929eef4adc8fbe4d6a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-android-resource-server/default.nix
+++ b/distros/melodic/cob-android-resource-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy }:
 buildRosPackage {
   pname = "ros-melodic-cob-android-resource-server";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_resource_server/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "aabbcf56633153105deb9131389d793848906c458654e5bed84206b0cd7106b8";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_resource_server/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "afc85c9ae6b2d8aeb6da8cd63a4c40108485b3303750b65e1a08bada2b16d87b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-android-script-server/default.nix
+++ b/distros/melodic/cob-android-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-script-server, rospy }:
 buildRosPackage {
   pname = "ros-melodic-cob-android-script-server";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_script_server/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "ea5eb372ef9f8f09cc5e3526ea3a2f49559b7cff6cd83e9a800fffecbf1b825a";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_script_server/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "f6eaa639895b8b9151feb035d8f7a8b94fbcf33122ab3e53053dd46ca153a185";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-android-settings/default.nix
+++ b/distros/melodic/cob-android-settings/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-android-settings";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_settings/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "59602692b35e9a17cc5379696012c86046d51533d3f7900e822ef5b1316336e5";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android_settings/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "34afaa2a6946c228340eafa3515b36c4dbbd2593c3cd19781086ee1471414cff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-android/default.nix
+++ b/distros/melodic/cob-android/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-android-msgs, cob-android-resource-server, cob-android-script-server, cob-android-settings }:
 buildRosPackage {
   pname = "ros-melodic-cob-android";
-  version = "0.1.6-r1";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "d14eb86dac83a30e8cc4769108244b84d84ca3aa59646e6c660f7f17b46cb99a";
+    url = "https://github.com/ipa320/cob_android-release/archive/release/melodic/cob_android/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "9d6950e3aed168e81db74ce2fb4c467e79d8b4e2f6608c59186bc26a4867ae91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-base-controller-utils/default.nix
+++ b/distros/melodic/cob-base-controller-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, rospy, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-melodic-cob-base-controller-utils";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_base_controller_utils/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "2c2319407fb608a89d011c62d7d924610cbcc07e783d3c6147d4686d6e0a720d";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_base_controller_utils/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "3cae435ee98d0f230513f6d5e7c42bba4aa48e0d457984aef0a2c81620ac3d97";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_base_controller_utils package'';
+    description = ''The cob_base_controller_utils package contains common utils for various base_controllers.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-base-velocity-smoother/default.nix
+++ b/distros/melodic/cob-base-velocity-smoother/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-base-velocity-smoother";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_base_velocity_smoother/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "4feaadef5cd6375527ff72d0b69cdb721c6fd66185f0d518bac51c03f3735639";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_base_velocity_smoother/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "5c070d2a670d41413cc1cc833838e252f02fe17db2539af51ea89cdc63ab50e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-calibration-data/default.nix
+++ b/distros/melodic/cob-calibration-data/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-supported-robots, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cob-calibration-data";
-  version = "0.6.13-r1";
+  version = "0.6.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/melodic/cob_calibration_data/0.6.13-1.tar.gz";
-    name = "0.6.13-1.tar.gz";
-    sha256 = "9af7547788449e0127ace2c0c938cfba0efcc3cb874d28769e3864d59f0e9838";
+    url = "https://github.com/ipa320/cob_calibration_data-release/archive/release/melodic/cob_calibration_data/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "69c652f79ead3069950b9f9ad46a70362ff79682853b65962c652914c1d16a3b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-cam3d-throttle/default.nix
+++ b/distros/melodic/cob-cam3d-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, nodelet, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-cam3d-throttle";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_cam3d_throttle/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "4451dd7a369723340dba5a3f593d8923faa7924bacb7cd7575f815256c13c6e6";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_cam3d_throttle/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "fa670c475faf439a3407cfc32bb2688624cf3786ac6f77e93fc9508e6ed72861";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-cartesian-controller/default.nix
+++ b/distros/melodic/cob-cartesian-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-frame-tracker, cob-script-server, cob-srvs, cob-twist-controller, geometry-msgs, message-generation, message-runtime, robot-state-publisher, roscpp, roslint, rospy, rviz, std-msgs, std-srvs, tf, topic-tools, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cob-cartesian-controller";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_cartesian_controller/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "676934ceb346e29f9fd3c43c8e12460d7479a56ecdf3608fefd198b201e08e44";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_cartesian_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "66c6820bbfe0aaa0a324e4cb9d3500de7543d8e7b280bfbf85f5af6f6b3866ab";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation roslint ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs boost cob-frame-tracker cob-srvs cob-twist-controller geometry-msgs message-runtime robot-state-publisher roscpp rospy rviz std-msgs std-srvs tf topic-tools visualization-msgs xacro ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs boost cob-frame-tracker cob-script-server cob-srvs cob-twist-controller geometry-msgs message-runtime robot-state-publisher roscpp rospy rviz std-msgs std-srvs tf topic-tools visualization-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-collision-velocity-filter/default.nix
+++ b/distros/melodic/cob-collision-velocity-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-footprint-observer, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, tf, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-collision-velocity-filter";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_collision_velocity_filter/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "167363d3942a00dccba154510dbaf68cecd2b08f4b404490797c867ac9a0561f";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_collision_velocity_filter/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "1bc3611ef0aaf3b3008387cf583e531e20b0f2ffce6970c6e8dea8a8539fbd79";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-command-gui/default.nix
+++ b/distros/melodic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, pythonPackages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-melodic-cob-command-gui";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_command_gui/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "21a5bb8f2619868678ef2ba20893b78bcb378393d19b5ebebe034405f510a16d";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_command_gui/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "3644232d816a6243f187a4611b82d0d5fc00452235d48fcd9f7b0f2675fb3ab4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-command-tools/default.nix
+++ b/distros/melodic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-melodic-cob-command-tools";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_command_tools/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "84a137502724a990c827376866b80330d8273dd1780931940f0e03bd9a1aebd8";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_command_tools/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "aef237dca40a18d3760f67c9162de2a3d30965dfeca975e6d300526921128167";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-common/default.nix
+++ b/distros/melodic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-melodic-cob-common";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_common/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "5a95533dc1a09a861e9ca6bd7aa0cbd8818861ab78fccb575a96cb0436fb6fc1";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_common/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "aa7aa82a608755458abb6e66d2460048f79f3931abc9199eacc39b5cd4be3480";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-control-mode-adapter/default.nix
+++ b/distros/melodic/cob-control-mode-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-manager-msgs, roscpp, roslint, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-control-mode-adapter";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control_mode_adapter/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "e9f645239ae0f8c11405e5417b45d85db5aa2da90a8903d4c6b9a876b59fa713";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control_mode_adapter/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "552fe26de125e1241aa19ce2a49f3d5b531545e22caa098f129a8acc5aab2931";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_control_mode_adapter package'';
+    description = ''The cob_control_mode_adapter package provides a node that automatically loads respective ros_controllers depending on required control mode.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-control-msgs/default.nix
+++ b/distros/melodic/cob-control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-control-msgs";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control_msgs/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9b46e954b2e2e6b8ff110fe67a879280598d2b8153228d3e61febd1ffbfab493";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control_msgs/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "aa1cb8725ea52e0a64036570fb0b0f562033e4ee858a2a5c134d9080b149669e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-control/default.nix
+++ b/distros/melodic/cob-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-base-controller-utils, cob-base-velocity-smoother, cob-cartesian-controller, cob-collision-velocity-filter, cob-control-mode-adapter, cob-control-msgs, cob-footprint-observer, cob-frame-tracker, cob-hardware-emulation, cob-mecanum-controller, cob-model-identifier, cob-obstacle-distance, cob-omni-drive-controller, cob-trajectory-controller, cob-tricycle-controller, cob-twist-controller }:
 buildRosPackage {
   pname = "ros-melodic-cob-control";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "5f7b91ff5d46b13a707e1a79061dcadf5fb637cb95b227e6e1fe3973a387e8f1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_control/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "7e93306499aab7543d3f887fefdde1b152434de9dcbece314475dee55ba6a6ab";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cob-base-controller-utils cob-base-velocity-smoother cob-cartesian-controller cob-collision-velocity-filter cob-control-mode-adapter cob-control-msgs cob-footprint-observer cob-frame-tracker cob-hardware-emulation cob-model-identifier cob-obstacle-distance cob-omni-drive-controller cob-trajectory-controller cob-tricycle-controller cob-twist-controller ];
+  propagatedBuildInputs = [ cob-base-controller-utils cob-base-velocity-smoother cob-cartesian-controller cob-collision-velocity-filter cob-control-mode-adapter cob-control-msgs cob-footprint-observer cob-frame-tracker cob-hardware-emulation cob-mecanum-controller cob-model-identifier cob-obstacle-distance cob-omni-drive-controller cob-trajectory-controller cob-tricycle-controller cob-twist-controller ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-dashboard/default.nix
+++ b/distros/melodic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-melodic-cob-dashboard";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_dashboard/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "2a34b89fda4cc72d128bf661db6d259658942ae505f3a78d010cc9d44c9bcb25";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_dashboard/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "482845721bc87b574dc175ab0679994923bd6b8a386ff2045c34e91d01ad1d42";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-default-env-config/default.nix
+++ b/distros/melodic/cob-default-env-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-cob-default-env-config";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_default_env_config/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "367b393e0eaba908fab4e6cca65b1cb1c7448c3762558ae0e5131b1e9eaf02e1";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_default_env_config/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "d1e459919f059b334c6a24685c711fb4b007d06123c376ea9463c6b08f9ad646";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-description/default.nix
+++ b/distros/melodic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cob-description";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_description/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "9c1bf2a21aecd087d7383deb60102cf6654b3e08832160b3a6fe3e4f3c804d0c";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_description/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "d049d97db04bec0aa75d97c08ae7fc65b08be183dc21a75140212b0694e7fb47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-docker-control/default.nix
+++ b/distros/melodic/cob-docker-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-docker-control";
-  version = "0.6.8-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_docker_control/0.6.8-1.tar.gz";
-    name = "0.6.8-1.tar.gz";
-    sha256 = "1082dfa38de002e21fee734a6e8f2606d35ed961e990897ae4de27aa4e352413";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_docker_control/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "9b202926dab21ab34206f93c371c540ef70fb0a7c0cc998703a8414e163c74da";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-environments/default.nix
+++ b/distros/melodic/cob-environments/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
 buildRosPackage {
   pname = "ros-melodic-cob-environments";
-  version = "0.6.10-r1";
+  version = "0.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_environments/0.6.10-1.tar.gz";
-    name = "0.6.10-1.tar.gz";
-    sha256 = "e3cb6c21bfd6e5961efdfc0784f72a914aad138a464ba557c6e4b44c6fc1d107";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_environments/0.6.11-1.tar.gz";
+    name = "0.6.11-1.tar.gz";
+    sha256 = "b02a6060eb21ff68a0c881971f71fe8e99b6b1ba34964792947a8e4ffa5a2021";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-extern/default.nix
+++ b/distros/melodic/cob-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
 buildRosPackage {
   pname = "ros-melodic-cob-extern";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/cob_extern/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "fab9731beb0fcf45a6e334bf275249c15cc48945b23f1c637ef6b92271367ebc";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/cob_extern/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "f66e09c3bd349f884e0520d107b9a11ac19aa361f1ad73730f5a77793653cbf8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-footprint-observer/default.nix
+++ b/distros/melodic/cob-footprint-observer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-cob-footprint-observer";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_footprint_observer/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9bacb5b8aff7810ca1e8dea91ccb400aeaea17a5921bdc7889142212f7e0c143";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_footprint_observer/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "61d3cf68462666c80df9dc6c87310a5068fc86626d8574af5d67c44debd07ea1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-frame-tracker/default.nix
+++ b/distros/melodic/cob-frame-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, cob-srvs, control-toolbox, dynamic-reconfigure, geometry-msgs, interactive-markers, kdl-conversions, kdl-parser, message-generation, message-runtime, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-frame-tracker";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_frame_tracker/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "99edb7d79527805ee5010885fb6b60afe4ba9121448605699553ca960a333ccc";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_frame_tracker/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "369d6563c8827a77ea06734d5109b4b031e77313cc4b6745da97b80ca101e254";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_frame_tracker package'';
+    description = ''The cob_frame_tracker package contains nodes that publish Twist commands based on the distance to the desired tf frame target.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-gazebo-plugins/default.nix
+++ b/distros/melodic/cob-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-gazebo-ros-control }:
 buildRosPackage {
   pname = "ros-melodic-cob-gazebo-plugins";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_plugins/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "3a73bcd2de6ec60706da22c0f39ade36c2cc02c1cd51f6771b38be9ca7fd3770";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_plugins/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "d1b7bd521adfd41fd0232ba9ec0b63107f979236c7d933c3545da5e80c11455d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-gazebo-ros-control/default.nix
+++ b/distros/melodic/cob-gazebo-ros-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros, gazebo-ros-control, gazeboSimulator, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-cob-gazebo-ros-control";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_ros_control/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "a4f50274e0b24a27cdf983d3a4b1827c38065df889c876a1238a51f840e40f04";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_ros_control/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "2dff0323105ded5f8c582052e7e80f2377675c67e0777a54697ccd3341d2a9ab";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ controller-manager gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface pluginlib roscpp transmission-interface urdf ];
+  propagatedBuildInputs = [ controller-manager gazebo-ros gazebo-ros-control gazeboSimulator.gazebo hardware-interface joint-limits-interface pluginlib roscpp transmission-interface urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-hardware-emulation/default.nix
+++ b/distros/melodic/cob-hardware-emulation/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, nav-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, nav-msgs, roscpp, rosgraph-msgs, rospy, sensor-msgs, std-srvs, tf-conversions, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-cob-hardware-emulation";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_hardware_emulation/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "8646a2e4321a0d1ec4b879c791d201041573cfde46cde0a5066e4ece0ca3f44c";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_hardware_emulation/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "335a5da03b4720ea1cd4d406851c841bfd391eb6cfb318775d4e5379b8d088cc";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib control-msgs nav-msgs rospy sensor-msgs std-srvs tf-conversions tf2-ros ];
+  propagatedBuildInputs = [ actionlib control-msgs nav-msgs roscpp rosgraph-msgs rospy sensor-msgs std-srvs tf-conversions tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_hardware_emulation package'';
+    description = ''The cob_hardware_emulation package provides idealized nodes emulating real robot hardware and/or physics simulation.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-helper-tools/default.nix
+++ b/distros/melodic/cob-helper-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-helper-tools";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_helper_tools/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "11cdb917fbbe0c352146a2e282741deaac0fd7eea4bb55cb0eb2b1612e2a7438";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_helper_tools/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "fa94f47cbf774c0f463c4c045f8a7e644c805fa905202fb02a0117929e7a530e";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ cob-msgs cob-script-server diagnostic-msgs dynamic-reconfigure message-runtime rospy tf visualization-msgs ];
+  propagatedBuildInputs = [ cob-msgs cob-script-server diagnostic-msgs dynamic-reconfigure message-runtime rospy std-srvs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-image-flip/default.nix
+++ b/distros/melodic/cob-image-flip/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-perception-msgs, cv-bridge, geometry-msgs, image-transport, nodelet, opencv3, pcl-conversions, pcl-ros, pluginlib, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-cob-image-flip";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_image_flip/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "a75ea8e5dfca1653e7b14e9df4be8714858decb9898bc20059a68b85eadf8cc0";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_image_flip/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "24d907e7083a5b2ee4a371925916f47eb003126769cd4541f0a78474df057c49";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-interactive-teleop/default.nix
+++ b/distros/melodic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-interactive-teleop";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_interactive_teleop/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "951e70090c4936c9c40a0f57e7728040512e045de237b7c750d3c8b3f7ef9fac";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_interactive_teleop/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "774c58a8e4a2eec21b04172da7df89cacc9efa4cba901cdb506671ed1dbe2e6b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-mecanum-controller/default.nix
+++ b/distros/melodic/cob-mecanum-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-cob-mecanum-controller";
+  version = "0.8.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_mecanum_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "3f6a5f1b54674464e3a00a22b0437cf057bb3a5c19747de6fee6069e28494b27";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_mecanum_controller_node provides a lightweight base controller for mecanum drive robots. 
+    The out/input for the wheel command/state are wheel velocities in rad/s for the wheels 
+    [front left, front right, rear left, rear right]'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cob-model-identifier/default.nix
+++ b/distros/melodic/cob-model-identifier/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, geometry-msgs, kdl-parser, orocos-kdl, roscpp, roslint, rospy, sensor-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-cob-model-identifier";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_model_identifier/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "1e04326126ce9e7b5fd42e3ff2cb8840bf56c81dda46d8c1c9bc720c2c66e5e1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_model_identifier/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "c16d726b03061b0c6ccc5aa84139171f3cc41e59c89fe7ba9507cbe95d0696d8";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_model_identifier package'';
+    description = ''The cob_model_identifier package provides nodes to analyse the system response behavior of actuators to optimally tune PID controllers to be used with cob_twist_controller framework.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-monitoring/default.nix
+++ b/distros/melodic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, pythonPackages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-cob-monitoring";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_monitoring/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "7f458dc0a7d3897c31208791af38a6d966233ca1bdabd2d6a4af229d09d03660";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_monitoring/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "ad950a5720509c17f742c7738d5626b4dac69b6870baba83273f8eee5a4a8dfa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-msgs/default.nix
+++ b/distros/melodic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "59363a11bfee152e46fc580aa8dc768ea9e8323f5e54e72634c9e4e057ea9ea0";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "99d31afe431ee18434d8febaa177e820594ea4348455cd59a6ce1f568f764e25";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-object-detection-msgs/default.nix
+++ b/distros/melodic/cob-object-detection-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cob-object-detection-msgs";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_object_detection_msgs/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "973a7ecbb144a06fe0ca33c7547a9d365e30d1b3fc4aefc715db24719e01402b";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_object_detection_msgs/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "494602233338235f774e6abe434af7cc09ec32ed57eab11d6cb7e1bf2406c3ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-object-detection-visualizer/default.nix
+++ b/distros/melodic/cob-object-detection-visualizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cob-object-detection-msgs, cv-bridge, eigen-conversions, image-transport, message-filters, opencv3, pcl, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-object-detection-visualizer";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_object_detection_visualizer/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "6f69b00121d7cb02ff0da6cbe8867092c3a752238dd84fa3664cb75ff6bf6df7";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_object_detection_visualizer/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "08226e1ae1acda5a369fb8b06e8a6ee9f0e542c6a06a2779d19079838126825e";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_object_detection_visualizer package'';
+    description = ''The cob_object_detection_visualizer package visualizes the object detection result.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-omni-drive-controller/default.nix
+++ b/distros/melodic/cob-omni-drive-controller/default.nix
@@ -2,24 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, message-generation, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, sensor-msgs, std-msgs, std-srvs, tf, tf2, urdf }:
 buildRosPackage {
   pname = "ros-melodic-cob-omni-drive-controller";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_omni_drive_controller/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "ee36867f9fc83fb99b6627e49fc510c211f69b8abee2b4868261d3b41de83ec1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_omni_drive_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "f4141c530fb4aa129b56117cf4665d8d24478104de56551a1f5b4b0adeb6c5a1";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
   propagatedBuildInputs = [ angles boost cob-base-controller-utils controller-interface dynamic-reconfigure geometry-msgs hardware-interface nav-msgs pluginlib realtime-tools roscpp sensor-msgs std-msgs std-srvs tf tf2 urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_omni_drive_controller package'';
+    description = ''The cob_omni_drive_controller package provides a ros_controller plugin for the Care-O-bot omni-directional base platform.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-perception-common/default.nix
+++ b/distros/melodic/cob-perception-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-3d-mapping-msgs, cob-cam3d-throttle, cob-image-flip, cob-object-detection-msgs, cob-object-detection-visualizer, cob-perception-msgs, cob-vision-utils }:
 buildRosPackage {
   pname = "ros-melodic-cob-perception-common";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_perception_common/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "97bfc63a8a31d06503529bb80f7aa1c04f59b2872541c970c21a9e8a8677f11c";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_perception_common/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "04403c8155733ee09b9b684ee03c35ce0206103616fd92068626fa7c435ce9d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-perception-msgs/default.nix
+++ b/distros/melodic/cob-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-perception-msgs";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_perception_msgs/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "f0c8e8e7dc0f98f089f97101695d493772a9996b037b1f59e4c3e553a50d6ae1";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_perception_msgs/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "1208d6a78743452ad56cd57355dcb47ce93e266ba0eaa8f8ea1cb58f6cfa69d7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-reflector-referencing/default.nix
+++ b/distros/melodic/cob-reflector-referencing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-reflector-referencing";
-  version = "0.6.8-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_reflector_referencing/0.6.8-1.tar.gz";
-    name = "0.6.8-1.tar.gz";
-    sha256 = "f6fd5812a4814bf65b6281e10f2c1af67c42c1404dede7bdec68a9f7a62924ba";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_reflector_referencing/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "140585c4be261ea1aff6d9cf607ce3d6e31f2d168c21cda87daedbdea1b543c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-safety-controller/default.nix
+++ b/distros/melodic/cob-safety-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-safety-controller";
-  version = "0.6.8-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_safety_controller/0.6.8-1.tar.gz";
-    name = "0.6.8-1.tar.gz";
-    sha256 = "fcb88a994fea2fef7b5606e83f114abf435b37e45919a8d18a684a267b6fa685";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_safety_controller/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "411e9149ab894d95a59f321b5dfbc7f9810bb9b863459b98eae62b0ab5cea84f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-script-server/default.nix
+++ b/distros/melodic/cob-script-server/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, pythonPackages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-melodic-cob-script-server";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_script_server/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "0fd4ca6b6036b377bf01c359af44641436d6d1a37801f28662519031b2f0b8e4";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_script_server/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "539e3d72ea0a33a54f77854b6c8741de24cb8b89f12231a461a7e1ee8f37cb7f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cob-actions cob-light cob-mimic cob-sound control-msgs geometry-msgs message-runtime move-base-msgs pythonPackages.ipython pythonPackages.pygraphviz rospy rostest std-msgs std-srvs tf trajectory-msgs urdfdom-py ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cob-actions cob-light cob-mimic cob-sound control-msgs geometry-msgs message-runtime move-base-msgs pythonPackages.ipython pythonPackages.pygraphviz pythonPackages.six rospy rostest std-msgs std-srvs tf trajectory-msgs urdfdom-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-srvs/default.nix
+++ b/distros/melodic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-cob-srvs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_srvs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "9d921f5eaef707c1c9e09e5d80b3951f408bf5d57c448310372e8bb24f849f3c";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_srvs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "602cfa83943a258e384ac3d9a2e02628ee57ed80c5e614c11c9943bea66f6896";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-substitute/default.nix
+++ b/distros/melodic/cob-substitute/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-docker-control, cob-reflector-referencing, cob-safety-controller }:
 buildRosPackage {
   pname = "ros-melodic-cob-substitute";
-  version = "0.6.8-r1";
+  version = "0.6.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_substitute/0.6.8-1.tar.gz";
-    name = "0.6.8-1.tar.gz";
-    sha256 = "39faebf1b1bfabbbe07bbf0054a4417bde87fbd0f8331df06e2a16783a6d50c5";
+    url = "https://github.com/ipa320/cob_substitute-release/archive/release/melodic/cob_substitute/0.6.9-1.tar.gz";
+    name = "0.6.9-1.tar.gz";
+    sha256 = "fdefa29b8dff0b7d7c6649d2501d359f4fa28bb85557685137d918f59631dbab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-supported-robots/default.nix
+++ b/distros/melodic/cob-supported-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-supported-robots";
-  version = "0.6.13-r1";
+  version = "0.6.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/melodic/cob_supported_robots/0.6.13-1.tar.gz";
-    name = "0.6.13-1.tar.gz";
-    sha256 = "32e121b69c9c52d7e09fc882bc115ee2c05e0350da0c8dd5df73450df241ea96";
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/melodic/cob_supported_robots/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "c5fcee979f72ca6a7399db095ed527f9c90745cb670b78130e3d8ec06e2f084e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-teleop/default.nix
+++ b/distros/melodic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cob-teleop";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_teleop/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "47c3e837841c74f8c931e2ec96410a6fb3a0e4233a1028570b0401a27d59d598";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/cob_teleop/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "6d732c435142eeacd23a80acd230566100acddc4d063b23ed6a9e1f751340b8e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-trajectory-controller/default.nix
+++ b/distros/melodic/cob-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-srvs, control-msgs, dynamic-reconfigure, roscpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-trajectory-controller";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_trajectory_controller/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "49589031541a9e8feaf550fe37dbd9305b1c9d6c7a103639067266d6ac4e202b";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_trajectory_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "42e4f9f21398b1ee3d044363b2e02fcba4209c372bc018fc6794cba427ac6c13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-tricycle-controller/default.nix
+++ b/distros/melodic/cob-tricycle-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cob-base-controller-utils, controller-interface, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-cob-tricycle-controller";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_tricycle_controller/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "27c1c03e70d7b4ef6981c4546eb50354cf1daedb705da774c3e85ea2dafa43eb";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_tricycle_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "27370d65c606f8e2d18c4b8d45dd0b2643d36951a67b1f64e75bd3c9008d2939";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The cob_tricycle_controller package'';
+    description = ''The cob_omni_drive_controller package provides a ros_controller plugin for the Care-O-bot tricycle base platform.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/cob-twist-controller/default.nix
+++ b/distros/melodic/cob-twist-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cob-control-msgs, cob-frame-tracker, cob-script-server, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, geometry-msgs, kdl-conversions, kdl-parser, nav-msgs, orocos-kdl, pluginlib, pythonPackages, robot-state-publisher, roscpp, roslint, rospy, rviz, sensor-msgs, std-msgs, tf, tf-conversions, topic-tools, trajectory-msgs, urdf, visualization-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cob-twist-controller";
-  version = "0.8.1-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_twist_controller/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "a36acbaa6a924ea2a8987a59b4408f345a13373653e62ac4bcc0f011cdcb4fc1";
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_twist_controller/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "b985dab97a8feece57648a23bd2aec3f9ac25857894cd7b078fbd063a7d7e53d";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  propagatedBuildInputs = [ boost cmake-modules cob-control-msgs cob-frame-tracker cob-srvs dynamic-reconfigure eigen eigen-conversions geometry-msgs kdl-conversions kdl-parser nav-msgs orocos-kdl pluginlib robot-state-publisher roscpp rospy rviz sensor-msgs std-msgs tf tf-conversions topic-tools trajectory-msgs urdf visualization-msgs xacro ];
+  propagatedBuildInputs = [ boost cmake-modules cob-control-msgs cob-frame-tracker cob-script-server cob-srvs dynamic-reconfigure eigen eigen-conversions geometry-msgs kdl-conversions kdl-parser nav-msgs orocos-kdl pluginlib pythonPackages.matplotlib pythonPackages.six robot-state-publisher roscpp rospy rviz sensor-msgs std-msgs tf tf-conversions topic-tools trajectory-msgs urdf visualization-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/cob-vision-utils/default.nix
+++ b/distros/melodic/cob-vision-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, opencv3, roscpp, tinyxml, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-vision-utils";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_vision_utils/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "0894dd4b7fc497310d4c8236696415b60d40314380217ee024058833f1944fa4";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/cob_vision_utils/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "75226313152a19e399106ed4ac5ecb3a8e19dc8113ef2cce09ead98a1bded930";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-2d/default.nix
+++ b/distros/melodic/costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, map-server, message-filters, message-generation, message-runtime, nav-msgs, pluginlib, rosbag, rosconsole, roscpp, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-melodic-costmap-2d";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/costmap_2d/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "4b87108cf46851e93561aa4a3a657c87cfeb84af35d4e9ad44dd2e4158460d89";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/costmap_2d/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "083ee3e6069b58ef74ae9fb032da9c0f63117bc67561d8884c07e3946533641a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "64e29a50f1836ecde1f862da091885dc79aa30303c9707bbd0164e7d1309de5c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "05393e2df40afb4b6180f5f825867c00ad36a8989556f88db7f02ebc507b91c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dccomms-ros-msgs/default.nix
+++ b/distros/melodic/dccomms-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dccomms-ros-msgs";
-  version = "0.0.2-r3";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/dcentelles/dccomms_ros_pkgs-release/archive/release/melodic/dccomms_ros_msgs/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "2ab6fd1788d1f12507f2da9ee2ef3e1c267b7651ee86541fc89d56b09b08980a";
+    url = "https://github.com/dcentelles/dccomms_ros_pkgs-release/archive/release/melodic/dccomms_ros_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "cc0b887b4b28a595f9cb549d74fc086b39221414e63d65c3976573a14ae7aef2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dccomms-ros/default.nix
+++ b/distros/melodic/dccomms-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dccomms-ros-msgs, git, message-generation, message-runtime, roscpp, rospy, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-dccomms-ros";
-  version = "0.0.2-r3";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/dcentelles/dccomms_ros_pkgs-release/archive/release/melodic/dccomms_ros/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "21186c2bbba1b93a960a28d092b9f9cf3a0a678bffde2fa2c673ed1b51fd1ff1";
+    url = "https://github.com/dcentelles/dccomms_ros_pkgs-release/archive/release/melodic/dccomms_ros/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "9c82b3dcef96d0211f6267f3c6f9bdc87c0d127a2607240f102c17cd65f5a010";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dwa-local-planner/default.nix
+++ b/distros/melodic/dwa-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, eigen, nav-core, nav-msgs, pluginlib, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-dwa-local-planner";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/dwa_local_planner/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "7ca61eac531ed242b94ffa002ded99686091776c363c27187e9b7e1531b3d4ea";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/dwa_local_planner/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "0b81ca30ea8bfd54a76ec7f5d8a0538cd6681f15f89e319f28c98d74e64ce827";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-reconfigure/default.nix
+++ b/distros/melodic/dynamic-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, roscpp, roscpp-serialization, roslib, rospy, rosservice, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-reconfigure";
-  version = "1.6.1-r1";
+  version = "1.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/melodic/dynamic_reconfigure/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "3c95ad978ea8c1aa62ebecba8eb2ec65581bad745eca98aa0142cc070c54d6d6";
+    url = "https://github.com/ros-gbp/dynamic_reconfigure-release/archive/release/melodic/dynamic_reconfigure/1.6.3-1.tar.gz";
+    name = "1.6.3-1.tar.gz";
+    sha256 = "8113045db4c6471f5cb6bdd00ec27b5c5ffb2572247377f106a0f2e9a0b62fc2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fake-localization/default.nix
+++ b/distros/melodic/fake-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, message-filters, nav-msgs, rosconsole, roscpp, rospy, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-fake-localization";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/fake_localization/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "d5ce67bdb141caa1e0477419d3ebd806c685f9c3f950532b88e00b5387ef4bd3";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/fake_localization/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "1679a2887da35c86356729c40c4a9d5e138468d0b4a4adb2f683b6b0bd4cc9f2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -368,6 +368,8 @@ self: super: {
 
  cob-mapping-slam = self.callPackage ./cob-mapping-slam {};
 
+ cob-mecanum-controller = self.callPackage ./cob-mecanum-controller {};
+
  cob-mimic = self.callPackage ./cob-mimic {};
 
  cob-model-identifier = self.callPackage ./cob-model-identifier {};
@@ -1277,6 +1279,8 @@ self: super: {
  jackal-viz = self.callPackage ./jackal-viz {};
 
  jderobot-assets = self.callPackage ./jderobot-assets {};
+
+ jderobot-camviz = self.callPackage ./jderobot-camviz {};
 
  jderobot-color-tuner = self.callPackage ./jderobot-color-tuner {};
 
@@ -2895,6 +2899,8 @@ self: super: {
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
+
+ scenario-test-tools = self.callPackage ./scenario-test-tools {};
 
  scheduler-msgs = self.callPackage ./scheduler-msgs {};
 

--- a/distros/melodic/generic-throttle/default.nix
+++ b/distros/melodic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-generic-throttle";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/generic_throttle/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "8f7eb12d899b0852220f99dc0d0271979c3f357b9619d3bf9f80d80e36cad91d";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/generic_throttle/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "4f83ae889cde213636d3036fbf0185ce7c2856a4e229efdde1b3a0c2ef69f94e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/global-planner/default.nix
+++ b/distros/melodic/global-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-global-planner";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/global_planner/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "82880b6eec784f800278406caa3cad623752012c411667bdcf7df3600dffc4d4";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/global_planner/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "1d3716a22c0885ab9790bfb37a5c9bb3d5b32ce2a7bb2d1035210bab21a2d67d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gmapping/default.nix
+++ b/distros/melodic/gmapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nav-msgs, nodelet, openslam-gmapping, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-melodic-gmapping";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/slam_gmapping-release/archive/release/melodic/gmapping/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "0cb572f0b00c39ecc0989a195f137172cf6a3481a176bb829484d6d731a00ea1";
+    url = "https://github.com/ros-gbp/slam_gmapping-release/archive/release/melodic/gmapping/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "2296a00ee0763992b9b67cff969f3e7c8021e14df878d351406104a4c321e4af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ipa-3d-fov-visualization/default.nix
+++ b/distros/melodic/ipa-3d-fov-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ipa-3d-fov-visualization";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/ipa_3d_fov_visualization/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "3292a38aa2ff33ae3f094e672e3e7f74e919f0dcba2b05f3bda5530b8cb557d9";
+    url = "https://github.com/ipa320/cob_perception_common-release/archive/release/melodic/ipa_3d_fov_visualization/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "c2c16ed332dc5ab010e04b3aad8f9dc46805d1ca1c777ce7c8b01483b95c13b0";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The ipa_3d_fov_visualization package'';
+    description = ''The ipa_3d_fov_visualization package allows to visualize the field-of-view of a camera.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/melodic/ipr-extern/default.nix
+++ b/distros/melodic/ipr-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libmodbus, libreflexxestype2, ros-reflexxes }:
 buildRosPackage {
   pname = "ros-melodic-ipr-extern";
-  version = "0.9.0-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ipr_extern/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e3884879277729178b8a6de7ff1de7916eaec4f6489a1adbad72568bce0de1fb";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ipr_extern/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "a117475704fac421bb5f283eb775ab4339944f6ea148c2c996c0fb7642bb0fe8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-camviz/default.nix
+++ b/distros/melodic/jderobot-camviz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cv-bridge, diagnostic-msgs, image-transport, pkg-config, python3Packages, roscpp, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-jderobot-camviz";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/CamViz-release/archive/release/melodic/jderobot_camviz/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "ccd4116e49d5abb982a9ccc79b6aca866891d6b56475b966416f1a1792ad918f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pkg-config ];
+  checkInputs = [ diagnostic-msgs ];
+  propagatedBuildInputs = [ cv-bridge image-transport python3Packages.pyyaml roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''camViz package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/joint-state-publisher-gui/default.nix
+++ b/distros/melodic/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, python-qt-binding, rospy }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-publisher-gui";
-  version = "1.12.14-r1";
+  version = "1.12.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher_gui/1.12.14-1.tar.gz";
-    name = "1.12.14-1.tar.gz";
-    sha256 = "702d43d0986b4f6dca2ada79959c1781854bbba5935bc188c3fb581e3c0c210e";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher_gui/1.12.15-1.tar.gz";
+    name = "1.12.15-1.tar.gz";
+    sha256 = "f728911eb7f886ce99289fc18cd27528c91cb630c84a29d76d406f970ed775b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-state-publisher/default.nix
+++ b/distros/melodic/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-publisher";
-  version = "1.12.14-r1";
+  version = "1.12.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher/1.12.14-1.tar.gz";
-    name = "1.12.14-1.tar.gz";
-    sha256 = "b2c30af5afd1e6796feb427ae60526e4485a3dfc565502814bed9bdf73a71e14";
+    url = "https://github.com/ros-gbp/joint_state_publisher-release/archive/release/melodic/joint_state_publisher/1.12.15-1.tar.gz";
+    name = "1.12.15-1.tar.gz";
+    sha256 = "623eb3bb3613bfd2a6b61ab1a631e6927450b41ef2a4871b044925b7c60aeaf3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "c16c7323d543de65aebd0eb183f5d577d566d9c8398122e8f17ce4342f6c5a06";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "7ac345926b70e2c189d79685bd735e45ff368a7ccbe0072a20b6171ddc255077";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libdlib/default.nix
+++ b/distros/melodic/libdlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libdlib";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libdlib/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "59af6be6eb20b19841039979092d1c0d586b455712a87b42c92ed75d7ce1506a";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libdlib/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "dd89ad44c6a58bcff0d2469e2f47df90728e2840b19ca036256c1fdb02841162";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmodbus/default.nix
+++ b/distros/melodic/libmodbus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules }:
 buildRosPackage {
   pname = "ros-melodic-libmodbus";
-  version = "0.9.0-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libmodbus/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "383dfdd6819424090d457f987f790dfb026cdfe768ab5e00dd7d5fb2e602312d";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libmodbus/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "f5b0b1453abb1f1950ad1ca3378b061979259515d0d5bdc5958dd46a5c6b3c36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libntcan/default.nix
+++ b/distros/melodic/libntcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dpkg }:
 buildRosPackage {
   pname = "ros-melodic-libntcan";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libntcan/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "e63d1f84157dca1b139c3a8746f4712b02b869b207f04bf7be7500bb9779058c";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libntcan/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "c0ded6c692f2ad8240eedcdf1ba1fb36c53ff9ce0b43e79455127cd0a048170e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libpcan/default.nix
+++ b/distros/melodic/libpcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libpcan";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libpcan/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "261e7b4b413a23796bb4eec4744829006cfa89c83ec9ef0804091576a87f136c";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libpcan/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "54c1838f0cc34f94a2d65b6c18433baf7e2182834d375b070162d93a15ab3709";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libphidgets/default.nix
+++ b/distros/melodic/libphidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb }:
 buildRosPackage {
   pname = "ros-melodic-libphidgets";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libphidgets/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "a34ac46d7679c615ab632f4c7d59472db4794c323677ca94ac4d335527a82d62";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libphidgets/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "ce2b730fbc5ff5c07f1bacc3c957ff3d9c5d1867fb27ae08cca4b8f8c7a95d22";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libreflexxestype2/default.nix
+++ b/distros/melodic/libreflexxestype2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libreflexxestype2";
-  version = "0.9.0-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libreflexxestype2/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "feda77d853652f9dff5e1e0e2df972c45916ade312570696cf789d1c6ec02a6c";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/libreflexxestype2/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "ff69ec96c35d48bc4b768dc25812ea2dbece052f25a8d3de96f5460296eb0ccf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "71f30eef728e13157e0d7806eb2a976a31d97a8a43be503b73a62fcafdb4983e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "02cb69d62e889d0be678acb004e410f495981da1ae4d7d226a7357ff562d8c12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-server/default.nix
+++ b/distros/melodic/map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL, SDL_image, bullet, catkin, libyamlcpp, nav-msgs, roscpp, rospy, rostest, rosunit, tf2 }:
 buildRosPackage {
   pname = "ros-melodic-map-server";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/map_server/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "14b8e2d84c29498d56176af12b405792f0900a434fcd8d2152ec903729976cb7";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/map_server/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "d43cb497847c144cf794e82f096bb1dad4f858c8752d0325278f31fd0a861548";
   };
 
   buildType = "catkin";

--- a/distros/melodic/message-filters/default.nix
+++ b/distros/melodic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-message-filters";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "6fe27c6275e968e86f0d7301933b6667e2e1d83fc8bf122b81960cf7e1b1058e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "5a24340fa66ecbd6a7d2ad52274499592f6dee34605ea173f2f0017688a3e9ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base/default.nix
+++ b/distros/melodic/move-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, base-local-planner, catkin, clear-costmap-recovery, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-core, nav-msgs, navfn, pluginlib, roscpp, rospy, rotate-recovery, std-srvs, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-move-base";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/move_base/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "bcbd72e91c8fa918793de71abd05348116a0971f835b5878ca1becb6634f791c";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/move_base/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "bcbf22ee17a865bbed322c6849a243f02460468cdbbfc99434b13dac3bee5584";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-slow-and-clear/default.nix
+++ b/distros/melodic/move-slow-and-clear/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, nav-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-move-slow-and-clear";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/move_slow_and_clear/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "c7d3b70b5e4b7819281982f5002090f2d8c3910079c32c23d8ab52faa31c8596";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/move_slow_and_clear/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "729fb7ba60cc55cdb265843e46d3d821ef9a3f74290051df79b0dbffcdf44ecc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nav-core/default.nix
+++ b/distros/melodic/nav-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-nav-core";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/nav_core/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "e8d636295cb999749982295ead8e6a6031fc634d23b0bb8a1c7dd347606031b3";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/nav_core/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "a493713c58e0767d192b5a2b50d73319d7bf2a314dc7043c0e67ddfd382446ca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/navfn/default.nix
+++ b/distros/melodic/navfn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, geometry-msgs, message-generation, message-runtime, nav-core, nav-msgs, netpbm, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-navfn";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/navfn/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "8ca907d6880447afde6555eb906b0b2c2d99b97ca3460a945b71e642b0e2ea0c";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/navfn/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "624d80b13e17898bfff8ca0e9776fa8f0ebe0fd80d9f4040667e944d60fd62b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/navigation/default.nix
+++ b/distros/melodic/navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, carrot-planner, catkin, clear-costmap-recovery, costmap-2d, dwa-local-planner, fake-localization, global-planner, map-server, move-base, move-base-msgs, move-slow-and-clear, nav-core, navfn, rotate-recovery, voxel-grid }:
 buildRosPackage {
   pname = "ros-melodic-navigation";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/navigation/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "dd0a7c55c307fece0764881bbaed395e1a6052bf680ed13a2d918c6c02d1f72c";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/navigation/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "bd70248d618e9918e3235ecbd1547ed79f446f8ff2787d1ccb3ce6798472dbcc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7a8736cd6b9933009a4533fdd9c05eaf5bd3073e809ae8f97c5fa0eaff094aae";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "1c7ab0fba0704015d3dff8b70bf4dc16cd005779e92a33c73e9a6a179338e05a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "596ebba0fadf9936a1287bf902b904c175b9f64978c0edfc5b26054e745a1b3a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "51ac695f182be32cf0b27cf3e29e3d4217fa4cc9a3311111d6b73331f96341f3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "f364d5582a5286313f38881662ddc457c19e909deedb75c02e48be93c5737e13";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "263d5a033046ce2a3098d8210fab91070187862b13d40a235dca2e31f0226fcc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "f5bcdea0f80f8cdb26b51c74f75db2050ef83310361df7d8e39082d8b1351838";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "24f41121d3fbe15f65b02cca7fc395b45a4201c3bbacc58105e617c81c3f37e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opengm/default.nix
+++ b/distros/melodic/opengm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-opengm";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/opengm/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "9fb81f609d688597d62a6c37ee622271598c08d258b3c4cc97fbcf7fb83f6242";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/opengm/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "415765b68cc4a5d744bd6488e4eecd71d72fcfd2de9b20f36c308336a02c3bca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ea707cf2b37bc807b9a78091fd894ef95ef7df88f9b42aae854b2bdd45995ed4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b572a39b688ff1d73c95935ebd979190e1ce6a40b0160935a4bccc80c239ab6c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/raw-description/default.nix
+++ b/distros/melodic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-raw-description";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/raw_description/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "289f14730e2ab175508fa0268b95b411e8dcd30e090f825b586e611aeb43c90c";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/raw_description/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "5d2a5d6f22934576c575d09942d4e96c51c0948fce7693c1d694da89d476d497";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-comm/default.nix
+++ b/distros/melodic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-ros-comm";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "0cc2b02139a75e3c75e8e2a9df4b27742e4cc9e64ff80148621b6dff7786bef3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "fb2171682f4d084f3c8bf122be93decb5729eee0f9c145cfd3c7b3404ec8a416";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-reflexxes/default.nix
+++ b/distros/melodic/ros-reflexxes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, pluginlib, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, libreflexxestype2, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-ros-reflexxes";
-  version = "0.9.0-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ros_reflexxes/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "c06bc668e6c5108f1b2bfb8b0422144ba633892237ed063350579b25b53d3e72";
+    url = "https://github.com/KITrobotics/ipr_extern-release/archive/release/melodic/ros_reflexxes/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "76626c036fcf97fd86efb214887ddffe715d343b660a6117eddd0f833ef11fda";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ libreflexxestype2 pluginlib roscpp ];
+  propagatedBuildInputs = [ libreflexxestype2 roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbag-storage/default.nix
+++ b/distros/melodic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-storage";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "156f2616e58d3c1b67926880965b651ac469c5a9677cb8947841e1d1f085350e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "e64d43dd0f9f4e2fab0d6eb6df1cd4b6dedec6bf934063474b8b9d64579e6410";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag/default.nix
+++ b/distros/melodic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "bdb1c2e5434908ae0ddd4b7ccac15d692d567ca089b024f3e817fb50d1a5d788";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "642cb2b16b92366f8deaad9ec65d148e29f4ca550194fc2010a49670925610d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roscpp/default.nix
+++ b/distros/melodic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-roscpp";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "11553612eb3fad80b82648d4b7ddadc37fdf020dbb6ac5bad26c2e51cc9272da";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "cfd1297d7d46a60b5ff0620808294b408e44441499237ad80388d2dce0976004";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosgraph/default.nix
+++ b/distros/melodic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosgraph";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "a6114c91030f00fbe820116eeebcee9da63c8eba5e9ece92b2ef47d6ebfe9dc0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "13f5d55c64d54e8684ac8a82b4b7c8df84520dde89b145afe785639b6e867fd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslaunch/default.nix
+++ b/distros/melodic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslaunch";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "704271921eccee832dade4fdf745f3dc711a38780a49e7a5a111f73fc016fc50";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "98c1723ad727bee6e0cde2290683a4242f47a12b779a19772280660979051d71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslz4/default.nix
+++ b/distros/melodic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslz4";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "1129ea680ea8135a32455736ed48f5659110e94cb1c6b1303b771c65baeb7963";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "c4641789f93152d33263e333988001e8f6e49327870c42c57540391e524d818b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmaster/default.nix
+++ b/distros/melodic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosmaster";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "c806ff1dd463b78c8d0ca33b565e2ea5f9a91dfa3c71797946d36e33f9702ece";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "7866b79124969719d512b3ef46d2e2b795542a477a056f04607a8881a746135e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmsg/default.nix
+++ b/distros/melodic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosmsg";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "c689588adce5b0a32480530998def90c1467bdce019c88ca6b5f8ef0ab9b5bca";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "d039d629202ea7100ef81533bb6787b45debc529f103cefa23fe88f625c31b49";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosnode/default.nix
+++ b/distros/melodic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-rosnode";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "5bf1275a9569bdc2831ce1cfec25578ae8ac15fa19e312e77336c6d2084676ef";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "0ff95b420d2206c246092bf9f776a3cf02e3b91c29bd77d44ea0bf5297e20240";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosout/default.nix
+++ b/distros/melodic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosout";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "798e3dbfec8d074158bc178e527234ac2f8caa21524f6c7ed25670d0a514a44a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "364440c03fbc6835577b9dc710a7e9eacd246bc11424ecbe75ac2d8c8db605e5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosparam/default.nix
+++ b/distros/melodic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosparam";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "4a7a3c6e99330b00ac2de5d0554bbef8f9b340bce1bb7c2ffb803a19706c3890";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "7bfa5fb9c39c0d3a627bfdfa683ddd3b2b1dbc400adec23b791e2e427e2109ed";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy/default.nix
+++ b/distros/melodic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospy";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "e0bf020cc8a6e4e55c9fb5cd0f427d9d89800ebb8129e0e30831c6452eb80f12";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "1d4ffc44a7a048e2df92a40675a89ec597c5d98c6d4f5ddb34763f0bdd8953c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosservice/default.nix
+++ b/distros/melodic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosservice";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "8e0d4bf832cb7b84ae91250b5263cfe097aa6593ccf5b44e6dfd84dc2c156afd";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "bab389b8331b0f16d55658660750f53f1d9657b0b76384e5ee5531fc086fc64b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostest/default.nix
+++ b/distros/melodic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-rostest";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "abccd164444500f0e4a0ef53767eb61f7dd783aa475a4e5c3878f4bd09d41651";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "923c0eac3a633ea26435c69044cf52e25aca4ce5eb559e43bf98b6eeb51c10e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostopic/default.nix
+++ b/distros/melodic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rostopic";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "5cfecd95805dff36f19e3b24d6be14066744501aca3c6cdd8f20105443015095";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "671feff9f65d4ef61ee1508805c1defba40223b28bdcfd6329d95ecaf025802e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswtf/default.nix
+++ b/distros/melodic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-roswtf";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "2c98c830dfb6871c3d45a54af5534290089c256151f68fc3df73d111851b55ff";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "4e84d669372890c3dad667d66eae1ceb594c0e02f1d21e7d2a0fabb4b4e8e2f5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rotate-recovery/default.nix
+++ b/distros/melodic/rotate-recovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, cmake-modules, costmap-2d, eigen, geometry-msgs, nav-core, pluginlib, roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rotate-recovery";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/rotate_recovery/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "c3ebcc10979748845b2040068e39e88066c03f86aaab42ba9cd7112d1c4b2c03";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/rotate_recovery/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "7d71affe33fe0698ca2ef2eac6b7184ae1444df0f691a45613b274a20be04df6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "5fdef3a8da0aedc459520cb4ae07fcdcc753d16ac5e05ccda8213c6421090d89";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "e2542386d58be3497b222c7a5d7537c3f5aec1af9eedba829dd3fd4265900cd1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/scenario-test-tools/default.nix
+++ b/distros/melodic/scenario-test-tools/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, rospy, std-msgs, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-scenario-test-tools";
+  version = "0.6.16-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/scenario_test_tools/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "f73d377c1ade62aa94ee9400c06e47be112b5dea2b7a57c825dfe9b032656cc9";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ cob-sound cob-srvs control-msgs geometry-msgs ];
+  propagatedBuildInputs = [ actionlib move-base-msgs rospy std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The scenario_test_tools package implements helpers for scriptable scenario testing.
+    It allows to set up a test harness for eg. a state machine or other high level behavior by
+    providing mocked implementations for various action servers and services that work together'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/service-tools/default.nix
+++ b/distros/melodic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-melodic-service-tools";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/service_tools/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "60e10e9daee6608854f266791367db4dc6d651946043ccd4cd9753629625498a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/melodic/service_tools/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "8a24fdde35fc9a6236aea1d848f015240e1fe4d077fa55bf1903c917832ccd0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slam-gmapping/default.nix
+++ b/distros/melodic/slam-gmapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gmapping, openslam-gmapping }:
 buildRosPackage {
   pname = "ros-melodic-slam-gmapping";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/slam_gmapping-release/archive/release/melodic/slam_gmapping/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "4adbd05d0930a653589ec957ec87bc93075f2372e08fc8c4b2514b88423fad0b";
+    url = "https://github.com/ros-gbp/slam_gmapping-release/archive/release/melodic/slam_gmapping/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "8ed5a534e68076a909ce36d5ba2f351e362738ab42d433e00a4ac8ffc1aaadb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/topic-tools/default.nix
+++ b/distros/melodic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-topic-tools";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "a58944808a07e43acbfdfe7817719e0654621fd6c699fefdb71e0689755dbfb7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "bc58ba5173aed4ee21f8a6524a642d2415d6360585f631b224273d0b5feeb249";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "91bc3c09f098981e1d88e3b651e4c033f3848808f903cdcf64b765cbfa49fbd1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "1427c71488c9b2c3e551d4be5fba19c15ef435c55e9d26272f056960de6ae666";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "91002f95b1ba6661bb8a334b15cf085acfc3fdc58e2e9839e383108c99d302cd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "489d14419dee6bdeda50420797e9d2e2868699c786ab2c442839fef426845040";
   };
 
   buildType = "catkin";

--- a/distros/melodic/underwater-sensor-msgs/default.nix
+++ b/distros/melodic/underwater-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-underwater-sensor-msgs";
-  version = "1.4.2-r1";
+  version = "1.4.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/underwater_sensor_msgs/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "6f513f997476171784008d90480f099e9e8cdca04601f4f4cac841de53d56709";
+    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/underwater_sensor_msgs/1.4.2-2.tar.gz";
+    name = "1.4.2-2.tar.gz";
+    sha256 = "a8e03f363c895d4cc1a498af6c461b9258af25b757e6352d38b5f2714614600d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/underwater-vehicle-dynamics/default.nix
+++ b/distros/melodic/underwater-vehicle-dynamics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, rospy, sensor-msgs, std-msgs, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-underwater-vehicle-dynamics";
-  version = "1.4.2-r1";
+  version = "1.4.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/underwater_vehicle_dynamics/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "f71af4d9080f1ff8f59de9f1195263f67c9087db6a39cd02c569c9e76621d3fe";
+    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/underwater_vehicle_dynamics/1.4.2-2.tar.gz";
+    name = "1.4.2-2.tar.gz";
+    sha256 = "5c5e774b45272b8d9cc3f73c652311e4e2325172c86bb10c3533b9abaa5c1d18";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-node/default.nix
+++ b/distros/melodic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-melodic-urg-node";
-  version = "0.1.11";
+  version = "0.1.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.11-0.tar.gz";
-    name = "0.1.11-0.tar.gz";
-    sha256 = "86fec955adf084d6ebdf11e8a17ecb03586afcfab3b15329e02535a773dc7a4d";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "788bc2f2c97a4ec356e4080f7b42ac732c6a38d00146f7afa1fb2d6f586559c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uwsim/default.nix
+++ b/distros/melodic/uwsim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dccomms-ros, fftw, fftwSinglePrec, geographiclib, geometry-msgs, image-transport, interactive-markers, kdl-parser, libGL, libGLU, libxmlxx, muparser, nav-msgs, openscenegraph, osg-interactive-markers, osg-markers, osg-utils, pcl-ros, pluginlib, resource-retriever, robot-state-publisher, roscpp, sensor-msgs, tf, underwater-sensor-msgs, urdf, uwsim-bullet, uwsim-osgbullet, uwsim-osgocean, uwsim-osgworks, xacro }:
 buildRosPackage {
   pname = "ros-melodic-uwsim";
-  version = "1.4.2-r1";
+  version = "1.4.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/uwsim/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "b10919106f1185052b450d190c70df712898a2d6902d3fe0d74e34a8e0065019";
+    url = "https://github.com/uji-ros-pkg/underwater_simulation-release/archive/release/melodic/uwsim/1.4.2-2.tar.gz";
+    name = "1.4.2-2.tar.gz";
+    sha256 = "92afdf72aa7141f92f121e15c367606f35a72dce8ed3382aed7b11e4183c598a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/voxel-grid/default.nix
+++ b/distros/melodic/voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-voxel-grid";
-  version = "1.16.4-r1";
+  version = "1.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/voxel_grid/1.16.4-1.tar.gz";
-    name = "1.16.4-1.tar.gz";
-    sha256 = "fc8932c039bd8e1f25461510504ae536da91256634d0b3bd31881dca0aa9afdc";
+    url = "https://github.com/ros-gbp/navigation-release/archive/release/melodic/voxel_grid/1.16.5-1.tar.gz";
+    name = "1.16.5-1.tar.gz";
+    sha256 = "6dcf7076c4175966170938ecf8bf1c1650c8ce95d897aa9a9255ea5aa7c354aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xmlrpcpp/default.nix
+++ b/distros/melodic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-melodic-xmlrpcpp";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "c85ab2f81e3aad59df291da99b9618ae7908e132a42c8c019496786119bf8fe2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "b766cdf6c839a83ecd29b87eaf615dae5e6f482d23c1b05615b99a3c4300ca00";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 4cd892656ce41cb7baa14a795930c21e8200ae78.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *class-loader 1.3.2-r1 --> 1.3.3-r1*
* *launch-ros 0.8.7-r1 --> 0.8.8-r1*
* *launch-testing-ros 0.8.7-r1 --> 0.8.8-r1*
* *osrf-testing-tools-cpp 1.2.1-r1 --> 1.2.2-r1*
* *rmw-fastrtps-cpp 0.7.6-r1 --> 0.7.7-r1*
* *rmw-fastrtps-dynamic-cpp 0.7.6-r1 --> 0.7.7-r1*
* *rmw-fastrtps-shared-cpp 0.7.6-r1 --> 0.7.7-r1*
* *ros1-bridge 0.7.4-r1 --> 0.7.5-r1*
* *ros2action 0.7.9-r1 --> 0.7.10-r1*
* *ros2cli 0.7.9-r1 --> 0.7.10-r1*
* *ros2component 0.7.9-r1 --> 0.7.10-r1*
* *ros2launch 0.8.7-r1 --> 0.8.8-r1*
* *ros2lifecycle 0.7.9-r1 --> 0.7.10-r1*
* *ros2msg 0.7.9-r1 --> 0.7.10-r1*
* *ros2multicast 0.7.9-r1 --> 0.7.10-r1*
* *ros2node 0.7.9-r1 --> 0.7.10-r1*
* *ros2param 0.7.9-r1 --> 0.7.10-r1*
* *ros2pkg 0.7.9-r1 --> 0.7.10-r1*
* *ros2run 0.7.9-r1 --> 0.7.10-r1*
* *ros2service 0.7.9-r1 --> 0.7.10-r1*
* *ros2srv 0.7.9-r1 --> 0.7.10-r1*
* *ros2topic 0.7.9-r1 --> 0.7.10-r1*
* *rosidl-adapter 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-cmake 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-generator-c 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-generator-cpp 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-parser 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-typesupport-interface 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-typesupport-introspection-c 0.7.8-r1 --> 0.7.9-r1*
* *rosidl-typesupport-introspection-cpp 0.7.8-r1 --> 0.7.9-r1*
* *test-osrf-testing-tools-cpp 1.2.1-r1 --> 1.2.2-r1*

Eloquent Changes:
-----------------
* *urg-node-msgs 1.0.0-r1*

Kinetic Changes:
----------------
* *async-comm 0.1.1 --> 0.2.0-r1*
* *costmap-cspace 0.8.0-r1 --> 0.8.1-r1*
* *ipr-extern 0.9.0-r1 --> 0.8.8*
* *joystick-interrupt 0.8.0-r1 --> 0.8.1-r1*
* *libmodbus 0.9.0-r1 --> 0.8.8*
* *libreflexxestype2 0.9.0-r1 --> 0.8.8*
* *map-organizer 0.8.0-r1 --> 0.8.1-r1*
* *neonavigation 0.8.0-r1 --> 0.8.1-r1*
* *neonavigation-common 0.8.0-r1 --> 0.8.1-r1*
* *neonavigation-launch 0.8.0-r1 --> 0.8.1-r1*
* *obj-to-pointcloud 0.8.0-r1 --> 0.8.1-r1*
* *planner-cspace 0.8.0-r1 --> 0.8.1-r1*
* *robot-indicator 0.1.3-r1*
* *ros-reflexxes 0.9.0-r1 --> 0.8.8*
* *safety-limiter 0.8.0-r1 --> 0.8.1-r1*
* *track-odometry 0.8.0-r1 --> 0.8.1-r1*
* *trajectory-tracker 0.8.0-r1 --> 0.8.1-r1*
* *urg-node 0.1.11 --> 0.1.12-r1*

Melodic Changes:
----------------
* *amcl 1.16.4-r1 --> 1.16.5-r1*
* *async-comm 0.1.1 --> 0.2.0-r1*
* *base-local-planner 1.16.4-r1 --> 1.16.5-r1*
* *carrot-planner 1.16.4-r1 --> 1.16.5-r1*
* *clear-costmap-recovery 1.16.4-r1 --> 1.16.5-r1*
* *cob-3d-mapping-msgs 0.6.14-r1 --> 0.6.15-r1*
* *cob-actions 0.7.1-r1 --> 0.7.2-r1*
* *cob-android 0.1.6-r1 --> 0.1.7-r1*
* *cob-android-msgs 0.1.6-r1 --> 0.1.7-r1*
* *cob-android-resource-server 0.1.6-r1 --> 0.1.7-r1*
* *cob-android-script-server 0.1.6-r1 --> 0.1.7-r1*
* *cob-android-settings 0.1.6-r1 --> 0.1.7-r1*
* *cob-base-controller-utils 0.8.1-r1 --> 0.8.10-r1*
* *cob-base-velocity-smoother 0.8.1-r1 --> 0.8.10-r1*
* *cob-calibration-data 0.6.13-r1 --> 0.6.14-r1*
* *cob-cam3d-throttle 0.6.14-r1 --> 0.6.15-r1*
* *cob-cartesian-controller 0.8.1-r1 --> 0.8.10-r1*
* *cob-collision-velocity-filter 0.8.1-r1 --> 0.8.10-r1*
* *cob-command-gui 0.6.15-r1 --> 0.6.16-r1*
* *cob-command-tools 0.6.15-r1 --> 0.6.16-r1*
* *cob-common 0.7.1-r1 --> 0.7.2-r1*
* *cob-control 0.8.1-r1 --> 0.8.10-r1*
* *cob-control-mode-adapter 0.8.1-r1 --> 0.8.10-r1*
* *cob-control-msgs 0.8.1-r1 --> 0.8.10-r1*
* *cob-dashboard 0.6.15-r1 --> 0.6.16-r1*
* *cob-default-env-config 0.6.10-r1 --> 0.6.11-r1*
* *cob-description 0.7.1-r1 --> 0.7.2-r1*
* *cob-docker-control 0.6.8-r1 --> 0.6.9-r1*
* *cob-environments 0.6.10-r1 --> 0.6.11-r1*
* *cob-extern 0.6.14-r1 --> 0.6.15-r1*
* *cob-footprint-observer 0.8.1-r1 --> 0.8.10-r1*
* *cob-frame-tracker 0.8.1-r1 --> 0.8.10-r1*
* *cob-gazebo-plugins 0.7.3-r1 --> 0.7.4-r1*
* *cob-gazebo-ros-control 0.7.3-r1 --> 0.7.4-r1*
* *cob-hardware-emulation 0.8.1-r1 --> 0.8.10-r1*
* *cob-helper-tools 0.6.15-r1 --> 0.6.16-r1*
* *cob-image-flip 0.6.14-r1 --> 0.6.15-r1*
* *cob-interactive-teleop 0.6.15-r1 --> 0.6.16-r1*
* *cob-mecanum-controller 0.8.10-r1*
* *cob-model-identifier 0.8.1-r1 --> 0.8.10-r1*
* *cob-monitoring 0.6.15-r1 --> 0.6.16-r1*
* *cob-msgs 0.7.1-r1 --> 0.7.2-r1*
* *cob-object-detection-msgs 0.6.14-r1 --> 0.6.15-r1*
* *cob-object-detection-visualizer 0.6.14-r1 --> 0.6.15-r1*
* *cob-omni-drive-controller 0.8.1-r1 --> 0.8.10-r1*
* *cob-perception-common 0.6.14-r1 --> 0.6.15-r1*
* *cob-perception-msgs 0.6.14-r1 --> 0.6.15-r1*
* *cob-reflector-referencing 0.6.8-r1 --> 0.6.9-r1*
* *cob-safety-controller 0.6.8-r1 --> 0.6.9-r1*
* *cob-script-server 0.6.15-r1 --> 0.6.16-r1*
* *cob-srvs 0.7.1-r1 --> 0.7.2-r1*
* *cob-substitute 0.6.8-r1 --> 0.6.9-r1*
* *cob-supported-robots 0.6.13-r1 --> 0.6.14-r1*
* *cob-teleop 0.6.15-r1 --> 0.6.16-r1*
* *cob-trajectory-controller 0.8.1-r1 --> 0.8.10-r1*
* *cob-tricycle-controller 0.8.1-r1 --> 0.8.10-r1*
* *cob-twist-controller 0.8.1-r1 --> 0.8.10-r1*
* *cob-vision-utils 0.6.14-r1 --> 0.6.15-r1*
* *costmap-2d 1.16.4-r1 --> 1.16.5-r1*
* *costmap-cspace 0.8.0-r1 --> 0.8.1-r1*
* *dccomms-ros 0.0.2-r3 --> 0.0.3-r1*
* *dccomms-ros-msgs 0.0.2-r3 --> 0.0.3-r1*
* *dwa-local-planner 1.16.4-r1 --> 1.16.5-r1*
* *dynamic-reconfigure 1.6.1-r1 --> 1.6.3-r1*
* *fake-localization 1.16.4-r1 --> 1.16.5-r1*
* *generic-throttle 0.6.15-r1 --> 0.6.16-r1*
* *global-planner 1.16.4-r1 --> 1.16.5-r1*
* *gmapping 1.4.0-r1 --> 1.4.1-r1*
* *ipa-3d-fov-visualization 0.6.14-r1 --> 0.6.15-r1*
* *ipr-extern 0.9.0-r1 --> 0.8.8-r1*
* *jderobot-camviz 0.1.0-r1*
* *joint-state-publisher 1.12.14-r1 --> 1.12.15-r1*
* *joint-state-publisher-gui 1.12.14-r1 --> 1.12.15-r1*
* *joystick-interrupt 0.8.0-r1 --> 0.8.1-r1*
* *libdlib 0.6.14-r1 --> 0.6.15-r1*
* *libmodbus 0.9.0-r1 --> 0.8.8-r1*
* *libntcan 0.6.14-r1 --> 0.6.15-r1*
* *libpcan 0.6.14-r1 --> 0.6.15-r1*
* *libphidgets 0.6.14-r1 --> 0.6.15-r1*
* *libreflexxestype2 0.9.0-r1 --> 0.8.8-r1*
* *map-organizer 0.8.0-r1 --> 0.8.1-r1*
* *map-server 1.16.4-r1 --> 1.16.5-r1*
* *message-filters 1.14.4-r1 --> 1.14.5-r1*
* *move-base 1.16.4-r1 --> 1.16.5-r1*
* *move-slow-and-clear 1.16.4-r1 --> 1.16.5-r1*
* *nav-core 1.16.4-r1 --> 1.16.5-r1*
* *navfn 1.16.4-r1 --> 1.16.5-r1*
* *navigation 1.16.4-r1 --> 1.16.5-r1*
* *neonavigation 0.8.0-r1 --> 0.8.1-r1*
* *neonavigation-common 0.8.0-r1 --> 0.8.1-r1*
* *neonavigation-launch 0.8.0-r1 --> 0.8.1-r1*
* *obj-to-pointcloud 0.8.0-r1 --> 0.8.1-r1*
* *opengm 0.6.14-r1 --> 0.6.15-r1*
* *planner-cspace 0.8.0-r1 --> 0.8.1-r1*
* *raw-description 0.7.1-r1 --> 0.7.2-r1*
* *ros-comm 1.14.4-r1 --> 1.14.5-r1*
* *ros-reflexxes 0.9.0-r1 --> 0.8.8-r1*
* *rosbag 1.14.4-r1 --> 1.14.5-r1*
* *rosbag-storage 1.14.4-r1 --> 1.14.5-r1*
* *roscpp 1.14.4-r1 --> 1.14.5-r1*
* *rosgraph 1.14.4-r1 --> 1.14.5-r1*
* *roslaunch 1.14.4-r1 --> 1.14.5-r1*
* *roslz4 1.14.4-r1 --> 1.14.5-r1*
* *rosmaster 1.14.4-r1 --> 1.14.5-r1*
* *rosmsg 1.14.4-r1 --> 1.14.5-r1*
* *rosnode 1.14.4-r1 --> 1.14.5-r1*
* *rosout 1.14.4-r1 --> 1.14.5-r1*
* *rosparam 1.14.4-r1 --> 1.14.5-r1*
* *rospy 1.14.4-r1 --> 1.14.5-r1*
* *rosservice 1.14.4-r1 --> 1.14.5-r1*
* *rostest 1.14.4-r1 --> 1.14.5-r1*
* *rostopic 1.14.4-r1 --> 1.14.5-r1*
* *roswtf 1.14.4-r1 --> 1.14.5-r1*
* *rotate-recovery 1.16.4-r1 --> 1.16.5-r1*
* *safety-limiter 0.8.0-r1 --> 0.8.1-r1*
* *scenario-test-tools 0.6.16-r1*
* *service-tools 0.6.15-r1 --> 0.6.16-r1*
* *slam-gmapping 1.4.0-r1 --> 1.4.1-r1*
* *topic-tools 1.14.4-r1 --> 1.14.5-r1*
* *track-odometry 0.8.0-r1 --> 0.8.1-r1*
* *trajectory-tracker 0.8.0-r1 --> 0.8.1-r1*
* *underwater-sensor-msgs 1.4.2-r1 --> 1.4.2-r2*
* *underwater-vehicle-dynamics 1.4.2-r1 --> 1.4.2-r2*
* *urg-node 0.1.11 --> 0.1.12-r1*
* *uwsim 1.4.2-r1 --> 1.4.2-r2*
* *voxel-grid 1.16.4-r1 --> 1.16.5-r1*
* *xmlrpcpp 1.14.4-r1 --> 1.14.5-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-bson
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-bson
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

