### PR TITLE
rosdistro sync, Fri Apr  3 17:41:29 2020

### DIFF
--- a/distros/dashing/aws-common/default.nix
+++ b/distros/dashing/aws-common/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, cmake, curl, openssl, ros-environment, utillinux, zlib }:
 buildRosPackage {
   pname = "ros-dashing-aws-common";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_common-release/archive/release/dashing/aws_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ea08a28f13ac3dd0aab080d68757d4b3c45232a1c210a547356271097224fd1f";
+    url = "https://github.com/aws-gbp/aws_common-release/archive/release/dashing/aws_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "51f68c1c9186a85cc0162af5c9f1211a164b711e1c950b5c46e3e24176d941bc";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ];
   propagatedBuildInputs = [ curl openssl utillinux zlib ];
-  nativeBuildInputs = [ cmake ];
+  nativeBuildInputs = [ ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {
     description = ''Common AWS SDK utilities, intended for use by ROS packages using the AWS SDK'';

--- a/distros/dashing/aws-ros2-common/default.nix
+++ b/distros/dashing/aws-ros2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, aws-common, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-aws-ros2-common";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_ros2_common-release/archive/release/dashing/aws_ros2_common/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7fa53146b92ceb4ed583d97920f0a77ed73fba95b201017ea99d355e1a254d87";
+    url = "https://github.com/aws-gbp/aws_ros2_common-release/archive/release/dashing/aws_ros2_common/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "829163bb785f3a980733de6ca21c2ad07f5c8c2cbdd67249c90fcb98e45731c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cloudwatch-logger/default.nix
+++ b/distros/dashing/cloudwatch-logger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, aws-common, aws-ros2-common, cloudwatch-logs-common, launch, launch-ros, rcl-interfaces, rclcpp, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-logger";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/dashing/cloudwatch_logger/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "2bc69c3139f5bd23ed2a69807c040b880871a171aa344b244ad4ff8dac82be65";
+    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/dashing/cloudwatch_logger/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "75a541dfb583d5f056a7e8f2042313984f625ec66c549e0753a408a2088dfc19";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cloudwatch-logs-common/default.nix
+++ b/distros/dashing/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite, file-management }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-logs-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "02a0f0b6fa4f57da332b379dbb2b5d12a1dae647be942232c6078430f38c1ee7";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "a04fc18cc569b86a49b377cddd10a040adae45a5c87bd2da35abde099d5fdf49";
   };
 
   buildType = "cmake";

--- a/distros/dashing/cloudwatch-metrics-collector/default.nix
+++ b/distros/dashing/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, aws-common, aws-ros2-common, cloudwatch-metrics-common, launch, launch-ros, rclcpp, rmw-implementation, ros-monitoring-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-metrics-collector";
-  version = "3.0.0-r2";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/dashing/cloudwatch_metrics_collector/3.0.0-2.tar.gz";
-    name = "3.0.0-2.tar.gz";
-    sha256 = "bc55f53db04781623c25c55f2b2e63d136f0bb3b799ab4757ee0598e2819107c";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/dashing/cloudwatch_metrics_collector/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "41e7c4eb96ba963bcbdcf4e0e0188c54b52e56239fa10b4ab3658ab2cf5a8d7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cloudwatch-metrics-common/default.nix
+++ b/distros/dashing/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite, file-management }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-metrics-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "aa6226c67e5609a4c0266f64492155d352b404564ee9839f8aaa3277bd68432e";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "6f99b5a7abac254acb71a5857b3d7233bce11c1417f2bdaeb17651c34122ba23";
   };
 
   buildType = "cmake";

--- a/distros/dashing/dataflow-lite/default.nix
+++ b/distros/dashing/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake }:
 buildRosPackage {
   pname = "ros-dashing-dataflow-lite";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3b8be01f3b1b075c22c70ab6de3fbfc0ae8aa776c286eda4f426b94cad0f95a2";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "5a8ac08083f7b11b4f1d3623f9a3f1b60e131e6420fe4ac55b5c478be345aae8";
   };
 
   buildType = "cmake";

--- a/distros/dashing/file-management/default.nix
+++ b/distros/dashing/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite }:
 buildRosPackage {
   pname = "ros-dashing-file-management";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "246be5b507c788ba825c691da1771ab4c2659a84e9a3153b6f9a0f1d441237e2";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "592aea742ec6c451eac6c91ba77c0c46de3b6f0bfc9637c7110281a705e9c766";
   };
 
   buildType = "cmake";

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -948,6 +948,8 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ swri-console = self.callPackage ./swri-console {};
+
  swri-console-util = self.callPackage ./swri-console-util {};
 
  swri-dbw-interface = self.callPackage ./swri-dbw-interface {};

--- a/distros/dashing/pcl-conversions/default.nix
+++ b/distros/dashing/pcl-conversions/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
-    sha256 = "1dee570593be56530a89248cd15ba13a1eb72daad1c1a4d452ed7b396db8a134";
+    sha256 = "7e5a799ac5e1a196d385a9247cffabe2b8589c554b22a4a1cb10896ff3bfcb07";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/ros2trace/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "64237813f80593f21dffe7f61ba91f290111e8a994449bc55800e9d42acf29c5";
+    sha256 = "be0044a3cd8924c54627d963ea29c6987aec28afa21b3d875f0ea34bed8ad7ff";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/swri-console-util/default.nix
+++ b/distros/dashing/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-console-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "cfbc0c6cdfd5bab294fbd579b026011c22820b648690330e58e5de7ca9dae754";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "72a905c022001460cc7f6ffe22bd36bb86623dcb8bab918155a772d44c64b2ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-console/default.nix
+++ b/distros/dashing/swri-console/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, qt5, rcl-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-dashing-swri-console";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/swri_console-release/archive/release/dashing/swri_console/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "e2e31cfd1a28d2afb8d8a45354847c0840879990cd7e27e895aa804bcee8d6f8";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost qt5.qtbase rcl-interfaces rclcpp rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A rosout GUI viewer developed at Southwest Research Insititute as an
+     alternative to rqt_console.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/swri-dbw-interface/default.nix
+++ b/distros/dashing/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-swri-dbw-interface";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "fae8828419a7a45b97df0f7605adf9cb94c0cec06edf6877b43f7b029bef7320";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "15277bba230a37b49087285ae17538617137b8562c078f1449c6fcac7449d0f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-geometry-util/default.nix
+++ b/distros/dashing/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-geometry-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "9dd5099da1c066daafc55a6aff174a37accbfc4a27dadfac6adc8ad717c4517b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "a1fc89c8e5ef6fd1a41d05540245e5deff6f2ad32d257438bc0b54c0a7d33e20";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-image-util/default.nix
+++ b/distros/dashing/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-image-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "13383b5325aac6f8ec818ae1a50bd0991e963d35c78cea098cd0b112237d885e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0269fe6aa3adc63a25bddbc89a44f20bf4ce00557092f5108dc831851dd2118e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-math-util/default.nix
+++ b/distros/dashing/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-math-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "96b2f85c86acca733b8c10c872bc27dae369b29fd776c1a6b4eb81294836fb78";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "d5bc7ccca607b7146c7e3be86fb869493b3b69d98ff4e17a1c46d39ebdc64b9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-opencv-util/default.nix
+++ b/distros/dashing/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-dashing-swri-opencv-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "738818b73a162c155749aa73c72a49d0542e0c0773add32a186633d75641d9d2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "88be1fe02979fe7db97a183c606db0dff6ea1f67c52d31c566944f4bdd0b1a7d";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-prefix-tools/default.nix
+++ b/distros/dashing/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-swri-prefix-tools";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "f351dc7353b8f1f7db6f6be25306148136ac6ec842c21934f33b6a88de9e0afc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "898d0edb78a2a324a9156a5d9b88767450f9ad7e66bb5dda08b6a805bf14cc9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-roscpp/default.nix
+++ b/distros/dashing/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-swri-roscpp";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "aa69852446a9718f1e667b8842470eaae14ef1783fffa1eb5b42b27dfd5ed93a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0b2c29db1223b5e1b644979d5406270ff4a4b23e494e031c297c5bd07ea7999f";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-route-util/default.nix
+++ b/distros/dashing/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-swri-route-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "5330ea2c8509c8aa64b02ed68d8ef61c9b31ae1fca5890e97ea95d2b44a10edd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "656b966bd6590cfb6fc1bd6a164241d1c8efda47cfe31679aa6a44968b387b25";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-serial-util/default.nix
+++ b/distros/dashing/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-dashing-swri-serial-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "31c6b1c337648d7bf51b49baf6d9e2dba9bfc81c5c91da3621ba00cc5f0c7d4c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "dedf5d107fdccde1ff3e4f894a4aa0b0b0d38d61d73cd2f81d55389024f56286";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-system-util/default.nix
+++ b/distros/dashing/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-system-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "d5502493ffb2819b7ff7c46005b213b57d9cc34635f1497c20dcfbdf4dd6efe6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "2aceb418ff552fef9c14ffa6cbdfb7745ffff2323e11e504852a2623cfd132da";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-transform-util/default.nix
+++ b/distros/dashing/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-dashing-swri-transform-util";
-  version = "3.0.5-r2";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.0.5-2.tar.gz";
-    name = "3.0.5-2.tar.gz";
-    sha256 = "316d4b56c77b7bb86c37f241a8048c466d93458acde86224175ec7b475bb9e68";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c447065eed9a841a4a872ae8b0635b95e6fbe5048e9d63dff632585cce5727f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/tracetools/default.nix
+++ b/distros/dashing/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "5ccad4d10ecd2ebe25e0d1d8f1de0aae46d6285b2fef0cc7e7a32a4c354d8724";
+    sha256 = "41d143bfa711fd0099511994140865377d0951df75711d5a22e409d5427c2ecf";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/xacro/default.nix
+++ b/distros/dashing/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-xacro";
-  version = "2.0.1-r2";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.1-2.tar.gz";
-    name = "2.0.1-2.tar.gz";
-    sha256 = "c24475d924228bf75f7260fb8d3454dfa4af6add26078b04b61ccdc385049c31";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8795d2a28b0cf6fe6b2a47050bf124833c96038d4e920a6e0ce03b60df259ba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -900,6 +900,8 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ swri-console = self.callPackage ./swri-console {};
+
  swri-console-util = self.callPackage ./swri-console-util {};
 
  swri-dbw-interface = self.callPackage ./swri-dbw-interface {};

--- a/distros/eloquent/swri-console-util/default.nix
+++ b/distros/eloquent/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-console-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_console_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "d00789e4702b243bed9c2deb70db746aec0aa720cb4f8d4ca56b03d7ffdb5877";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_console_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "0c722fb1e0a46274f5d62abfbdcd9145abe5dd0a11e038ed21909fbc3756ff5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-console/default.nix
+++ b/distros/eloquent/swri-console/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, qt5, rcl-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-eloquent-swri-console";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/swri_console-release/archive/release/eloquent/swri_console/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "874260be784119341dd355ab712fb51bd41f4ea9e29e4a312d9b96da3fca4900";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost qt5.qtbase rcl-interfaces rclcpp rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A rosout GUI viewer developed at Southwest Research Insititute as an
+     alternative to rqt_console.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-dbw-interface/default.nix
+++ b/distros/eloquent/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-eloquent-swri-dbw-interface";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_dbw_interface/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "14a08b22551407eb582ef32f48265aa8232b68fd462931beb4300102e060219f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_dbw_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "925236c44833cf91d0e4516f537cd1be2560c05581a94c2369423305fd081749";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-geometry-util/default.nix
+++ b/distros/eloquent/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-swri-geometry-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_geometry_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "ce3fbf8fef81e533e994635f2fdb010984c799d86c43df3c164533902fce9756";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_geometry_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "c7c23c5650319144acdba54ef8786137f58110460692bb3f061409b72d7f50b2";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-image-util/default.nix
+++ b/distros/eloquent/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-swri-image-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_image_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "5930e396244ba7095b7a0a0e7895973dc3ef297ff5e46582cc6df5878ddeca03";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_image_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "15ebbf6ca4c6a568257a8fc38947d2c2e369cba0a668eb9e0e1bab25fddbe3aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-math-util/default.nix
+++ b/distros/eloquent/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-math-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_math_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "b8ef28a941d94832e13c2ae949d27e3e6a7794f2b90c17e9bfdbb185d885afdc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_math_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "5bd22162d2cbf7a42b5027fc4816e479d2956e1846304e61a52e442e07446546";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-opencv-util/default.nix
+++ b/distros/eloquent/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-eloquent-swri-opencv-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_opencv_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "d0845e09c2896a59a4528085c68c22a8660ac301281c4d881d315b1c2596aedd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_opencv_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "17379424410214dd8871297600cf4c5cfd102389b7ea32705ad3bfd6b952b45d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-prefix-tools/default.nix
+++ b/distros/eloquent/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-swri-prefix-tools";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_prefix_tools/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "9a1465d6cd9fd94aeadf9508e6f6d35e02abaf35ac00a5f098f51b419a5da117";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_prefix_tools/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "fb223f1fee5e79da4b746bff3bc9930bae203e4e805db8613c1836c918fc374c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-roscpp/default.nix
+++ b/distros/eloquent/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-swri-roscpp";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_roscpp/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "03e23bb4dc7aa91387a5287f74d89796c2b5695782fed0ba53fde4b760aaf224";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_roscpp/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b98ed606d99160a6d73bb8c016d59e19a677ea75f76dabf51c4c3d874b1f06d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-route-util/default.nix
+++ b/distros/eloquent/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-swri-route-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_route_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "940b43f9a9edb41b2cf8dbf4e2b8cdcf11f7a872dcac1ad4a22002f65dd50354";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_route_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "6ca53fad1eb78b0887b6f83ba046271371dc853195c8039f2af41bfc962f6adc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-serial-util/default.nix
+++ b/distros/eloquent/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-eloquent-swri-serial-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_serial_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "909797a777c2b5413776218672beb52cef2368f3a6bce902a3a3ce83cff1dc1c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_serial_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "8325a03493ac13ec4ae36d0216ef202a4f118a242637e83adab641e398a3f62b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-system-util/default.nix
+++ b/distros/eloquent/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-system-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_system_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "869469b0bf65d9035f262c41ff5b29ea56120c49195a4039dcb3b5a7c70f4b9a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_system_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "12e78b58862030d0a477bfdd0f7045d90d29f7e332b76ed8c68003b2223aac99";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-transform-util/default.nix
+++ b/distros/eloquent/swri-transform-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-swri-transform-util";
-  version = "3.0.5-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_transform_util/3.0.5-1.tar.gz";
-    name = "3.0.5-1.tar.gz";
-    sha256 = "efd1e50a943795722e98ba1c4970a720d12b4e3dee552fc438efcfec16538ff7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_transform_util/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "903260be29286e1bd2582be04f9e5cf1b558c55aa85933a79f8a35a83eec41e2";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/eloquent/xacro/default.nix
+++ b/distros/eloquent/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-eloquent-xacro";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/eloquent/xacro/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "01bc661553bdb5c16ad426d47c5896c934cd7dd6cfdd2be179396d1bf41a8e98";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/eloquent/xacro/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "dd56e630bd27996cba0ab40b65cf49e8a67193733d14ee2e54ce6a97c571cd47";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/agni-tf-tools/default.nix
+++ b/distros/kinetic/agni-tf-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, qt5, roscpp, rviz, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-agni-tf-tools";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/kinetic/agni_tf_tools/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "1cc9302bdd66eaaa569b4de93b923c9ee04625e896f55af22912d7481b8305a5";
+    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/kinetic/agni_tf_tools/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "690ffbece3374b5ed1d4321c3e4bfd9e619676d184ee67406610af006584a545";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/aws-common/default.nix
+++ b/distros/kinetic/aws-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, gmock, gtest, openssl, ros-environment, utillinux, zlib }:
 buildRosPackage {
   pname = "ros-kinetic-aws-common";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_common-release/archive/release/kinetic/aws_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "95f363f028c2b15f7984ea22111aee79c8272050933bc8f1b504d4eed60c2009";
+    url = "https://github.com/aws-gbp/aws_common-release/archive/release/kinetic/aws_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "51ceeb20fc9843a1ce53d5e81ffd87de44bce363aa48ff932ca3db621f46dbf5";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/aws-ros1-common/default.nix
+++ b/distros/kinetic/aws-ros1-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-aws-ros1-common";
-  version = "2.0.1-r1";
+  version = "2.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/kinetic/aws_ros1_common/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a6809dc8925f253335963fe069c7043ecc8d4143f21fc60aca776655afb2f132";
+    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/kinetic/aws_ros1_common/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "89e0fd46b76fe14eb2ab4f00b77cb554fa1b8c1ed81dc9259d5eaefe32625f4c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cloudwatch-logger/default.nix
+++ b/distros/kinetic/cloudwatch-logger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gmock, gtest, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-cloudwatch-logger";
-  version = "2.2.1-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/kinetic/cloudwatch_logger/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "98734d499324a044e0099062ae3c32e342b813457822a521acec95f878d0c7a4";
+    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/kinetic/cloudwatch_logger/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "30dc9d555f677995a3f02535c6fc8811ba3a0f6d04c68220e7f2cf200bd7d3dd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cloudwatch-logs-common/default.nix
+++ b/distros/kinetic/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
 buildRosPackage {
   pname = "ros-kinetic-cloudwatch-logs-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/cloudwatch_logs_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "9112c93641794ca1c8bd3c51becbf8509d772ed61f5420349877544ecee5bdc9";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/cloudwatch_logs_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "a66aeeeebd195571b09262c3132754c3acc676237dd7cddc740d4dc95a662c4f";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/cloudwatch-metrics-collector/default.nix
+++ b/distros/kinetic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gmock, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-cloudwatch-metrics-collector";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/kinetic/cloudwatch_metrics_collector/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2d6819e4eac7ce7bc0b665a23942bc1e7a74155e017db04bf8adb0a8a0040bdd";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/kinetic/cloudwatch_metrics_collector/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "0283f3f8774b37e49b1847b0fe77e9adb917c2eedd11f6993c4359a8a2581d90";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cloudwatch-metrics-common/default.nix
+++ b/distros/kinetic/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
 buildRosPackage {
   pname = "ros-kinetic-cloudwatch-metrics-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/cloudwatch_metrics_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3c282acd458d7f092443dffc0cff8da79fa23186931f6bc1b4d9886ce15695b9";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/cloudwatch_metrics_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "0ddb4fa17d979a3e9b966ad684099ce481f33173d85511d84b0b87b467936cf6";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/dataflow-lite/default.nix
+++ b/distros/kinetic/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, gmock, gtest }:
 buildRosPackage {
   pname = "ros-kinetic-dataflow-lite";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/dataflow_lite/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "c1d35faa289f8c795f0304d70b0f40763320cd8703e1ab882148dfaccaa37cb7";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/dataflow_lite/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "73748fc97027f95437fee9118357f2875670f516c06aee31060fc5fab7aa9f22";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/easy-markers/default.nix
+++ b/distros/kinetic/easy-markers/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roslib, rospy, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roslint, rospy, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-easy-markers";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/easy_markers/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "23ff1f37c017bc511dd6643fb9dbab42fc15ac9137f0ce2071b4da67202ebe99";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/easy_markers/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "e631fbab573fe7c8b30e5ae1048a15262d31408bcd0fba05c9fb0a4976b5fdce";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs interactive-markers roslib rospy tf visualization-msgs ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs interactive-markers rospy tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/file-management/default.nix
+++ b/distros/kinetic/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gmock, gtest }:
 buildRosPackage {
   pname = "ros-kinetic-file-management";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/file_management/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "2f20f7bf35dbc68ad55d8f032d2c23d2691ff7bc0e0d55e13d41d89b2e0115b4";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/kinetic/file_management/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "1fba4345287d982c011cecf8069852e5b1aa40d59e71cfc1492d6642deac45bb";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/health-metric-collector/default.nix
+++ b/distros/kinetic/health-metric-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-health-metric-collector";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/kinetic/health_metric_collector/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "10f98c84b00af1a744645482ce9d264136b7779306e31666f0e9efd60280047a";
+    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/kinetic/health_metric_collector/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "18254dab64e59ab796df8ee321cc0a7e4a234a4a1112d28fd3cfaf3eb95c653f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joy-listener/default.nix
+++ b/distros/kinetic/joy-listener/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-joy-listener";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/joy_listener/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "e9bd30cc98788deb6a8ca51733ee07569d541eec0c261229bd5ca627d87aecdc";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/joy_listener/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "84ffab25040e6dc468343cc12be8ddd522caa6780773672a3ba9b7ce313997b1";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/kalman-filter/default.nix
+++ b/distros/kinetic/kalman-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-kalman-filter";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/kalman_filter/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "bb6f05577b69f4d215ad358c43736840b8b5ad26906b6f359ee118e7bb1ac7b7";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/kalman_filter/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "8c16221b1f5444ac282ed1ee2a3547365989ed16ec9c716663d5fe2ca8ffccc2";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/mbf-abstract-core/default.nix
+++ b/distros/kinetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-core";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "e8274dfaa11775f7b74ef4db2248679797f8c03ff9e87e69ab8e8a99ebcedcac";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "91373d480620eed15e47d39b302c32da6eb77298893d06cfbdc836d76de39bce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-nav/default.nix
+++ b/distros/kinetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "0e34de9c44d226c112ab14053f66015b77f52e79c5f76fb067af2d7c1e08f494";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "bae3becf8a73e6ad179daeb0884f5fcbf305468d97e2efced356b822a6118354";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The mbf_abstract_nav package contains the abstract navigation server implementation of Move Base Flex (MBF). The abstract navigation server is not bound to any map representation. It provides the actions for planning, controlling and recovering. MBF loads all defined plugins at the program start. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/mbf-costmap-core/default.nix
+++ b/distros/kinetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-core";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "868c2f13857df6fae747b29108f7103e8da308a084ffa70bef4fc2aff1feda64";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b09d65641e28fa583a1a11b36a8230c16eb4860ae6461e7ad04dce851e2f9443";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-nav/default.nix
+++ b/distros/kinetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, base-local-planner, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "60cc902bbd88738e899603b7bb08e00cf54e6fa1824827a2870c5462ef3eb515";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "62d29ad544278ed375a4950304625b5f323fbcaa0885a372e5d83e24c0662e55";
   };
 
   buildType = "catkin";
@@ -21,6 +21,6 @@ buildRosPackage {
     description = ''The mbf_costmap_nav package contains the costmap navigation server implementation of Move Base Flex (MBF). The costmap navigation server is bound to the <a href="wiki.ros.org/costmap_2d">costmap_2d</a> representation. It provides the Actions for planning, controlling and recovering. At the time of start MBF loads all defined plugins. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
 
         Additionally the mbf_costmap_nav package comes with a wrapper for the old navigation stack and the plugins which inherits from the <a href="wiki.ros.org/nav_core">nav_core</a> base classes. Preferably it tries to load plugins for the new API. However, plugins could even support both <a href="wiki.ros.org/move_base">move_base</a> and <a href="wiki.ros.org/move_base_flex">move_base_flex</a> by inheriting both base class interfaces located in the <a href="wiki.ros.org/nav_core">nav_core</a> package and in the <a href="mbf_costmap_core">mbf_costmap_core</a> package.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/mbf-msgs/default.nix
+++ b/distros/kinetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-msgs";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "bd33e16df6541fd87dc9fd0a52283a64c0bcb674d849020f3397c5256a2cfa45";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "db0436afa836c6fb7b0581049ee8ae3c27d8afa22147a4718000881483eae070";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''The move_base_flex messages package providing the action definition files for the action GetPath, ExePath, Recovery and MoveBase. The action servers providing these action are implemented in <a href="http://wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a>.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/mbf-simple-nav/default.nix
+++ b/distros/kinetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-simple-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "d872488879ca26cfa60f4df76cf62c74bd6a679c5c2b7a188f0930b2832096bd";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "c64fa7f4e11f66a6e91553531dbfdb1994488858332e1d4d082114d01c65961c";
   };
 
   buildType = "catkin";
@@ -21,6 +21,6 @@ buildRosPackage {
     description = ''The mbf_simple_nav package contains a simple navigation server implementation of Move Base Flex (MBF). The simple navigation server is bound to no map representation. It provides actions for planning, controlling and recovering. MBF loads all defined plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
 
         It tries to load the defined plugins which implements the defined interfaces in <a href="wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/mbf-utility/default.nix
+++ b/distros/kinetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-utility";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "959d2bdcfd96d1bef6d6a2e4df17ad48f22df57ee2400949c7c867900f8175d6";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "7bdace7fd313f586812b8e8e3e0dbc77a26a0712c18029bb6abb1e3e0a262b99";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "5ac1d2caf2b59158e501da90e376eff9ef97d4f52498e1ff6d5e7a76cf7dad67";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "3a40351befa31d70bee7ea7d4c90f38bea957ca06fcc1f79c5b2c1f4ac2ed522";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base-flex/default.nix
+++ b/distros/kinetic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-flex";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "395da044edf9690f145eba5f4f2f76bd57537965116c37e9c268c7e2a4d405bf";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "d0196e1f0d28316d972ee46c0cad4f429a3c1ea224220fa5a68d41b61a127999";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbaglive/default.nix
+++ b/distros/kinetic/rosbaglive/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosbag, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, rosbag, roslint, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosbaglive";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/rosbaglive/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "05f114eeab224925fdc550ca9e6181eab2415920984f0eb8fc017de138da44dd";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/rosbaglive/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "62b6b18e4b468092cfc902a22a8ffd210add45b99a024d2e7a3b097edd729110";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rosbag rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/rosflight-firmware/default.nix
+++ b/distros/kinetic/rosflight-firmware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight-firmware";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_firmware/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "94b6cad351a4af7ccbb8c9f04062cfbe5204b9e72779ceb43a333b524f74a23e";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_firmware/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "2253298d9c713833c91e59217fdff27af3019aaf5f6f1bf65bff82406a193e32";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosflight-msgs/default.nix
+++ b/distros/kinetic/rosflight-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "6d5830b7aac38099b27c8624b510b3874ab2f641f58fea539b2db3353402a7a6";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_msgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "39a35c0520ec1d118148930ce07752cca3e9155fd1a10fed789d7f48cec6f9af";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosflight-pkgs/default.nix
+++ b/distros/kinetic/rosflight-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosflight, rosflight-firmware, rosflight-msgs, rosflight-sim, rosflight-utils }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight-pkgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_pkgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "677806d2c97a015f0de8925424bf615d4959362c7e6d712fa8213a695ad6ac4a";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_pkgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "bd151bf889152aa3d1014ca0cd47b9d105738f3a2d9e47c14fc522e27b9994c2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosflight-sim/default.nix
+++ b/distros/kinetic/rosflight-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, gazebo-plugins, gazebo-ros, gazeboSimulator, geometry-msgs, roscpp, rosflight-firmware, rosflight-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight-sim";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_sim/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "fccbbd117fbc2b75a795a09ae755fe95d39b82c185faf12ac595dc1900622d84";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_sim/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "180368072bd4d9aab0e7304c69444ca4e03e3a7acc7b5f0af34f4eb4caf0fea0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosflight-utils/default.nix
+++ b/distros/kinetic/rosflight-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, rosbag, roscpp, rosflight, rosflight-firmware, rosflight-msgs, rosflight-sim, rosgraph-msgs, rospy, sensor-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight-utils";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_utils/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "33856ab4a6949c5ac259da3cdf89f1b7d42154a53da392749426fd626a158a61";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight_utils/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "dc06084a4c23a4df3a8b1f63547a42909c53c3a846d46ce5835c541865cc3a63";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosflight/default.nix
+++ b/distros/kinetic/rosflight/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, eigen, eigen-stl-containers, geometry-msgs, git, libyamlcpp, pkg-config, roscpp, rosflight-msgs, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-rosflight";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "a8fba8f79d9d2b9659ae15f033448623e033c8e61f16f853b09ae2b019d261f1";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/kinetic/rosflight/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "afe902f6bceec451c52de9fd202de12e740871b41c4de07665d5765ef75561e9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sparse-bundle-adjustment/default.nix
+++ b/distros/kinetic/sparse-bundle-adjustment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, blas, catkin, cmake-modules, eigen, liblapack, suitesparse }:
 buildRosPackage {
   pname = "ros-kinetic-sparse-bundle-adjustment";
-  version = "0.3.2";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/kinetic/sparse_bundle_adjustment/0.3.2-0.tar.gz";
-    name = "0.3.2-0.tar.gz";
-    sha256 = "5135a9ad619561403a733ba7d1405364d417963f4863d32229e3f19a3e5dbccd";
+    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/kinetic/sparse_bundle_adjustment/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "8af8b44d522cb5351316d3f11fb3dd553228ea1bb3c29dac1596b280e987bd4c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/tracetools/default.nix
+++ b/distros/kinetic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/kinetic/tracetools/0.2.1-0.tar.gz";
     name = "0.2.1-0.tar.gz";
-    sha256 = "59ed304f0ac9078e5b0875444b5594170921f29d35ba304a7f60f17eadd54f57";
+    sha256 = "0c51e131b0461a9aeb8822e368147433d331bbf9c972062f775d9f4e73a0636e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.12-r1";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.12-1.tar.gz";
-    name = "0.1.12-1.tar.gz";
-    sha256 = "7e8b6fa6f623347a42fc45c34cd36bc12b41998dbcdbc1753e1dabc52c8e4c04";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "9b65f9cfc1bb5eb6faf82404c4853ec3ea9625c9b8be8c15144d91bb4e32f949";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/wu-ros-tools/default.nix
+++ b/distros/kinetic/wu-ros-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, easy-markers, joy-listener, kalman-filter, rosbaglive }:
 buildRosPackage {
   pname = "ros-kinetic-wu-ros-tools";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/wu_ros_tools/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "1af04eed17642d9b3b65758a7693fc3d8df725cc1fa62ee5f04d83040fde532d";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/kinetic/wu_ros_tools/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "54af143f632a19a42e35f21fc98a15cede5980ce94889b82259adce0d1da2c1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/agni-tf-tools/default.nix
+++ b/distros/melodic/agni-tf-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, qt5, roscpp, rviz, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-agni-tf-tools";
-  version = "0.1.4-r2";
+  version = "0.1.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/melodic/agni_tf_tools/0.1.4-2.tar.gz";
-    name = "0.1.4-2.tar.gz";
-    sha256 = "ec2d2a3ebc4b6c869e7ae4a89d89129c911992f09a41c218abb899cc65d1eab4";
+    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/melodic/agni_tf_tools/0.1.4-3.tar.gz";
+    name = "0.1.4-3.tar.gz";
+    sha256 = "1386e6d00515a71d35456916af8c0f65261b41f33c39b0612f249529d53c7a34";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.3-0.tar.gz";
-    name = "0.3.3-0.tar.gz";
-    sha256 = "c24552309d44459372bb344e5d02af47ce6f9451329cb1f73e99e57833d734cb";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "78a408a44823f4bffce98e9a503ac4da670cff6c6b1efd4648993b3961d3b49d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.3-0.tar.gz";
-    name = "0.3.3-0.tar.gz";
-    sha256 = "119fea466f5d72ff6fab2bb92fed76cf3665441eb4b6012ff202817c5c42fe02";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "88919594d2887febbb2fe7c27ba072d19c029775d34e86ca7091e1be2b93c122";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.3-0.tar.gz";
-    name = "0.3.3-0.tar.gz";
-    sha256 = "c30da5fa52747bb15685265588f9da95b14d15bb7f4cb569f954e9bba90cf8a7";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "79696350d2096a5c7d524d0a76ec5d31be6a104ebb9e7579bcb055e59cce2852";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.3";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.3-0.tar.gz";
-    name = "0.3.3-0.tar.gz";
-    sha256 = "a3c3715c6c4d70959103aa529c2e2cdcf46e6a07d500ed262146038ecdcb07c5";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "8cb68e5ddd9a5c689952f33b40f187a2edc7dfac7f0539dfe46879ea846ecd6e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/aws-common/default.nix
+++ b/distros/melodic/aws-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, curl, gmock, gtest, openssl, ros-environment, utillinux, zlib }:
 buildRosPackage {
   pname = "ros-melodic-aws-common";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "eac5a55756b1eb20e37a7b38217345fdae6b4fa24c142e983c177a35f3d3b557";
+    url = "https://github.com/aws-gbp/aws_common-release/archive/release/melodic/aws_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ca6b356a24bbfc7851da14716f3f90cdc751ce5d7620f5eda2401cdfebdddbfe";
   };
 
   buildType = "cmake";

--- a/distros/melodic/aws-ros1-common/default.nix
+++ b/distros/melodic/aws-ros1-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-aws-ros1-common";
-  version = "2.0.1-r1";
+  version = "2.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c4a4208d835285e1c0301cc0269f3915962c6fc14631b6fcb8cc8dd08a83ba07";
+    url = "https://github.com/aws-gbp/aws_ros1_common-release/archive/release/melodic/aws_ros1_common/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "6ce3c5da6d51c25b2c8453af0a780dbeaa94561baf086346a2fdc2b3ed27caac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logger/default.nix
+++ b/distros/melodic/cloudwatch-logger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gmock, gtest, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logger";
-  version = "2.2.1-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "03cca488a1f918e13adf56eda946a89c3858f949cac82f14ccc1cbeb9c3bce81";
+    url = "https://github.com/aws-gbp/cloudwatch_logger-release/archive/release/melodic/cloudwatch_logger/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "b76d61d2863ba0edb061c39e0b0722df5a54f62d0f215dc7f5152fe4850fc871";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-logs-common/default.nix
+++ b/distros/melodic/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logs-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "9f5c4824fa5f2c6fb4806a69d2f259ae73f93b74af62b3eac011a8903617c192";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_logs_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "08487534fd32112a15bb53a4ab17e099775ac3772057135f1e5b49ddbf523168";
   };
 
   buildType = "cmake";

--- a/distros/melodic/cloudwatch-metrics-collector/default.nix
+++ b/distros/melodic/cloudwatch-metrics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gmock, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-collector";
-  version = "2.2.0-r1";
+  version = "2.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e42cf30115b38b5976b736aaaa0e00e27c69ef6e6086e61eb1dc91f42630691a";
+    url = "https://github.com/aws-gbp/cloudwatch_metrics_collector-release/archive/release/melodic/cloudwatch_metrics_collector/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "1c8d20e04ea8096f94cf510c3624385a2b1f8effc03276fe4a0fcd6f6b3fb3f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cloudwatch-metrics-common/default.nix
+++ b/distros/melodic/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-common";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "5443a3551b566a6a1fbb36a3ea78f287c0500e19de1628914cd94e443bb0b0eb";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/cloudwatch_metrics_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "3431eb900e1ad83dc7fa87a7c4b35a1dcf967d4b5b2ecacae9c46768bab7ad45";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dataflow-lite/default.nix
+++ b/distros/melodic/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, gmock, gtest }:
 buildRosPackage {
   pname = "ros-melodic-dataflow-lite";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "9d672144635cb6d0ec0bb039f13f5b779c6faae225a2834f8388802e39170855";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/dataflow_lite/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "1a3dc4ccb5db55082bdb0a2ad25ed9ec8442b1d889e48969b142ad8839c7a938";
   };
 
   buildType = "cmake";

--- a/distros/melodic/easy-markers/default.nix
+++ b/distros/melodic/easy-markers/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roslib, rospy, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roslint, rospy, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-easy-markers";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/easy_markers/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "64fea822e5e6ee2d58d4bfbd23519485c3197e5a8a8d74ef97ec91abc5e35088";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/easy_markers/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "813965652574355bf8c57995dfcd7c70da0f96b78fdf1c75df4e7c51f3454b42";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs interactive-markers roslib rospy tf visualization-msgs ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs interactive-markers rospy tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "1.6.9-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/1.6.9-1.tar.gz";
-    name = "1.6.9-1.tar.gz";
-    sha256 = "19c90893ececf5e4b3c5df332d25ece65702a3ef53df0636ee7687db031ba044";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "71e42f8606ed7c6b4fb93ba6dd4a9bca7721acb15f992709f240e47aa17ae417";
   };
 
   buildType = "cmake";

--- a/distros/melodic/file-management/default.nix
+++ b/distros/melodic/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gmock, gtest }:
 buildRosPackage {
   pname = "ros-melodic-file-management";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "da43a316c11b0fd8f057e0a4019bdfd21d98de93dffb98fb940896532bb47379";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/melodic/file_management/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "1077f5c11c901a41e166e2bd718a220b04d98c2abc6ea085da2ef9c54f2c68df";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1350,6 +1350,8 @@ self: super: {
 
  jsk-pcl-ros-utils = self.callPackage ./jsk-pcl-ros-utils {};
 
+ jsk-planning = self.callPackage ./jsk-planning {};
+
  jsk-pr2eus = self.callPackage ./jsk-pr2eus {};
 
  jsk-recognition = self.callPackage ./jsk-recognition {};
@@ -2078,6 +2080,12 @@ self: super: {
 
  pcl-ros = self.callPackage ./pcl-ros {};
 
+ pddl-msgs = self.callPackage ./pddl-msgs {};
+
+ pddl-planner = self.callPackage ./pddl-planner {};
+
+ pddl-planner-viewer = self.callPackage ./pddl-planner-viewer {};
+
  people = self.callPackage ./people {};
 
  people-msgs = self.callPackage ./people-msgs {};
@@ -2202,6 +2210,14 @@ self: super: {
 
  pr2-gripper-action = self.callPackage ./pr2-gripper-action {};
 
+ pr2-gripper-sensor = self.callPackage ./pr2-gripper-sensor {};
+
+ pr2-gripper-sensor-action = self.callPackage ./pr2-gripper-sensor-action {};
+
+ pr2-gripper-sensor-controller = self.callPackage ./pr2-gripper-sensor-controller {};
+
+ pr2-gripper-sensor-msgs = self.callPackage ./pr2-gripper-sensor-msgs {};
+
  pr2-hardware-interface = self.callPackage ./pr2-hardware-interface {};
 
  pr2-head-action = self.callPackage ./pr2-head-action {};
@@ -2301,6 +2317,8 @@ self: super: {
  py-trees-ros = self.callPackage ./py-trees-ros {};
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
+
+ pyquaternion = self.callPackage ./pyquaternion {};
 
  pyros-test = self.callPackage ./pyros-test {};
 
@@ -3117,6 +3135,8 @@ self: super: {
  talos-description-calibration = self.callPackage ./talos-description-calibration {};
 
  talos-description-inertial = self.callPackage ./talos-description-inertial {};
+
+ task-compiler = self.callPackage ./task-compiler {};
 
  teb-local-planner = self.callPackage ./teb-local-planner {};
 

--- a/distros/melodic/health-metric-collector/default.nix
+++ b/distros/melodic/health-metric-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-health-metric-collector";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f5e60876143b1062f020f54087a4513795c1f1b5b1c8facc4b466a95ac25a7a9";
+    url = "https://github.com/aws-gbp/health_metric_collector-release/archive/release/melodic/health_metric_collector/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "de3cceb8580f9dea5b9dc921ff1364c6486c89e217ae42ebf5349d67f8668c0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joy-listener/default.nix
+++ b/distros/melodic/joy-listener/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joy-listener";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/joy_listener/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "55b1bf4cf89b9ea2a405f878640a53c30f9205b7a328b88f2052629994e697f3";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/joy_listener/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "c3a314410863c09fdf904cae518744a981c5290d9db85848d99f16df301d4351";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/jsk-planning/default.nix
+++ b/distros/melodic/jsk-planning/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-msgs, pddl-planner, pddl-planner-viewer, task-compiler }:
+buildRosPackage {
+  pname = "ros-melodic-jsk-planning";
+  version = "0.1.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/melodic/jsk_planning/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "8182d06f0742a80fa8b31184bfd8f1fd385b69d660e0716a0091e5d4b248137d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pddl-msgs pddl-planner pddl-planner-viewer task-compiler ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains planning package for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/kalman-filter/default.nix
+++ b/distros/melodic/kalman-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy }:
 buildRosPackage {
   pname = "ros-melodic-kalman-filter";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/kalman_filter/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "dae8cee834dfdb902000812bf4e6141f678bf813a077dd6b6f1580a90a909876";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/kalman_filter/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "475f257f7956a310bf68174451cc299d57b40d0933c72a6d2ec878c9deef76fb";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/mbf-abstract-core/default.nix
+++ b/distros/melodic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-core";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "28c8b32a8305de2e0edea5f6cbae3c08b65009c29884a3c02c13fcefac0982c6";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "a51ae935d820470f1098ec87e3a14390939cfb4b723cb88cb2b7d1cdda1bb8d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-nav/default.nix
+++ b/distros/melodic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "5bc61f3d268b4221844aa5fbd038a14f32e5569fcf646341231a89006f34c999";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "65d2e258e06eace744982193d47390e9bf5b441629de6b7575c0d70b4321723b";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The mbf_abstract_nav package contains the abstract navigation server implementation of Move Base Flex (MBF). The abstract navigation server is not bound to any map representation. It provides the actions for planning, controlling and recovering. MBF loads all defined plugins at the program start. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mbf-costmap-core/default.nix
+++ b/distros/melodic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-core";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "6b073c66ee63f2e425425402058e2e5cf7d0a22617b28adb0017e616a22d3790";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0ee41154878f2884fbf18cb7308bea1a1e52b6c7207c4e4522364f282a900177";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-nav/default.nix
+++ b/distros/melodic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, base-local-planner, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "9bcf5fc8d5fb225a165dca3f2ce12e4a1cea0c875b183ad922cbf63a51ea65ff";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1537c7eaa6559970fdd305e6f6d2294fd382153e30f3cec0cdfcdf1a8d64ba4b";
   };
 
   buildType = "catkin";
@@ -21,6 +21,6 @@ buildRosPackage {
     description = ''The mbf_costmap_nav package contains the costmap navigation server implementation of Move Base Flex (MBF). The costmap navigation server is bound to the <a href="wiki.ros.org/costmap_2d">costmap_2d</a> representation. It provides the Actions for planning, controlling and recovering. At the time of start MBF loads all defined plugins. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
 
         Additionally the mbf_costmap_nav package comes with a wrapper for the old navigation stack and the plugins which inherits from the <a href="wiki.ros.org/nav_core">nav_core</a> base classes. Preferably it tries to load plugins for the new API. However, plugins could even support both <a href="wiki.ros.org/move_base">move_base</a> and <a href="wiki.ros.org/move_base_flex">move_base_flex</a> by inheriting both base class interfaces located in the <a href="wiki.ros.org/nav_core">nav_core</a> package and in the <a href="mbf_costmap_core">mbf_costmap_core</a> package.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mbf-msgs/default.nix
+++ b/distros/melodic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-msgs";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "20416ab6883406abbb41d55b922c4f07040d09b1404762d980d28c6528e7ce0a";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "ebb9fb21336bf09cf9fb28dab78d7b1a4e0b1a559ae7f9b3cdaca634c952bf00";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''The move_base_flex messages package providing the action definition files for the action GetPath, ExePath, Recovery and MoveBase. The action servers providing these action are implemented in <a href="http://wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a>.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mbf-simple-nav/default.nix
+++ b/distros/melodic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-simple-nav";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "1c1d1503c03f6aba7f2a373ce469b55dde56c5656ff91bf60dbce5c4312f179d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "b8afead05e5ced60d4843bf2fe0a1e25eeb5fcc38e3a97fc8a50d34d40f64b74";
   };
 
   buildType = "catkin";
@@ -21,6 +21,6 @@ buildRosPackage {
     description = ''The mbf_simple_nav package contains a simple navigation server implementation of Move Base Flex (MBF). The simple navigation server is bound to no map representation. It provides actions for planning, controlling and recovering. MBF loads all defined plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
 
         It tries to load the defined plugins which implements the defined interfaces in <a href="wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>.'';
-    license = with lib.licenses; [ "3-Clause BSD" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/mbf-utility/default.nix
+++ b/distros/melodic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-utility";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "dea46e27479efeab347376c097252b8b0cecd8d5fe8b46fa594219b927135602";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "c259c54609623b2d8db7c67482f821d672857cd65a2638d89b4e300aaa6a1b4e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "cbc4b7bc153ea1c011045c4b0a8a1f20c699fabfe052290162e0b5a54c1f76c3";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "27a96b81864d369681c78855d2801102a426c6a1eefb0c9ee47470182f06fa47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base-flex/default.nix
+++ b/distros/melodic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
 buildRosPackage {
   pname = "ros-melodic-move-base-flex";
-  version = "0.2.5-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.2.5-1.tar.gz";
-    name = "0.2.5-1.tar.gz";
-    sha256 = "69c419020bc835705d5f93b2a1f12cd151577b12d4bbd0bccdbce7e47e29e061";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "eb05b3a7a4ce947cc0bbcb19dc602820865cfc4ad813af53daeac34e4df760ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-conversions/default.nix
+++ b/distros/melodic/pcl-conversions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, pcl, pcl-msgs, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pcl-conversions";
-  version = "1.7.0-r2";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "3e7994bc21f63d0a4f4de8475c70bd018cccbe17cf7fa797bc746ebeeb9337ef";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_conversions/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "9f4ad1d914a86127a3e1dfb6f6694c3036294a08c58da707e24778a5cc8260ec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pcl-ros/default.nix
+++ b/distros/melodic/pcl-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, eigen, geometry-msgs, message-filters, nodelet, nodelet-topic-tools, pcl, pcl-conversions, pcl-msgs, pluginlib, rosbag, rosconsole, roscpp, roslib, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pcl-ros";
-  version = "1.7.0-r2";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "ada9b2af2498d10817c956af471f2c36e6cb1a088a5daeb74188746b7177acd6";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/pcl_ros/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "1cc711667ed0aa93dae9e7b33c1a2cf91a194af1377031d0118232b3e3a13a80";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pddl-msgs/default.nix
+++ b/distros/melodic/pddl-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-melodic-pddl-msgs";
+  version = "0.1.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/melodic/pddl_msgs/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "44eaf9851a6ce49a825dacbd6ed4ae64ac09161024121ae261ed5923e50fa52d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message for pddl planner'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pddl-planner-viewer/default.nix
+++ b/distros/melodic/pddl-planner-viewer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-planner }:
+buildRosPackage {
+  pname = "ros-melodic-pddl-planner-viewer";
+  version = "0.1.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/melodic/pddl_planner_viewer/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "4496310c975f2847fc8b6ba03073810225b48e166ba3da11c06aabaa1c7031af";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pddl-planner ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''a viewer of pddl_planner.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/pddl-planner/default.nix
+++ b/distros/melodic/pddl-planner/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, downward, ff, ffha, lpg-planner, pddl-msgs, rospy, time }:
+buildRosPackage {
+  pname = "ros-melodic-pddl-planner";
+  version = "0.1.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/melodic/pddl_planner/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "e686d7ea6ca73282c5a3166e1a2628f43a1e52da107fadb97fc5fcc06a27e2ba";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib downward ff ffha lpg-planner pddl-msgs rospy time ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pddl planner wrappers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/perception-pcl/default.nix
+++ b/distros/melodic/perception-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-conversions, pcl-msgs, pcl-ros }:
 buildRosPackage {
   pname = "ros-melodic-perception-pcl";
-  version = "1.7.0-r2";
+  version = "1.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.0-2.tar.gz";
-    name = "1.7.0-2.tar.gz";
-    sha256 = "8d884831c2fe71ec25a5b74158ae50b4cd3a9c4a1694bc0271c7fa8eac87685b";
+    url = "https://github.com/ros-gbp/perception_pcl-release/archive/release/melodic/perception_pcl/1.7.1-1.tar.gz";
+    name = "1.7.1-1.tar.gz";
+    sha256 = "e9dcc8b15f57efae94a5475f931f2a945c6f78a6ae455be270e0a5e9ff69eb0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pr2-gripper-sensor-action/default.nix
+++ b/distros/melodic/pr2-gripper-sensor-action/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, pr2-controllers-msgs, pr2-gripper-sensor-controller, pr2-gripper-sensor-msgs, pr2-machine, pr2-mechanism-controllers, pr2-mechanism-model, robot-mechanism-controllers, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-pr2-gripper-sensor-action";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_gripper_sensor-release/archive/release/melodic/pr2_gripper_sensor_action/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "0682a7eac228a00a8b89c01cb4208ac6831965277ec97dcdaaf392490189a27a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime pr2-controllers-msgs pr2-gripper-sensor-controller pr2-gripper-sensor-msgs pr2-machine pr2-mechanism-controllers pr2-mechanism-model robot-mechanism-controllers roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_sensor_action package provides an action interface for talking to the pr2_gripper_sensor_controller real-time controller.
+
+  It provides several different actions for getting high-level sensor information from the PR2 palm-mounted accelerometers, fingertip pressure arrays, and gripper motor/encoder, as well as several sensor-based gripper control actions that respond with low-latency in real-time.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pr2-gripper-sensor-controller/default.nix
+++ b/distros/melodic/pr2-gripper-sensor-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, pluginlib, pr2-controller-interface, pr2-controller-manager, pr2-controllers-msgs, pr2-gripper-sensor-msgs, pr2-mechanism-model, realtime-tools, roscpp, roslib, rosrt, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-pr2-gripper-sensor-controller";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_gripper_sensor-release/archive/release/melodic/pr2_gripper_sensor_controller/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "3e681c304070ead6e875be6fa66bf85ca38897dac7d332fbfab2714755b42c99";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib-msgs pluginlib pr2-controller-interface pr2-controller-manager pr2-controllers-msgs pr2-gripper-sensor-msgs pr2-mechanism-model realtime-tools roscpp roslib rosrt std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_sensor_controller package is a real-time controller that integrates signals from the PR2 hand-mounted accelerometer and finger-mounted pressure sensors with motor control of the gripper joint to do highly responsive sensing and low-latency closed-loop control.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pr2-gripper-sensor-msgs/default.nix
+++ b/distros/melodic/pr2-gripper-sensor-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pr2-gripper-sensor-msgs";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_gripper_sensor-release/archive/release/melodic/pr2_gripper_sensor_msgs/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "73b4e57e83829b425005008b01ce603b6c62ef1783e84a28e6af72e18092fd53";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_sensor_msgs package contains various actions and messages that are used in the pr2_gripper_sensor* packages. The structure of the API used by pr2_gripper_sensor_action, and pr2_gripper_sensor_controller packages is as follows: 
+
+Users will send a goal to an Action in the message format of PR2Gripper*Command (where * replaces the name of the particular Action from pr2_gripper_sensor_action). Feedback and Result information for the action is then returned in the format of PR2Gripper*Data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pr2-gripper-sensor/default.nix
+++ b/distros/melodic/pr2-gripper-sensor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-gripper-sensor-action, pr2-gripper-sensor-controller, pr2-gripper-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pr2-gripper-sensor";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_gripper_sensor-release/archive/release/melodic/pr2_gripper_sensor/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "d27388ef2f16ca671e6490422924065a3555335d61e3fe1916611e6176d256ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-gripper-sensor-action pr2-gripper-sensor-controller pr2-gripper-sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_sensor package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pyquaternion/default.nix
+++ b/distros/melodic/pyquaternion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-melodic-pyquaternion";
+  version = "0.9.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/pyquaternion-release/archive/release/melodic/pyquaternion/0.9.6-1.tar.gz";
+    name = "0.9.6-1.tar.gz";
+    sha256 = "951aa79d9675b3a3bcd33c6554bb52ebfd0364ab26765a5607b5f4802c3a4185";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.numpy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''quaternion operations'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/robot-state-publisher/default.nix
+++ b/distros/melodic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, kdl-parser, orocos-kdl, rosconsole, roscpp, rostest, rostime, sensor-msgs, tf, tf2-kdl, tf2-ros, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-melodic-robot-state-publisher";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/melodic/robot_state_publisher/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "e80bd4391f22b6a8817f78c36ecfa37cf9e2161a9909f027a6516bcd7a6be10a";
+    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/melodic/robot_state_publisher/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "76dca47e16db4a89542e6f14ecbb5a1211b8948acd00ae6554a2f6a4e100ce48";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/melodic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish-test-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "5fe57d22385d5e12ec288f9160c4f039a6e16ca618fae43994f40d983c691e65";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "5299ee347c8c25e69103927f07c546b9d91a4e38366e1b2d465900fdc156a520";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-babel-fish/default.nix
+++ b/distros/melodic/ros-babel-fish/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, roslib, std-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish";
-  version = "0.8.0-r1";
+  version = "0.8.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "06ffcd85e9807a408e0fd1a3ffdff26bcfde5cc9c259eef8d76e89832df8706d";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "6b35808c8c22be44ee5b1fbdfc573d84e00a992e6b7280574fb77cdeee240378";
   };
 
   buildType = "catkin";
-  checkInputs = [ ros-babel-fish-test-msgs rosapi roscpp-tutorials ];
-  propagatedBuildInputs = [ actionlib openssl roscpp roslib std-msgs ];
+  checkInputs = [ geometry-msgs ros-babel-fish-test-msgs rosapi roscpp-tutorials rosgraph-msgs rostest std-msgs std-srvs visualization-msgs ];
+  propagatedBuildInputs = [ actionlib openssl roscpp roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbaglive/default.nix
+++ b/distros/melodic/rosbaglive/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rosbag, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, rosbag, roslint, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosbaglive";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/rosbaglive/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "96a3356c1fe0467cb3049b0a3962a1a987b55aa11fc69d4dfdd9e7ec9c4d666e";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/rosbaglive/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "c7493934d67cb74ec6c94a40eb7089f647945123c38dd4f3e61f597eb05316fd";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslint ];
   propagatedBuildInputs = [ rosbag rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rosflight-firmware/default.nix
+++ b/distros/melodic/rosflight-firmware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-rosflight-firmware";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_firmware/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "b01e239c396ee61224ba3d8d504de3e13e4d2134ea40d8b3a406a741c8bbcd91";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_firmware/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "213ec9686d4046dbfc0caf442b617cfef900f5ce3e9e5cc02ada4ef1c3b3cf8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosflight-msgs/default.nix
+++ b/distros/melodic/rosflight-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosflight-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "bd8462701427e321d59c399e8f0038390ef6f843cf470313afd05de6ecabff8a";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_msgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "52d7c9becbc24bb69b7cda495f0d7b85ca368607ab545a90f28248773e343a48";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosflight-pkgs/default.nix
+++ b/distros/melodic/rosflight-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosflight, rosflight-firmware, rosflight-msgs, rosflight-sim, rosflight-utils }:
 buildRosPackage {
   pname = "ros-melodic-rosflight-pkgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_pkgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "ef1aaec83ab37b30fd65790f9a535e548f71737cccd5123c2bda55932c4d4fa0";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_pkgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "d35450427eefe3c64eb5c88a514f4462e73f75ef53cf9a66bf80521380ef309b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosflight-sim/default.nix
+++ b/distros/melodic/rosflight-sim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, gazebo-plugins, gazebo-ros, gazeboSimulator, geometry-msgs, roscpp, rosflight-firmware, rosflight-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosflight-sim";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_sim/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "bb6c6a13d3319d143524cda687befd926a4e1f3e970aaf7debbcad4639ea686e";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_sim/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "231909a454064b5b3d1d7a37839d4b35238e308318ae9f04857a7f0b45691283";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosflight-utils/default.nix
+++ b/distros/melodic/rosflight-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, rosbag, roscpp, rosflight, rosflight-firmware, rosflight-msgs, rosflight-sim, rosgraph-msgs, rospy, sensor-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosflight-utils";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_utils/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "a1fe534970cf57f94189e3eb37e2445b03a8b96967e5e68b8c50dedf27aed531";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight_utils/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "5a9ff019490687c98ed678a9b1074534a44e3c3d07c3cedc79d91688d4607e35";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosflight/default.nix
+++ b/distros/melodic/rosflight/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, eigen, eigen-stl-containers, geometry-msgs, git, libyamlcpp, pkg-config, roscpp, rosflight-msgs, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rosflight";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "3a4fce88ea7aadaa17da9a58951fd8335899e14e1c927951d7dad2544916278e";
+    url = "https://github.com/rosflight/rosflight-release/archive/release/melodic/rosflight/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "39677cf16d92770db360bc6aada7d212a62d80aa96c40b1027b34c327cd488d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.7-r1";
+  version = "1.13.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.7-1.tar.gz";
-    name = "1.13.7-1.tar.gz";
-    sha256 = "dca2adee6cd8a58c2c4b9d996989770102943a5cb37b514999f8c1f7f4a70b1e";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.9-2.tar.gz";
+    name = "1.13.9-2.tar.gz";
+    sha256 = "9baf5a8fd92d72bcf47cfbba70fa894bb01392541b3a906683dc297e280622fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sparse-bundle-adjustment/default.nix
+++ b/distros/melodic/sparse-bundle-adjustment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, blas, catkin, eigen, liblapack, roscpp, suitesparse }:
 buildRosPackage {
   pname = "ros-melodic-sparse-bundle-adjustment";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/melodic/sparse_bundle_adjustment/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "01999d93ad1a1991f5e80606f43a52dd27906b2da58c9f3296af6868f497aa1e";
+    url = "https://github.com/ros-gbp/sparse_bundle_adjustment-release/archive/release/melodic/sparse_bundle_adjustment/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "e6425dad1b8dff51a83846a5e7ae5fd70477183c6acfd5c952fb39f006168837";
   };
 
   buildType = "catkin";

--- a/distros/melodic/task-compiler/default.nix
+++ b/distros/melodic/task-compiler/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pddl-planner, roseus-smach, rostest, smach-viewer }:
+buildRosPackage {
+  pname = "ros-melodic-task-compiler";
+  version = "0.1.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_planning-release/archive/release/melodic/task_compiler/0.1.12-1.tar.gz";
+    name = "0.1.12-1.tar.gz";
+    sha256 = "0d42aa893bab08122853cd293c293b1b3099bbf0dde19872b5d0d21d4d205aba";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pddl-planner roseus-smach smach-viewer ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''task_compiler
+
+     Compiler that translate task description in PDDL (Planning Domain Description Language) to SMACH (state machine based execution and coordination system) description.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tracetools/default.nix
+++ b/distros/melodic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/melodic/tracetools/0.2.1-1.tar.gz";
     name = "0.2.1-1.tar.gz";
-    sha256 = "1c5114e1acce416cfb16dfca419508fd9dfcfd682ffdd63eafbe7a609d5f14f7";
+    sha256 = "1432003c36ab6c12cd03dc132dba1e8dd87986ae2fbf3bb4537001369bd47fc4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urdfdom-py/default.nix
+++ b/distros/melodic/urdfdom-py/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-urdfdom-py";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "c36e2459b2604566af7d5b9a212e156303a7a4094518dd62e2485d76a98b4db6";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "fa17c8b80a42f70c63b37729a6dfc6b71930cdb3f25df0aee577cd76a43936d9";
   };
 
   buildType = "catkin";
   checkInputs = [ pythonPackages.mock ];
-  propagatedBuildInputs = [ pythonPackages.lxml pythonPackages.pyyaml rospy ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml rospy ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python implementation of the URDF parser.'';

--- a/distros/melodic/urg-node/default.nix
+++ b/distros/melodic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-melodic-urg-node";
-  version = "0.1.12-r1";
+  version = "0.1.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.12-1.tar.gz";
-    name = "0.1.12-1.tar.gz";
-    sha256 = "788bc2f2c97a4ec356e4080f7b42ac732c6a38d00146f7afa1fb2d6f586559c7";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.13-1.tar.gz";
+    name = "0.1.13-1.tar.gz";
+    sha256 = "d7af4323e1d394519ee0fc519284a6b19400492c8a449089860649f44a8e23b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/wu-ros-tools/default.nix
+++ b/distros/melodic/wu-ros-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, easy-markers, joy-listener, kalman-filter, rosbaglive }:
 buildRosPackage {
   pname = "ros-melodic-wu-ros-tools";
-  version = "0.2.4";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/wu_ros_tools/0.2.4-0.tar.gz";
-    name = "0.2.4-0.tar.gz";
-    sha256 = "c27fe7753efad044328dfe5dc67e04deb7ea2a9d69b54b1fe34bdcbdc82d7335";
+    url = "https://github.com/wu-robotics/wu_ros_tools/archive/release/melodic/wu_ros_tools/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "557457c728d9cafede598ef48db73051845b4d377959a8b5ccd9b7a2847e14a8";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 98cab6dc222d7d98563ea8ec046c726896e166ed.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *aws-common 2.1.0-r1 --> 2.2.0-r1*
* *aws-ros2-common 1.0.0-r1 --> 1.0.1-r1*
* *cloudwatch-logger 3.0.0-r2 --> 3.0.1-r1*
* *cloudwatch-logs-common 1.1.2-r1 --> 1.1.3-r1*
* *cloudwatch-metrics-collector 3.0.0-r2 --> 3.0.1-r1*
* *cloudwatch-metrics-common 1.1.2-r1 --> 1.1.3-r1*
* *dataflow-lite 1.1.2-r1 --> 1.1.3-r1*
* *file-management 1.1.2-r1 --> 1.1.3-r1*
* *swri-console 2.0.0-r1*
* *swri-console-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-dbw-interface 3.0.5-r2 --> 3.1.0-r1*
* *swri-geometry-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-image-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-math-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-opencv-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-prefix-tools 3.0.5-r2 --> 3.1.0-r1*
* *swri-roscpp 3.0.5-r2 --> 3.1.0-r1*
* *swri-route-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-serial-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-system-util 3.0.5-r2 --> 3.1.0-r1*
* *swri-transform-util 3.0.5-r2 --> 3.1.0-r1*
* *xacro 2.0.1-r2 --> 2.0.2-r1*

Eloquent Changes:
-----------------
* *swri-console 2.0.0-r1*
* *swri-console-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-dbw-interface 3.0.5-r1 --> 3.1.0-r1*
* *swri-geometry-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-image-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-math-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-opencv-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-prefix-tools 3.0.5-r1 --> 3.1.0-r1*
* *swri-roscpp 3.0.5-r1 --> 3.1.0-r1*
* *swri-route-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-serial-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-system-util 3.0.5-r1 --> 3.1.0-r1*
* *swri-transform-util 3.0.5-r1 --> 3.1.0-r1*
* *xacro 2.0.1-r1 --> 2.0.2-r1*

Kinetic Changes:
----------------
* *agni-tf-tools 0.1.2-r1 --> 0.1.3-r1*
* *aws-common 2.1.0-r1 --> 2.2.0-r1*
* *aws-ros1-common 2.0.1-r1 --> 2.0.1-r2*
* *cloudwatch-logger 2.2.1-r1 --> 2.3.1-r1*
* *cloudwatch-logs-common 1.1.2-r1 --> 1.1.3-r1*
* *cloudwatch-metrics-collector 2.2.0-r1 --> 2.2.1-r1*
* *cloudwatch-metrics-common 1.1.2-r1 --> 1.1.3-r1*
* *dataflow-lite 1.1.2-r1 --> 1.1.3-r1*
* *easy-markers 0.2.4 --> 0.2.6-r1*
* *file-management 1.1.2-r1 --> 1.1.3-r1*
* *health-metric-collector 2.0.1-r1 --> 2.0.2-r1*
* *joy-listener 0.2.4 --> 0.2.6-r1*
* *kalman-filter 0.2.4 --> 0.2.6-r1*
* *mbf-abstract-core 0.2.5-r1 --> 0.3.0-r1*
* *mbf-abstract-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-costmap-core 0.2.5-r1 --> 0.3.0-r1*
* *mbf-costmap-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-msgs 0.2.5-r1 --> 0.3.0-r1*
* *mbf-simple-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-utility 0.2.5-r1 --> 0.3.0-r1*
* *mcl-3dl 0.2.1-r1 --> 0.2.2-r1*
* *move-base-flex 0.2.5-r1 --> 0.3.0-r1*
* *rosbaglive 0.2.4 --> 0.2.6-r1*
* *rosflight 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-firmware 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-msgs 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-pkgs 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-sim 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-utils 1.3.0-r1 --> 1.3.1-r1*
* *sparse-bundle-adjustment 0.3.2 --> 0.3.3-r1*
* *urg-node 0.1.12-r1 --> 0.1.13-r1*
* *wu-ros-tools 0.2.4 --> 0.2.6-r1*

Melodic Changes:
----------------
* *agni-tf-tools 0.1.4-r2 --> 0.1.4-r3*
* *audio-capture 0.3.3 --> 0.3.4-r1*
* *audio-common 0.3.3 --> 0.3.4-r1*
* *audio-common-msgs 0.3.3 --> 0.3.4-r1*
* *audio-play 0.3.3 --> 0.3.4-r1*
* *aws-common 2.1.0-r1 --> 2.2.0-r1*
* *aws-ros1-common 2.0.1-r1 --> 2.0.1-r2*
* *cloudwatch-logger 2.2.1-r1 --> 2.3.1-r1*
* *cloudwatch-logs-common 1.1.2-r1 --> 1.1.3-r1*
* *cloudwatch-metrics-collector 2.2.0-r1 --> 2.2.1-r2*
* *cloudwatch-metrics-common 1.1.2-r1 --> 1.1.3-r1*
* *dataflow-lite 1.1.2-r1 --> 1.1.3-r1*
* *easy-markers 0.2.4 --> 0.2.6-r1*
* *eigenpy 1.6.9-r1 --> 2.2.2-r1*
* *file-management 1.1.2-r1 --> 1.1.3-r1*
* *health-metric-collector 2.0.1-r1 --> 2.0.2-r1*
* *joy-listener 0.2.4 --> 0.2.6-r1*
* *jsk-planning 0.1.12-r1*
* *kalman-filter 0.2.4 --> 0.2.6-r1*
* *mbf-abstract-core 0.2.5-r1 --> 0.3.0-r1*
* *mbf-abstract-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-costmap-core 0.2.5-r1 --> 0.3.0-r1*
* *mbf-costmap-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-msgs 0.2.5-r1 --> 0.3.0-r1*
* *mbf-simple-nav 0.2.5-r1 --> 0.3.0-r1*
* *mbf-utility 0.2.5-r1 --> 0.3.0-r1*
* *mcl-3dl 0.2.1-r1 --> 0.2.2-r1*
* *move-base-flex 0.2.5-r1 --> 0.3.0-r1*
* *pcl-conversions 1.7.0-r2 --> 1.7.1-r1*
* *pcl-ros 1.7.0-r2 --> 1.7.1-r1*
* *pddl-msgs 0.1.12-r1*
* *pddl-planner 0.1.12-r1*
* *pddl-planner-viewer 0.1.12-r1*
* *perception-pcl 1.7.0-r2 --> 1.7.1-r1*
* *pr2-gripper-sensor 1.0.11-r1*
* *pr2-gripper-sensor-action 1.0.11-r1*
* *pr2-gripper-sensor-controller 1.0.11-r1*
* *pr2-gripper-sensor-msgs 1.0.11-r1*
* *pyquaternion 0.9.6-r1*
* *robot-state-publisher 1.14.0-r1 --> 1.14.1-r1*
* *ros-babel-fish 0.8.0-r1 --> 0.8.0-r2*
* *ros-babel-fish-test-msgs 0.8.0-r1 --> 0.8.0-r2*
* *rosbaglive 0.2.4 --> 0.2.6-r1*
* *rosflight 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-firmware 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-msgs 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-pkgs 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-sim 1.3.0-r1 --> 1.3.1-r1*
* *rosflight-utils 1.3.0-r1 --> 1.3.1-r1*
* *rviz 1.13.7-r1 --> 1.13.9-r2*
* *sparse-bundle-adjustment 0.4.3-r1 --> 0.4.4-r1*
* *task-compiler 0.1.12-r1*
* *urdfdom-py 0.4.2-r1 --> 0.4.3-r1*
* *urg-node 0.1.12-r1 --> 0.1.13-r1*
* *wu-ros-tools 0.2.4 --> 0.2.6-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

