### PR TITLE
rosdistro sync, Sat May  2 01:00:47 2020

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -122,10 +122,6 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
- apex-containers = self.callPackage ./apex-containers {};
-
- apex-test-tools = self.callPackage ./apex-test-tools {};
-
  apriltag = self.callPackage ./apriltag {};
 
  apriltag-msgs = self.callPackage ./apriltag-msgs {};
@@ -774,10 +770,6 @@ self: super: {
 
  ros2topic = self.callPackage ./ros2topic {};
 
- ros2trace = self.callPackage ./ros2trace {};
-
- ros2trace-analysis = self.callPackage ./ros2trace-analysis {};
-
  ros-base = self.callPackage ./ros-base {};
 
  ros-controllers = self.callPackage ./ros-controllers {};
@@ -992,8 +984,6 @@ self: super: {
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
- test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
-
  test-interface-files = self.callPackage ./test-interface-files {};
 
  test-msgs = self.callPackage ./test-msgs {};
@@ -1029,14 +1019,6 @@ self: super: {
  tlsf-cpp = self.callPackage ./tlsf-cpp {};
 
  topic-monitor = self.callPackage ./topic-monitor {};
-
- tracetools = self.callPackage ./tracetools {};
-
- tracetools-analysis = self.callPackage ./tracetools-analysis {};
-
- tracetools-launch = self.callPackage ./tracetools-launch {};
-
- tracetools-test = self.callPackage ./tracetools-test {};
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
@@ -1083,8 +1065,6 @@ self: super: {
  urg-node = self.callPackage ./urg-node {};
 
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
-
- v4l2-camera = self.callPackage ./v4l2-camera {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/dashing/joy-teleop/default.nix
+++ b/distros/dashing/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, rclpy, sensor-msgs, teleop-tools-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-dashing-joy-teleop";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/joy_teleop/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ae20e98e28091af8ad97150e4b84f1626195f0b30ef97ada9244294be390d5e6";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/joy_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "30d5897d7266ee5014dd9ee22d5f71f8bec96dd72ad2f3c32bca2d37153c01c2";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/key-teleop/default.nix
+++ b/distros/dashing/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-key-teleop";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/key_teleop/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "45f8e4c06f88eaceac3f7d60a9094294a524d5f8085f5121f58cc5569df57977";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/key_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "be0f8d71f65a9eda2c40580a0b5517d93afc6dcf361871f9767b2491e395d451";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/mouse-teleop/default.nix
+++ b/distros/dashing/mouse-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-mouse-teleop";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/mouse_teleop/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "babea784bc146a28073dbea6b81db017798770ff11791fa8d777a2bd31ee8013";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/mouse_teleop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c722d4681e47885a171854765c73df62dd119b49ea8dc344e7adc915058122f7";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/pcl-conversions/default.nix
+++ b/distros/dashing/pcl-conversions/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/perception_pcl-release/archive/release/dashing/pcl_conversions/2.0.0-1.tar.gz";
     name = "2.0.0-1.tar.gz";
-    sha256 = "1dee570593be56530a89248cd15ba13a1eb72daad1c1a4d452ed7b396db8a134";
+    sha256 = "7e5a799ac5e1a196d385a9247cffabe2b8589c554b22a4a1cb10896ff3bfcb07";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/teleop-tools-msgs/default.nix
+++ b/distros/dashing/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-dashing-teleop-tools-msgs";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "6a16f3d22cd21a42dfe0c8261d0a6b192aa7471e418f973df28b4a22723f0248";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9f5944724a8a37c1f5030e717fcb866dc2709f4fb145a66ac04ed7e508988768";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/teleop-tools/default.nix
+++ b/distros/dashing/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-dashing-teleop-tools";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "2ff018eb2e76415e08eab89f9b0a973a58213cbfde24e2d2d8c778956c7cd12b";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/dashing/teleop_tools/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "b1a539b62ee4ca467b944c3ae3bc16683c9e62a6401b3fa1750512e21afe0545";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/unique-identifier-msgs/default.nix
+++ b/distros/dashing/unique-identifier-msgs/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-dashing-unique-identifier-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/dashing/unique_identifier_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5326318e7c7ca7de056dffca5e1045d1022c93c8c3cfc868a6d51e15f92108c4";
+    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/dashing/unique_identifier_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "5b482f635ae2c8a388e31dc0cb75db4edd1490e2bb72bae3e65f529378a2210b";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -128,10 +128,6 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
- apex-containers = self.callPackage ./apex-containers {};
-
- apex-test-tools = self.callPackage ./apex-test-tools {};
-
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
 
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
@@ -738,10 +734,6 @@ self: super: {
 
  ros2topic = self.callPackage ./ros2topic {};
 
- ros2trace = self.callPackage ./ros2trace {};
-
- ros2trace-analysis = self.callPackage ./ros2trace-analysis {};
-
  ros-base = self.callPackage ./ros-base {};
 
  ros-core = self.callPackage ./ros-core {};
@@ -944,8 +936,6 @@ self: super: {
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
- test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
-
  test-interface-files = self.callPackage ./test-interface-files {};
 
  test-msgs = self.callPackage ./test-msgs {};
@@ -982,14 +972,6 @@ self: super: {
 
  topic-monitor = self.callPackage ./topic-monitor {};
 
- tracetools = self.callPackage ./tracetools {};
-
- tracetools-analysis = self.callPackage ./tracetools-analysis {};
-
- tracetools-launch = self.callPackage ./tracetools-launch {};
-
- tracetools-test = self.callPackage ./tracetools-test {};
-
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
  turtlesim = self.callPackage ./turtlesim {};
@@ -1011,8 +993,6 @@ self: super: {
  urg-node = self.callPackage ./urg-node {};
 
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
-
- v4l2-camera = self.callPackage ./v4l2-camera {};
 
  velocity-smoother = self.callPackage ./velocity-smoother {};
 

--- a/distros/kinetic/audio-capture/default.nix
+++ b/distros/kinetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-audio-capture";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_capture/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "cadf6833b69a096f0083973232df537714dae83d7f5f053cf94614dfddcef219";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_capture/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "79dd5347611a43e888155da07c2a2bdb91c5a9db3032a0be638d38bec8f62540";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-common-msgs/default.nix
+++ b/distros/kinetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-audio-common-msgs";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common_msgs/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "f0a762b9e45aa92890ff756f3d3b51d0548720c8c3abca9750bae1d6f5c29e62";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common_msgs/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "64fc801e022b581f2d0089b4c9354c1985bc59848a49238d8cc619aa5da8538e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-common/default.nix
+++ b/distros/kinetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-kinetic-audio-common";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "011976436a2b03300923dc195c8d7cdca4f48cccd5e59e6031ed47cdccedae22";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "c07b9462617918dfeec33f3c6ce22ca2403fc0270ae9d1dd6dbd98817425e901";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-play/default.nix
+++ b/distros/kinetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-audio-play";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_play/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "5129694c4f4d5657cad09d1da3fb697f6dae316d5648e6cbd1147576382d4cf8";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_play/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "d65f77c84ee911b19b12080dc740a481a869de7140c9f6058c417b370e5da28f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/behaviortree-cpp-v3/default.nix
+++ b/distros/kinetic/behaviortree-cpp-v3/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cppzmq, roslib }:
+{ lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-kinetic-behaviortree-cpp-v3";
-  version = "3.1.0-r3";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/kinetic/behaviortree_cpp_v3/3.1.0-3.tar.gz";
-    name = "3.1.0-3.tar.gz";
-    sha256 = "6cebfa97ecdd80f3df387d2793bac8d99d69a9a73de102d207dda917deb287d3";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/kinetic/behaviortree_cpp_v3/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "9beeb6883bf81e441fa7a746e1597a078cf508361120ea4d7cb39f5a2cceca18";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cppzmq roslib ];
+  propagatedBuildInputs = [ cppzmq ncurses roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "c5f1a02afc22cd86f89ae348e2b543771b1444249fffe92ad39dfcc61b9765f7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "12d2f6b13509d2e481a516d4177ee1c055a0ae8049afdecc5d25f67efdc3e8e5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2668,6 +2668,10 @@ self: super: {
 
  novatel-msgs = self.callPackage ./novatel-msgs {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  o3m151-driver = self.callPackage ./o3m151-driver {};
@@ -2715,6 +2719,8 @@ self: super: {
  odometry-publisher-tutorial = self.callPackage ./odometry-publisher-tutorial {};
 
  odva-ethernetip = self.callPackage ./odva-ethernetip {};
+
+ oled-display-node = self.callPackage ./oled-display-node {};
 
  ompl = self.callPackage ./ompl {};
 
@@ -3409,20 +3415,6 @@ self: super: {
  rc-visard-driver = self.callPackage ./rc-visard-driver {};
 
  rcdiscover = self.callPackage ./rcdiscover {};
-
- rdl = self.callPackage ./rdl {};
-
- rdl-benchmark = self.callPackage ./rdl-benchmark {};
-
- rdl-cmake = self.callPackage ./rdl-cmake {};
-
- rdl-dynamics = self.callPackage ./rdl-dynamics {};
-
- rdl-msgs = self.callPackage ./rdl-msgs {};
-
- rdl-ros-tools = self.callPackage ./rdl-ros-tools {};
-
- rdl-urdfreader = self.callPackage ./rdl-urdfreader {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
 
@@ -4616,20 +4608,6 @@ self: super: {
 
  topic-tools = self.callPackage ./topic-tools {};
 
- toposens = self.callPackage ./toposens {};
-
- toposens-description = self.callPackage ./toposens-description {};
-
- toposens-driver = self.callPackage ./toposens-driver {};
-
- toposens-markers = self.callPackage ./toposens-markers {};
-
- toposens-msgs = self.callPackage ./toposens-msgs {};
-
- toposens-pointcloud = self.callPackage ./toposens-pointcloud {};
-
- toposens-sync = self.callPackage ./toposens-sync {};
-
  towr = self.callPackage ./towr {};
 
  towr-ros = self.callPackage ./towr-ros {};
@@ -4815,6 +4793,18 @@ self: super: {
  universal-robot = self.callPackage ./universal-robot {};
 
  universal-robots = self.callPackage ./universal-robots {};
+
+ uos-common-urdf = self.callPackage ./uos-common-urdf {};
+
+ uos-diffdrive-teleop = self.callPackage ./uos-diffdrive-teleop {};
+
+ uos-freespace = self.callPackage ./uos-freespace {};
+
+ uos-gazebo-worlds = self.callPackage ./uos-gazebo-worlds {};
+
+ uos-maps = self.callPackage ./uos-maps {};
+
+ uos-tools = self.callPackage ./uos-tools {};
 
  ur10-e-moveit-config = self.callPackage ./ur10-e-moveit-config {};
 

--- a/distros/kinetic/husky-base/default.nix
+++ b/distros/kinetic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-husky-base";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_base/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "252b5ba0a374c2d69f12e19d7b55ba2b8fe43bbb3a3fb980fbea15631fc3a0d8";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_base/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "52b74b91570c6636e22b797e0c2b5d5cb8b810b0e5d75d4d0d5a928424fbf373";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-bringup/default.nix
+++ b/distros/kinetic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7 }:
 buildRosPackage {
   pname = "ros-kinetic-husky-bringup";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_bringup/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "0821f961f49166cc6a2b475c2f8b6dab5e72251a38575b014cd35305c77e2aba";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_bringup/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "df298a29948a5a2dcae7d1ff019416549b3a4d64d8dca7c17bb82a36b869ec66";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-control/default.nix
+++ b/distros/kinetic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-husky-control";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_control/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "c65c97c84dd3875967c7ac0a7847003d89af12ced44b6db88d3b44cd31daaaf9";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_control/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "bcf15ba2de1c5bbbca1367dc2bef72b73c304d3145b45adebd66f12571f70d13";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-description/default.nix
+++ b/distros/kinetic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-husky-description";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_description/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "fedf90617d9fb41b2d5f2df85a59667c98886c991f4ffdcc8dd16a3e060aeb9b";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_description/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "387168d1e28d8f46c98ec81ffe966268cf6460257892fa15f29d4a5a23c46954";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-desktop/default.nix
+++ b/distros/kinetic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-kinetic-husky-desktop";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_desktop/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "6dfdafd3a696725af0049ef5e451ba18225820396637c729ed1bc0f8dd0c34d9";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_desktop/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "a1f42c978c9e60f01c1592aef95ff988359d0cbaadb532aa8e46c2e561c36e27";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-gazebo/default.nix
+++ b/distros/kinetic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic }:
 buildRosPackage {
   pname = "ros-kinetic-husky-gazebo";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_gazebo/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "b0d68f02a49a24e5eabf96451f8e6fe28f4f713d4b39840cf10fbe8f1264e9ad";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_gazebo/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "3e1620c6790d0feadd2773d240cc6b0451af08182b757916ead94ef8982df12d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-msgs/default.nix
+++ b/distros/kinetic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-husky-msgs";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_msgs/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "21e9582c26d8caa706f51b70d8371fb67bc621af7a4247c4b1cc15712e056a05";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_msgs/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "cabadeca4e965d3bb4a1a3f9a2f913d95453bbbe8a46908f51570861fb23cfa8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-navigation/default.nix
+++ b/distros/kinetic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, frontier-exploration, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-kinetic-husky-navigation";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_navigation/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "d7ff2b3af3b8aa2ceb7e5ce0f9fb310b95b259325f57a2683af2c2d5b19c27af";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_navigation/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "63fbf18b8a5d141f814409fd19dbe731c942b3760d031e33f322087989c6a0c2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-robot/default.nix
+++ b/distros/kinetic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-kinetic-husky-robot";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_robot/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "ad06c547f123ce4a535e1ffb1920d75376dc86e7edc7675c76cf534f211de95f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_robot/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "bd50c77fe1eb71020a6ce9ebdede158e6f81e33028647e4ec636d7dbc8309cc5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-simulator/default.nix
+++ b/distros/kinetic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-kinetic-husky-simulator";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_simulator/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "76c15775bfdca282ec2698b39b1cc4172a7790d8d6e5fb00aebb1fdb781798cb";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_simulator/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "496b3e21dc0b8f05537563bc2a506aeb2a2b9896c912c6ed5151304ce136716d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/husky-viz/default.nix
+++ b/distros/kinetic/husky-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
+{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-kinetic-husky-viz";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_viz/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "13e38f605d1bb454e73c47f7396c4c829519ef57c228ef60db5511301aba549d";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/kinetic/husky_viz/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "5a35275c530567fd502e300f0284acc0f10d31753296e0db888d353f4a4bed0b";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ husky-description joint-state-publisher robot-state-publisher rviz rviz-imu-plugin ];
+  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz rviz-imu-plugin ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/jackal-control/default.nix
+++ b/distros/kinetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-control";
-  version = "0.6.4-r1";
+  version = "0.6.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "6c80fb7642b9a3495a36c883a76cc891ae8473a81ab02df3acc89d7ac849b872";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.5-2.tar.gz";
+    name = "0.6.5-2.tar.gz";
+    sha256 = "e6042b859ce4d2797f6fd20ca1f327a829d55c05c10f0e6cb85ae33f2b27c4bc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-description/default.nix
+++ b/distros/kinetic/jackal-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-description";
-  version = "0.6.4-r1";
+  version = "0.6.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "5038df4c1b634582d9334b8ce74e9f2c255ec298765286d2362c43234a30ab91";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.5-2.tar.gz";
+    name = "0.6.5-2.tar.gz";
+    sha256 = "0d7b5e317d400bdce94acc32d4c1a34aea12ed72759e9c2eabc9676c418090fa";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/jackal-msgs/default.nix
+++ b/distros/kinetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-msgs";
-  version = "0.6.4-r1";
+  version = "0.6.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "473913df23930c85c13b3a7bb666997de48ddad7ef629dea96f9581858d9a943";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.5-2.tar.gz";
+    name = "0.6.5-2.tar.gz";
+    sha256 = "3c3e90ebd20daf761cd865c9264a5bcc21c20be771da2df151af0f72a665f968";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-navigation/default.nix
+++ b/distros/kinetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-navigation";
-  version = "0.6.4-r1";
+  version = "0.6.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "c53313a7ac2c40a6dca6d763332c9c4828994603b47dc12d2b07b0b6bfb9360b";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.5-2.tar.gz";
+    name = "0.6.5-2.tar.gz";
+    sha256 = "9866bb9ef54e3c22bc355352fa742147185c8dafa46cb5d2954d7a179dd36d00";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-tutorials/default.nix
+++ b/distros/kinetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-tutorials";
-  version = "0.6.4-r1";
+  version = "0.6.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "593bb5d76d07caad934a721f6ee62da170a83d2f8104723394f5dc89347e4a44";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.5-2.tar.gz";
+    name = "0.6.5-2.tar.gz";
+    sha256 = "4fcfae07f72acc2baa8ca5e3965bf6d736d2e9d7c6d2cc9ad654a76a731aad1b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "3246929713406fbc04feea8eb6a14fffc2822b88790aa9e6ccaaa9c6eb8c1bed";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "68c3c2fc98797ed694dd9aebcc4e9073b5019aa693707ff92acfa0acff521ed4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "12ef0fd5d914a4cdc42408f0b06689510488bd3a358e01850f306198f5de45ca";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "6e9d351be35ce226bac33c9f5d49de3ab1a9e268a1f8bd85d834b8bac344f914";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "5bdecb432121951607d704f156d13a9642c01d01990ca3707b8b2017790f33ed";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "3c88335b2465e532902a12cdb6ea7114a4c0776ebf6220708a6bb3f5498054ad";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "63e50ae34722647c565e168afe122d8e9fb091d15b25a59c0da97e4300a665d8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "90f94b612ac0ed5104b89e3481e8a6ec404bb170a5d137b4a0d709adfdc55cf5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "a3a5d77b4ca9fb8bab3b65fb0d62c1c9271a90806370034c1e361fee68e02e69";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "19ba9492c90be61503160a063ad0015f452fa9294588b1186acf24e313acb501";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/novatel-oem7-driver/default.nix
+++ b/distros/kinetic/novatel-oem7-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-novatel-oem7-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5e54dcef4b884a9da5a813b8b9e4249e5b51a711da4f86d7e108264a5ad31560";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gps-common tf ];
+  propagatedBuildInputs = [ nodelet novatel-oem7-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NovAtel Oem7 ROS Driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/novatel-oem7-msgs/default.nix
+++ b/distros/kinetic/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-novatel-oem7-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "26dbbcd6fb2372414fdb39248fa0fbbc788a03179216cbf04d43457ff9b30025";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for NovAtel Oem7 family of receivers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "b14caf0a82de61d9b891f0c8c8b1dd0c47bf93eee726b979da957cfc88a73933";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "66e7a22fd4646d5a11566ed1331780b414ddf4724f86c1a27f4fc708c8148b6b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/oled-display-node/default.nix
+++ b/distros/kinetic/oled-display-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-oled-display-node";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/oled_display_node-release/archive/release/kinetic/oled_display_node/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "43240dde0e6784a7a8f4f38849cb4df6215b785295752dece1534894bb0f78ff";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''OLED I2C display node package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "977c9bba473f783ed447844c4d695e614ce609b54ed054670d13d129cd9975b3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "a54d77ba4327fcba01cfe34c8decd47e084a9a37ee7c3728fa97e7c68d914d8b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robot-calibration-msgs/default.nix
+++ b/distros/kinetic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-robot-calibration-msgs";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration_msgs/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "6d5a257a5fdb203d09db0235dfa25f5ac1c665ab66ca489e82085cf2a45a7d41";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration_msgs/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "5e054864ce1f940b7cef0d198652da25126691165b082b7f426e66b4e0572206";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robot-calibration/default.nix
+++ b/distros/kinetic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-robot-calibration";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "1af1165e28690ee3d217c54b06513d7f7b1c33180eb4b8c47214e2b1712c8ec0";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/kinetic/robot_calibration/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "b6df85f96bc5e824eaa23de941bc50df4ddb324356c8789b5ae2222bee29dfea";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosapi/default.nix
+++ b/distros/kinetic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosapi";
-  version = "0.11.5-r1";
+  version = "0.11.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "2537c2bbf13e3b6bf077de2191441cc0b7efd06f5e0c70cf4e51307885869ae8";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.6-2.tar.gz";
+    name = "0.11.6-2.tar.gz";
+    sha256 = "f00486d358e8b78257632b59492b67ede0b9fda80c8e9a4ea093ebb8674eb190";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-library/default.nix
+++ b/distros/kinetic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-library";
-  version = "0.11.5-r1";
+  version = "0.11.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "783f274a4e80158fbb082bed2d8301cf0bb85b4516d95fecedc59727bb132867";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.6-2.tar.gz";
+    name = "0.11.6-2.tar.gz";
+    sha256 = "08214b3a2dc01ae6c2f824bb5ee98293158b668b8ef6c0d1eb1d75408624745e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-msgs/default.nix
+++ b/distros/kinetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-msgs";
-  version = "0.11.5-r1";
+  version = "0.11.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "0072212038f251ca52a3da103e4617f9ba8396662c2006ec3e2091ef011a8d3f";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.6-2.tar.gz";
+    name = "0.11.6-2.tar.gz";
+    sha256 = "a81b691987901f9dc552ce91ae04fcf1a953f33323f4a5d28b781f693a7dfcf7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-server/default.nix
+++ b/distros/kinetic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-server";
-  version = "0.11.5-r1";
+  version = "0.11.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "f4d675bbc4bb29dc1a20e8d990fb2ca5b5dde0a26246edd9ef3e839d5351a0a9";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.6-2.tar.gz";
+    name = "0.11.6-2.tar.gz";
+    sha256 = "ffc4e69d0bfbcc9a8dd8e949960ebe7216995d6bba6bfe52a60d9c26f34ef76a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-suite/default.nix
+++ b/distros/kinetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-suite";
-  version = "0.11.5-r1";
+  version = "0.11.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "af943b73df80aba7222d29f578b4cc481d22507be94fc21642b2cafc1b67a00d";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.6-2.tar.gz";
+    name = "0.11.6-2.tar.gz";
+    sha256 = "c574bd00467fc2c36b1c71f4643c0cf495c81751ec600c3847b2ce8e450c0260";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmon-core/default.nix
+++ b/distros/kinetic/rosmon-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python, pythonPackages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-kinetic-rosmon-core";
-  version = "2.1.1-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon_core/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "204b5172290fd99a412014360ffd5b1a1141ccb6e0f8e38d30a16a336b9722ae";
+    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon_core/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "672021d7b3f29927273dcc6c06e89a4351b2c872e163ce3f4fd10350a1a7f974";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmon-msgs/default.nix
+++ b/distros/kinetic/rosmon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosmon-msgs";
-  version = "2.1.1-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon_msgs/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "3a60194e864a62dc02f2f0a36002c431cf23c12d978a621149056946c73b060b";
+    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon_msgs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "50247fbf2a2658613a2805a0acf89198a7b5aebff583fa8ba75a7bafc61eb89e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmon/default.nix
+++ b/distros/kinetic/rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosmon-core, rqt-rosmon }:
 buildRosPackage {
   pname = "ros-kinetic-rosmon";
-  version = "2.1.1-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ae51f9e2f84a9eb57fd295877efbfd402facbe0af9abab95723ebfcd49804265";
+    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rosmon/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7cb39cba789a7701528375fd6f7687afd391fad222d1f61ebd5e66565e6158bc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rqt-rosmon/default.nix
+++ b/distros/kinetic/rqt-rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, roscpp, rosmon-msgs, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-rosmon";
-  version = "2.1.1-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rqt_rosmon/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "ba83db3aedef145609e8d9c89937a33a12866e2c6e1e6fe5b2d5bfb0d7b874a6";
+    url = "https://github.com/xqms/rosmon-release/archive/release/kinetic/rqt_rosmon/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d8e64676a5edea223fc9e9ac19b78d2f4e79ed41c6049b0ab7eadb45bb5fc1bf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "12996245a7fc9d1584b4586ad196f0542f449719fb94878a8bd386cc270ed5e2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "6efe75609028a2d9dc6779f0e439aee14b3a133dd3a5dfe1c5a2c730902eee17";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/tracetools/default.nix
+++ b/distros/kinetic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/kinetic/tracetools/0.2.1-0.tar.gz";
     name = "0.2.1-0.tar.gz";
-    sha256 = "59ed304f0ac9078e5b0875444b5594170921f29d35ba304a7f60f17eadd54f57";
+    sha256 = "0c51e131b0461a9aeb8822e368147433d331bbf9c972062f775d9f4e73a0636e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "bd0c173413a1e4287e6264c4d83f2849e86c62feb6c056485b3f3d49084c413a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "00f4e2fc6c0a6c21ff594ee06cc8780402c0726743d35b222300d3dd7b0553d1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "73da8f58b2fddca203abf9688bcc5b59588106f892bcd15540d1ccad9d72b984";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "444e1f08016b1c86d44eb102989846948ebd8f00e79dedd0d0a67bbe81e5766b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/uos-common-urdf/default.nix
+++ b/distros/kinetic/uos-common-urdf/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-common-urdf";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_common_urdf/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "a5f8126702edd3fca2341e78613c2d6bbc777689ece6e9a3cc3a1542e90fa5ed";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-plugins urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains URDF descriptions of the UOS robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/uos-diffdrive-teleop/default.nix
+++ b/distros/kinetic/uos-diffdrive-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, ps3joy, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-diffdrive-teleop";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_diffdrive_teleop/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "e34befd57cb66e4d83a4521694a0d0c8b8e328820358396dc9dcba575ce35292";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs ps3joy roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''uos_diffdrive_teleop'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/uos-freespace/default.nix
+++ b/distros/kinetic/uos-freespace/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-freespace";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_freespace/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b71f45dc6130241aa383a580a6daa8b6ee670279aab3e521d758890ba41d3c6b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''uos_freespace package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/uos-gazebo-worlds/default.nix
+++ b/distros/kinetic/uos-gazebo-worlds/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-gazebo-worlds";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_gazebo_worlds/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "e250f2f04b094f8c624d69188f4e937cb696ec734c44bd1f02b8baca1eaedf27";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo world and model files for UOS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/uos-maps/default.nix
+++ b/distros/kinetic/uos-maps/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-maps";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_maps/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "73a8406a83ef53fd734c0e19abbe0a7244f416c92911b2e2e90b35b53162b48b";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Navigation maps of the Osnabrueck University'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/uos-tools/default.nix
+++ b/distros/kinetic/uos-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, uos-common-urdf, uos-diffdrive-teleop, uos-freespace, uos-gazebo-worlds, uos-maps }:
+buildRosPackage {
+  pname = "ros-kinetic-uos-tools";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/kinetic/uos_tools/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b0adc72c49218352d9f60d21a2aa6d2f98d1fa0e0910e9acf0d53538220716f0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ uos-common-urdf uos-diffdrive-teleop uos-freespace uos-gazebo-worlds uos-maps ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various helper utilities not associated with a particular stack'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/warehouse-ros/default.nix
+++ b/distros/kinetic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-warehouse-ros";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/kinetic/warehouse_ros/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "d1c58ca0544269702a600c838af44c88551bf2778a4c28a96d65f07ac58b8d51";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/kinetic/warehouse_ros/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "a9cc5e4ce61b60a68494544a17d64230327a760bc67f9acd0d7bcc903b3e7138";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/webrtc-ros/default.nix
+++ b/distros/kinetic/webrtc-ros/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, image-transport, nodelet, roscpp, webrtc }:
+{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, image-transport, message-generation, message-runtime, nodelet, roscpp, std-msgs, webrtc }:
 buildRosPackage {
   pname = "ros-kinetic-webrtc-ros";
-  version = "59.0.3";
+  version = "59.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/kinetic/webrtc_ros/59.0.3-0.tar.gz";
-    name = "59.0.3-0.tar.gz";
-    sha256 = "a8aafe6029f2c0bb249388524edfb8ba4616d6aa24ef17c925ff775fbe6832e8";
+    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/kinetic/webrtc_ros/59.0.4-1.tar.gz";
+    name = "59.0.4-1.tar.gz";
+    sha256 = "79b78d5d83144c42163507e3c1f9571f4a5f212725a17688d82ad00013d50dc4";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ async-web-server-cpp cv-bridge image-transport nodelet roscpp webrtc ];
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ async-web-server-cpp cv-bridge image-transport message-runtime nodelet roscpp std-msgs webrtc ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/webrtc/default.nix
+++ b/distros/kinetic/webrtc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, alsaLib, cmake, git, glib, gtk2, gtk3, pulseaudio, wget }:
 buildRosPackage {
   pname = "ros-kinetic-webrtc";
-  version = "59.0.3";
+  version = "59.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/kinetic/webrtc/59.0.3-0.tar.gz";
-    name = "59.0.3-0.tar.gz";
-    sha256 = "afa18dd5fdfadd08f2c2707c74d3119beabe30017a946d973176d56ce9b24094";
+    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/kinetic/webrtc/59.0.4-1.tar.gz";
+    name = "59.0.4-1.tar.gz";
+    sha256 = "4aa9805ace4bccb00314202e08d7ea02f8107da8548b94c98c84fd5dbef3af79";
   };
 
   buildType = "cmake";

--- a/distros/melodic/ackermann-steering-controller/default.nix
+++ b/distros/melodic/ackermann-steering-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, diff-drive-controller, gazebo-ros, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, rosunit, std-msgs, std-srvs, tf, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, rosunit, std-msgs, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ackermann-steering-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "322a175e8e262849f1159517354c0bd1713a08577465dc0f789068b1d11bc674";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ackermann_steering_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "c553bdd6e14ac072c421684f6e69b8c01c1e617593efb2a3cbd0032307cde4de";
   };
 
   buildType = "catkin";
-  checkInputs = [ controller-manager gazebo-ros geometry-msgs rostest rosunit std-msgs std-srvs xacro ];
+  checkInputs = [ controller-manager geometry-msgs rostest rosunit std-msgs std-srvs xacro ];
   propagatedBuildInputs = [ boost controller-interface diff-drive-controller hardware-interface nav-msgs pluginlib realtime-tools roscpp tf urdf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "78a408a44823f4bffce98e9a503ac4da670cff6c6b1efd4648993b3961d3b49d";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "ef77fec8cc306f279d4440e66a146ce401af424777a28631210aa4717d881936";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "88919594d2887febbb2fe7c27ba072d19c029775d34e86ca7091e1be2b93c122";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "764b01bbf6a9ab75dda8eeaef65a0bfaebdb0046fceead812311623cdfa12058";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "79696350d2096a5c7d524d0a76ec5d31be6a104ebb9e7579bcb055e59cce2852";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "2bf5dee17349f20dd5c12b136b29eab4ea7abb6fde874e9ca3f7d8a07986b9cb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "8cb68e5ddd9a5c689952f33b40f187a2edc7dfac7f0539dfe46879ea846ecd6e";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "58251f44161ddffe7484815955ee2c10be04312d117216e405d2d8c5b4f724b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/behaviortree-cpp-v3/default.nix
+++ b/distros/melodic/behaviortree-cpp-v3/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cppzmq, roslib }:
+{ lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-melodic-behaviortree-cpp-v3";
-  version = "3.1.0-r2";
+  version = "3.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "2c5f5784135cd3f4ff117b3b965ad455fc879f2e2be4a243662ac98917a3443e";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.4.0-1.tar.gz";
+    name = "3.4.0-1.tar.gz";
+    sha256 = "338a680bc897676926b316b51279596b622c0b7e14da9c628abbd8ccaf484150";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cppzmq roslib ];
+  propagatedBuildInputs = [ cppzmq ncurses roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3bb6111f5f09f08aab5941a388925b99ab2506940210739a9b80e2ac4578079d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "153d8a79f12f963bf0db013834ce4c32d518b9cc0faf6ef8552a042a0d69e352";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "f2947c31e921445c735dc4c2279b5528405df82c5b47ff9d971618d87465925a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "5a29b530a08c7d363b3ce201e8e923a1ad29ba3761e27977fe6ccd7c996704a2";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
+  checkInputs = [ roslint rostest ];
   propagatedBuildInputs = [ costmap-cspace-msgs geometry-msgs laser-geometry nav-msgs neonavigation-common roscpp sensor-msgs tf2-geometry-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/diff-drive-controller/default.nix
+++ b/distros/melodic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-diff-drive-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "bba19fbf9898f70fcbcad93bbb0594073bd1385f49e6a5767603077f2b4e61e6";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/diff_drive_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "2476bfceda9168520a679861630e4831777f46ca300db35c13e822b105ef05e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/effort-controllers/default.nix
+++ b/distros/melodic/effort-controllers/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, pluginlib, realtime-tools, urdf }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, pluginlib, realtime-tools, robot-state-publisher, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-effort-controllers";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "08a47328c88cab240dd5e07e72ca7f615bf47758907c7a380f4a56bf808fc37b";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/effort_controllers/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "f646bf26b6253bccccd8b69dfbc2bcb0c5a956101019d2265edc5f0d330fac58";
   };
 
   buildType = "catkin";
+  checkInputs = [ controller-manager hardware-interface robot-state-publisher rosgraph-msgs rostest sensor-msgs std-msgs xacro ];
   propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface forward-command-controller pluginlib realtime-tools urdf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/force-torque-sensor-controller/default.nix
+++ b/distros/melodic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-force-torque-sensor-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "0d79ee174d2afda41b87f1a13683d7d1b31c1e6671162cdc351d381f19d74414";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/force_torque_sensor_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "9b10aac4a8aa7270e5802655d1832467e69278cd6a82bda8d1489b126e7ee3e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/forward-command-controller/default.nix
+++ b/distros/melodic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-forward-command-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "b04daaf8ae46594040fe7ab857d20706190b65c273ad76ff91cdc851e5ef4c98";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/forward_command_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "c44eafec99c5d1625187d02225b2231089e39f599df2e9e9404b708ac89867f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/four-wheel-steering-controller/default.nix
+++ b/distros/melodic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, std-srvs, tf, urdf-geometry-parser }:
 buildRosPackage {
   pname = "ros-melodic-four-wheel-steering-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "471f11668627322bb06fabb1d59fce96de3d40f7d6dd4f548ca20b7141e19473";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/four_wheel_steering_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "5f0e1608b80dfcc937eb2280a5c460a72656ce5d3e98dee382d6d2c498c56fd9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-dev/default.nix
+++ b/distros/melodic/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazeboSimulator }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-dev";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_dev/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "8d841ef18dab02cf584a0b7d85226cf6b5f529aaf8ee3597dac4206fd3472aeb";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_dev/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "6f4a77811479925460c669ec6b9bd8c883c0e932a848affadaa81c9aac8f6b41";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-msgs/default.nix
+++ b/distros/melodic/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-msgs";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_msgs/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "823bf8f1534ecf1a3842c89e751e29e1b7de4a8cb8ebcee5fac5bd0a333cdc3a";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_msgs/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "65a804640e4e2f3ed6c1f3cc4ba8a3133b61ba1cbd8d1f87b4dae9560009572e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-plugins/default.nix
+++ b/distros/melodic/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, camera-info-manager, catkin, cv-bridge, diagnostic-updater, dynamic-reconfigure, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, polled-camera, rosconsole, roscpp, rosgraph-msgs, rospy, rostest, sensor-msgs, std-msgs, std-srvs, tf, tf2-ros, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-plugins";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_plugins/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "1132d0788599aa72775a5cc72d316aafb94cd1e1afc271795226a25607920f73";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_plugins/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "625b943a9b31c39631b7af384aff458903170b38a252424ea1f259228d0114f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-ros-control/default.nix
+++ b/distros/melodic/gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, joint-limits-interface, pluginlib, roscpp, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-ros-control";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros_control/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "92e01882d9f3e1a454bc6b728d9699564759d37b52f0faf4fbe1a28ddd58ecb8";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros_control/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "ecdf8af43115ba2e33784fc929f2a3db6c686ab9b5536e6276939ba846fd6b3e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-ros-pkgs/default.nix
+++ b/distros/melodic/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-ros-pkgs";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros_pkgs/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "1726df1903a6b0db65c91eb830df5e7e0df4cc0e5a69a9d6e941a3c00fe1c2f6";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros_pkgs/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "32f8f2bec39336a5ee3896b263f8d2b02dcd74b077e08ae74c0f836bb02a0c7b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/gazebo-ros/default.nix
+++ b/distros/melodic/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, gazebo-dev, gazebo-msgs, geometry-msgs, python, roscpp, rosgraph-msgs, roslib, std-msgs, std-srvs, tf, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-ros";
-  version = "2.8.6-r1";
+  version = "2.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros/2.8.6-1.tar.gz";
-    name = "2.8.6-1.tar.gz";
-    sha256 = "dc8f1d47eec49a2d86ddc34eac347d015076e2d99ccb01ef0e41bd833087f260";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/melodic/gazebo_ros/2.8.7-1.tar.gz";
+    name = "2.8.7-1.tar.gz";
+    sha256 = "15d999f6d119f015cf13d6bd41fcbed70138fc57ca3244e23170755949ae7067";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1086,6 +1086,8 @@ self: super: {
 
  haros-catkin = self.callPackage ./haros-catkin {};
 
+ hdf5-map-io = self.callPackage ./hdf5-map-io {};
+
  health-metric-collector = self.callPackage ./health-metric-collector {};
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
@@ -1151,6 +1153,10 @@ self: super: {
  hpp-fcl = self.callPackage ./hpp-fcl {};
 
  hrpsys = self.callPackage ./hrpsys {};
+
+ hrpsys-ros-bridge = self.callPackage ./hrpsys-ros-bridge {};
+
+ hrpsys-tools = self.callPackage ./hrpsys-tools {};
 
  husky-base = self.callPackage ./husky-base {};
 
@@ -1434,6 +1440,8 @@ self: super: {
 
  kvh-geo-fog-3d-rviz = self.callPackage ./kvh-geo-fog-3d-rviz {};
 
+ label-manager = self.callPackage ./label-manager {};
+
  lanelet2 = self.callPackage ./lanelet2 {};
 
  lanelet2-core = self.callPackage ./lanelet2-core {};
@@ -1642,6 +1650,8 @@ self: super: {
 
  mbf-msgs = self.callPackage ./mbf-msgs {};
 
+ mbf-recovery-behaviors = self.callPackage ./mbf-recovery-behaviors {};
+
  mbf-simple-nav = self.callPackage ./mbf-simple-nav {};
 
  mbf-utility = self.callPackage ./mbf-utility {};
@@ -1661,6 +1671,14 @@ self: super: {
  mecanum-gazebo-plugin = self.callPackage ./mecanum-gazebo-plugin {};
 
  media-export = self.callPackage ./media-export {};
+
+ mesh-msgs = self.callPackage ./mesh-msgs {};
+
+ mesh-msgs-hdf5 = self.callPackage ./mesh-msgs-hdf5 {};
+
+ mesh-msgs-transform = self.callPackage ./mesh-msgs-transform {};
+
+ mesh-tools = self.callPackage ./mesh-tools {};
 
  message-filters = self.callPackage ./message-filters {};
 
@@ -1718,6 +1736,8 @@ self: super: {
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
+ moveback-recovery = self.callPackage ./moveback-recovery {};
+
  moveit = self.callPackage ./moveit {};
 
  moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
@@ -1753,6 +1773,8 @@ self: super: {
  moveit-ros-manipulation = self.callPackage ./moveit-ros-manipulation {};
 
  moveit-ros-move-group = self.callPackage ./moveit-ros-move-group {};
+
+ moveit-ros-occupancy-map-monitor = self.callPackage ./moveit-ros-occupancy-map-monitor {};
 
  moveit-ros-perception = self.callPackage ./moveit-ros-perception {};
 
@@ -1964,6 +1986,10 @@ self: super: {
 
  novatel-msgs = self.callPackage ./novatel-msgs {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
@@ -2043,6 +2069,10 @@ self: super: {
  openni-launch = self.callPackage ./openni-launch {};
 
  openrtm-aist = self.callPackage ./openrtm-aist {};
+
+ openrtm-ros-bridge = self.callPackage ./openrtm-ros-bridge {};
+
+ openrtm-tools = self.callPackage ./openrtm-tools {};
 
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
 
@@ -2472,20 +2502,6 @@ self: super: {
 
  rcdiscover = self.callPackage ./rcdiscover {};
 
- rdl = self.callPackage ./rdl {};
-
- rdl-benchmark = self.callPackage ./rdl-benchmark {};
-
- rdl-cmake = self.callPackage ./rdl-cmake {};
-
- rdl-dynamics = self.callPackage ./rdl-dynamics {};
-
- rdl-msgs = self.callPackage ./rdl-msgs {};
-
- rdl-ros-tools = self.callPackage ./rdl-ros-tools {};
-
- rdl-urdfreader = self.callPackage ./rdl-urdfreader {};
-
  realsense2-camera = self.callPackage ./realsense2-camera {};
 
  realsense2-description = self.callPackage ./realsense2-description {};
@@ -2772,6 +2788,8 @@ self: super: {
 
  rosnode = self.callPackage ./rosnode {};
 
+ rosnode-rtc = self.callPackage ./rosnode-rtc {};
+
  rosout = self.callPackage ./rosout {};
 
  rospack = self.callPackage ./rospack {};
@@ -2966,9 +2984,15 @@ self: super: {
 
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
+ rtmbuild = self.callPackage ./rtmbuild {};
+
+ rtmros-common = self.callPackage ./rtmros-common {};
+
  rviz = self.callPackage ./rviz {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
+
+ rviz-mesh-plugin = self.callPackage ./rviz-mesh-plugin {};
 
  rviz-plugin-tutorials = self.callPackage ./rviz-plugin-tutorials {};
 
@@ -3242,23 +3266,11 @@ self: super: {
 
  tile-map = self.callPackage ./tile-map {};
 
+ timed-roslaunch = self.callPackage ./timed-roslaunch {};
+
  timestamp-tools = self.callPackage ./timestamp-tools {};
 
  topic-tools = self.callPackage ./topic-tools {};
-
- toposens = self.callPackage ./toposens {};
-
- toposens-description = self.callPackage ./toposens-description {};
-
- toposens-driver = self.callPackage ./toposens-driver {};
-
- toposens-markers = self.callPackage ./toposens-markers {};
-
- toposens-msgs = self.callPackage ./toposens-msgs {};
-
- toposens-pointcloud = self.callPackage ./toposens-pointcloud {};
-
- toposens-sync = self.callPackage ./toposens-sync {};
 
  towr = self.callPackage ./towr {};
 
@@ -3401,6 +3413,18 @@ self: super: {
  unique-id = self.callPackage ./unique-id {};
 
  unique-identifier = self.callPackage ./unique-identifier {};
+
+ uos-common-urdf = self.callPackage ./uos-common-urdf {};
+
+ uos-diffdrive-teleop = self.callPackage ./uos-diffdrive-teleop {};
+
+ uos-freespace = self.callPackage ./uos-freespace {};
+
+ uos-gazebo-worlds = self.callPackage ./uos-gazebo-worlds {};
+
+ uos-maps = self.callPackage ./uos-maps {};
+
+ uos-tools = self.callPackage ./uos-tools {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/melodic/gripper-action-controller/default.nix
+++ b/distros/melodic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-gripper-action-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "2337e0adb4170e7b59a23577e3ad6be54e451df5bc51d840a859e33460ea68ed";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/gripper_action_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "ba24a858c7376329a726f362aab150d7ddaa9bf13fc903f42690180219f6f802";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hdf5-map-io/default.nix
+++ b/distros/melodic/hdf5-map-io/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, hdf5 }:
+buildRosPackage {
+  pname = "ros-melodic-hdf5-map-io";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/hdf5_map_io/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "4b25fc9823b115e2ffddf5f274ec81719b69c4b1761564c11072e0cdde9514fd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost hdf5 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The hdf5_map_io package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/hrpsys-ros-bridge/default.nix
+++ b/distros/melodic/hrpsys-ros-bridge/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, camera-info-manager, catkin, collada-urdf, control-msgs, diagnostic-aggregator, diagnostic-msgs, dynamic-reconfigure, euscollada, geometry-msgs, git, hostname, hrpsys, hrpsys-tools, image-transport, message-generation, mk, nav-msgs, nettools, pkg-config, pr2-controllers-msgs, pr2-msgs, procps, pythonPackages, robot-pose-ekf, robot-state-publisher, rosbuild, roscpp, roslang, rosnode, rostest, rqt-gui, rqt-gui-py, rqt-robot-dashboard, rqt-robot-monitor, rtmbuild, sensor-msgs, subversion, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-hrpsys-ros-bridge";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/hrpsys_ros_bridge/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "6952e7f4b1edeb8a7a51d03a8c1e082775257a5ed9e6a79ab3a7e8da680fb7bc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles euscollada git hostname message-generation mk nettools pkg-config procps pythonPackages.rosdep rosbuild roslang subversion ];
+  propagatedBuildInputs = [ actionlib camera-info-manager collada-urdf control-msgs diagnostic-aggregator diagnostic-msgs dynamic-reconfigure geometry-msgs hrpsys hrpsys-tools image-transport nav-msgs pr2-controllers-msgs pr2-msgs pythonPackages.ipython pythonPackages.psutil robot-pose-ekf robot-state-publisher roscpp rosnode rostest rqt-gui rqt-gui-py rqt-robot-dashboard rqt-robot-monitor rtmbuild sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''hrpsys_ros_bridge package provides basic functionalities to bind
+  	<a href="http://wiki.ros.org/hrpsys">hrpsys</a>, a 
+  	<a href="http://openrtm.org/">OpenRTM</a>-based controller, and ROS.<br/> 
+    By using this package, you can write your ROS packages that communicate with your
+    non-ROS robots that run on hrpsys.
+  		
+    For communicating with the robots that run on OpenRTM without hrpsys,
+  	you can use <a href="http://wiki.ros.org/openrtm_ros_bridge">openrtm_ros_bridge</a>
+  	package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/hrpsys-tools/default.nix
+++ b/distros/melodic/hrpsys-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hrpsys, openrtm-tools, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-hrpsys-tools";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/hrpsys_tools/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "022b471d0ff125eb3e55e527a04b71984645c5fcf74185e834f640356461a8fc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ hrpsys openrtm-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The hrpsys_tools package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/hrpsys/default.nix
+++ b/distros/melodic/hrpsys/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL, cmake, doxygen, freeglut, git, glew, graphviz, irrlicht, libxml2, mk, opencv3, openhrp3, pkg-config, pythonPackages, qhull, xorg }:
 buildRosPackage {
   pname = "ros-melodic-hrpsys";
-  version = "315.15.0-r2";
+  version = "315.15.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/hrpsys-release/archive/release/melodic/hrpsys/315.15.0-2.tar.gz";
-    name = "315.15.0-2.tar.gz";
-    sha256 = "f269e0d246394a0ba686759946bffb35754748b3d6d8bd9ea7c3119374cffd25";
+    url = "https://github.com/tork-a/hrpsys-release/archive/release/melodic/hrpsys/315.15.0-6.tar.gz";
+    name = "315.15.0-6.tar.gz";
+    sha256 = "0d9b09484ec3842dec6080ff782e6f6da298cf12df140c0764cb4d45d301a1f7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "563aa35de332fa99821c0756f900c27bf44185757f9d745d20842c321457d1f7";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "b7c4233e073c95588cdbecf98e25eabf3776c866f397e8f5117f48a00e40a8f5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7 }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "f407b778f65237dcf58ff694a305a30ac104e394aacc1df4175a63e22ad01c57";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "5db7908ee7a78015c2562c561dd821494f0488ad853c7cbb5a1bfb837459dfa2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "bceb125b2585ee266ec050570247422ad633aa859e42377140f3d20d28929425";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "654e57a7a237122883f45ec6606bb664496ec8c1e4298f0e6bbe4743971cf3f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "79f2f85a823b49a15f1d81cbffe530aeb28f3dc8c08c8b4c95c762c9fb722855";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "d6bb1c74b737fe60527f241c6fe7a1e0db64f06c4610b6b46de0bbe8238b7353";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "b5332794b91af65a13ba560e935f1b0008e9703de67598175ddfd4e2eeb3518a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "6474931a870dcc4b91400a6f4f96d5d51d3503362b5b6c77838e9e692f55ed42";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "19ba9b5eaf533e3685eca5564218f3e6086ad5fabab3e59d988f8028d72757da";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "764f523cad40ac87cf73f32d3ab12ed80f848fc74e2db3fcf716b2fcf2b1da4e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "ff3b6b60aebe40d7de6b4cc679f32942797b7d5aa57f36a882cf0425f933ebc5";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a85802bb73a11739a38ac81506040efaed7a89bb11ba949d545bb1317ca7c4d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "605a9afe049cfec4eb315037bf7973ac4bba43217da55c7b7a2b880eb44acae0";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "869b4cdd12a13d3293496babdc593ae6fa72e1f735bbc913647b11bc6323d804";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "0a9259108259aa128424730f996fb2c7496e7e1deaf8c4c2318ede571653c669";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "89860a5587cba228235f7e434f6c7b7bc7bd901323e65673fe17ac56fe13e7f6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "957f8edd097f405656df436cf93bc1f7fdb3b4cc2a8fd2c465b56b3596c43a94";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "f2b533e89aa0929f338bf3cb8b24bccd0a122325c61a016fc1662b627ed11f12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
+{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "c22a2d95e4ad42762a0c1c39e4941dff2f7ec2a645486b0d870b9c370de6f544";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "753cdf0cf96fbea1722939adf0328eed6832cf72375e8a9e2d49576547009d41";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ husky-description joint-state-publisher robot-state-publisher rviz rviz-imu-plugin ];
+  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz rviz-imu-plugin ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/imu-sensor-controller/default.nix
+++ b/distros/melodic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-imu-sensor-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "79b75d3618a15c1ae465aa3cf30a0054426298e2175144d77a8dd23f7a225927";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/imu_sensor_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "906bde9773a111c797bdd07926b294ac58a367ba5059b1fba96ffd9152501ea4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.6.4-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "e3cca2cc1ace4e6c7ab89462c917dc7459b2d2c03dd8717c8f90a8394485f9c3";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b87aedff58d263b73ec2f59b1841fc320d7d5cbb661db4f6ad9290a2a9b0c46d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.6.4-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "292362838901a248f37d703c3ac77429ee40ad8ce765db21f35188d61232c9d7";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "0738d3acd56ac0b1d87965b578c3e996e4d1ee0c40bfb8d1768868bbff031caf";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.6.4-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "cb6a1230e23907146141d5e41a45ef47140f0aa8c243630634b6f2436ca09163";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "f9115648d7b2cb878751d3a793f5eac53954c24b603360f1165ac78b2edb588d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.6.4-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "ded7d60ecc878baa0ee210543a9815814bc84f38bc7e3ac260b69179fc23f868";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "619c6e1d03c9c4bb478230ab2f2c51d4ad4178cd92b332e537e045ab76a8e24a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.6.4-r3";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.6.4-3.tar.gz";
-    name = "0.6.4-3.tar.gz";
-    sha256 = "2b4a50407187182e5fcc4f33d017595d3587838f2438331abdfd8a702f961532";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "83d78cc8d4181f497dc7d4b527863b22068c2ee387a1ca11bd760adf28eedef4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-assets/default.nix
+++ b/distros/melodic/jderobot-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-assets";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "3996e6a1135cf02649e93b30f5db9b1b61b9ab1383cf99d3cab72ec480059864";
+    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b19ca427101bbd076aa5a9c30e8f5f50f0d0c0cb9869079957d6287dd2791ffd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-state-controller/default.nix
+++ b/distros/melodic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joint-state-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "368aeb4a599f094d510015612695922a46f8e0690a2d39ae054c4fcd7c5297f1";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_state_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "afd433ac211b557c256b4df313751d486781afd7611b3d6557febb5b45462982";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-trajectory-controller/default.nix
+++ b/distros/melodic/joint-trajectory-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, cmake-modules, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-joint-trajectory-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "206fd84efd527fa25f341effcfcdec8aeba5cc81d1373ee9c36d128909eb7d14";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/joint_trajectory_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "ce380dee069d4e871548d288950017dec77dab8ba4a37c5462ea05053845592d";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  checkInputs = [ controller-manager rostest xacro ];
+  checkInputs = [ code-coverage controller-manager rostest xacro ];
   propagatedBuildInputs = [ actionlib angles control-msgs control-toolbox controller-interface hardware-interface pluginlib realtime-tools roscpp trajectory-msgs urdf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "5f0d27608d4349658a0c58cd51b41da17370c96cbcf489f69fe6a916a8ef7ffc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "e61ac90a1ba9d65216eaf10976c95e59158e652eedfe45c103f59e81927f413f";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
+  checkInputs = [ roslint rostest ];
   propagatedBuildInputs = [ geometry-msgs neonavigation-common roscpp sensor-msgs topic-tools ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/label-manager/default.nix
+++ b/distros/melodic/label-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, genmsg, mesh-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-label-manager";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/label_manager/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "97b371fb101be7bf59209d81b3c9780abe22d1a78eeb2555a86a320e754c03b7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs genmsg mesh-msgs message-generation message-runtime roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Serving and persisting label information'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "0a1fa810e076522de4be63caaa23306901462e3a0c59c66ada357ade2ded2ca3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "f3db30f9baa916050537a4f48a7f8c81d543d194d2228b838fbf8309d56067cf";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ cmake-modules eigen eigen-conversions geometry-msgs map-organizer-msgs map-server nav-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs map-organizer-msgs map-server nav-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mbf-recovery-behaviors/default.nix
+++ b/distros/melodic/mbf-recovery-behaviors/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveback-recovery }:
+buildRosPackage {
+  pname = "ros-melodic-mbf-recovery-behaviors";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mbf_recovery_behaviors/archive/release/melodic/mbf_recovery_behaviors/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "d46c033ea04bf57baed8c42ac931e8c18d2ee24158d6fb4f66e4e195f6ddab5e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ moveback-recovery ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mbf_recovery_behaviors package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mesh-msgs-hdf5/default.nix
+++ b/distros/melodic/mesh-msgs-hdf5/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mesh-msgs-hdf5";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_hdf5/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "d405f421ec7bff3d7b22d58e86d613174332b3fadbffff4f04b402413fbf6dc6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hdf5-map-io label-manager mesh-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Read and write mesh_msgs to and from hdf5'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mesh-msgs-transform/default.nix
+++ b/distros/melodic/mesh-msgs-transform/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mesh-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-mesh-msgs-transform";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_transform/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "774eb5801a209f2939d76b1d058112b2472405fa5790d28c7e9bcf4375e0810d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs mesh-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Methods to transform mesh_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mesh-msgs/default.nix
+++ b/distros/melodic/mesh-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mesh-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "d120ce3a5e6b61a59a4e0d959d0d62575be556f0172cd5860b5e4ece4c9996e6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various Message Types for Mesh Data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mesh-tools/default.nix
+++ b/distros/melodic/mesh-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs, mesh-msgs-transform, rviz-map-plugin, rviz-mesh-plugin }:
+buildRosPackage {
+  pname = "ros-melodic-mesh-tools";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_tools/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "ab25a7aa81386ca73f2978593edcaa93a85ca3108815c4ac5fd68d58c877dfa1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hdf5-map-io label-manager mesh-msgs mesh-msgs-transform rviz-map-plugin rviz-mesh-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mesh_tools package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/moveback-recovery/default.nix
+++ b/distros/melodic/moveback-recovery/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, costmap-2d, mbf-costmap-core, mbf-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-moveback-recovery";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mbf_recovery_behaviors/archive/release/melodic/moveback_recovery/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "4f8e01790e4812b87346b38c5f7d92aedb8ad318bf152e797280b065258156a2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ base-local-planner costmap-2d mbf-costmap-core mbf-msgs pluginlib roscpp tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Move Base Flex (MBF) recovery behavior moves the robot back for specified length.
+        It also checks the costmap for a possible collision behind the robot while moving and
+        stops the robot if necessary.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "4bb3527f09b0eacd6fb565b2f967f166c4c5e7cc38f94861701e61e6d3fc82ea";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "8fb1d0d33df9a57feaf8d3fd529b948f46d4dc915e7dc1e53993e400237178d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3ac00ba25d7359af9dd91ff581b2189e04a1a4328913389f1c2f100379782a1f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "e62906b7f9ab4e5cf65c6d43cb4139335c1fae7e8ca22732686f3d770ac0f977";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-experimental/default.nix
+++ b/distros/melodic/moveit-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-experimental";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_experimental/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ef4bbc171b72dcaf152c7695ee588e443636c85cd2ab2b67bbd2faa05d96a285";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_experimental/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "e190eb9b55f5c626a308d5666f0fb668fa4db91ca965eb81f71f71f0b0f257e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "81da969af27c558f406c4349b97cc26710f55df559cf16b4123cea90d6c17f03";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "d401c9fce5789c2ac1e772247330c762169487ef9d07adff5f58ce748b2c1c8f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "5b691b09f0e6b7560ab0971ee94fb84a351142b5619dab071b3c1924a6766c13";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "cd987af131360fdc327814593634712222a737c98fc86962ce68e9e44d8636d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1da3d5449339b872017fe01d4592569a79c24dbcea3e64d2c045f2f1393ea35d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "e5511388a2fc552cde9b005d6499179cb9a4bae9528108d04437f5e0501c3922";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "57dbd0aaf20ebe0619ed16d10a7835fee61df22ad5438da662dcbe71c670bdce";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "d227e3d845246b39a128d484459933a3ab94de35cd45bf3cf318f68dc0ae1fac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "d8a75310db98a3d553e69a95401e22b704290dbad14be446fa3c0b1aa19e30bf";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "64bf18b4e525c88b0f58d2773265145dbbc8a156503ca87f232a1893b6c36501";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "50d9d908c1d2fa7fe7f064d766471adb9daf453293026ca33ad7c6d87129aed6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "f1006e772d6bbeb56b89ea7ff5c4f8c208090c78491d54a8476c096d394c29be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "4d739a977e815a45a45542b52f31244a1755d4e4df62d68399d5bada565e3fed";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "79f40a97093eb0be0703290346e212737d4713420834516fc3386520a92df0d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "94c405b03bee2a9f793c5350d25551c215e10102cb3360b465f14030f96992d7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "d85299f39ee21f1ad34d5e9dfa031a760a05cdc3ff9c5f7c04435fda7300b64c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "156ae51dac52174c5702fd6c73088fe6b3cb36da1a202e8eddb5a4b02e843b51";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "b294d0dce3b01473b2a38a28fd41fa4ded0f8da5abcdb44e35f63cb44dd53449";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "d769750daaea1f09c9e550295c4b04c4fb609c3d514a6ae03f4a7c38c81ab515";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "84d6e721e0c286ca8895bb4509cf17da26d3334899f2009d04289521cf544d0f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
+  version = "1.0.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "d5dae1ae2579cb36e079012e30ff83d894eb16e5b0c3a171e924a55ab527bb67";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometric-shapes moveit-core moveit-msgs octomap pluginlib tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Components of MoveIt! connecting to occupancy map'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, message-filters, moveit-core, moveit-msgs, object-recognition-msgs, octomap, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0a8638101732055e5933e49417462de4594a41c707c520e90704f920d6452c8e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "2d8c5f25f8a211ac3cb47548bd48366ba318a408e63690e11fee5e4e294faee7";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport libGL libGLU message-filters moveit-core moveit-msgs object-recognition-msgs octomap pluginlib rosconsole roscpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros urdf ];
+  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport libGL libGLU message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor object-recognition-msgs pluginlib rosconsole roscpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "f68c495c75d0c3ee11bf1e8235f63df94439df395eb19a9265baf8a70356b57f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "211cfc07cba0a114fdb54ee6ff2939e9dd22d5f6b336ad4b69dc2745f916904e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-perception, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "c3b8fc441f13cfac3da59cf186ac92f8c8b60449bccc9ae029b01e8a1f2c9871";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "06bc30b72ce32f3bfe35c736ae79b17c60411a5378f1c5a146585a9e0801ba9e";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen ];
-  propagatedBuildInputs = [ actionlib dynamic-reconfigure message-filters moveit-core moveit-msgs moveit-ros-perception pluginlib rosconsole roscpp srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
+  propagatedBuildInputs = [ actionlib dynamic-reconfigure message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rosconsole roscpp srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "3332b6537faed0c98ece9ea5d64d1b6c3253fa4b3b2ee738fa9bee14b2c772c6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "bc9cfbbe671543cd62980ebda44de721c9e8e535158514a7e291d2534d359b1f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "9df003a3b5efded0a174f70c81b91525535fba541f5ead44c240493baff63c79";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "d5d8a13def50004da86f5fe4523086eae412fa67c268549a1aff42f2df31277c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "6170d8dc44945f1f314818a9bf4e14420f5966b38be89893ab9e91cddda3877e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "4ade914f0a1261e8b0326bd6ff96b89acad5a1b774887661b41311bea8a67765";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "8b551243c80a94f093cc3dfb6039e7f18ff80de60972a1e942bb2c2f9ff10fd8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "1b4ff1c14e32d97c81a48d2a6a84a5db25510e695263ba15bfc6c7d0c4f93705";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "316540c39d80e5428634877875126cd10290f49cfaa7099b8a316e7f688fbc67";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "835395c63e5b9a9504f1230dd89b1f019818e2d075a1e6aee9bf352c3d919f71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "02f195ff7a606823dccf0c07cc5a77f1abff255ed1849b796a6faa8d97b6ac2d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "ad91800be3f51848a367d9b79b91476ee58b56dbca39fbc6428bd5f978b9c70b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "2d9df58ece4beca42b4d6b27da0c2f308c866f5ea5842a63eaa2bbe7258499ee";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "17279df23dadd10afe22d00bf93e1991b369f48c9725ad8e1d9210d762cd9304";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7ec4031dbef08128c3a4ed9b7f82b6a01700046c221076e236ce5c352d27084b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "ce38602900aca0b81cf1598a3fa21f935930834bd309176e901bfc4300310d5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "49f292f2f9e52436f64d5a66a818ba80362c5ad6e8b0fcc7ad52361990512d6d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "98a3010401fd8946e6a9b37c7b7bf7d3220f9e68641bb3c0abb55c10f3a784fb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "ff0b242789319d1d23acb0a8e6edc846a989cd8c14ee29c7894f6d708ef42696";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "4947fa557e7c7b8095ba8bbee3ca92f80f29f4fdddeecefcd131af7a3c08744e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "e9381147a667c8be966c125634234d4dae9dc249114ffeb1f2f8849a208fcc7e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "d36f58ad6d070c7aecf34dd7a11d126d9ad8ca4f32c4dc3255e0d92894cd3dd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/novatel-oem7-driver/default.nix
+++ b/distros/melodic/novatel-oem7-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, tf }:
+buildRosPackage {
+  pname = "ros-melodic-novatel-oem7-driver";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "914ada691690a247290b82c32d26d86fb323d75a50d93f5558559e6c4170187d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gps-common tf ];
+  propagatedBuildInputs = [ nodelet novatel-oem7-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NovAtel Oem7 ROS Driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/novatel-oem7-msgs/default.nix
+++ b/distros/melodic/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-novatel-oem7-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7d44b73cf9773088ba1a6bb954dbf0de680419cd59e4c3654ffe0d46e4795298";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for NovAtel Oem7 family of receivers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "2c835a6423eb7fc6dc2abe70921f8ed00b1798d7d92f3e719ee7a2e4719c1bd8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "cf20f16f1f384d608666a4ceefc036a0b8ac2ddd3ef8b2d9a89133009b00c5dc";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ eigen eigen-conversions geometry-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/octomap-mapping/default.nix
+++ b/distros/melodic/octomap-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap-server }:
 buildRosPackage {
   pname = "ros-melodic-octomap-mapping";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_mapping/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "3127fd19d50255f4cbf65da0504e92bd95058ea6a1a744326d88422012fbca0c";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_mapping/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "f1f29ddb95c6b2ff8a93fa7f3fa91cbc1fce4c0a8901bcce4bc45cb1b6eb3b0a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap-msgs/default.nix
+++ b/distros/melodic/octomap-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-octomap-msgs";
-  version = "0.3.3-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_msgs-release/archive/release/melodic/octomap_msgs/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "416e70d1633904e7a65bfcd4e1665e5ff5e013d8a9d6a53329d2a449c2002304";
+    url = "https://github.com/ros-gbp/octomap_msgs-release/archive/release/melodic/octomap_msgs/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "9a17e5f2d6aa6d1e40c0e24b551b14439b03237e7913ee907d257f8bc9eedeea";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package provides messages and serializations / conversion for the <a href="http://octomap.github.com">OctoMap library</a>.'';
+    description = ''This package provides messages and serializations / conversion for the <a href="http://octomap.github.io">OctoMap library</a>.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/octomap-ros/default.nix
+++ b/distros/melodic/octomap-ros/default.nix
@@ -5,16 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, octomap, octomap-msgs, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-octomap-ros";
-  version = "0.4.0";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_ros-release/archive/release/melodic/octomap_ros/0.4.0-0.tar.gz";
-    name = "0.4.0-0.tar.gz";
-    sha256 = "50dca555a5c7883b74068ae676db17671fa15da854f2985ed4999feff70089fd";
+    url = "https://github.com/ros-gbp/octomap_ros-release/archive/release/melodic/octomap_ros/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "e66f9ef8bd86b238099ae4a3188262a92cabfc7e4a1294d2b843b548b0f69eb1";
   };
 
   buildType = "catkin";
-  buildInputs = [ catkin ];
   propagatedBuildInputs = [ octomap octomap-msgs sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/octomap-server/default.nix
+++ b/distros/melodic/octomap-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nav-msgs, nodelet, octomap, octomap-msgs, octomap-ros, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-octomap-server";
-  version = "0.6.4-r1";
+  version = "0.6.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_server/0.6.4-1.tar.gz";
-    name = "0.6.4-1.tar.gz";
-    sha256 = "0566a8102c15d7177b9018a564f8f2629bddbc74a061fdb299a6bfd5ef96d286";
+    url = "https://github.com/ros-gbp/octomap_mapping-release/archive/release/melodic/octomap_server/0.6.5-1.tar.gz";
+    name = "0.6.5-1.tar.gz";
+    sha256 = "160f1233069756cee1dd7109eb1f685d02f1e076fccd395e28c53ac508b5569c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/open-karto/default.nix
+++ b/distros/melodic/open-karto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-melodic-open-karto";
-  version = "1.2.0";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.0-0.tar.gz";
-    name = "1.2.0-0.tar.gz";
-    sha256 = "dd134fee71bd93a6e756305e084c1767c516f369c0afe70f921c87d040f84d1b";
+    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "f6a11770361d07634e263ed217b7b5f619cd2a4b0c5e1080f0ec9ff726a57d75";
   };
 
   buildType = "catkin";

--- a/distros/melodic/openrtm-ros-bridge/default.nix
+++ b/distros/melodic/openrtm-ros-bridge/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, openrtm-tools, roscpp, rostest, rtmbuild, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-openrtm-ros-bridge";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/openrtm_ros_bridge/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "7ea540a376bea8c3571a05fa6a377fb08b527310ad3e2be525f32fe03d28f622";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation rostest rtmbuild ];
+  propagatedBuildInputs = [ openrtm-tools roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''openrtm_ros_bridge package provides basic functionalities to bind
+    two robotics framework: <a href="http://openrtm.org/">OpenRTM</a> and ROS.<br/>
+    By using this package, you can write your ROS packages that communicate with your
+    non-ROS robots that run on OpenRTM.
+  		
+    For communicating with the robots that run on hrpsys, you can use
+    <a href="http://wiki.ros.org/hrpsys_ros_bridge">hrpsys_ros_bridge</a> package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/openrtm-tools/default.nix
+++ b/distros/melodic/openrtm-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, openrtm-aist, openrtm-aist-python, rosbash, rostest, rtshell }:
+buildRosPackage {
+  pname = "ros-melodic-openrtm-tools";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/openrtm_tools/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "49f4aecff4ed1770796d07d505e850852fc4cd0a5d1b8e5879bbbfddc46539e1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ openrtm-aist openrtm-aist-python rosbash rtshell ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The openrtm_tools package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "4341efab2ef0bb88394aafacaaa24f2e612255d0bafb17fd71cbfdc65bd90e4d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "a19835f315e2e9a029200780176be94e2a0ba94ba8113c891db6eff94ecb10a8";
   };
 
   buildType = "catkin";
-  checkInputs = [ map-server roslint rostest rosunit trajectory-tracker ];
+  checkInputs = [ map-server roslint rostest trajectory-tracker ];
   propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater geometry-msgs move-base-msgs nav-msgs neonavigation-common planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.6.3-r1";
+  version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.6.3-1.tar.gz";
-    name = "2.6.3-1.tar.gz";
-    sha256 = "7f78fcb94bfcb27dbdd5e23c2b2fabce901fa38cdd989383b696df3d8509cdf6";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.6.4-1.tar.gz";
+    name = "2.6.4-1.tar.gz";
+    sha256 = "6899f626b1e32980678b197f633463f8473bed1fb40308853eea557dc16d8906";
   };
 
   buildType = "catkin";

--- a/distros/melodic/position-controllers/default.nix
+++ b/distros/melodic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-position-controllers";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "f0d988dc23a38324ae43c88ef559e459a93a36df418ce2d6242f25f7a7d14554";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/position_controllers/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "99e5a31cfeacf9bbb3676680a31610836d9b3d7eaca5af206f7425a34003cbf0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-desktop/default.nix
+++ b/distros/melodic/ridgeback-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ridgeback-msgs, ridgeback-viz }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-desktop";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_desktop/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "fa60a97d87f148815a154f6790fbf49f532669678b7ff381326cbf2797ee00f1";
+    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_desktop/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "5c7eeeaf0246b33c3f906ea00a4a525686eade472f858b50e81cf0cfcb111b5f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-viz/default.nix
+++ b/distros/melodic/ridgeback-viz/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, ridgeback-description, roslaunch, rviz }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, ridgeback-description, roslaunch, rviz }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-viz";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_viz/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "14418566a065e1a70a90730c24796c9bc51d78f797302f8fecbafd525be7483f";
+    url = "https://github.com/clearpath-gbp/ridgeback_desktop-release/archive/release/melodic/ridgeback_viz/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "bbeb69b326c060ceb4aca963b3e28511c57803b188f2b33c0836fb0dca66db07";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ joint-state-publisher ridgeback-description rviz ];
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui ridgeback-description rviz ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "4a07a06b1397c6eea1a2c2bf954b3e896e7c862cd74f93108b28cf7164249e7e";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "8aa932a83ec1488c67647070770efd2241c5c652f44aa9b7dd76bc1e34182b4a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "c422f0ddb088f4fb73a7b17c11db4cbefc351c76413b6c6395af17bbe2e0f043";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "0f1548a3bcd88d07310993c9f28dead1bce7eaca3590986a6959a58968ba6f90";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers/default.nix
+++ b/distros/melodic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-ros-controllers";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "cccce233d5580224c90c3c77bde2c9229855d9b85595cd3a0edb1b24812ba739";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/ros_controllers/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "3a15ab6a4ad86632c636759a0936e8848dd8a40d920c28260f49c570b5d341c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosapi/default.nix
+++ b/distros/melodic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosapi";
-  version = "0.11.5-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "dded6c686297bd748abc320a754165afaa919e211b1429e04488c1f20f59f507";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "d57fe24f52aeb237a0d6edf985920ccd8b4a06be59b9f8a1ef733bfabcd34111";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-library/default.nix
+++ b/distros/melodic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-library";
-  version = "0.11.5-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "3ef9abab5a9136c34ece18fbe45697373f7084c0c3669fe08f7092046d05a7c2";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "e2216884dda6bfa0aa793bbcb1ac95b466aea0c28ec532e215583a338bbc12d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-msgs/default.nix
+++ b/distros/melodic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-msgs";
-  version = "0.11.5-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "832a9ce4a0bde324413836712ed73598f72cfb49361bfe4e20e36e670aa1c083";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "e8df452b5bb209511872e7d43e2d11f1092b5e15e5edb97e85790aab1a395b04";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-server/default.nix
+++ b/distros/melodic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-server";
-  version = "0.11.5-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "a35339d1541b517a4e48417cf244537cf9f575dff7497e1f2ef40fecaca44b39";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "1d5855d12cb3b36729960337cfea1103dcc441d609bbc0e02c701f82e4d331e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-suite/default.nix
+++ b/distros/melodic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-suite";
-  version = "0.11.5-r1";
+  version = "0.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.5-1.tar.gz";
-    name = "0.11.5-1.tar.gz";
-    sha256 = "e7caf17d00fc655be18e9d899ccadf5eff030e64807ab4b50ad1e21a450601fd";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.6-1.tar.gz";
+    name = "0.11.6-1.tar.gz";
+    sha256 = "87abaf5237150ab2738be990c14dbebf72de91d9569a3d9c4fa09c3adf7af05b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosnode-rtc/default.nix
+++ b/distros/melodic/rosnode-rtc/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, openrtm-tools, roscpp-tutorials, rospy, rostopic }:
+buildRosPackage {
+  pname = "ros-melodic-rosnode-rtc";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/rosnode_rtc/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "67abf6f423674d1ae9d0f5e41197ee68ae00697f676338b98ec345fd7af8eee8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roscpp-tutorials rospy rostopic ];
+  propagatedBuildInputs = [ openrtm-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package gives transparency between RTM and ROS.
+
+     rtmros-data-bridge.py is a RT-Component for dataport/topic.
+     This automatically convert ROS/topic into RTM/dataport.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/melodic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-joint-trajectory-controller";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "45a2846b2dd5700ada8d6505e4018f5e6ad7c07f14e8ce4b9d744f6220d6c178";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/rqt_joint_trajectory_controller/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "c48c4ed42551f04f47eb98d21bb8b028869a97a9ab466f2db8c210f7b3872372";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtmbuild/default.nix
+++ b/distros/melodic/rtmbuild/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, blas, catkin, cmake-modules, liblapack, message-generation, message-runtime, omniorb, openrtm-aist, openrtm-aist-python, pkg-config, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rtmbuild";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/rtmbuild/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "d2b853594a8ee7bb2672d6b2e8f15a2c78e564e3197468a8fd8dc77f686b108a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ blas cmake-modules liblapack message-generation message-runtime omniorb openrtm-aist openrtm-aist-python pkg-config rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Build scripts for OpenRTM and OpenHRP'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rtmros-common/default.nix
+++ b/distros/melodic/rtmros-common/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hrpsys-ros-bridge, hrpsys-tools, openrtm-ros-bridge, openrtm-tools, rosnode-rtc, rtmbuild }:
+buildRosPackage {
+  pname = "ros-melodic-rtmros-common";
+  version = "1.4.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_common-release/archive/release/melodic/rtmros_common/1.4.3-1.tar.gz";
+    name = "1.4.3-1.tar.gz";
+    sha256 = "0af1052d8862dc6e92b5ea1c656d311b32b1a55ad6127972c6c7be977f324cbc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hrpsys-ros-bridge hrpsys-tools openrtm-ros-bridge openrtm-tools rosnode-rtc rtmbuild ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A package suite that provides all the capabilities for
+    the ROS users to connect to the robots that run on
+    <a href="http://www.openrtm.org/openrtm/en/content/what-rt-middleware-0">RT Middleware</a>
+    or RTM-based controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rviz-mesh-plugin/default.nix
+++ b/distros/melodic/rviz-mesh-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mesh-msgs, qt5, roscpp, rviz, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-rviz-mesh-plugin";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/rviz_mesh_plugin/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "1ac3536d778bcff8100d72b5038947172f31cc12c6e88026f9f2acf06f289ed0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mesh-msgs qt5.qtbase roscpp rviz std-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RViz display types and tools for the mesh_msgs package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.9-r2";
+  version = "1.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.9-2.tar.gz";
-    name = "1.13.9-2.tar.gz";
-    sha256 = "9baf5a8fd92d72bcf47cfbba70fa894bb01392541b3a906683dc297e280622fb";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.11-1.tar.gz";
+    name = "1.13.11-1.tar.gz";
+    sha256 = "f69eb62ef7327e980024c28717ac29997b8f1ee6856ee229bf92561a3544076d";
   };
 
   buildType = "catkin";
-  buildInputs = [ cmake-modules eigen urdfdom urdfdom-headers ];
+  buildInputs = [ cmake-modules eigen message-generation urdfdom urdfdom-headers ];
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf tinyxml-2 urdf visualization-msgs ];
+  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf tinyxml-2 urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "b923849bf5569ff0ce0137929f24fd13eff2bcdc9d5624a8a3f3d0f1d469cd8b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "5fedf016c7758a5e7f2bc4758cb70e69e6151295a27fc7a7c90c0894d3dc97c1";
   };
 
   buildType = "catkin";
   checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/timed-roslaunch/default.nix
+++ b/distros/melodic/timed-roslaunch/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-timed-roslaunch";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MoriKen254/timed_roslaunch-release/archive/release/melodic/timed_roslaunch/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "bc837c15627dd4cbf4eef4543e75d3240948dcc6d0671941723ecece6ff3bdfd";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Script to delay the launch of a roslaunch file'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tracetools/default.nix
+++ b/distros/melodic/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/boschresearch/ros1-tracetools-release/archive/release/melodic/tracetools/0.2.1-1.tar.gz";
     name = "0.2.1-1.tar.gz";
-    sha256 = "1c5114e1acce416cfb16dfca419508fd9dfcfd682ffdd63eafbe7a609d5f14f7";
+    sha256 = "1432003c36ab6c12cd03dc132dba1e8dd87986ae2fbf3bb4537001369bd47fc4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "d67db9b09c74ebc491742cfccd5c785b7b3e035dc2959d79ffb64a117b105f58";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "0861f16d24b3dcf9b31f0bd96d72bb4807af8402980f43b31240e51b1653c59a";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs message-filters nav-msgs neonavigation-common roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ];
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ eigen geometry-msgs message-filters nav-msgs neonavigation-common roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.2-r1";
+  version = "0.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "e8ee31c4962d201f848bf30eddfa7b56b740429ca3768d0e94e8974f4f2c4288";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.4-1.tar.gz";
+    name = "0.8.4-1.tar.gz";
+    sha256 = "e134e8915ecd8bd1a9a91f25a06f8656f347c5e7d7a556cf7dc1f35a7452a779";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ eigen geometry-msgs interactive-markers nav-msgs neonavigation-common roscpp tf2 tf2-geometry-msgs tf2-ros trajectory-tracker-msgs ];
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ eigen geometry-msgs interactive-markers nav-msgs neonavigation-common roscpp std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/uos-common-urdf/default.nix
+++ b/distros/melodic/uos-common-urdf/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-uos-common-urdf";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_common_urdf/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "41c678b2d59e49d1eb379276f10f0a81a48bb3b8d8c0057ff523311efcf74712";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-plugins urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains URDF descriptions of the UOS robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/uos-diffdrive-teleop/default.nix
+++ b/distros/melodic/uos-diffdrive-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, ps3joy, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-uos-diffdrive-teleop";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_diffdrive_teleop/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ed2ad1015d480ccef3959ab73923dd4100fb7f549e5827e15a56a3bfdc31c593";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs ps3joy roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''uos_diffdrive_teleop'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/uos-freespace/default.nix
+++ b/distros/melodic/uos-freespace/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-uos-freespace";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_freespace/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "094436bef80668f6373054bfe27b1da1151870f89a9fb3f1682dbe12289410df";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''uos_freespace package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/uos-gazebo-worlds/default.nix
+++ b/distros/melodic/uos-gazebo-worlds/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros }:
+buildRosPackage {
+  pname = "ros-melodic-uos-gazebo-worlds";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_gazebo_worlds/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0f1469768073221cf8a8e529515771c3190b98a165f7520affb304d332321c39";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo world and model files for UOS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/uos-maps/default.nix
+++ b/distros/melodic/uos-maps/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-uos-maps";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_maps/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "31a5e6d9a32f503c309b3affeb2ec5034ca6b874603c53702be6d7b965c65c38";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Navigation maps of the Osnabrueck University'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/uos-tools/default.nix
+++ b/distros/melodic/uos-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, uos-common-urdf, uos-diffdrive-teleop, uos-freespace, uos-gazebo-worlds, uos-maps }:
+buildRosPackage {
+  pname = "ros-melodic-uos-tools";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_tools/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9344f44a6c6c074f29f225c67b60535d298d9b7301bce5c589809df92ed0b7d1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ uos-common-urdf uos-diffdrive-teleop uos-freespace uos-gazebo-worlds uos-maps ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various helper utilities not associated with a particular stack'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/velocity-controllers/default.nix
+++ b/distros/melodic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, pluginlib, realtime-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-velocity-controllers";
-  version = "0.15.1-r1";
+  version = "0.16.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.15.1-1.tar.gz";
-    name = "0.15.1-1.tar.gz";
-    sha256 = "9a3fc8815f8747560c40fbb82154b9780a1180822f65f40608f4e8c31631eacb";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/melodic/velocity_controllers/0.16.1-1.tar.gz";
+    name = "0.16.1-1.tar.gz";
+    sha256 = "bc1e29e6c7cf47f38bf0214c2f2839e575f6602eb681eae06b40020a574de136";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warehouse-ros/default.nix
+++ b/distros/melodic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, geometry-msgs, gtest, pluginlib, roscpp, rostest, rostime, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-warehouse-ros";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "9bc798170ca3d679ac4f4bf3b5db4fa7d748397c9262be0a2373085a18b051ce";
+    url = "https://github.com/ros-gbp/warehouse_ros-release/archive/release/melodic/warehouse_ros/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "30ead0eff97639e117939b3dbf2a7310e922dfe53ce2963591e2fb20976a27e7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/webrtc-ros/default.nix
+++ b/distros/melodic/webrtc-ros/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, image-transport, nodelet, roscpp, webrtc }:
+{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, image-transport, message-generation, message-runtime, nodelet, roscpp, std-msgs, webrtc }:
 buildRosPackage {
   pname = "ros-melodic-webrtc-ros";
-  version = "59.0.3";
+  version = "59.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/melodic/webrtc_ros/59.0.3-0.tar.gz";
-    name = "59.0.3-0.tar.gz";
-    sha256 = "2e24d39a6cf8c98c8f2b9229dd5a0fabd731cf495abf76547baf476d26b98f96";
+    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/melodic/webrtc_ros/59.0.4-1.tar.gz";
+    name = "59.0.4-1.tar.gz";
+    sha256 = "134243c7a0ebad22eec7f32cad62908716de537fce354fe1b8853478b58e862c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ async-web-server-cpp cv-bridge image-transport nodelet roscpp webrtc ];
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ async-web-server-cpp cv-bridge image-transport message-runtime nodelet roscpp std-msgs webrtc ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/webrtc/default.nix
+++ b/distros/melodic/webrtc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, alsaLib, cmake, git, glib, gtk2, gtk3, pulseaudio, wget }:
 buildRosPackage {
   pname = "ros-melodic-webrtc";
-  version = "59.0.3";
+  version = "59.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/melodic/webrtc/59.0.3-0.tar.gz";
-    name = "59.0.3-0.tar.gz";
-    sha256 = "bdc2b6651bda28702a87bdc1cb9a53dbcd5a47dc7363d71bd81ea87dc0271e77";
+    url = "https://github.com/RobotWebTools-release/webrtc_ros-release/archive/release/melodic/webrtc/59.0.4-1.tar.gz";
+    name = "59.0.4-1.tar.gz";
+    sha256 = "2889d9f998f589846868676e8bed291496807b9bb8e8f88bbdbf97b8ab5223a6";
   };
 
   buildType = "cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit cfffea0454c9588a981ad529d45d5283acf73c7b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *joy-teleop 1.0.2-r1 --> 1.1.0-r1*
* *key-teleop 1.0.2-r1 --> 1.1.0-r1*
* *mouse-teleop 1.0.2-r1 --> 1.1.0-r1*
* *teleop-tools 1.0.2-r1 --> 1.1.0-r1*
* *teleop-tools-msgs 1.0.2-r1 --> 1.1.0-r1*
* *unique-identifier-msgs 2.1.0-r1 --> 2.1.1-r1*

Kinetic Changes:
----------------
* *audio-capture 0.3.4-r1 --> 0.3.5-r1*
* *audio-common 0.3.4-r1 --> 0.3.5-r1*
* *audio-common-msgs 0.3.4-r1 --> 0.3.5-r1*
* *audio-play 0.3.4-r1 --> 0.3.5-r1*
* *behaviortree-cpp-v3 3.1.0-r3 --> 3.4.0-r1*
* *costmap-cspace 0.8.2-r1 --> 0.8.3-r1*
* *husky-base 0.3.5-r1 --> 0.3.6-r1*
* *husky-bringup 0.3.5-r1 --> 0.3.6-r1*
* *husky-control 0.3.5-r1 --> 0.3.6-r1*
* *husky-description 0.3.5-r1 --> 0.3.6-r1*
* *husky-desktop 0.3.5-r1 --> 0.3.6-r1*
* *husky-gazebo 0.3.5-r1 --> 0.3.6-r1*
* *husky-msgs 0.3.5-r1 --> 0.3.6-r1*
* *husky-navigation 0.3.5-r1 --> 0.3.6-r1*
* *husky-robot 0.3.5-r1 --> 0.3.6-r1*
* *husky-simulator 0.3.5-r1 --> 0.3.6-r1*
* *husky-viz 0.3.5-r1 --> 0.3.6-r1*
* *jackal-control 0.6.4-r1 --> 0.6.5-r2*
* *jackal-description 0.6.4-r1 --> 0.6.5-r2*
* *jackal-msgs 0.6.4-r1 --> 0.6.5-r2*
* *jackal-navigation 0.6.4-r1 --> 0.6.5-r2*
* *jackal-tutorials 0.6.4-r1 --> 0.6.5-r2*
* *joystick-interrupt 0.8.2-r1 --> 0.8.3-r1*
* *map-organizer 0.8.2-r1 --> 0.8.3-r1*
* *neonavigation 0.8.2-r1 --> 0.8.3-r1*
* *neonavigation-common 0.8.2-r1 --> 0.8.3-r1*
* *neonavigation-launch 0.8.2-r1 --> 0.8.3-r1*
* *novatel-oem7-driver 1.0.0-r1*
* *novatel-oem7-msgs 1.0.0-r1*
* *obj-to-pointcloud 0.8.2-r1 --> 0.8.3-r1*
* *oled-display-node 1.0.0-r1*
* *planner-cspace 0.8.2-r1 --> 0.8.3-r1*
* *robot-calibration 0.6.2-r1 --> 0.6.3-r1*
* *robot-calibration-msgs 0.6.2-r1 --> 0.6.3-r1*
* *rosapi 0.11.5-r1 --> 0.11.6-r2*
* *rosbridge-library 0.11.5-r1 --> 0.11.6-r2*
* *rosbridge-msgs 0.11.5-r1 --> 0.11.6-r2*
* *rosbridge-server 0.11.5-r1 --> 0.11.6-r2*
* *rosbridge-suite 0.11.5-r1 --> 0.11.6-r2*
* *rosmon 2.1.1-r1 --> 2.2.1-r1*
* *rosmon-core 2.1.1-r1 --> 2.2.1-r1*
* *rosmon-msgs 2.1.1-r1 --> 2.2.1-r1*
* *rqt-rosmon 2.1.1-r1 --> 2.2.1-r1*
* *safety-limiter 0.8.2-r1 --> 0.8.3-r1*
* *track-odometry 0.8.2-r1 --> 0.8.3-r1*
* *trajectory-tracker 0.8.2-r1 --> 0.8.3-r1*
* *uos-common-urdf 1.0.0-r2*
* *uos-diffdrive-teleop 1.0.0-r2*
* *uos-freespace 1.0.0-r2*
* *uos-gazebo-worlds 1.0.0-r2*
* *uos-maps 1.0.0-r2*
* *uos-tools 1.0.0-r2*
* *warehouse-ros 0.9.3-r1 --> 0.9.4-r1*
* *webrtc 59.0.3 --> 59.0.4-r1*
* *webrtc-ros 59.0.3 --> 59.0.4-r1*

Melodic Changes:
----------------
* *ackermann-steering-controller 0.15.1-r1 --> 0.16.1-r1*
* *audio-capture 0.3.4-r1 --> 0.3.5-r1*
* *audio-common 0.3.4-r1 --> 0.3.5-r1*
* *audio-common-msgs 0.3.4-r1 --> 0.3.5-r1*
* *audio-play 0.3.4-r1 --> 0.3.5-r1*
* *behaviortree-cpp-v3 3.1.0-r2 --> 3.4.0-r1*
* *chomp-motion-planner 1.0.2-r1 --> 1.0.3-r2*
* *costmap-cspace 0.8.2-r1 --> 0.8.4-r1*
* *diff-drive-controller 0.15.1-r1 --> 0.16.1-r1*
* *effort-controllers 0.15.1-r1 --> 0.16.1-r1*
* *force-torque-sensor-controller 0.15.1-r1 --> 0.16.1-r1*
* *forward-command-controller 0.15.1-r1 --> 0.16.1-r1*
* *four-wheel-steering-controller 0.15.1-r1 --> 0.16.1-r1*
* *gazebo-dev 2.8.6-r1 --> 2.8.7-r1*
* *gazebo-msgs 2.8.6-r1 --> 2.8.7-r1*
* *gazebo-plugins 2.8.6-r1 --> 2.8.7-r1*
* *gazebo-ros 2.8.6-r1 --> 2.8.7-r1*
* *gazebo-ros-control 2.8.6-r1 --> 2.8.7-r1*
* *gazebo-ros-pkgs 2.8.6-r1 --> 2.8.7-r1*
* *gripper-action-controller 0.15.1-r1 --> 0.16.1-r1*
* *hdf5-map-io 1.0.0-r2*
* *hrpsys 315.15.0-r2 --> 315.15.0-r6*
* *hrpsys-ros-bridge 1.4.3-r1*
* *hrpsys-tools 1.4.3-r1*
* *husky-base 0.4.2-r1 --> 0.4.3-r1*
* *husky-bringup 0.4.2-r1 --> 0.4.3-r1*
* *husky-control 0.4.2-r1 --> 0.4.3-r1*
* *husky-description 0.4.2-r1 --> 0.4.3-r1*
* *husky-desktop 0.4.2-r1 --> 0.4.3-r1*
* *husky-gazebo 0.4.2-r1 --> 0.4.3-r1*
* *husky-msgs 0.4.2-r1 --> 0.4.3-r1*
* *husky-navigation 0.4.2-r1 --> 0.4.3-r1*
* *husky-robot 0.4.2-r1 --> 0.4.3-r1*
* *husky-simulator 0.4.2-r1 --> 0.4.3-r1*
* *husky-viz 0.4.2-r1 --> 0.4.3-r1*
* *imu-sensor-controller 0.15.1-r1 --> 0.16.1-r1*
* *jackal-control 0.6.4-r3 --> 0.7.0-r1*
* *jackal-description 0.6.4-r3 --> 0.7.0-r1*
* *jackal-msgs 0.6.4-r3 --> 0.7.0-r1*
* *jackal-navigation 0.6.4-r3 --> 0.7.0-r1*
* *jackal-tutorials 0.6.4-r3 --> 0.7.0-r1*
* *jderobot-assets 1.0.1-r1 --> 1.0.2-r1*
* *joint-state-controller 0.15.1-r1 --> 0.16.1-r1*
* *joint-trajectory-controller 0.15.1-r1 --> 0.16.1-r1*
* *joystick-interrupt 0.8.2-r1 --> 0.8.4-r1*
* *label-manager 1.0.0-r2*
* *map-organizer 0.8.2-r1 --> 0.8.4-r1*
* *mbf-recovery-behaviors 0.1.0-r1*
* *mesh-msgs 1.0.0-r2*
* *mesh-msgs-hdf5 1.0.0-r2*
* *mesh-msgs-transform 1.0.0-r2*
* *mesh-tools 1.0.0-r2*
* *moveback-recovery 0.1.0-r1*
* *moveit 1.0.2-r1 --> 1.0.3-r2*
* *moveit-chomp-optimizer-adapter 1.0.2-r1 --> 1.0.3-r2*
* *moveit-controller-manager-example 1.0.2-r1 --> 1.0.3-r2*
* *moveit-experimental 1.0.2-r1 --> 1.0.3-r2*
* *moveit-fake-controller-manager 1.0.2-r1 --> 1.0.3-r2*
* *moveit-kinematics 1.0.2-r1 --> 1.0.3-r2*
* *moveit-planners 1.0.2-r1 --> 1.0.3-r2*
* *moveit-planners-chomp 1.0.2-r1 --> 1.0.3-r2*
* *moveit-planners-ompl 1.0.2-r1 --> 1.0.3-r2*
* *moveit-plugins 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-benchmarks 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-control-interface 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-manipulation 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-move-group 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-occupancy-map-monitor 1.0.3-r2*
* *moveit-ros-perception 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-planning 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-planning-interface 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-robot-interaction 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-visualization 1.0.2-r1 --> 1.0.3-r2*
* *moveit-ros-warehouse 1.0.2-r1 --> 1.0.3-r2*
* *moveit-runtime 1.0.2-r1 --> 1.0.3-r2*
* *moveit-setup-assistant 1.0.2-r1 --> 1.0.3-r2*
* *moveit-simple-controller-manager 1.0.2-r1 --> 1.0.3-r2*
* *neonavigation 0.8.2-r1 --> 0.8.4-r1*
* *neonavigation-common 0.8.2-r1 --> 0.8.4-r1*
* *neonavigation-launch 0.8.2-r1 --> 0.8.4-r1*
* *novatel-oem7-driver 1.0.0-r1*
* *novatel-oem7-msgs 1.0.0-r1*
* *obj-to-pointcloud 0.8.2-r1 --> 0.8.4-r1*
* *octomap-mapping 0.6.4-r1 --> 0.6.5-r1*
* *octomap-msgs 0.3.3-r1 --> 0.3.5-r1*
* *octomap-ros 0.4.0 --> 0.4.1-r1*
* *octomap-server 0.6.4-r1 --> 0.6.5-r1*
* *open-karto 1.2.0 --> 1.2.1-r1*
* *openrtm-ros-bridge 1.4.3-r1*
* *openrtm-tools 1.4.3-r1*
* *planner-cspace 0.8.2-r1 --> 0.8.4-r1*
* *plotjuggler 2.6.3-r1 --> 2.6.4-r1*
* *position-controllers 0.15.1-r1 --> 0.16.1-r1*
* *ridgeback-desktop 0.1.1-r1 --> 0.1.2-r1*
* *ridgeback-viz 0.1.1-r1 --> 0.1.2-r1*
* *robot-calibration 0.6.2-r1 --> 0.6.3-r1*
* *robot-calibration-msgs 0.6.2-r1 --> 0.6.3-r1*
* *ros-controllers 0.15.1-r1 --> 0.16.1-r1*
* *rosapi 0.11.5-r1 --> 0.11.6-r1*
* *rosbridge-library 0.11.5-r1 --> 0.11.6-r1*
* *rosbridge-msgs 0.11.5-r1 --> 0.11.6-r1*
* *rosbridge-server 0.11.5-r1 --> 0.11.6-r1*
* *rosbridge-suite 0.11.5-r1 --> 0.11.6-r1*
* *rosnode-rtc 1.4.3-r1*
* *rqt-joint-trajectory-controller 0.15.1-r1 --> 0.16.1-r1*
* *rtmbuild 1.4.3-r1*
* *rtmros-common 1.4.3-r1*
* *rviz 1.13.9-r2 --> 1.13.11-r1*
* *rviz-mesh-plugin 1.0.0-r2*
* *safety-limiter 0.8.2-r1 --> 0.8.4-r1*
* *timed-roslaunch 0.1.4-r1*
* *track-odometry 0.8.2-r1 --> 0.8.4-r1*
* *trajectory-tracker 0.8.2-r1 --> 0.8.4-r1*
* *uos-common-urdf 1.0.0-r1*
* *uos-diffdrive-teleop 1.0.0-r1*
* *uos-freespace 1.0.0-r1*
* *uos-gazebo-worlds 1.0.0-r1*
* *uos-maps 1.0.0-r1*
* *uos-tools 1.0.0-r1*
* *velocity-controllers 0.15.1-r1 --> 0.16.1-r1*
* *warehouse-ros 0.9.3-r1 --> 0.9.4-r1*
* *webrtc 59.0.3 --> 59.0.4-r1*
* *webrtc-ros 59.0.3 --> 59.0.4-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

