### PR TITLE
rosdistro sync, Fri May  8 12:40:39 2020

### DIFF
--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/ros2trace/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "64237813f80593f21dffe7f61ba91f290111e8a994449bc55800e9d42acf29c5";
+    sha256 = "be0044a3cd8924c54627d963ea29c6987aec28afa21b3d875f0ea34bed8ad7ff";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/code-coverage/default.nix
+++ b/distros/kinetic/code-coverage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-code-coverage";
-  version = "0.4.0-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/kinetic/code_coverage/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "7536df4e4a072ea93e0a0dac89b5bc235f0ad28b8ffbb95143e03b207c1a5f1b";
+    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/kinetic/code_coverage/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "3da97df4d465ae25f17378ffdd930cc272acbec10fc56358ce68fe4311909227";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "12d2f6b13509d2e481a516d4177ee1c055a0ae8049afdecc5d25f67efdc3e8e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "49af4ba08762878d1553ea8deb9e54fbc3c5d13740399d356ed2a5d17c19f101";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
+  checkInputs = [ roslint rostest ];
   propagatedBuildInputs = [ costmap-cspace-msgs geometry-msgs laser-geometry nav-msgs neonavigation-common roscpp sensor-msgs tf2-geometry-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -4226,6 +4226,8 @@ self: super: {
 
  scratch4robots = self.callPackage ./scratch4robots {};
 
+ sdc21x0 = self.callPackage ./sdc21x0 {};
+
  sdhlibrary-cpp = self.callPackage ./sdhlibrary-cpp {};
 
  seed-r7-bringup = self.callPackage ./seed-r7-bringup {};

--- a/distros/kinetic/image-exposure-msgs/default.nix
+++ b/distros/kinetic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-image-exposure-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/image_exposure_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "ba20ae27f4147f3d553fcb60484a0c45ba67c55f6b14946a4e869c38e4702bfb";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/image_exposure_msgs/0.14.1-2.tar.gz";
+    name = "0.14.1-2.tar.gz";
+    sha256 = "aa83576e2d13ddfab6979bbee6efe9666f9310cad0fdaf03ae66837dab134ce4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "68c3c2fc98797ed694dd9aebcc4e9073b5019aa693707ff92acfa0acff521ed4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "51d21e6acee79383e6d7c1e536dc406caaac77cb858b41e319ef38bf47101cde";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
+  checkInputs = [ roslint rostest ];
   propagatedBuildInputs = [ geometry-msgs neonavigation-common roscpp sensor-msgs topic-tools ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "6e9d351be35ce226bac33c9f5d49de3ab1a9e268a1f8bd85d834b8bac344f914";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "b29f50556cdcba48c4d9d74459224234361821e7d7e9b46db3394fb21ed762b0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ cmake-modules eigen eigen-conversions geometry-msgs map-organizer-msgs map-server nav-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ eigen geometry-msgs map-organizer-msgs map-server nav-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2020.4.4-r1";
+  version = "2020.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.4.4-1.tar.gz";
-    name = "2020.4.4-1.tar.gz";
-    sha256 = "39fa9f5c1363be83720e2f465379d69e1c6c854b3a9e8a8aeedfdb62629603a5";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.5.5-1.tar.gz";
+    name = "2020.5.5-1.tar.gz";
+    sha256 = "4cc76d072de4faf47fa6cd5e833c5fba4ba609bfcd6f73e21f8a60e265540746";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mir-actions/default.nix
+++ b/distros/kinetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-actions";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_actions/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ddba3d3464ca1ad4a70aca95f833838f908da27352c1fb0fe2c16966e627e130";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_actions/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "a308f5edc08b8b1274b2843f068007f5aef103d14eba52ff61450272dc9b2400";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-description/default.nix
+++ b/distros/kinetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-mir-description";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_description/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "4ce897c6f81728c305ef19b076ee285156108633af535d7290dc1386fdd5170c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_description/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "d7542203a627724970317427d3bdb231a98e1e389bef4e5896f5fb040ca4a88d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-driver/default.nix
+++ b/distros/kinetic/mir-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, mir-actions, mir-description, mir-msgs, move-base-msgs, nav-msgs, pythonPackages, robot-state-publisher, rosgraph-msgs, roslaunch, rospy, rospy-message-converter, sensor-msgs, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-driver";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_driver/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "94fd8404a52b48030c960461863968b9a3466122a3f18678e3ac951beeca8869";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_driver/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "d48e623c37ddb143b1cce33e0c9bd794af4064324e5c09c7cbb0473c4c3c35da";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-dwb-critics/default.nix
+++ b/distros/kinetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-dwb-critics";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_dwb_critics/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "eb840e0508e14fe48b12292492d2b03907498f66fd4c52b32b7ce89870552cb5";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_dwb_critics/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "8f37317612bfb7bd6b868b579e2627a281d3efc6bda2075745b5f6c48e1b3ecf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-gazebo/default.nix
+++ b/distros/kinetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-mir-gazebo";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_gazebo/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "21dc52888daa0604d1c537426a35df641c3eba536e88cd511a5db7df98a6aab8";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_gazebo/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9768bc48df81edc35577c6cbd8da0ea8a8c20e39fd778f1ca8841286cf9c0802";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-msgs/default.nix
+++ b/distros/kinetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-mir-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c84911a8d749759ba2a64bc4d540d92c67fa6a67b12a1d95509f1899fe2c4b6d";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "c430d1bab09c720c0e33f1c7dffbda52c51a52a22869753eb3216bf1c695a03c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-navigation/default.nix
+++ b/distros/kinetic/mir-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, map-server, mir-driver, mir-dwb-critics, move-base, nav-core-adapter, roslaunch, sbpl-lattice-planner }:
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, move-base, nav-core-adapter, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-kinetic-mir-navigation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_navigation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "5c9dc0cc272ba6e26ef3bb3704453d1ec9e9e98c6ec3f05346aefa9264f6ba0c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_navigation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "dfee12d16ab06ed62177ae14301d0654c74f03bb179f275610a7db74b3e4d0fc";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins map-server mir-driver mir-dwb-critics move-base nav-core-adapter sbpl-lattice-planner ];
+  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics move-base nav-core-adapter sbpl-lattice-planner ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/mir-robot/default.nix
+++ b/distros/kinetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation }:
 buildRosPackage {
   pname = "ros-kinetic-mir-robot";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_robot/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "475b342d4a11b35ebdc5def92fec108508f374b3b216bb576c41fc6fb8309012";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_robot/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3f03ec0a7e1b8a4320a6a554e4921379e981a18e12fa6ed51f7fab57844b237d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "3c88335b2465e532902a12cdb6ea7114a4c0776ebf6220708a6bb3f5498054ad";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "12c94443a7215e1f95c59de71314117e8a992c04adbd126036805f49170c5007";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "90f94b612ac0ed5104b89e3481e8a6ec404bb170a5d137b4a0d709adfdc55cf5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "eb94a2505dff0a7f8d0f0418556deff3e2c3c49c6a111dcbc3a36a813174968a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "19ba9492c90be61503160a063ad0015f452fa9294588b1186acf24e313acb501";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "deec1cf685cb0485e7db3472b956733b844babb202645e39cefd94103630a76d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/novatel-oem7-driver/default.nix
+++ b/distros/kinetic/novatel-oem7-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, tf }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, rostest, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-novatel-oem7-driver";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_driver/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5e54dcef4b884a9da5a813b8b9e4249e5b51a711da4f86d7e108264a5ad31560";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8718d0171c074453ea3634c45181149d8c82cecc7765e2edbdd0d42ec860c2f0";
   };
 
   buildType = "catkin";
-  buildInputs = [ gps-common tf ];
-  propagatedBuildInputs = [ nodelet novatel-oem7-msgs roscpp ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost gps-common nodelet novatel-oem7-msgs roscpp sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/novatel-oem7-msgs/default.nix
+++ b/distros/kinetic/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-novatel-oem7-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "26dbbcd6fb2372414fdb39248fa0fbbc788a03179216cbf04d43457ff9b30025";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/kinetic/novatel_oem7_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "98e237ba6981316bda278cf9c1d83e62252e5efa3fdd492e25f044719c955aef";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, eigen-conversions, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "66e7a22fd4646d5a11566ed1331780b414ddf4724f86c1a27f4fc708c8148b6b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "386def1cddbb83debefff8f7747ca5cd05d3c93094c0bda6b7199634e3524de0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ eigen eigen-conversions geometry-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs neonavigation-common pcl pcl-conversions roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, rosunit, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "a54d77ba4327fcba01cfe34c8decd47e084a9a37ee7c3728fa97e7c68d914d8b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "591fa2fc7427bcfd45770c327c13d9f7393162aa5a0d7602d06d7036dd637266";
   };
 
   buildType = "catkin";
-  checkInputs = [ map-server roslint rostest rosunit trajectory-tracker ];
+  checkInputs = [ map-server roslint rostest trajectory-tracker ];
   propagatedBuildInputs = [ actionlib costmap-cspace costmap-cspace-msgs diagnostic-updater geometry-msgs move-base-msgs nav-msgs neonavigation-common planner-cspace-msgs roscpp sensor-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.6.3-r2";
+  version = "2.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.6.3-2.tar.gz";
-    name = "2.6.3-2.tar.gz";
-    sha256 = "1358bec6177c98f50169106d25793d3172a125523cebc5ebbce1e761c2bdcfd0";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.6.4-1.tar.gz";
+    name = "2.6.4-1.tar.gz";
+    sha256 = "c0b561fddebadee52496b47e47d33bdf6b02337bc69f3aa16ca5ac0913d2ab92";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pointgrey-camera-description/default.nix
+++ b/distros/kinetic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-pointgrey-camera-description";
-  version = "0.14.0-r1";
+  version = "0.14.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/pointgrey_camera_description/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "8364b94b089dd0a1feb2fd0c2928320969d86f898154349a8de4ce4d4d7af38e";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/pointgrey_camera_description/0.14.1-2.tar.gz";
+    name = "0.14.1-2.tar.gz";
+    sha256 = "c155f6b71d1645fd7f01b4fd8c30ee10125b0e59045c9f0a7acb9d8b4cba77f9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/pointgrey-camera-driver/default.nix
+++ b/distros/kinetic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-pointgrey-camera-driver";
-  version = "0.14.0-r1";
+  version = "0.14.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/pointgrey_camera_driver/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "55606b5a931781aeec887cdf0b78e5b0cfc2e594474c110c6704a81fcddefc91";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/pointgrey_camera_driver/0.14.1-2.tar.gz";
+    name = "0.14.1-2.tar.gz";
+    sha256 = "b1decf9215597d9387a0a2c70c2230f9e63415f0529f98473bd314aa9b9f67f4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "6efe75609028a2d9dc6779f0e439aee14b3a133dd3a5dfe1c5a2c730902eee17";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "39818b6b32a76be1129e13fe76f9eb1c46f7f5a331de42dc1beccf10dd1b8f65";
   };
 
   buildType = "catkin";
   checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/sdc21x0/default.nix
+++ b/distros/kinetic/sdc21x0/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-sdc21x0";
+  version = "1.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/sdc21x0/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7c13abb1e3f9012598ddfebe3731916e71c453340276da1f545e8ac90e1b2a76";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message definitions for the sdc21x0 motor controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/statistics-msgs/default.nix
+++ b/distros/kinetic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-statistics-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/statistics_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "23e1c4ff8273d4ffed6626792c00f56af216bdac19dc18f0e39ddd09b6739e0a";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/statistics_msgs/0.14.1-2.tar.gz";
+    name = "0.14.1-2.tar.gz";
+    sha256 = "7f305ef5f02d05607329c730bef9157f69142db1610365e8ae10f7097f55a3e1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "00f4e2fc6c0a6c21ff594ee06cc8780402c0726743d35b222300d3dd7b0553d1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "e6a9de4b1d2263be9691b4be35430734c04d86a611e09044dccb4b48cd3641f2";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs message-filters nav-msgs neonavigation-common roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ];
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ eigen geometry-msgs message-filters nav-msgs neonavigation-common roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, rosunit, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.3-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.3-1.tar.gz";
-    name = "0.8.3-1.tar.gz";
-    sha256 = "444e1f08016b1c86d44eb102989846948ebd8f00e79dedd0d0a67bbe81e5766b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "bebec0d4eb18d4a055307be2faf815b7955eef2f8668bf1e0103759d804abb47";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint rostest rosunit ];
-  propagatedBuildInputs = [ eigen geometry-msgs interactive-markers nav-msgs neonavigation-common roscpp tf2 tf2-geometry-msgs tf2-ros trajectory-tracker-msgs ];
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ eigen geometry-msgs interactive-markers nav-msgs neonavigation-common roscpp std-srvs tf2 tf2-geometry-msgs tf2-ros trajectory-tracker-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/wfov-camera-msgs/default.nix
+++ b/distros/kinetic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-wfov-camera-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/wfov_camera_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "e9c34cd8b18724bed7b9c50dc22bee4f2c994fdb3cbdfe6f80e864f5024fbff3";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/kinetic/wfov_camera_msgs/0.14.1-2.tar.gz";
+    name = "0.14.1-2.tar.gz";
+    sha256 = "a1d8cebe477d3cd00d27310b8f3798902b9adab74048547e3e6078486df84143";
   };
 
   buildType = "catkin";

--- a/distros/melodic/code-coverage/default.nix
+++ b/distros/melodic/code-coverage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-code-coverage";
-  version = "0.4.0-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/melodic/code_coverage/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "0c4bba84a8d48c83e42344871f6889429f3e24317fa3dfc3368437d6d86a0255";
+    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/melodic/code_coverage/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "8e1eb481b08b7d162e0cd7c9863661b260536f8806f92da44b56a19f2957782a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "5a29b530a08c7d363b3ce201e8e923a1ad29ba3761e27977fe6ccd7c996704a2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "7bebc9d6d945c9d6fe5a2b5f9c04afc2e57bdf976ac940dd9e7c7ca597c3db93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "d86c729dcfeb36890fe7bd4f7825e856e77dda955452debffdd1468a32cef4c8";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "252ea35894a5aec19ce5a1e26a6012eb788a722a22881a19148d13a89500932c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3058,6 +3058,8 @@ self: super: {
 
  schunk-simulated-tactile-sensors = self.callPackage ./schunk-simulated-tactile-sensors {};
 
+ sdc21x0 = self.callPackage ./sdc21x0 {};
+
  sdhlibrary-cpp = self.callPackage ./sdhlibrary-cpp {};
 
  seed-r7-bringup = self.callPackage ./seed-r7-bringup {};

--- a/distros/melodic/geometric-shapes/default.nix
+++ b/distros/melodic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-geometric-shapes";
-  version = "0.6.1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.1-0.tar.gz";
-    name = "0.6.1-0.tar.gz";
-    sha256 = "d30facbce2033851ba0b121a75c8d41c47a91831e51efb11dafe3bc877a50809";
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "33763d4b3dca7e34f84d7fe2973c7386a9f662861f13c0c66f20a53bdfd9e383";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hrpsys/default.nix
+++ b/distros/melodic/hrpsys/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL, cmake, doxygen, freeglut, git, glew, graphviz, irrlicht, libxml2, mk, opencv3, openhrp3, pkg-config, pythonPackages, qhull, xorg }:
 buildRosPackage {
   pname = "ros-melodic-hrpsys";
-  version = "315.15.0-r6";
+  version = "315.15.0-r8";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/hrpsys-release/archive/release/melodic/hrpsys/315.15.0-6.tar.gz";
-    name = "315.15.0-6.tar.gz";
-    sha256 = "0d9b09484ec3842dec6080ff782e6f6da298cf12df140c0764cb4d45d301a1f7";
+    url = "https://github.com/tork-a/hrpsys-release/archive/release/melodic/hrpsys/315.15.0-8.tar.gz";
+    name = "315.15.0-8.tar.gz";
+    sha256 = "c7041e257756bd66cf745714ba92fc1b9e34342a68687d812a0495e716180f9c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/image-exposure-msgs/default.nix
+++ b/distros/melodic/image-exposure-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-exposure-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "c613528add09cac7ad59befdf4add5701767932ce57c758d0845be319cf56e41";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/image_exposure_msgs/0.14.1-1.tar.gz";
+    name = "0.14.1-1.tar.gz";
+    sha256 = "1a1518bbeb26d3e52459bc25560ad67da0c3c059fa238494d411cc1585366a9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-drones";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "3fb47b09572914f7c0cdadf589845476dbde4661bb67fa3b950f82aafb744cd1";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "d53a0db7afeb4da1bf8bdfc7cdcf4104258630e97f750a9ce84244964a998e47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "e61ac90a1ba9d65216eaf10976c95e59158e652eedfe45c103f59e81927f413f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "f23d095400f4772b9439af38452fdd08798a27e499112caa030c6fb81bf372c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "f3db30f9baa916050537a4f48a7f8c81d543d194d2228b838fbf8309d56067cf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "746c527d89884c962cfdf4b255052b03b53018e0328922db55e5270667342c6c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2020.4.4-r1";
+  version = "2020.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.4.4-1.tar.gz";
-    name = "2020.4.4-1.tar.gz";
-    sha256 = "0e5a3032e6a6e231e7ed2784cc0239a877d3009f41a1761463511a5bc2c497e2";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.5.5-1.tar.gz";
+    name = "2020.5.5-1.tar.gz";
+    sha256 = "9f88b4db301c19945673e3875f7c0b1a39a4d46c39d9c6c2a614aa371f4c641c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mir-actions/default.nix
+++ b/distros/melodic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-actions";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "aaf73d32129e1084e5460ae1c6279641d6ee78931c8d05e89aa943836d79807c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ed6913d1fc7c8fe102bc7e31ba0dc1f05c81442dc80d8dedaa1c36dd62b9a055";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-description/default.nix
+++ b/distros/melodic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-mir-description";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "75e85e0254228274ed31f3f39461d07ea16571e44b55b5714ed2d5c4257c81be";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3cf57c7254bd9a345aeeea4f6a4e4f6a3b3ba2c3d32c3760c89f0eb24d6222f9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-driver/default.nix
+++ b/distros/melodic/mir-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, mir-actions, mir-description, mir-msgs, move-base-msgs, nav-msgs, pythonPackages, robot-state-publisher, rosgraph-msgs, roslaunch, rospy, rospy-message-converter, sensor-msgs, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-driver";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "da99d11e458c15ad666321a49d43326ee91a75b969f98f8bb904c7bf0a071188";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "b72f6635778d21dec2fd3c412744ae0073e965f87b44ec6ce38903aa4e7fc500";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-dwb-critics/default.nix
+++ b/distros/melodic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-dwb-critics";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "72ef1187b0c85ee0de3f41cf602bb84854fbfdfb65422ea25b44d9e70b6b76f4";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "b3ece039be162784bb4305a96ec12c4e771e3c5130cfc7dc98ce7b2d1c2d7caf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-gazebo/default.nix
+++ b/distros/melodic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-mir-gazebo";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "433d7b8eb2aa43766ee2147af39d967f7a7ef8df494fbde42eb423af0b3a4fdd";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "4d4e7cfe1b55c4a98068d32ae389393b2e3669ca19598bb1899822eecdc36b9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-msgs/default.nix
+++ b/distros/melodic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-mir-msgs";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "60ccda62899a4d92718a5a4074e21faa865d2ee0c53d33730ff367c6bf402f38";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3ac5976bc4e9062f3ce820192f9423111c680a961ba3c64713d80371a812bf02";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-navigation/default.nix
+++ b/distros/melodic/mir-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, map-server, mir-driver, mir-dwb-critics, move-base, nav-core-adapter, roslaunch, sbpl-lattice-planner }:
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, move-base, nav-core-adapter, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-melodic-mir-navigation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1ac9fd30f725c0b8fb509496fd475584d0cb21e6b526e19e4d41f6b853b4fec6";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "60a275e2ec18af8d30071139da1cc18923533cf11bb6daa20ee1e1c68e30ff4e";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins map-server mir-driver mir-dwb-critics move-base nav-core-adapter sbpl-lattice-planner ];
+  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics move-base nav-core-adapter sbpl-lattice-planner ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mir-robot/default.nix
+++ b/distros/melodic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation }:
 buildRosPackage {
   pname = "ros-melodic-mir-robot";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1be447be46d3485524682a594f9f55d972b07c44b4e29e31c2c57105530be475";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "2d4af270a8e0186d252672c198c7a0208474dfed1c0695c0398f5a9698f03e43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "98a3010401fd8946e6a9b37c7b7bf7d3220f9e68641bb3c0abb55c10f3a784fb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "94cd53482428921a1f15815dfbfdbf437ff5152ea0b3127a6b94c4878ee460ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "4947fa557e7c7b8095ba8bbee3ca92f80f29f4fdddeecefcd131af7a3c08744e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "6581eb2479258e9da5197977bb0b5473969ccf20a1baad0f6cdc0adce6469ca1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "d36f58ad6d070c7aecf34dd7a11d126d9ad8ca4f32c4dc3255e0d92894cd3dd8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "dcf767b8a36d634f1568c6a2328e40e716fd229afe2374f8b4ecb4baace6a1c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/novatel-oem7-driver/default.nix
+++ b/distros/melodic/novatel-oem7-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, tf }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, rostest, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-novatel-oem7-driver";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_driver/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "914ada691690a247290b82c32d26d86fb323d75a50d93f5558559e6c4170187d";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e80774b05614c514c0427512b4b1cb1cf34f405df6ffee7b4951c1b7994774e9";
   };
 
   buildType = "catkin";
-  buildInputs = [ gps-common tf ];
-  propagatedBuildInputs = [ nodelet novatel-oem7-msgs roscpp ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost gps-common nodelet novatel-oem7-msgs roscpp sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/novatel-oem7-msgs/default.nix
+++ b/distros/melodic/novatel-oem7-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-novatel-oem7-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7d44b73cf9773088ba1a6bb954dbf0de680419cd59e4c3654ffe0d46e4795298";
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/melodic/novatel_oem7_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d0952fe69e8b17debe00444af3639a6050fafe5c5efccba23060c05346156445";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "cf20f16f1f384d608666a4ceefc036a0b8ac2ddd3ef8b2d9a89133009b00c5dc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "8b4e8eaa0b64bf63ce02de66abb4626aa5bb16387909f8c051e573f9c93cc414";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-control/default.nix
+++ b/distros/melodic/pilz-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, joint-trajectory-controller, pilz-utils, roscpp, roslint, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-control";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "d6c277a94b8bd6a12f2b867829cdaaebc8bf177bc5cb5f019e93ba6aae2bafa7";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "f399607f785b4ff741cc69b474af2a6c08d41c6f68abedf4cb3f53af98bf8030";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-robots/default.nix
+++ b/distros/melodic/pilz-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-control, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robots";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "5b5e6734dd3ac62c99843a9cb477b0dba8fc801ca003b5c4482ff510bb2f8c79";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "7932a7090c71333be17780fb6f270991cdc530e6933b900509bf4b78788af12f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-status-indicator-rqt/default.nix
+++ b/distros/melodic/pilz-status-indicator-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, prbt-hardware-support, pythonPackages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-status-indicator-rqt";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "b539a5240ba8d28f28179faa26b73162876a46dd45d29d797871f95e79b0e5fc";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "847b44e7eb7467166a0b3ad3120ec832c61b8d605a15ee226486f9befe1ccef1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-testutils/default.nix
+++ b/distros/melodic/pilz-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pilz-testutils";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "c67d04bf22b08aee5f9d8932bd3372d4ee7630daea6b721995ddbbea6718cda4";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "a0c9b4e1bf638806c8ff5b10180badf4b4a287c8c497b63718018dcaa65e11a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-utils/default.nix
+++ b/distros/melodic/pilz-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clang, cmake-modules, code-coverage, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pilz-utils";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "1bcefccc449f970dafccbd1f504fa64253a52514b6eda0d930b5577bfa850715";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "22cd531acff2eeac360631054d80d7a21bc19c951fce419e36e75cddc959d5df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "a19835f315e2e9a029200780176be94e2a0ba94ba8113c891db6eff94ecb10a8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "ecd16e9e6ade0023330890cd2eb106d7525bcbef7530d5baec0c9735df01d0e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-description/default.nix
+++ b/distros/melodic/pointgrey-camera-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-description";
-  version = "0.14.0-r1";
+  version = "0.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "adc547f573337719e1fc1f58cbae8f4aa5bce277ba588324e8de10c61f58c88c";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_description/0.14.1-1.tar.gz";
+    name = "0.14.1-1.tar.gz";
+    sha256 = "2598eda647491180bf86ca9c4ad06da2c600237482b5c817ea0375710377f2a9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pointgrey-camera-driver/default.nix
+++ b/distros/melodic/pointgrey-camera-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pointgrey-camera-driver";
-  version = "0.14.0-r1";
+  version = "0.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "1ef68ed1ed47f135db7f0c03150932994a800be88c783e3bcd54906dcf6a3670";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/pointgrey_camera_driver/0.14.1-1.tar.gz";
+    name = "0.14.1-1.tar.gz";
+    sha256 = "a548c8bab220b708ada9bfb8410c7ac17137e9bc1862d294a164b9cf5d733109";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-gazebo/default.nix
+++ b/distros/melodic/prbt-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-gazebo";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "41617b657b2eaef709aebcf6244968d8cb40d0419a41cc32f8e1afead2084645";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "58316bb9962a5e4ca1a848465baeb2d8b093f7eb09219eb2216a53a855d779b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-hardware-support/default.nix
+++ b/distros/melodic/prbt-hardware-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-prbt-hardware-support";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "d726c347c6a26e1fd16d2a1518f19daf16779b15faf21a277d9f09aec3ad013f";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "6c9329a0b1d218e9d9aed5a13c96d111409303ab2ed66f8e2461567d4e0fcf0f";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Control hardware functions of the PRBT manipulator like STO for Stop1 functionality.'';
+    description = ''Control hardware functions of the PRBT manipulator like RUN_PERMITTED for Stop1 functionality.'';
     license = with lib.licenses; [ lgpl2 ];
   };
 }

--- a/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, eigen-conversions, moveit-core, moveit-ros-planning, pluginlib, roscpp, rostest, rosunit, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-prbt-ikfast-manipulator-plugin";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "dfd8dbab410bf1a26f89085d3bc843e0bf910ca8c4c97a226f16bce72a6a7f5a";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "c16cb9410266cbc8b36dbeeabd110c57e3f510386223a9b5d80ad9a105a3b1bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-moveit-config/default.nix
+++ b/distros/melodic/prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roslaunch, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-moveit-config";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "3f70afb6ae76e4d0d8927f9e93f6ed1963626fb933445212ed2bea0627d187ca";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "a58360b2c96a7a3920ad2c124f036de8573cbff6bcceeb9aa747e2331d8ef8fc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-support/default.nix
+++ b/distros/melodic/prbt-support/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, rosservice, rostest, rviz, topic-tools, xacro }:
+{ lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, pilz-status-indicator-rqt, pilz-testutils, pilz-utils, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-support";
-  version = "0.5.14-r1";
+  version = "0.5.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.14-1.tar.gz";
-    name = "0.5.14-1.tar.gz";
-    sha256 = "b86814f440ed26ec5b466d056ca7680f43f2e4db489a515fb91b66bf70bc3b47";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.15-1.tar.gz";
+    name = "0.5.15-1.tar.gz";
+    sha256 = "552ba9cbbd81bc2f05cf531750e773974f8e37a0628fca27d0e209e7bee8f5ed";
   };
 
   buildType = "catkin";
-  checkInputs = [ cmake-modules eigen joint-state-publisher moveit-core moveit-ros-planning prbt-hardware-support roslaunch rostest rviz ];
-  propagatedBuildInputs = [ canopen-motor-node controller-manager joint-state-controller pilz-control prbt-hardware-support robot-state-publisher roscpp rosservice topic-tools xacro ];
+  buildInputs = [ canopen-chain-node pilz-utils sensor-msgs ];
+  checkInputs = [ cmake-modules code-coverage eigen joint-state-publisher moveit-core moveit-ros-planning pilz-testutils prbt-hardware-support roslaunch rostest rosunit rviz ];
+  propagatedBuildInputs = [ canopen-motor-node controller-manager joint-state-controller pilz-control pilz-status-indicator-rqt prbt-hardware-support robot-state-publisher roscpp rosservice topic-tools xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "7790a97effdd08d073ff9bf2565e8a8352eca540b181d0b8c3197d5cb91842ab";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "61b1eae75a53d8ec6c989d5611f28bcaab8d028a24f5f25477a05dd3f01d4a36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "e24d28aacaff383d7e8c51fe4e26dba42991d6903b3e7ab15452eca86f596eb0";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "ef9edd7c24d0640d1571fe8ac6a23d1bbd4ba42b959ce33f49ed682f10ed0c24";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.11-r1";
+  version = "1.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.11-1.tar.gz";
-    name = "1.13.11-1.tar.gz";
-    sha256 = "f69eb62ef7327e980024c28717ac29997b8f1ee6856ee229bf92561a3544076d";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.12-1.tar.gz";
+    name = "1.13.12-1.tar.gz";
+    sha256 = "f446d50353caf457b1c9406df0c407e832f18e265f8914584247eef0313d4932";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "5fedf016c7758a5e7f2bc4758cb70e69e6151295a27fc7a7c90c0894d3dc97c1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "ebec80cff098b3c5a10c69331cd73ecc59289be5a4223a7636ea9a679c3290cd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sdc21x0/default.nix
+++ b/distros/melodic/sdc21x0/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-sdc21x0";
+  version = "1.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/sdc21x0/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e598a2ca7c39c8e209b6124a7d0106afb0c230e78da63f4f2b3348fd5e001a1a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message definitions for the sdc21x0 motor controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/statistics-msgs/default.nix
+++ b/distros/melodic/statistics-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-statistics-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "e9924391df2cb9f0f51eef44229a150307f8073b644c0c299f197f31ea330eac";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/statistics_msgs/0.14.1-1.tar.gz";
+    name = "0.14.1-1.tar.gz";
+    sha256 = "db97291f1aa312ba3d199b22c2b70e0c1309200445779cf7c74f8d812a117057";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "0861f16d24b3dcf9b31f0bd96d72bb4807af8402980f43b31240e51b1653c59a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "5311cdf7e141dbdc3fe2ff0e3b184dd54cae8b3c546978869b5e0d110a2b0041";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.4-r1";
+  version = "0.8.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.4-1.tar.gz";
-    name = "0.8.4-1.tar.gz";
-    sha256 = "e134e8915ecd8bd1a9a91f25a06f8656f347c5e7d7a556cf7dc1f35a7452a779";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.5-1.tar.gz";
+    name = "0.8.5-1.tar.gz";
+    sha256 = "8909b82af5b1043834dff21cf6b22ce480a3a7f39f1752d6f58bd99fa8466678";
   };
 
   buildType = "catkin";

--- a/distros/melodic/wfov-camera-msgs/default.nix
+++ b/distros/melodic/wfov-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-wfov-camera-msgs";
-  version = "0.14.0-r1";
+  version = "0.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.0-1.tar.gz";
-    name = "0.14.0-1.tar.gz";
-    sha256 = "0c84349f64c14db580835dc43245429174e59bd389c30aa03097676f4def6007";
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/melodic/wfov_camera_msgs/0.14.1-1.tar.gz";
+    name = "0.14.1-1.tar.gz";
+    sha256 = "c9b9f265c88ee3687366617abbb64324044753b3ba24b8967123014a7fb51fbc";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit f6ea96fde91c5cb038453b76f72f0f7383a8b75a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Kinetic Changes:
----------------
* *code-coverage 0.4.0-r1 --> 0.4.2-r1*
* *costmap-cspace 0.8.3-r1 --> 0.8.5-r1*
* *image-exposure-msgs 0.14.0-r1 --> 0.14.1-r2*
* *joystick-interrupt 0.8.3-r1 --> 0.8.5-r1*
* *map-organizer 0.8.3-r1 --> 0.8.5-r1*
* *mavlink 2020.4.4-r1 --> 2020.5.5-r1*
* *mir-actions 1.0.4-r1 --> 1.0.5-r1*
* *mir-description 1.0.4-r1 --> 1.0.5-r1*
* *mir-driver 1.0.4-r1 --> 1.0.5-r1*
* *mir-dwb-critics 1.0.4-r1 --> 1.0.5-r1*
* *mir-gazebo 1.0.4-r1 --> 1.0.5-r1*
* *mir-msgs 1.0.4-r1 --> 1.0.5-r1*
* *mir-navigation 1.0.4-r1 --> 1.0.5-r1*
* *mir-robot 1.0.4-r1 --> 1.0.5-r1*
* *neonavigation 0.8.3-r1 --> 0.8.5-r1*
* *neonavigation-common 0.8.3-r1 --> 0.8.5-r1*
* *neonavigation-launch 0.8.3-r1 --> 0.8.5-r1*
* *novatel-oem7-driver 1.0.0-r1 --> 1.1.0-r1*
* *novatel-oem7-msgs 1.0.0-r1 --> 1.1.0-r1*
* *obj-to-pointcloud 0.8.3-r1 --> 0.8.5-r1*
* *planner-cspace 0.8.3-r1 --> 0.8.5-r1*
* *plotjuggler 2.6.3-r2 --> 2.6.4-r1*
* *pointgrey-camera-description 0.14.0-r1 --> 0.14.1-r2*
* *pointgrey-camera-driver 0.14.0-r1 --> 0.14.1-r2*
* *safety-limiter 0.8.3-r1 --> 0.8.5-r1*
* *sdc21x0 1.0.5-r1*
* *statistics-msgs 0.14.0-r1 --> 0.14.1-r2*
* *track-odometry 0.8.3-r1 --> 0.8.5-r1*
* *trajectory-tracker 0.8.3-r1 --> 0.8.5-r1*
* *wfov-camera-msgs 0.14.0-r1 --> 0.14.1-r2*

Melodic Changes:
----------------
* *code-coverage 0.4.0-r1 --> 0.4.2-r1*
* *costmap-cspace 0.8.4-r1 --> 0.8.5-r1*
* *drone-wrapper 1.3.1-r1 --> 1.3.2-r1*
* *geometric-shapes 0.6.1 --> 0.6.2-r1*
* *hrpsys 315.15.0-r6 --> 315.15.0-r8*
* *image-exposure-msgs 0.14.0-r1 --> 0.14.1-r1*
* *jderobot-drones 1.3.1-r1 --> 1.3.2-r1*
* *joystick-interrupt 0.8.4-r1 --> 0.8.5-r1*
* *map-organizer 0.8.4-r1 --> 0.8.5-r1*
* *mavlink 2020.4.4-r1 --> 2020.5.5-r1*
* *mir-actions 1.0.4-r1 --> 1.0.5-r1*
* *mir-description 1.0.4-r1 --> 1.0.5-r1*
* *mir-driver 1.0.4-r1 --> 1.0.5-r1*
* *mir-dwb-critics 1.0.4-r1 --> 1.0.5-r1*
* *mir-gazebo 1.0.4-r1 --> 1.0.5-r1*
* *mir-msgs 1.0.4-r1 --> 1.0.5-r1*
* *mir-navigation 1.0.4-r1 --> 1.0.5-r1*
* *mir-robot 1.0.4-r1 --> 1.0.5-r1*
* *neonavigation 0.8.4-r1 --> 0.8.5-r1*
* *neonavigation-common 0.8.4-r1 --> 0.8.5-r1*
* *neonavigation-launch 0.8.4-r1 --> 0.8.5-r1*
* *novatel-oem7-driver 1.0.0-r1 --> 1.1.0-r1*
* *novatel-oem7-msgs 1.0.0-r1 --> 1.1.0-r1*
* *obj-to-pointcloud 0.8.4-r1 --> 0.8.5-r1*
* *pilz-control 0.5.14-r1 --> 0.5.15-r1*
* *pilz-robots 0.5.14-r1 --> 0.5.15-r1*
* *pilz-status-indicator-rqt 0.5.14-r1 --> 0.5.15-r1*
* *pilz-testutils 0.5.14-r1 --> 0.5.15-r1*
* *pilz-utils 0.5.14-r1 --> 0.5.15-r1*
* *planner-cspace 0.8.4-r1 --> 0.8.5-r1*
* *pointgrey-camera-description 0.14.0-r1 --> 0.14.1-r1*
* *pointgrey-camera-driver 0.14.0-r1 --> 0.14.1-r1*
* *prbt-gazebo 0.5.14-r1 --> 0.5.15-r1*
* *prbt-hardware-support 0.5.14-r1 --> 0.5.15-r1*
* *prbt-ikfast-manipulator-plugin 0.5.14-r1 --> 0.5.15-r1*
* *prbt-moveit-config 0.5.14-r1 --> 0.5.15-r1*
* *prbt-support 0.5.14-r1 --> 0.5.15-r1*
* *rqt-drone-teleop 1.3.1-r1 --> 1.3.2-r1*
* *rqt-ground-robot-teleop 1.3.1-r1 --> 1.3.2-r1*
* *rviz 1.13.11-r1 --> 1.13.12-r1*
* *safety-limiter 0.8.4-r1 --> 0.8.5-r1*
* *sdc21x0 1.0.5-r1*
* *statistics-msgs 0.14.0-r1 --> 0.14.1-r1*
* *track-odometry 0.8.4-r1 --> 0.8.5-r1*
* *trajectory-tracker 0.8.4-r1 --> 0.8.5-r1*
* *wfov-camera-msgs 0.14.0-r1 --> 0.14.1-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

