### PR TITLE
rosdistro sync, Fri May 22 12:41:12 2020

### DIFF
--- a/distros/dashing/rclc-examples/default.nix
+++ b/distros/dashing/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rcl, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclc-examples";
-  version = "0.1.1-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/micro-ROS/rclc-release/archive/release/dashing/rclc_examples/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "348de05554e376d6ae9e8189e6282a92eb1c462f50cbf636eda8dbd797125311";
+    url = "https://github.com/micro-ROS/rclc-release/archive/release/dashing/rclc_examples/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "e8a178fb546277476529284265f9e1127577cffa05cb2b7a1be2c74bdfd7bc6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclc/default.nix
+++ b/distros/dashing/rclc/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclc";
-  version = "0.1.1-r1";
+  version = "0.1.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/micro-ROS/rclc-release/archive/release/dashing/rclc/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "9161f5c94bf013a5bb7bf235d893309754f49cd7be55ec95b1154033f24c98ac";
+    url = "https://github.com/micro-ROS/rclc-release/archive/release/dashing/rclc/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "da67d7e01c93ebd960cfafd43a3de3e89bde2196f5a32b0f2765a8b3a70319a9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-typesupport-c ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing osrf-testing-tools-cpp std-msgs ];
   propagatedBuildInputs = [ rcl rcutils rosidl-generator-c ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/eloquent/joint-state-publisher-gui/default.nix
+++ b/distros/eloquent/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
 buildRosPackage {
   pname = "ros-eloquent-joint-state-publisher-gui";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher_gui/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "887ebb72a58819414bac54372188c1740038abb40791c586bfd83230d2082540";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher_gui/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8635cad96c5dc2d43d81c23ece1dafd7ef1517f5b9b34570496f40a20df100f5";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/joint-state-publisher/default.nix
+++ b/distros/eloquent/joint-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-joint-state-publisher";
-  version = "2.0.0-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "bef59b518cb96eafbf5d9aeffe2b3edcfc18532489e44da9c9e5717d47fd1148";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/eloquent/joint_state_publisher/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "d947f33d2048dbca636131783ae83828e888dbc513562d2b238d9a8a3abf6cac";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/rclc-examples/default.nix
+++ b/distros/eloquent/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, rcl, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rclc-examples";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/micro-ROS/rclc-release/archive/release/eloquent/rclc_examples/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "c94aef6f6db9d465641d352a2efaefae839451079dac8f9753565699742b684a";
+    url = "https://github.com/micro-ROS/rclc-release/archive/release/eloquent/rclc_examples/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "07b289929c64d83e4f20882d5ff474c07f19500eff441c32a0189fcf5b405444";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rclc/default.nix
+++ b/distros/eloquent/rclc/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rclc";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/micro-ROS/rclc-release/archive/release/eloquent/rclc/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "af816f529bcbc4f97638a5c2053ffa0c1670991a9b1ad21c697d899db4384c81";
+    url = "https://github.com/micro-ROS/rclc-release/archive/release/eloquent/rclc/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "ed640eee9434090e8a7e1a18d4b81eab06a514486e4ed206d8f06aac09cd7ef7";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rosidl-typesupport-c ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp std-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch-testing osrf-testing-tools-cpp std-msgs ];
   propagatedBuildInputs = [ rcl rcutils rosidl-generator-c ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/kinetic/behaviortree-cpp-v3/default.nix
+++ b/distros/kinetic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-kinetic-behaviortree-cpp-v3";
-  version = "3.4.0-r1";
+  version = "3.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/kinetic/behaviortree_cpp_v3/3.4.0-1.tar.gz";
-    name = "3.4.0-1.tar.gz";
-    sha256 = "9beeb6883bf81e441fa7a746e1597a078cf508361120ea4d7cb39f5a2cceca18";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/kinetic/behaviortree_cpp_v3/3.5.0-2.tar.gz";
+    name = "3.5.0-2.tar.gz";
+    sha256 = "4090aeee2d7816ec7c5e273b3638b5e31ea99618f3360c0c0d296eba896a1bb7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "49af4ba08762878d1553ea8deb9e54fbc3c5d13740399d356ed2a5d17c19f101";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "fedc732fbd0e31ddedb51b26fd34d7d1f9fcdbf906e49467700b148cf4ec0331";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2376,6 +2376,8 @@ self: super: {
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
 
+ moveit-opw-kinematics-plugin = self.callPackage ./moveit-opw-kinematics-plugin {};
+
  moveit-planners = self.callPackage ./moveit-planners {};
 
  moveit-planners-chomp = self.callPackage ./moveit-planners-chomp {};
@@ -3407,6 +3409,8 @@ self: super: {
  rc-pick-client = self.callPackage ./rc-pick-client {};
 
  rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
+
+ rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
 
  rc-tagdetect-client = self.callPackage ./rc-tagdetect-client {};
 

--- a/distros/kinetic/interactive-marker-tutorials/default.nix
+++ b/distros/kinetic/interactive-marker-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-interactive-marker-tutorials";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/interactive_marker_tutorials/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "538c214100b3c57362642b43903a64528777f92d038462d88dc6ca297afde123";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/interactive_marker_tutorials/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "b788374e8a3b3b9b429e4548f5b264d51fe953f915c58f7f4c332577dc23beb5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "51d21e6acee79383e6d7c1e536dc406caaac77cb858b41e319ef38bf47101cde";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "811aafcbdcf3fc7998c50ab43f330d7903642fb14d7b0435e5c398c014c5e2d6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librviz-tutorial/default.nix
+++ b/distros/kinetic/librviz-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-kinetic-librviz-tutorial";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/librviz_tutorial/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "b5a720da115f3a9db015b020c78c0b9336a48e77d848fd6aa237f53ef4099d13";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/librviz_tutorial/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "2d459f808d11c76ff9fbd67aeb3d85b308b020f3c802b5dce2e2ef6a64fdfc57";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "b29f50556cdcba48c4d9d74459224234361821e7d7e9b46db3394fb21ed762b0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "0553f5c72564e963cb9d013b428646004d61be0416aaba160a83167251697858";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mapviz-plugins/default.nix
+++ b/distros/kinetic/mapviz-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, libqt-core, libqt-dev, libqt-opengl, libqt-opengl-dev, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt-qmake, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, libqt-core, libqt-dev, libqt-opengl, libqt-opengl-dev, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt-qmake, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mapviz-plugins";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/mapviz_plugins/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "9e9b464fb9cf09a68796b2668edd65ed68ab81d1a0870e3fd3ad3793679baa81";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/mapviz_plugins/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7659e1618f9346a04641cfb0b6de4397e988d1a32c525f7e9bf464ee8f92edf0";
   };
 
   buildType = "catkin";
   buildInputs = [ libqt-dev libqt-opengl-dev ];
-  propagatedBuildInputs = [ actionlib cv-bridge gps-common image-transport libqt-core libqt-opengl map-msgs mapviz marti-common-msgs marti-nav-msgs marti-visualization-msgs move-base-msgs nav-msgs pluginlib roscpp sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util swri-yaml-util tf visualization-msgs ];
+  propagatedBuildInputs = [ actionlib cv-bridge gps-common image-transport libqt-core libqt-opengl map-msgs mapviz marti-common-msgs marti-nav-msgs marti-sensor-msgs marti-visualization-msgs move-base-msgs nav-msgs pluginlib roscpp sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util swri-yaml-util tf visualization-msgs ];
   nativeBuildInputs = [ catkin qt-qmake ];
 
   meta = {

--- a/distros/kinetic/mapviz/default.nix
+++ b/distros/kinetic/mapviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, libqt-core, libqt-dev, libqt-opengl, libqt-opengl-dev, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt-qmake, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
 buildRosPackage {
   pname = "ros-kinetic-mapviz";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/mapviz/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8a27377ddcd860bdbf067431053f68118bc4500c507be494242c942f00ddf99a";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/mapviz/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "00faeea7e77351f0eb0298716331f01defb03ab5226fc17eda4166c5bcd065ab";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-data-structures/default.nix
+++ b/distros/kinetic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-marti-data-structures";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/marti_data_structures/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "3f98a7edbb002fa2ebe98b1576f36fd45fffc971014471ba5d2cd7b7fa3beb12";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/marti_data_structures/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "cbb911c97d06df2c7b522f09317b559227b0c56442a69c3d45d0de9d178b2da3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2020.5.5-r1";
+  version = "2020.5.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.5.5-1.tar.gz";
-    name = "2020.5.5-1.tar.gz";
-    sha256 = "4cc76d072de4faf47fa6cd5e833c5fba4ba609bfcd6f73e21f8a60e265540746";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.5.21-1.tar.gz";
+    name = "2020.5.21-1.tar.gz";
+    sha256 = "5e8fa0bd5a8364d25f37ab8ae1020af491c82fe0316c78cb6f669c5f145a6065";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/moveit-opw-kinematics-plugin/default.nix
+++ b/distros/kinetic/moveit-opw-kinematics-plugin/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-kinetic-moveit-opw-kinematics-plugin";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release/archive/release/kinetic/moveit_opw_kinematics_plugin/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "dd903218c7b494841533ca25ff0ea9d4fca492923644630a70b9d3816f2d4eae";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ moveit-resources rostest ];
+  propagatedBuildInputs = [ moveit-core moveit-ros-planning pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+      MoveIt kinematics plugin for industrial robots.
+    </p>
+    <p>
+      This plugin uses an analytical inverse kinematic library, opw_kinematics,
+      to calculate the inverse kinematics for industrial robots with 6 degrees of freedom,
+      two parallel joints, and a spherical wrist.
+    </p>'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/multires-image/default.nix
+++ b/distros/kinetic/multires-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, libqt-core, libqt-dev, libqt-opengl, libqt-opengl-dev, mapviz, pluginlib, qt-qmake, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-kinetic-multires-image";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/multires_image/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "c270152ffb38cb659a576f23beb54d4d688f5d5b35cc43cbabaeccaf496f85f2";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/multires_image/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b2e71689028550637415ca94f4ab23de6ce253d68cd7b5edd10fbfcd08c36cca";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "12c94443a7215e1f95c59de71314117e8a992c04adbd126036805f49170c5007";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "fd69ef38944d9226d1e4b13ad8559cff22f6810cd72da281ba1a4da66fd68328";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "eb94a2505dff0a7f8d0f0418556deff3e2c3c49c6a111dcbc3a36a813174968a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "6140c24f85bfde25e2e1e4bee98274c8f309b04fcd599ac1a396d3a8fd468547";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "deec1cf685cb0485e7db3472b956733b844babb202645e39cefd94103630a76d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "4fc679eb4bb5b8219b7a282503075f493bf208845449d7416f6b8d484ed7a8bd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "386def1cddbb83debefff8f7747ca5cd05d3c93094c0bda6b7199634e3524de0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "d8a7a3c6f3394a85986a4dcc8a61da0813121b1c1758766590eeed99a101dc95";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "591fa2fc7427bcfd45770c327c13d9f7393162aa5a0d7602d06d7036dd637266";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "614f6cf59b21fea5130f8bb5d8ecaa49e857d86a23a12837cb91567f2fb4c2e3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-common-msgs/default.nix
+++ b/distros/kinetic/rc-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-common-msgs";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/kinetic/rc_common_msgs/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "396a499a59bef9bd7a45960ca7258f934c6e908cf41248965321fbb079d45fee";
+    url = "https://github.com/roboception-gbp/rc_common_msgs-release/archive/release/kinetic/rc_common_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "7b620577c4bdda1766e820a35e16288c3b840e9fc838505662b6651cc0f800dd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/kinetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-rc-hand-eye-calibration-client";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "d50b5a327fa70e9be566222647223b8fe7eda9b19e283b48175af2969e31e076";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "d60c0f00e089d228646fbdf4fd215cc2ea94ee7ce366ab200911f9bcbdeb7abc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-pick-client/default.nix
+++ b/distros/kinetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-pick-client";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "f6b60ba9ae5fc4d4f72ab227fbc936eb74e842368a66824217e5d6df8ef011d0";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "f6e8c0060d4ffd1ee0b77ff1abbe4d426eea0cf605ada7379d5d128f240f132d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-roi-manager-gui/default.nix
+++ b/distros/kinetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-kinetic-rc-roi-manager-gui";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "91f18f08c008d8e3a0a058825048dac14feb683b6ccfd1a6d2847a4d21bd3ee2";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "cda593d4ee247a407c8c29fb7c828362428a48d1b78797bd79d333eee8396fbf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-silhouettematch-client/default.nix
+++ b/distros/kinetic/rc-silhouettematch-client/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rc-silhouettematch-client";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "82dde0bc71cd01da22f51ce5f31f0d94dd60024b1942772b9067eea49d4b8ea2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ curl dynamic-reconfigure geometry-msgs message-runtime rc-common-msgs rcdiscover roscpp tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros client for roboception silhouette match module'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/rc-tagdetect-client/default.nix
+++ b/distros/kinetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-tagdetect-client";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "8470d56fb825c58b61c71167adf735e8c9450489fdc11242e1c6530c318856ba";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "9dca7979cf797d867e6211d4cccfaf380c7c775bc25dab51ff127a7893aa0f60";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-description/default.nix
+++ b/distros/kinetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-description";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "a1812fff44cb5f08941e3997fe62f04e1b02015406f481dbd8ca8ff5ec2f1da5";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "974eee6d99db839c51e357a4ff69d821930fbc3cdd475a7d3e98acdfd26c1937";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-driver/default.nix
+++ b/distros/kinetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-driver";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "e3aac13f1e408cec679a5561a6ffc51697c3bff4f12e8d67bb38596e2e767260";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "e9dc2341b59e512fe5c83837f5e9f8e4382f152ee5c452db78473505c182f78e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard/default.nix
+++ b/distros/kinetic/rc-visard/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
+{ lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard";
-  version = "2.7.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/2.7.0-1.tar.gz";
-    name = "2.7.0-1.tar.gz";
-    sha256 = "f14ee03711355119b717ecc3a5eaba69deffed9476f4e1b2e529bc36530b843e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "60149b8c4a531a3b334bba36ca5c4e2070b8340a74aae07a5a12664bd677ab33";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-roi-manager-gui rc-tagdetect-client rc-visard-description rc-visard-driver ];
+  propagatedBuildInputs = [ rc-hand-eye-calibration-client rc-pick-client rc-roi-manager-gui rc-silhouettematch-client rc-tagdetect-client rc-visard-description rc-visard-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rosapi/default.nix
+++ b/distros/kinetic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosapi";
-  version = "0.11.6-r2";
+  version = "0.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.6-2.tar.gz";
-    name = "0.11.6-2.tar.gz";
-    sha256 = "f00486d358e8b78257632b59492b67ede0b9fda80c8e9a4ea093ebb8674eb190";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.8-1.tar.gz";
+    name = "0.11.8-1.tar.gz";
+    sha256 = "3d78d3b3997d7ca150f12d1c4f5a81451581e0fd1b775ced908652d4e6e82616";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-library/default.nix
+++ b/distros/kinetic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-library";
-  version = "0.11.6-r2";
+  version = "0.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.6-2.tar.gz";
-    name = "0.11.6-2.tar.gz";
-    sha256 = "08214b3a2dc01ae6c2f824bb5ee98293158b668b8ef6c0d1eb1d75408624745e";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.8-1.tar.gz";
+    name = "0.11.8-1.tar.gz";
+    sha256 = "386bfce38ea19e98ccd812f249db4937b383fec16fd83295a5814f92574dc31a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-msgs/default.nix
+++ b/distros/kinetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-msgs";
-  version = "0.11.6-r2";
+  version = "0.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.6-2.tar.gz";
-    name = "0.11.6-2.tar.gz";
-    sha256 = "a81b691987901f9dc552ce91ae04fcf1a953f33323f4a5d28b781f693a7dfcf7";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.8-1.tar.gz";
+    name = "0.11.8-1.tar.gz";
+    sha256 = "174d63a3b70f57b427c87a91a19b35b3691f87048b4adb9c6ebe7990daa5dba0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-server/default.nix
+++ b/distros/kinetic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-server";
-  version = "0.11.6-r2";
+  version = "0.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.6-2.tar.gz";
-    name = "0.11.6-2.tar.gz";
-    sha256 = "ffc4e69d0bfbcc9a8dd8e949960ebe7216995d6bba6bfe52a60d9c26f34ef76a";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.8-1.tar.gz";
+    name = "0.11.8-1.tar.gz";
+    sha256 = "9590fca5cbe04e0ec9062b171f70dbccdf9718e51fb11c851eee764eace3df4f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-suite/default.nix
+++ b/distros/kinetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-suite";
-  version = "0.11.6-r2";
+  version = "0.11.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.6-2.tar.gz";
-    name = "0.11.6-2.tar.gz";
-    sha256 = "c574bd00467fc2c36b1c71f4643c0cf495c81751ec600c3847b2ce8e450c0260";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.8-1.tar.gz";
+    name = "0.11.8-1.tar.gz";
+    sha256 = "79ee0ebbdae95878c235a267c010c467f0a336f803f4778d78925a5252bfacf1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rviz-plugin-tutorials/default.nix
+++ b/distros/kinetic/rviz-plugin-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, rviz }:
 buildRosPackage {
   pname = "ros-kinetic-rviz-plugin-tutorials";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/rviz_plugin_tutorials/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "76998d671893d077f5fe8a074f9c8bcef142956e81a5902250509a4d061d598a";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/rviz_plugin_tutorials/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "c5473143e9c8b4674397e415525c2505b4282e413ed1d870c23cec9f385de36a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rviz-python-tutorial/default.nix
+++ b/distros/kinetic/rviz-python-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rviz }:
 buildRosPackage {
   pname = "ros-kinetic-rviz-python-tutorial";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/rviz_python_tutorial/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "30bab9adabf6c5f06ce36eae6cbd2941fbda56fd51675330ced07110d9dee064";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/rviz_python_tutorial/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "c7e0327dce6a304352a1a1b2f1327d7cf4c2602426ba6ae184f7d9897aebb936";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "39818b6b32a76be1129e13fe76f9eb1c46f7f5a331de42dc1beccf10dd1b8f65";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "60b3d5e31a9607dbb84071bd20c46ec052b4b8ad6910b30269ba5ccea8f34f62";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-scan/default.nix
+++ b/distros/kinetic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-scan";
-  version = "1.4.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "1156e52208690cce3b765d90131e6303dd52182b0cae339f5307a7bb613663ec";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f88728990fc8d21ea6106cc0483812ac53bc177888a10eda782769ea24e8444d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-console-util/default.nix
+++ b/distros/kinetic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-kinetic-swri-console-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_console_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "9628e6e678a3efb3d8784ed0a1b933fa64c45ceb1f440cbf0a166ce792413fe6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_console_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "a6b7c426ca3a9998fdcef9adea46327401fbdb71d3a08ad34eb8d0d540b7018c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-dbw-interface/default.nix
+++ b/distros/kinetic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-swri-dbw-interface";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_dbw_interface/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "cd39519644168fc339150da3f96accdc3b221da45dd9f31fd8ed2f907e782f8e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_dbw_interface/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "9bf521f0d714a3bedf0785dbfa712d5725fcb2026b891521071e98992c25f83c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-geometry-util/default.nix
+++ b/distros/kinetic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-swri-geometry-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_geometry_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "2640befa92a89416d1ee3e11c493156f9035950ae123f1adecc20dbe83c338dd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_geometry_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "d3d40803902bc1e53673fdc57e1ab1de04442e26169005d41bff5630cde963fc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-image-util/default.nix
+++ b/distros/kinetic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-swri-image-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_image_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "adf606699c08283821ee645512a23adb417a21b3655b96e39570556da940b0c0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_image_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "cda80b354d3932a7104a70dd89c535c4623752e825f64b5fe0afa45e7282e450";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-math-util/default.nix
+++ b/distros/kinetic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-math-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_math_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "a4ced223b336ec16f08d2014ae579c91e62f01d77fa91cc8b82ea54e20ae5db3";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_math_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "2fd8969eafdfed745e39a4c5dd47748815d8e96c757cf3b0da229f1c3a01a572";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-nodelet/default.nix
+++ b/distros/kinetic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-nodelet";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_nodelet/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "a49620eeb22e41a96d3185cac8eafd0e4d32d6d12c559cc0741f7213f93dccf3";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_nodelet/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "980937ac94cf9420aeb402903426dd795515384dffbf21dd704dd7e781ec5bea";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-opencv-util/default.nix
+++ b/distros/kinetic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-kinetic-swri-opencv-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_opencv_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "3d79c030de02d8dd54d50835d15225a4f8f0d6c294eec999ea039d26a6d761f2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_opencv_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "fd925dcfb07729467e62401547b58d2e1a68b87c701956fbecfd731996aa260f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-prefix-tools/default.nix
+++ b/distros/kinetic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-swri-prefix-tools";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_prefix_tools/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "6291ee73a2a1b0263072937d49184fd9a419670d9d812abf2f132b5d98286841";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_prefix_tools/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "ea7711d89439e9c2ea9fecb20e21f3f777053b2d5dc6d5a4ee81b6b44ac882cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-roscpp/default.nix
+++ b/distros/kinetic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-roscpp";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_roscpp/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "0cef5c4d64913721c881f69b9ef0c9c07b1e4d4af824af87f162c37f90d5af79";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_roscpp/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "7fc19df332b743280336a5a9eb14ec668074dba80b2213baa0070fd07b14a327";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-rospy/default.nix
+++ b/distros/kinetic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-rospy";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_rospy/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "03e6fbcfdb0721e2ba1b83a0bccbd3a9a94f95eabcb90e1f6e458227c613df8d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_rospy/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "03fdd82d147c3beb8305fd3aab454bb35b863167e0e1b2bea304e6b4d66c28dd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-route-util/default.nix
+++ b/distros/kinetic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-route-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_route_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "7ba7a611571f0fed84a83f86831907b935e32112da34346c01e800b5485a96e1";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_route_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "a8b453104db0c1822813eaf4c65355c8f6eef1149966e247d616b6f7787e6a0f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-serial-util/default.nix
+++ b/distros/kinetic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-swri-serial-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_serial_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "4eda73ab02e0cb9eebe506308c5ff216f0c3c50300f77a4a4144dd22fe6931df";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_serial_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "99b7b4dd90f9accc25b6972729da7e38d44d80703b485508ecfc95e147f863f9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-string-util/default.nix
+++ b/distros/kinetic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-string-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_string_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "a71be8d4ebc222443f1d7d0bc450ba7c07bfd2e1d18ebbec1df3e480a6bb9b12";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_string_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "2f63b52295e2ef39c8eed29391ee1db277cc815cb2e8060200dd97509977f9bb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-system-util/default.nix
+++ b/distros/kinetic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-system-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_system_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "b806392249dc0a6e9be90073251532110c66bc3fd24f04e3b8aca7a454e3e442";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_system_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "cab76fa5f32d1df9b95c9f46c93802d9a5d7dad4a927cdee016fee13341215cc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-transform-util/default.nix
+++ b/distros/kinetic/swri-transform-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-swri-transform-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_transform_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "e38d88f259cf4d93992d857c5dae5513e01d3bd5b0dd9a46ced3a3cfee7b2f28";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_transform_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "19eac7d22587b19e27842071ea6522d75c8af6078e193fe5d9bb0c8b8286da02";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-yaml-util/default.nix
+++ b/distros/kinetic/swri-yaml-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
 buildRosPackage {
   pname = "ros-kinetic-swri-yaml-util";
-  version = "2.12.0-r1";
+  version = "2.13.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_yaml_util/2.12.0-1.tar.gz";
-    name = "2.12.0-1.tar.gz";
-    sha256 = "98c1e7358d7563be5409d7e1faa4143ae81acf87c1819c400e3dd4ae4e723073";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_yaml_util/2.13.1-1.tar.gz";
+    name = "2.13.1-1.tar.gz";
+    sha256 = "016adf7913159fa6c387cd06214df3517afd1a52adb92446fe78374989e509a7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/tile-map/default.nix
+++ b/distros/kinetic/tile-map/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, libqt-core, libqt-dev, libqt-opengl, libqt-opengl-dev, mapviz, pluginlib, qt-qmake, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
 buildRosPackage {
   pname = "ros-kinetic-tile-map";
-  version = "1.2.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/tile_map/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "041d6ece56c4323bb5fe5fd76b977b3cfe19541ff39c504927cd2cde06f55d36";
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/kinetic/tile_map/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b267adecda9a67a5ba2ce35a1865c6738695ac5c279e520c0b3c12e6ca6fe3ff";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "e6a9de4b1d2263be9691b4be35430734c04d86a611e09044dccb4b48cd3641f2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "61ae28d1dacebfe35df7a52e244815904b9a738d2a6a0ba3e42fd6e5de127a82";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.5-r1";
+  version = "0.8.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "bebec0d4eb18d4a055307be2faf815b7955eef2f8668bf1e0103759d804abb47";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.7-1.tar.gz";
+    name = "0.8.7-1.tar.gz";
+    sha256 = "0afadd54924c2b23d9abdc0c0dff9f7b29d9d28faa2199416c9fb1ac0723dc81";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/visualization-marker-tutorials/default.nix
+++ b/distros/kinetic/visualization-marker-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-visualization-marker-tutorials";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/visualization_marker_tutorials/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "1ad28a1371f55206159902d81177481fd832bcf9027153e040f4b65ddcaaccf2";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/visualization_marker_tutorials/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "67899fa850d2dd42bb55f3c327ccf68350d3f092402a52cde8326aa51cc40343";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/visualization-tutorials/default.nix
+++ b/distros/kinetic/visualization-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-marker-tutorials, librviz-tutorial, rviz-plugin-tutorials, rviz-python-tutorial, visualization-marker-tutorials }:
 buildRosPackage {
   pname = "ros-kinetic-visualization-tutorials";
-  version = "0.10.3";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/visualization_tutorials/0.10.3-0.tar.gz";
-    name = "0.10.3-0.tar.gz";
-    sha256 = "a801eaedfd07578c2e80ea595caf484306812b50a0758a34821348a0b1d403a1";
+    url = "https://github.com/ros-gbp/visualization_tutorials-release/archive/release/kinetic/visualization_tutorials/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "b9861b11940d4b13bb74d1b8f5948a0364043ad8887fc93dd2faee63f864cb80";
   };
 
   buildType = "catkin";

--- a/distros/melodic/camera-calibration/default.nix
+++ b/distros/melodic/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-geometry, message-filters, rospy, rostest, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-camera-calibration";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "95993469bff9fc345dc7571a24f041567125700df8ea75906cd4e7d45f67d18a";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/camera_calibration/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "184268a2b78b1373289cf8c047e3f2069911dff625cfeb36ae34a19dc241ba5f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "7bebc9d6d945c9d6fe5a2b5f9c04afc2e57bdf976ac940dd9e7c7ca597c3db93";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "b0ad0d49025935a78b2a67f7bfaf542ca44fc9ecb1b99f882ccce4d9c710e36e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/depth-image-proc/default.nix
+++ b/distros/melodic/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, cv-bridge, eigen-conversions, image-geometry, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-depth-image-proc";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "9bb74785d59b1e2cdecb8387b842bd95239d7b280f17d6c2a2284f593f69736b";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/depth_image_proc/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "dd1e8a0b66ed4ad80d8f4eb4cbeaa315ba8f1c6d3d5d096edf9b55153bd9f90a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1758,6 +1758,8 @@ self: super: {
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
 
+ moveit-opw-kinematics-plugin = self.callPackage ./moveit-opw-kinematics-plugin {};
+
  moveit-planners = self.callPackage ./moveit-planners {};
 
  moveit-planners-chomp = self.callPackage ./moveit-planners-chomp {};
@@ -3287,6 +3289,8 @@ self: super: {
  tf2-server = self.callPackage ./tf2-server {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf2-urdf = self.callPackage ./tf2-urdf {};
 
  tf2-web-republisher = self.callPackage ./tf2-web-republisher {};
 

--- a/distros/melodic/hector-compressed-map-transport/default.nix
+++ b/distros/melodic/hector-compressed-map-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, geometry-msgs, hector-map-tools, image-transport, nav-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-compressed-map-transport";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_compressed_map_transport/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "3be26fd7806ed4e643de57b603bb8b7fb8e4bdd46a6484d77d3c5ff113d4b391";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_compressed_map_transport/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "72b380538c9d4c4368b5631afa0a92e97a02d0cd20da07ee50723b65dd1b3a37";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-geotiff-plugins/default.nix
+++ b/distros/melodic/hector-geotiff-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-geotiff, hector-nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-geotiff-plugins";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_geotiff_plugins/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "a99af08c43131cca5c839e5680e3957315ecff893934b89d1b9da98bb8971ad0";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_geotiff_plugins/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "bad8710701ff02823d3cb1f85bf510bb986c55a91ecb498576dbdbbd931444f0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-geotiff/default.nix
+++ b/distros/melodic/hector-geotiff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-nav-msgs, nav-msgs, pluginlib, qt4, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-geotiff";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_geotiff/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c536b4ab26359dd301470c0b2aa2e26aba77ea63bd70b54b53e8f0686ef6dffb";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_geotiff/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "fc5fb0b6bbd507578ff03f1e117532994fc9fe1a10e5a15410edaf0e9cbf4be9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-imu-attitude-to-tf/default.nix
+++ b/distros/melodic/hector-imu-attitude-to-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-hector-imu-attitude-to-tf";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_imu_attitude_to_tf/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "16d5505067c30a8e510904884e6d3b677faf0ed8b44fd3c3ac14c35261ff81b8";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_imu_attitude_to_tf/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "2e186eb4656f497c7dc1438e672cc0990b11120a0bf41aab78c08ceed40bc35e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-imu-tools/default.nix
+++ b/distros/melodic/hector-imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-hector-imu-tools";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_imu_tools/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c470a8781962710ca68058006428879639b57ce29649d2660ee10a6b09289ff5";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_imu_tools/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "e2a39e77a85688b2bb89ef2d07975ea71558c94037a77c1a9bd7b478ee84b99d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-map-server/default.nix
+++ b/distros/melodic/hector-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-marker-drawing, hector-nav-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-hector-map-server";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_map_server/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b86414ff423348c86a9084d947ae80233e141f01394254ed5a424cfd84c9227e";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_map_server/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5d34745850c2814852fb3adbb67c7d9c219807449c3e24445573752b7ac53e6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-map-tools/default.nix
+++ b/distros/melodic/hector-map-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-map-tools";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_map_tools/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "980e8e3e48bdb9d27e68261ba79d1a55d3b361dcbb55835fa0407854bf5492a1";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_map_tools/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "85afa10dff34e1bc05af980434c524b99185acb91403a94bc3fba68fda31755d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-mapping/default.nix
+++ b/distros/melodic/hector-mapping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, eigen, laser-geometry, message-filters, message-generation, message-runtime, nav-msgs, roscpp, tf, tf-conversions, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-mapping";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_mapping/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "bc94afaf1df68b038253dca063f76b3afac667c9b0929cb648f888c147dcc81c";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_mapping/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "fc1af9c95dcce587f5d5f72025ccf8b487dba26ad2d6b1158a53b5de79d5b1d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-marker-drawing/default.nix
+++ b/distros/melodic/hector-marker-drawing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-marker-drawing";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_marker_drawing/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "087fbe514f592a80d5a3d7b8bb7e4a39aefbb7b4930b4d056bfc1fc6d5113cd3";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_marker_drawing/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "c17a86ba1a6c603dedfc4c757c6f19c5537e808d0eb01241bf18431e9ef0bbca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-nav-msgs/default.nix
+++ b/distros/melodic/hector-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hector-nav-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_nav_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d0d37e5ad6c0e3802a5d08ceb5c97cd6baa5d8c9e7b9f889e10f5e3c4ceb7d5f";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_nav_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "d13b74403ab5af03a0c127c92549a0aacc23d69fa968f69557dab5e4d99bc875";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-slam-launch/default.nix
+++ b/distros/melodic/hector-slam-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-geotiff, hector-geotiff-plugins, hector-map-server, hector-mapping, hector-trajectory-server }:
 buildRosPackage {
   pname = "ros-melodic-hector-slam-launch";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_slam_launch/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "f88c7c33d567ec3e10e4d619b8d8e61d787ea2df0504759bf8513bf142ce9486";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_slam_launch/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5f39ba101db27d43a79e682330cbbd248f46fff16ad6a8acbccd3a88e7cec850";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-slam/default.nix
+++ b/distros/melodic/hector-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-compressed-map-transport, hector-geotiff, hector-geotiff-plugins, hector-imu-attitude-to-tf, hector-map-server, hector-map-tools, hector-mapping, hector-marker-drawing, hector-nav-msgs, hector-slam-launch, hector-trajectory-server }:
 buildRosPackage {
   pname = "ros-melodic-hector-slam";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_slam/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "2285de5a4920e257cfb7d9f1a6bd121c00b53201c49060552c17ed78511ffb60";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_slam/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5de924ad2cd6d85d5b5ff4ea8762e2b9ea5e68139133e42a0dd7cb537503ee49";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-trajectory-server/default.nix
+++ b/distros/melodic/hector-trajectory-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-nav-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-hector-trajectory-server";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_trajectory_server/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "39aca0f4b342351570b3940a8570985e9be7ca0a11b5ebd081d8a05cd7ac112b";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/melodic/hector_trajectory_server/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "f7babbe07541363e5593fd7e7145b8c7be41e224f25242e11e462d7222901f44";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-pipeline/default.nix
+++ b/distros/melodic/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration, catkin, depth-image-proc, image-proc, image-publisher, image-rotate, image-view, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-image-pipeline";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "34c43d0ef5669dbc9727277b88207348a12155fe30033e2e5d3f033dbfa56729";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_pipeline/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "5101a0cae0545e8384888172b1b7a4bd870a221d7c741e128a1bc89186ef4c76";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-proc/default.nix
+++ b/distros/melodic/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-transport, nodelet, nodelet-topic-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-proc";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "8719ff0e5343cd91a069b4f258ceae8efc2e5b46d88b42eb201a32795306a3d3";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_proc/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "146972719c251c70dd8702ef84d65da3a188f8b30090e95ca70455cc8282d9a3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-publisher/default.nix
+++ b/distros/melodic/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-publisher";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "c9869c11a9829621393af0ce79d2530accfe38cfec200aadb5c826d9c19c3c1d";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_publisher/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "3117e0d51d6395341b07f4292606dee9bd69ebbfeb0327504e249e4ad5a61228";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-rotate/default.nix
+++ b/distros/melodic/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, dynamic-reconfigure, geometry-msgs, image-transport, nodelet, roscpp, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-image-rotate";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "4de3017fa1326bb63f07d03492be9cb7349601c3302a99230f2f2dc2687b65a3";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_rotate/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "5c0bacf9c4f2a6761d532cb05d28d6fc877c2ec6b10471bbf1e59eede33449b1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/image-view/default.nix
+++ b/distros/melodic/image-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, dynamic-reconfigure, gtk2, image-transport, message-filters, message-generation, nodelet, rosconsole, roscpp, rostest, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-image-view";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "318afe307395af61d529710e5fa4ca22acc92eb35910e3ed1fad8b333bf73b81";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/image_view/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "4642943d875d6450ed805d977595e993d7d6bf83fe487b018e1e1300e2edfa7a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "f23d095400f4772b9439af38452fdd08798a27e499112caa030c6fb81bf372c1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "7928a70e335dea79fc8ae7301e81adbe11d65977a2f8094dd93fe9cec2774b9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "746c527d89884c962cfdf4b255052b03b53018e0328922db55e5270667342c6c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "6865c68e34055fdca95511910d637374ebd508e9dd2a7858af4f31c024dab8ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2020.5.5-r1";
+  version = "2020.5.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.5.5-1.tar.gz";
-    name = "2020.5.5-1.tar.gz";
-    sha256 = "9f88b4db301c19945673e3875f7c0b1a39a4d46c39d9c6c2a614aa371f4c641c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.5.21-1.tar.gz";
+    name = "2020.5.21-1.tar.gz";
+    sha256 = "f7abeb7789efb15d6072cb4ef9e394d95abd26e18fd999604e4556a5b5728a7c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/moveit-opw-kinematics-plugin/default.nix
+++ b/distros/melodic/moveit-opw-kinematics-plugin/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-moveit-opw-kinematics-plugin";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release/archive/release/melodic/moveit_opw_kinematics_plugin/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "be8f4501932be19f3ca9c59fa427b4a40188a1cd7b4e541c598f2ba4e791e786";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ moveit-resources moveit-ros-planning rostest ];
+  propagatedBuildInputs = [ moveit-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+      MoveIt kinematics plugin for industrial robots.
+    </p>
+    <p>
+      This plugin uses an analytical inverse kinematic library, opw_kinematics,
+      to calculate the inverse kinematics for industrial robots with 6 degrees of freedom,
+      two parallel joints, and a spherical wrist.
+    </p>'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "94cd53482428921a1f15815dfbfdbf437ff5152ea0b3127a6b94c4878ee460ac";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "9995652a9761db615085d7dae64d30d5fab91b5fc738db63321f3b126e707419";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "6581eb2479258e9da5197977bb0b5473969ccf20a1baad0f6cdc0adce6469ca1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "a5de742de2c6cd44cd89f3949ccc5f26f0722f0fa15cde52b8f82756f13ddac4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "dcf767b8a36d634f1568c6a2328e40e716fd229afe2374f8b4ecb4baace6a1c7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "c195f137bd19fb277fc26d014f32b388c6dc06f8cf3577456c2b190602a0748b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "8b4e8eaa0b64bf63ce02de66abb4626aa5bb16387909f8c051e573f9c93cc414";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "fb85f9403642b921db04e5487b78a7a4f9b94a6821ab5d4b93b32423d56acc30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-control/default.nix
+++ b/distros/melodic/pilz-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, joint-trajectory-controller, pilz-utils, roscpp, roslint, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-control";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "f399607f785b4ff741cc69b474af2a6c08d41c6f68abedf4cb3f53af98bf8030";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "d1f3fd4be9ebdb6a5fbc8c74391a942283c3a9013f3d2116f27f170187ab92fe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-robots/default.nix
+++ b/distros/melodic/pilz-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-control, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robots";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "7932a7090c71333be17780fb6f270991cdc530e6933b900509bf4b78788af12f";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "079c23ce1ca126a2036a87f3203e1a55aaa57e5e90ab1d4888210481c4f45955";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-status-indicator-rqt/default.nix
+++ b/distros/melodic/pilz-status-indicator-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, prbt-hardware-support, pythonPackages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-status-indicator-rqt";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "847b44e7eb7467166a0b3ad3120ec832c61b8d605a15ee226486f9befe1ccef1";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "0f3be1b7a4827a19a1d94ebace29d24561799b7fe0aa8264e64cb8662f6f13d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-testutils/default.nix
+++ b/distros/melodic/pilz-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-pilz-testutils";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "a0c9b4e1bf638806c8ff5b10180badf4b4a287c8c497b63718018dcaa65e11a2";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_testutils/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "fe37d1f5c24323ef619cc79954324d6e653cfc7bcbdd1026211a4a6182b8ee11";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-utils/default.nix
+++ b/distros/melodic/pilz-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clang, cmake-modules, code-coverage, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-pilz-utils";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "22cd531acff2eeac360631054d80d7a21bc19c951fce419e36e75cddc959d5df";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_utils/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "1cc0a269a54d6688870a40234d8cecee786c3528c3c3851ff707e322801e2ef5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "ecd16e9e6ade0023330890cd2eb106d7525bcbef7530d5baec0c9735df01d0e3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "747e5ab9555b17f558f50af85d68bc8564fbe11371f9db5ce2e646fdcaca8ed7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-gazebo/default.nix
+++ b/distros/melodic/prbt-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-gazebo";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "58316bb9962a5e4ca1a848465baeb2d8b093f7eb09219eb2216a53a855d779b4";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "cbe05647571eab5b77a2d2c3565e29020dc58535be40b74850bdefa0082ae818";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-hardware-support/default.nix
+++ b/distros/melodic/prbt-hardware-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-prbt-hardware-support";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "6c9329a0b1d218e9d9aed5a13c96d111409303ab2ed66f8e2461567d4e0fcf0f";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "411b1de9a2033579ddccf6f127758f74385b92f6797b68cd191b150f919d6d4e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, eigen-conversions, moveit-core, moveit-ros-planning, pluginlib, roscpp, rostest, rosunit, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-prbt-ikfast-manipulator-plugin";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "c16cb9410266cbc8b36dbeeabd110c57e3f510386223a9b5d80ad9a105a3b1bf";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "e81ee70be5209e2c99d746f4b00aa39dd90dc759f76c7b76f31315b4116dd265";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-moveit-config/default.nix
+++ b/distros/melodic/prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roslaunch, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-moveit-config";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "a58360b2c96a7a3920ad2c124f036de8573cbff6bcceeb9aa747e2331d8ef8fc";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "06a85c2f9d043ea9a05d1797d93c5dc12c6c69978333dba6589dbe6ebda9a20f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-support/default.nix
+++ b/distros/melodic/prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, pilz-status-indicator-rqt, pilz-testutils, pilz-utils, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-support";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "552ba9cbbd81bc2f05cf531750e773974f8e37a0628fca27d0e209e7bee8f5ed";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "5f3bd2b67eb3718c7a7df383f9c2fab880dfaab612dba9dbd567a2c0a173b610";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-control/default.nix
+++ b/distros/melodic/ridgeback-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-control";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "33f803fc34dbf1e8357630e46866eb452e79f613479cc651692fc068f399501d";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_control/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "6a4b2835003527236f6f60e87ba7ac8f168b701dd1d753bce8c96cb5bdbfd663";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-description/default.nix
+++ b/distros/melodic/ridgeback-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-description";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "d0960030ae9b4e77fd638f393cd6a3e9eb837bc4024be62a28a10c0b677a4be0";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "1302bf1c13fdff3e763c4f7edc51b2b0e1a0eb36e45a834931d826b20eea6937";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-msgs/default.nix
+++ b/distros/melodic/ridgeback-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-msgs";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "d00c2942895f19cb719d0957acc15950ea99066d4ed324dd68e66dac0c1bbe10";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_msgs/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "08adb29db070e70fcee3c3821b6e6f96f384af7a9611074fd3417cb5e107d696";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ridgeback-navigation/default.nix
+++ b/distros/melodic/ridgeback-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-ridgeback-navigation";
-  version = "0.2.3-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "393e37f9ec09f48df8d195e6b76485cdf66c1388eafad37feda78b9fd3f2c31a";
+    url = "https://github.com/clearpath-gbp/ridgeback-release/archive/release/melodic/ridgeback_navigation/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0516173ca1c373695c5d9eecfc9e97ee99e26eff1f8e5d9587e2edcf486dcdf1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "ebec80cff098b3c5a10c69331cd73ecc59289be5a4223a7636ea9a679c3290cd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "387c95342405cb560d5362dc85372176b6edcaf43490b1d49a856e25ad551dc1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/stereo-image-proc/default.nix
+++ b/distros/melodic/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, rostest, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-melodic-stereo-image-proc";
-  version = "1.14.0-r1";
+  version = "1.15.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "2f585cfbd533c88245330dfe58799c9ac7ffe7c03a54dd5fb2c5f01c8dd0adc4";
+    url = "https://github.com/ros-gbp/image_pipeline-release/archive/release/melodic/stereo_image_proc/1.15.0-1.tar.gz";
+    name = "1.15.0-1.tar.gz";
+    sha256 = "d5db016ee55d4ece1413ee83fe1d02315c43e0e97c4a320ece9310b061c45c1d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tf2-urdf/default.nix
+++ b/distros/melodic/tf2-urdf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, tf2, tf2-geometry-msgs, urdfdom-headers }:
+buildRosPackage {
+  pname = "ros-melodic-tf2-urdf";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/standmit/tf2_urdf-release/archive/release/melodic/tf2_urdf/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "3d8d4aaecc1db36b6dd50e8768a4f777fb09234db3bad9a9ecf3dfa79bbc2575";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ geometry-msgs urdfdom-headers ];
+  propagatedBuildInputs = [ tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''tf2_urdf'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "5311cdf7e141dbdc3fe2ff0e3b184dd54cae8b3c546978869b5e0d110a2b0041";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "0104ad5995a885821726540ca1279e34520f5ac2227e5238dc20b19b5ac9fd4b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "8909b82af5b1043834dff21cf6b22ce480a3a7f39f1752d6f58bd99fa8466678";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "8b63160e08a2da692f90a66f48aba63e81f403b9ac817cfb071e51b6e9a414bc";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit a09c1296fecdda3bf56c8fd9c4d234069714127d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *rclc 0.1.1-r1 --> 0.1.2-r2*
* *rclc-examples 0.1.1-r1 --> 0.1.2-r2*

Eloquent Changes:
-----------------
* *joint-state-publisher 2.0.0-r1 --> 2.1.0-r1*
* *joint-state-publisher-gui 2.0.0-r1 --> 2.1.0-r1*
* *rclc 0.1.1-r1 --> 0.1.2-r1*
* *rclc-examples 0.1.1-r1 --> 0.1.2-r1*

Kinetic Changes:
----------------
* *behaviortree-cpp-v3 3.4.0-r1 --> 3.5.0-r2*
* *costmap-cspace 0.8.5-r1 --> 0.8.7-r1*
* *interactive-marker-tutorials 0.10.3 --> 0.10.5-r1*
* *joystick-interrupt 0.8.5-r1 --> 0.8.7-r1*
* *librviz-tutorial 0.10.3 --> 0.10.5-r1*
* *map-organizer 0.8.5-r1 --> 0.8.7-r1*
* *mapviz 1.2.0-r1 --> 1.3.0-r1*
* *mapviz-plugins 1.2.0-r1 --> 1.3.0-r1*
* *marti-data-structures 2.12.0-r1 --> 2.13.1-r1*
* *mavlink 2020.5.5-r1 --> 2020.5.21-r1*
* *moveit-opw-kinematics-plugin 0.1.1-r1*
* *multires-image 1.2.0-r1 --> 1.3.0-r1*
* *neonavigation 0.8.5-r1 --> 0.8.7-r1*
* *neonavigation-common 0.8.5-r1 --> 0.8.7-r1*
* *neonavigation-launch 0.8.5-r1 --> 0.8.7-r1*
* *obj-to-pointcloud 0.8.5-r1 --> 0.8.7-r1*
* *planner-cspace 0.8.5-r1 --> 0.8.7-r1*
* *rc-common-msgs 0.4.1-r1 --> 0.5.0-r1*
* *rc-hand-eye-calibration-client 2.7.0-r1 --> 3.0.1-r1*
* *rc-pick-client 2.7.0-r1 --> 3.0.1-r1*
* *rc-roi-manager-gui 2.7.0-r1 --> 3.0.1-r1*
* *rc-silhouettematch-client 3.0.1-r1*
* *rc-tagdetect-client 2.7.0-r1 --> 3.0.1-r1*
* *rc-visard 2.7.0-r1 --> 3.0.1-r1*
* *rc-visard-description 2.7.0-r1 --> 3.0.1-r1*
* *rc-visard-driver 2.7.0-r1 --> 3.0.1-r1*
* *rosapi 0.11.6-r2 --> 0.11.8-r1*
* *rosbridge-library 0.11.6-r2 --> 0.11.8-r1*
* *rosbridge-msgs 0.11.6-r2 --> 0.11.8-r1*
* *rosbridge-server 0.11.6-r2 --> 0.11.8-r1*
* *rosbridge-suite 0.11.6-r2 --> 0.11.8-r1*
* *rviz-plugin-tutorials 0.10.3 --> 0.10.5-r1*
* *rviz-python-tutorial 0.10.3 --> 0.10.5-r1*
* *safety-limiter 0.8.5-r1 --> 0.8.7-r1*
* *sick-scan 1.4.2-r1 --> 1.6.0-r1*
* *swri-console-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-dbw-interface 2.12.0-r1 --> 2.13.1-r1*
* *swri-geometry-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-image-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-math-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-nodelet 2.12.0-r1 --> 2.13.1-r1*
* *swri-opencv-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-prefix-tools 2.12.0-r1 --> 2.13.1-r1*
* *swri-roscpp 2.12.0-r1 --> 2.13.1-r1*
* *swri-rospy 2.12.0-r1 --> 2.13.1-r1*
* *swri-route-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-serial-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-string-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-system-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-transform-util 2.12.0-r1 --> 2.13.1-r1*
* *swri-yaml-util 2.12.0-r1 --> 2.13.1-r1*
* *tile-map 1.2.0-r1 --> 1.3.0-r1*
* *track-odometry 0.8.5-r1 --> 0.8.7-r1*
* *trajectory-tracker 0.8.5-r1 --> 0.8.7-r1*
* *visualization-marker-tutorials 0.10.3 --> 0.10.5-r1*
* *visualization-tutorials 0.10.3 --> 0.10.5-r1*

Melodic Changes:
----------------
* *camera-calibration 1.14.0-r1 --> 1.15.0-r1*
* *costmap-cspace 0.8.5-r1 --> 0.8.6-r1*
* *depth-image-proc 1.14.0-r1 --> 1.15.0-r1*
* *hector-compressed-map-transport 0.4.0-r1 --> 0.4.1-r1*
* *hector-geotiff 0.4.0-r1 --> 0.4.1-r1*
* *hector-geotiff-plugins 0.4.0-r1 --> 0.4.1-r1*
* *hector-imu-attitude-to-tf 0.4.0-r1 --> 0.4.1-r1*
* *hector-imu-tools 0.4.0-r1 --> 0.4.1-r1*
* *hector-map-server 0.4.0-r1 --> 0.4.1-r1*
* *hector-map-tools 0.4.0-r1 --> 0.4.1-r1*
* *hector-mapping 0.4.0-r1 --> 0.4.1-r1*
* *hector-marker-drawing 0.4.0-r1 --> 0.4.1-r1*
* *hector-nav-msgs 0.4.0-r1 --> 0.4.1-r1*
* *hector-slam 0.4.0-r1 --> 0.4.1-r1*
* *hector-slam-launch 0.4.0-r1 --> 0.4.1-r1*
* *hector-trajectory-server 0.4.0-r1 --> 0.4.1-r1*
* *image-pipeline 1.14.0-r1 --> 1.15.0-r1*
* *image-proc 1.14.0-r1 --> 1.15.0-r1*
* *image-publisher 1.14.0-r1 --> 1.15.0-r1*
* *image-rotate 1.14.0-r1 --> 1.15.0-r1*
* *image-view 1.14.0-r1 --> 1.15.0-r1*
* *joystick-interrupt 0.8.5-r1 --> 0.8.6-r1*
* *map-organizer 0.8.5-r1 --> 0.8.6-r1*
* *mavlink 2020.5.5-r1 --> 2020.5.21-r1*
* *moveit-opw-kinematics-plugin 0.2.1-r1*
* *neonavigation 0.8.5-r1 --> 0.8.6-r1*
* *neonavigation-common 0.8.5-r1 --> 0.8.6-r1*
* *neonavigation-launch 0.8.5-r1 --> 0.8.6-r1*
* *obj-to-pointcloud 0.8.5-r1 --> 0.8.6-r1*
* *pilz-control 0.5.15-r1 --> 0.5.16-r1*
* *pilz-robots 0.5.15-r1 --> 0.5.16-r1*
* *pilz-status-indicator-rqt 0.5.15-r1 --> 0.5.16-r1*
* *pilz-testutils 0.5.15-r1 --> 0.5.16-r1*
* *pilz-utils 0.5.15-r1 --> 0.5.16-r1*
* *planner-cspace 0.8.5-r1 --> 0.8.6-r1*
* *prbt-gazebo 0.5.15-r1 --> 0.5.16-r1*
* *prbt-hardware-support 0.5.15-r1 --> 0.5.16-r1*
* *prbt-ikfast-manipulator-plugin 0.5.15-r1 --> 0.5.16-r1*
* *prbt-moveit-config 0.5.15-r1 --> 0.5.16-r1*
* *prbt-support 0.5.15-r1 --> 0.5.16-r1*
* *ridgeback-control 0.2.3-r1 --> 0.3.0-r1*
* *ridgeback-description 0.2.3-r1 --> 0.3.0-r1*
* *ridgeback-msgs 0.2.3-r1 --> 0.3.0-r1*
* *ridgeback-navigation 0.2.3-r1 --> 0.3.0-r1*
* *safety-limiter 0.8.5-r1 --> 0.8.6-r1*
* *stereo-image-proc 1.14.0-r1 --> 1.15.0-r1*
* *tf2-urdf 0.1.0-r1*
* *track-odometry 0.8.5-r1 --> 0.8.6-r1*
* *trajectory-tracker 0.8.5-r1 --> 0.8.6-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

