### PR TITLE
rosdistro sync, Fri May 29 13:21:24 2020

### DIFF
--- a/distros/dashing/joint-state-publisher-gui/default.nix
+++ b/distros/dashing/joint-state-publisher-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, joint-state-publisher, python-qt-binding, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-joint-state-publisher-gui";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher_gui/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "fdc9c350e4bc32ecf23b87f1c6231e5eb90b6884f6a635fdb0abe6883e2b1af1";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher_gui/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "75831c47196ff1d6ef0d8968d015ad94ae76602d9089ca372d431ca66f01a05f";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/joint-state-publisher/default.nix
+++ b/distros/dashing/joint-state-publisher/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, launch-testing, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-xmllint, pythonPackages, rclpy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-joint-state-publisher";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "a6954e9cc7c42c8dfb42f5f2dbae8071f247de380c8e66f6ef008f16c5213d34";
+    url = "https://github.com/ros2-gbp/joint_state_publisher-release/archive/release/dashing/joint_state_publisher/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "3fc458f2b85fc39fb805e45e21278cf7f062f4adb0b497a00bfc9bc837225245";
   };
 
   buildType = "ament_python";
-  checkInputs = [ ament-copyright ament-xmllint launch-testing launch-testing-ros pythonPackages.pytest ];
+  checkInputs = [ ament-copyright ament-xmllint pythonPackages.pytest ];
   propagatedBuildInputs = [ rclpy sensor-msgs std-msgs ];
 
   meta = {

--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/ros2trace/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "64237813f80593f21dffe7f61ba91f290111e8a994449bc55800e9d42acf29c5";
+    sha256 = "be0044a3cd8924c54627d963ea29c6987aec28afa21b3d875f0ea34bed8ad7ff";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -418,6 +418,8 @@ self: super: {
 
  kobuki-driver = self.callPackage ./kobuki-driver {};
 
+ kobuki-firmware = self.callPackage ./kobuki-firmware {};
+
  kobuki-ftdi = self.callPackage ./kobuki-ftdi {};
 
  kobuki-ros = self.callPackage ./kobuki-ros {};

--- a/distros/eloquent/kobuki-firmware/default.nix
+++ b/distros/eloquent/kobuki-firmware/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros }:
+buildRosPackage {
+  pname = "ros-eloquent-kobuki-firmware";
+  version = "1.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/kobuki_firmware-release/archive/release/eloquent/kobuki_firmware/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "c485bd3d61f7e81af7e2d73969b8d8fdc7a6e2963231d12aa3988e2b77a38a16";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Firmware blobs for kobuki.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/actionlib-lisp/default.nix
+++ b/distros/kinetic/actionlib-lisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, cl-utils, message-runtime, roslisp }:
 buildRosPackage {
   pname = "ros-kinetic-actionlib-lisp";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/actionlib_lisp/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "944509127f9f9bcb3feec5235c98617635f3ed829cb0a86416ba92e71af2abe0";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/actionlib_lisp/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "f8cf0b2aa6507254ba07dc32ed65a95798af11fe4fd7ef3ff96a749ccf3306e7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-capture/default.nix
+++ b/distros/kinetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-audio-capture";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_capture/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "79dd5347611a43e888155da07c2a2bdb91c5a9db3032a0be638d38bec8f62540";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_capture/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "cac64a4a78f8da13cc0b3d291ea7f92837d8c66d22fb969ce81bf9deab39902f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-common-msgs/default.nix
+++ b/distros/kinetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-audio-common-msgs";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common_msgs/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "64fc801e022b581f2d0089b4c9354c1985bc59848a49238d8cc619aa5da8538e";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common_msgs/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "813c4963360eaa480f1f48b014dd60eac08bc30d095a3891a20abd75a0d74395";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-common/default.nix
+++ b/distros/kinetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-kinetic-audio-common";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "c07b9462617918dfeec33f3c6ce22ca2403fc0270ae9d1dd6dbd98817425e901";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_common/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "fd3668130c108555751d8b72570684286d7599c126ca88ece0f622920c68c313";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/audio-play/default.nix
+++ b/distros/kinetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-audio-play";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_play/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "d65f77c84ee911b19b12080dc740a481a869de7140c9f6058c417b370e5da28f";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/kinetic/audio_play/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "96d9135c07074baf5213689460dc6b32ddb4506111a3bae3ab180d272aee4a03";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-tf/default.nix
+++ b/distros/kinetic/cl-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, cl-transforms-stamped, roslisp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-cl-tf";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_tf/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "a1bd861fd920a0291d8ea88c399ef01a1779d15605633ab3e1cc793cb2c39139";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_tf/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "0076f656c6f73ffde9c4d7ff536e6b45531405ef695fdabf46b58f22e2a49b7f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-tf2/default.nix
+++ b/distros/kinetic/cl-tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-lisp, catkin, cl-transforms-stamped, cl-utils, roslisp, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-cl-tf2";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_tf2/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "1caf596a067313c1a43dfb5f289e6dec64a468ed37f3f08ba05edaaf16983a8d";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_tf2/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "80c9b127e593ffd96e76927cc0d8fd2e4c029e35d9f465fc8f2e98c27a09427e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-transforms-stamped/default.nix
+++ b/distros/kinetic/cl-transforms-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, geometry-msgs, roslisp, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-cl-transforms-stamped";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_transforms_stamped/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "0bab621259d0ffecc5d54ea0682567a1308c289ea658be4ca43c22072f013822";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_transforms_stamped/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "e27c4d5cbc02b124f938350e41bd4cba2dbc354dce5d0d5c34f43d14b8a82c2c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-transforms/default.nix
+++ b/distros/kinetic/cl-transforms/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-utils, sbcl }:
 buildRosPackage {
   pname = "ros-kinetic-cl-transforms";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_transforms/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "58e617ff0a809352547cde2b6e3c10823b88de0d6eb65a43ce70044501bc46a0";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_transforms/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "dc00a9e26b22246aa96de099ea605e3bdc8ab51e42ec8988f361c9188ae4d99a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-urdf/default.nix
+++ b/distros/kinetic/cl-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, roslisp }:
 buildRosPackage {
   pname = "ros-kinetic-cl-urdf";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_urdf/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "444875b03ccfa1798808af973ec00a79e2af2766989810ea4a09e718faf83d96";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_urdf/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "70ffc640db6202786e1648cbc731e37279be559d5a51eb1826224f8fc0605a29";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cl-utils/default.nix
+++ b/distros/kinetic/cl-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sbcl }:
 buildRosPackage {
   pname = "ros-kinetic-cl-utils";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_utils/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "609745735e49cf5c9007acc74e6735e68aac37cbcc522dc379a7d42de6266b14";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/cl_utils/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "b5f60d4d6dc6c56fcd2a164af52098b0d7be489ed93795c4bfd6719788defd07";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-extern/default.nix
+++ b/distros/kinetic/cob-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
 buildRosPackage {
   pname = "ros-kinetic-cob-extern";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/cob_extern/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "e5e13ea6360cab194e1129d0743799da5bf263ef4b8197987df54699fe33621f";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/cob_extern/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "7e4770feda5ef892eb2c858bda6a94db757e428e8cda80f97f796aa53d90cee2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/hebi-cpp-api/default.nix
+++ b/distros/kinetic/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen }:
 buildRosPackage {
   pname = "ros-kinetic-hebi-cpp-api";
-  version = "3.2.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/HebiRobotics/hebi_cpp_api_ros-release/archive/release/kinetic/hebi_cpp_api/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "18e02a9e08359f8c085da9c01970533fb81e932c27b48adb00b42ffc7ee96e3f";
+    url = "https://github.com/HebiRobotics/hebi_cpp_api_ros-release/archive/release/kinetic/hebi_cpp_api/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "da06c66ce1d7708ad33aafb8846b2aa3e59351beb5d54f2c826c6c7e9e82f1c7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/imu-complementary-filter/default.nix
+++ b/distros/kinetic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-imu-complementary-filter";
-  version = "1.1.7-r1";
+  version = "1.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_complementary_filter/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "6df5f7b9dd5f341ce6fda5376a9723a6d8586a1b68951d9a382a97056b2426c7";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_complementary_filter/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "6497688201a3530c6fb45490152340ba0709eaca73db85cf07a484bdb3022291";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/imu-filter-madgwick/default.nix
+++ b/distros/kinetic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-imu-filter-madgwick";
-  version = "1.1.7-r1";
+  version = "1.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_filter_madgwick/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "9443da92f35b02f2ad69fefc9907f9aa6558a4364afbf03318b7234b2e6e84f4";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_filter_madgwick/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "4b6f07cd83da9fd8d60d6edeb43fc83b18fa0b0e1beb824e4e109dfd22988e59";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/imu-tools/default.nix
+++ b/distros/kinetic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-kinetic-imu-tools";
-  version = "1.1.7-r1";
+  version = "1.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_tools/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "79edfa193539b654ff325a22c225c68416fb51062657384caefe687b8328957d";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/imu_tools/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "6f5b247697b14842f9f8fd675e1355b2dccd326828adbdf48c167ad95166c8bb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libdlib/default.nix
+++ b/distros/kinetic/libdlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-libdlib";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libdlib/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "63fcb46ede6e16910a76e8f922e94c1f1189752b307d38220acb6f67aca2fb17";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libdlib/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "67039f7607e35ab2ea52c02fe19bf2f501a555b7b431185788ea55429d4415e6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libntcan/default.nix
+++ b/distros/kinetic/libntcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dpkg }:
 buildRosPackage {
   pname = "ros-kinetic-libntcan";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libntcan/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "597a0fdeea57a0893317523807c28e131f92653c120ae97cb5c002e0833b91ad";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libntcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "b6fb1d92265d70a55c1967371ff53576360ee096327efece14d21b347e53d10e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libpcan/default.nix
+++ b/distros/kinetic/libpcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-libpcan";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libpcan/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "b562bd45709caf5bbea9c015bf143c18ac505cb63b057310c2bce7c67eb6347a";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libpcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "a51009a216e4e81227970c7fc31e6d7f606cc9c9abd6d95eeb8a4904c3a9a2f2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libphidgets/default.nix
+++ b/distros/kinetic/libphidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb }:
 buildRosPackage {
   pname = "ros-kinetic-libphidgets";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libphidgets/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "2cd686076b1b2de0d7aca96d7f7bbcef9d05956e6758dd405f98f88e26942b2d";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/libphidgets/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "155d8cb6bc2c32fdf9ecb3938c5f1fe9d541db1e8eb65e420440822cbca97929";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-core/default.nix
+++ b/distros/kinetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-core";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "0eae935709c710eb72cdc7458940bd17d6d32ad2317d65c8d07eda84f9e34aa4";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "8718557c17fcd5eebc58aa18cecd379d25e6101834be280fe5bd6a65f61aee22";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-nav/default.nix
+++ b/distros/kinetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "ff1357be2ac361cf2228055d9535e38e7cd35291d6e261c34e843f161c4f5fc6";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "d1a6023ff353d18d173e9573c6f11bc65d1e783d5481b25b330739a8ab9b6c92";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-core/default.nix
+++ b/distros/kinetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-core";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "9208d1b1ff4500d1d5e45d2eed6857ede1dffce59ccaa0e6153e6f8d97f36abf";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "2ac0cafca70b0382f6d8acc0ff604dcd2159bac0963e60fa3c2c081f71f70dd2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-nav/default.nix
+++ b/distros/kinetic/mbf-costmap-nav/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, base-local-planner, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "7bfa3fd9383085b5b7884f463263e5913d9d4a41a3c8d8d4ff8a12125aafda8e";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a62d70772cc423caf139795d0d59937af0f8bc0cb4c01c828872a4eab13b42ee";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib actionlib-msgs base-local-planner dynamic-reconfigure geometry-msgs mbf-abstract-nav mbf-costmap-core mbf-msgs mbf-utility move-base move-base-msgs nav-core nav-msgs pluginlib roscpp std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs costmap-2d dynamic-reconfigure geometry-msgs mbf-abstract-nav mbf-costmap-core mbf-msgs mbf-utility move-base move-base-msgs nav-core nav-msgs pluginlib roscpp std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/mbf-msgs/default.nix
+++ b/distros/kinetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-msgs";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "376fca3b2fc6ea7a6721e308b24cfaa91d24eb86c63e9d72da0278f6fb4ae5bd";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "199b91621dc2a02b1f64d0e0f741433dff511693089400243baa7888bb35f23f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-simple-nav/default.nix
+++ b/distros/kinetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-simple-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "58a81307c0738509eb032aa03877ff0d374737bd4dfe01b629b6516f7a941b48";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "c92635eba54649772659840a73156a0e5941d464c67cec9d5d45be0854cda626";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-utility/default.nix
+++ b/distros/kinetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-utility";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "c016dc236c1d06d59fb056b35398ead39fca8d7942bc98e8751c6f0d0bc0777c";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "81c366c20496f1e1cbb670403bd72cea40be18ee065666ff65bb671a5db8ad66";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "b4224295ba6565b06cf94b5833f433652471c88712add82983e39d9c6dc66754";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "22c884d354534deffd7c9ac6669a773dd301191fb4d5a7f5ec8be494f7a4fc63";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base-flex/default.nix
+++ b/distros/kinetic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-flex";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "8129755f18e42aa7b19c7a73cd536c0b9941787ac0d582088983af79a043cd84";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "c83c3ec611b59746b6a0722b32d2dfab62de93e878ecab5f92422d4d7d6df6a2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/opengm/default.nix
+++ b/distros/kinetic/opengm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-opengm";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/opengm/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "ffc3451062ce000f196e92ce54572075e2acb51a2fd1affb974efabd16fdf9da";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/kinetic/opengm/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "5129c4e652fa1238fced7ee7d822cf68134785e2efb8a3bd93a2521111e4e62e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.6.4-r1";
+  version = "2.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "c0b561fddebadee52496b47e47d33bdf6b02337bc69f3aa16ca5ac0913d2ab92";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.8.1-2.tar.gz";
+    name = "2.8.1-2.tar.gz";
+    sha256 = "364648b8dd1ee2159b05c1429f7a114763f06adde8ddd6e663a3f5e9b2e451eb";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils diagnostic-msgs nav-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag rosbag-storage roscpp roscpp-serialization rostime tf topic-tools ];
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rosapi/default.nix
+++ b/distros/kinetic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosapi";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "3d78d3b3997d7ca150f12d1c4f5a81451581e0fd1b775ced908652d4e6e82616";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosapi/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "add06787e0db10a07115f1c0508c9dd2b5c33640fde29c445da98bb001ec3af0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-library/default.nix
+++ b/distros/kinetic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-library";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "386bfce38ea19e98ccd812f249db4937b383fec16fd83295a5814f92574dc31a";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_library/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "2d11550f1c25b0c6d9d5f496ce7c90cc2b2ae178aba1cff61ad7bb873456be48";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-msgs/default.nix
+++ b/distros/kinetic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-msgs";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "174d63a3b70f57b427c87a91a19b35b3691f87048b4adb9c6ebe7990daa5dba0";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_msgs/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "422e0cc5d694a1153bd2c00c8461c3278d07f0fbd8f11ebe6b45d2b2c6ebaebd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-server/default.nix
+++ b/distros/kinetic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-server";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "9590fca5cbe04e0ec9062b171f70dbccdf9718e51fb11c851eee764eace3df4f";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_server/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "caba5598bed1c092f8a9fc44f2dfa16215f7e7e5180c49bfde52900b050013df";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbridge-suite/default.nix
+++ b/distros/kinetic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-kinetic-rosbridge-suite";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "79ee0ebbdae95878c235a267c010c467f0a336f803f4778d78925a5252bfacf1";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/kinetic/rosbridge_suite/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "3f2d382a62096304f15536ca1eb6eb4ffca4700a79c9fd362d6127b43561db08";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslisp-common/default.nix
+++ b/distros/kinetic/roslisp-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-lisp, catkin, cl-tf, cl-tf2, cl-transforms, cl-transforms-stamped, cl-urdf, cl-utils, roslisp-utilities }:
 buildRosPackage {
   pname = "ros-kinetic-roslisp-common";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/roslisp_common/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "95da6418b0f3859552ac4dc79d2a09331227fd43208c2c6f8555a9b5d35b64f4";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/roslisp_common/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "8a00f10cc812e0452c0ec73ce1afbd32c0c7bbddfd3162211a0e0f8e64b8334d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslisp-utilities/default.nix
+++ b/distros/kinetic/roslisp-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslisp }:
 buildRosPackage {
   pname = "ros-kinetic-roslisp-utilities";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/roslisp_utilities/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "baca8b7ef4a7ca42ce81aa17ff6df99d2898573439a07849d6d60adb4a58c134";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/kinetic/roslisp_utilities/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "b6f9ac5f043171e5e72fed7a21c4e99d805f92875e465701aaa386b3d9246666";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy-message-converter/default.nix
+++ b/distros/kinetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy-message-converter";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "48bcd73deec2aa72e1065a58c04e45c4fc1313c48992483a68deb872eddcbd55";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "78e098de065db3aa6f8c4c8e2ce594e2e4ae728798d60d9598bfae7ade95ffb9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rviz-imu-plugin/default.nix
+++ b/distros/kinetic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-kinetic-rviz-imu-plugin";
-  version = "1.1.7-r1";
+  version = "1.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/rviz_imu_plugin/1.1.7-1.tar.gz";
-    name = "1.1.7-1.tar.gz";
-    sha256 = "451718edd552558e2ca746a9083c8b393a823ae5124fa61a7cd88fdb5f92ff5f";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/kinetic/rviz_imu_plugin/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "d1209a3afc8f7ed7dfa99176583cc85e43e0505445688fe5ff2f65d27bb1cd49";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-tim/default.nix
+++ b/distros/kinetic/sick-tim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-sick-tim";
-  version = "0.0.16-r1";
+  version = "0.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/sick_tim-release/archive/release/kinetic/sick_tim/0.0.16-1.tar.gz";
-    name = "0.0.16-1.tar.gz";
-    sha256 = "0f769093a849287fb25b954fd84118abbd8b58587f0b31bf975bc07537f6dc97";
+    url = "https://github.com/uos-gbp/sick_tim-release/archive/release/kinetic/sick_tim/0.0.17-1.tar.gz";
+    name = "0.0.17-1.tar.gz";
+    sha256 = "efe75a30df430fd5d819272516de755f7dd306876f7c5b70fd5823d42cccc602";
   };
 
   buildType = "catkin";

--- a/distros/melodic/actionlib-lisp/default.nix
+++ b/distros/melodic/actionlib-lisp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, cl-utils, message-runtime, roslisp }:
 buildRosPackage {
   pname = "ros-melodic-actionlib-lisp";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/actionlib_lisp/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "3002af2921ba296af1c5e75037094a24ae484f5cddae30abc5e6ff681669b280";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/actionlib_lisp/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "2a3d66692e70cd32ac8761c52744dcdfef0faa17f0ee8e8c1f49b985fc6e5f85";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "ef77fec8cc306f279d4440e66a146ce401af424777a28631210aa4717d881936";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "d7c0e48114a921c414f14d06767b66ebca276bdfec77474e3e933f6212bf1ef9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "764b01bbf6a9ab75dda8eeaef65a0bfaebdb0046fceead812311623cdfa12058";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "bbd09a5ae7754c1864e5b1396c328b17dec04d75c070eba0d6769839c80867a5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "2bf5dee17349f20dd5c12b136b29eab4ea7abb6fde874e9ca3f7d8a07986b9cb";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "e0e09034c6f8c7787f13025f29a06015773cbeff8b33470abe04213b3f4e0ad0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "58251f44161ddffe7484815955ee2c10be04312d117216e405d2d8c5b4f724b2";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "1eec7f36486efaab97f1127aac8cc160e5b85ad01d38db839e1468a1a7127bcb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-tf/default.nix
+++ b/distros/melodic/cl-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, cl-transforms-stamped, roslisp, tf }:
 buildRosPackage {
   pname = "ros-melodic-cl-tf";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_tf/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "53c3fc04760efac2a3158663f7c6fe4cfe74533606c9337cfb602afdc19d082d";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_tf/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "55f40c96b372a6be8a05277f034e5f465ea5bcf5038cfb8a0ddbc6c3046d43d7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-tf2/default.nix
+++ b/distros/melodic/cl-tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-lisp, catkin, cl-transforms-stamped, cl-utils, roslisp, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cl-tf2";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_tf2/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "3ef1ab744ff67f4a1b6a34194055decc9d0e6c7b5b53e5054ed00808661cbbdc";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_tf2/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "79a0f1f28598841bfb2d752b6229cee11aa0edb6e379f7e20607a3a682533ba3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-transforms-stamped/default.nix
+++ b/distros/melodic/cl-transforms-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, geometry-msgs, roslisp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cl-transforms-stamped";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_transforms_stamped/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "9b9627f15df25714fe9b26e0a2317733d94092d0f218a2824cc5caa0e8b17385";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_transforms_stamped/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "9cda9c3c92d59bf3de21f68f1da5f9c3e5babb07772be97bc033f6f26cde80ee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-transforms/default.nix
+++ b/distros/melodic/cl-transforms/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-utils, sbcl }:
 buildRosPackage {
   pname = "ros-melodic-cl-transforms";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_transforms/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "d77a7f302eba6656005c0bb83833f61d81c0f73ea3da5297b1f8cf6f23bfee23";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_transforms/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "2644bf9a6b816b70ca216290676f58e6d0b7d49c9b0d5f182928936f3aca9bd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-urdf/default.nix
+++ b/distros/melodic/cl-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cl-transforms, roslisp }:
 buildRosPackage {
   pname = "ros-melodic-cl-urdf";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_urdf/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "8fa0621108c3226d84f6ff36088c8fa3786387778ff598a0c4caf1eee4579ce5";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_urdf/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "e674017e0a9183139ef8f5de07c0e5464116b3c85b8b3dba21b0c514a46682d0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cl-utils/default.nix
+++ b/distros/melodic/cl-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sbcl }:
 buildRosPackage {
   pname = "ros-melodic-cl-utils";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_utils/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "d481e48d5fb6872e3be0fd8ec67fdcf061299f7e5153e3edbf7dc0b33f3343b8";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/cl_utils/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "ea2af3623291b7e4e5b9a3f1b267cb13f27e474bebfe33d2da138992233500b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-extern/default.nix
+++ b/distros/melodic/cob-extern/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
 buildRosPackage {
   pname = "ros-melodic-cob-extern";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/cob_extern/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "f66e09c3bd349f884e0520d107b9a11ac19aa361f1ad73730f5a77793653cbf8";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/cob_extern/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "b553ab87584e4a72347ee7149936c66d3c297f093dddd78f24c5da33bb3d8763";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-fadecandy-driver";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "cbce3658bbde18eedfe14719b2ce4e8d4c4f52068f6405314d3c87d0e1c73e74";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs pythonPackages.pyusb rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-fadecandy-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5cfa74b0c1db4f23c997db11624e95b1956167d92bc9d2eca08e6a86564d0328";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS msgs for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -824,6 +824,10 @@ self: super: {
 
  face-detector = self.callPackage ./face-detector {};
 
+ fadecandy-driver = self.callPackage ./fadecandy-driver {};
+
+ fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
+
  fake-joint = self.callPackage ./fake-joint {};
 
  fake-joint-driver = self.callPackage ./fake-joint-driver {};

--- a/distros/melodic/geometric-shapes/default.nix
+++ b/distros/melodic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-geometric-shapes";
-  version = "0.6.2-r1";
+  version = "0.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.2-1.tar.gz";
-    name = "0.6.2-1.tar.gz";
-    sha256 = "33763d4b3dca7e34f84d7fe2973c7386a9f662861f13c0c66f20a53bdfd9e383";
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.3-1.tar.gz";
+    name = "0.6.3-1.tar.gz";
+    sha256 = "bb058b1f9ae91e5c03d79a1fb85368a1dad5ab10fc85f173da5498d10a1c9257";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hebi-cpp-api/default.nix
+++ b/distros/melodic/hebi-cpp-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen }:
 buildRosPackage {
   pname = "ros-melodic-hebi-cpp-api";
-  version = "3.2.0-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/HebiRobotics/hebi_cpp_api_ros-release/archive/release/melodic/hebi_cpp_api/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "59ee5b1a8ff5e9421a71c6a0530e5f6b2708b3307aa38a8b451c58210acc4489";
+    url = "https://github.com/HebiRobotics/hebi_cpp_api_ros-release/archive/release/melodic/hebi_cpp_api/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "8bf76ffbba3dc13648069d8d9b293c791dd0c03ccc6ba6ebb51604691e6a2276";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-complementary-filter/default.nix
+++ b/distros/melodic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-imu-complementary-filter";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "a039e20b6d977288ca1672bb3a48cca17ee24935e497174cacea40a94f04ecb5";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "5a0386e57b5a89f5c6e0c4dd93ee25dddd8a80a8477c869e912cb37cdf35af6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-filter-madgwick/default.nix
+++ b/distros/melodic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-imu-filter-madgwick";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "508edb7c8f11f0bb31e1ed63f2f4825e19fc4ee5c02b1754c48b03347a1eeaed";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "698aeeefd73cade364967525d9d3199ff8397f72581a6dff89db000b2c735a78";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-tools/default.nix
+++ b/distros/melodic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-imu-tools";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "8fd6b517a5550d0e5151db6599ed9e4eacaca2e299846939932f35f5d0ca3569";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "4ee66ea61a29712ddfcafb76dade45b7d90d83093255fcdec12e7f68f3c5abe9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libdlib/default.nix
+++ b/distros/melodic/libdlib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libdlib";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libdlib/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "dd89ad44c6a58bcff0d2469e2f47df90728e2840b19ca036256c1fdb02841162";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libdlib/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "3c2cecdfae9dd0e4ae09e63cfcd50964d29f2949591f2f9f58e9fe6bbe3049e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libntcan/default.nix
+++ b/distros/melodic/libntcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dpkg }:
 buildRosPackage {
   pname = "ros-melodic-libntcan";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libntcan/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "c0ded6c692f2ad8240eedcdf1ba1fb36c53ff9ce0b43e79455127cd0a048170e";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libntcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "a54efc92a7411aaef217c0af73fa61b85d5a516c021912c383094236703b3e33";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libpcan/default.nix
+++ b/distros/melodic/libpcan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-libpcan";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libpcan/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "54c1838f0cc34f94a2d65b6c18433baf7e2182834d375b070162d93a15ab3709";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libpcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "c7db1c327f04ef81ff88a50c4b55d73406a634f179509f2eb3bf5cf62203328a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libphidgets/default.nix
+++ b/distros/melodic/libphidgets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb }:
 buildRosPackage {
   pname = "ros-melodic-libphidgets";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libphidgets/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "ce2b730fbc5ff5c07f1bacc3c957ff3d9c5d1867fb27ae08cca4b8f8c7a95d22";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/libphidgets/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "b6effbdb16d9b02d375266a7b24369e8f6bea86096777146546bccedff4884e5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-core/default.nix
+++ b/distros/melodic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-core";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "730adb956cb68e22ffbaca41f8428dfeb1c9cc8ded46e8866be50ba699ebaf29";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "59edfe99fab5417c478bbe7adbe2082191898ae7f486e1b39339d580f882fc09";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-nav/default.nix
+++ b/distros/melodic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "d3046621050e8d99a87fd994f66af34baa276d8bcb7954140890bb418a5a91f1";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "34c8bc49b61b4bfbdf54badb5ac8901819a389f181e13abe7f12719b87e9f284";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-core/default.nix
+++ b/distros/melodic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-core";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "ad971c5af6a065696b0017f7cd79c54a43eb93bc31d73f40da861c29ccab49e9";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "ab6a7064b0169cfe4c61611dc36bc0c7f887fe232819872ea3547c0746496d62";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-nav/default.nix
+++ b/distros/melodic/mbf-costmap-nav/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, base-local-planner, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "a8bd99dcca879d1cd4e805374650262ca41ceb139165f9bad2419e4753e6ccb2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "0605b881744f00116a3fe4c1a2a8d4620288e2229bc492c1fee448f3df56e05f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib actionlib-msgs base-local-planner dynamic-reconfigure geometry-msgs mbf-abstract-nav mbf-costmap-core mbf-msgs mbf-utility move-base move-base-msgs nav-core nav-msgs pluginlib roscpp std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs costmap-2d dynamic-reconfigure geometry-msgs mbf-abstract-nav mbf-costmap-core mbf-msgs mbf-utility move-base move-base-msgs nav-core nav-msgs pluginlib roscpp std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mbf-msgs/default.nix
+++ b/distros/melodic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-msgs";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "17453691617765d70b4765d5cbb29e6ba9b186aff2c6199e7aae251a40f8dfbb";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "80181a8a4b0eb59ec113ff61ece66c6fdd2d58e652cc299a023b59257b2f2c52";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-simple-nav/default.nix
+++ b/distros/melodic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-simple-nav";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "22706482f2e26afa04998e3064c2d3011fed20962b9022dbd7aecbfc840423e6";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "f09d2300a7f151743be743a8ed38a69ee9c856cec9277d9d1969a796b3c6db97";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-utility/default.nix
+++ b/distros/melodic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-utility";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "998d554afc2b6a44ecf5aa20e1372c52f4703d7da15f3db4f563a7b9e09350cb";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "19d944f0d4cce88d7d9f481c45287e83164496d1836346bdae868c055e5b926d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "366a0071b18d8df2846e76b353789a40a3c57a1c780fd3aca021e5f22bc4b88b";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "3ef8f2587688c04139b092c4a1fe82bf0ee76c041ecf82f55a454b162de4d573";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base-flex/default.nix
+++ b/distros/melodic/move-base-flex/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
 buildRosPackage {
   pname = "ros-melodic-move-base-flex";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "e54aacdcb64c7d389a78f74d7d3caf903d817df87a169dd0316ad499302ad318";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "6d3674af1d438357a5e6b236a28995a77a5f7c324abac3b51d7f8d0cc610ba0b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opengm/default.nix
+++ b/distros/melodic/opengm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-opengm";
-  version = "0.6.15-r1";
+  version = "0.6.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/opengm/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "415765b68cc4a5d744bd6488e4eecd71d72fcfd2de9b20f36c308336a02c3bca";
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/melodic/opengm/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "e97abb94a52a22d31e3dc253e1e4865d414989200b861141ef481e28e7b60fce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, catkin, diagnostic-msgs, nav-msgs, qt5, rosbag, rosbag-storage, roscpp, roscpp-serialization, rostime, tf, topic-tools }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.6.4-r1";
+  version = "2.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.6.4-1.tar.gz";
-    name = "2.6.4-1.tar.gz";
-    sha256 = "6899f626b1e32980678b197f633463f8473bed1fb40308853eea557dc16d8906";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.8.1-1.tar.gz";
+    name = "2.8.1-1.tar.gz";
+    sha256 = "003bb27782933e3388307f646b040be5a8e8fe9b0db8d6ace08783901bcede5d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils diagnostic-msgs nav-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag rosbag-storage roscpp roscpp-serialization rostime tf topic-tools ];
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-emacs-utils/default.nix
+++ b/distros/melodic/ros-emacs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp-repl, slime-ros, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-ros-emacs-utils";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/ros_emacs_utils/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "990b5e5da666f743e90acf3e00a9cc0d41fd9c72b982b0ae09822ee6fc2635b6";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/ros_emacs_utils/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "16c4f4392ebf6bdd5bbf145fe60fe6829255850fa1502dd1926572e44f9be447";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosapi/default.nix
+++ b/distros/melodic/rosapi/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosapi";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "453c6d90c3d3dd0d13149e74fda5d94fb76efcf094c638e94a7085c5be7412f9";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosapi/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "8dc78fe28105199785fafbb22b19d61fbbcd52e2c11fcae8d21dfc425456e5b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-library/default.nix
+++ b/distros/melodic/rosbridge-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-library";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "0d1428dbd1c2bbc7c653af4766645d7216a6857cb70239c0d30ca4b52a824a7d";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_library/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "6315402e431cb5ae50153ce2c70dcc41f2ac92d6eea7609dac59f9d5934800c8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-msgs/default.nix
+++ b/distros/melodic/rosbridge-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-msgs";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "30e38c14cd5dc863f7cc035d9007c9fe7af390c7e3dbb2195790eecf0d897af1";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_msgs/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "8c8c8afb0eca340db9dbce7c868b081069059e481062a689efdaabc2cf07f558";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-server/default.nix
+++ b/distros/melodic/rosbridge-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-server";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "e4e2633086c6c404ce2947f008079256aff6f0ef141e96201952852c9d3cc1ae";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_server/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "4909671f9febd312fd5633aca5017a53083fdaeb6d5f5eb4bb5140cd2317b2b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbridge-suite/default.nix
+++ b/distros/melodic/rosbridge-suite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
 buildRosPackage {
   pname = "ros-melodic-rosbridge-suite";
-  version = "0.11.8-r1";
+  version = "0.11.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.8-1.tar.gz";
-    name = "0.11.8-1.tar.gz";
-    sha256 = "2e542c613fcdf7116ac047a96244617dd9047f20787ea35f74b53504bba4cc14";
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/melodic/rosbridge_suite/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "7b96c8008b8dfc57ca2793752a597df86ac04941ebf16b37e19e91606027b01b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosemacs/default.nix
+++ b/distros/melodic/rosemacs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, emacs }:
 buildRosPackage {
   pname = "ros-melodic-rosemacs";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/rosemacs/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "80a2911c8cf86b70a771060e8304d9234b375b2f221fb42e63bfe5bfbf8f36a1";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/rosemacs/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "2a2cb471fbfaebdf764ed4472dbed5ce2de28e2b33e6ce35db052d86ecc0d345";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslisp-common/default.nix
+++ b/distros/melodic/roslisp-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-lisp, catkin, cl-tf, cl-tf2, cl-transforms, cl-transforms-stamped, cl-urdf, cl-utils, roslisp-utilities }:
 buildRosPackage {
   pname = "ros-melodic-roslisp-common";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/roslisp_common/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "f21f8982fd0069e1ee3f3611877153b9b675d57b019649f9c079d6c9251a57fd";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/roslisp_common/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "7fbfd8b1d0dc002023ed13524091df870f94315258f7db00c994c0ab6ce7e309";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslisp-repl/default.nix
+++ b/distros/melodic/roslisp-repl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-ros, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-roslisp-repl";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/roslisp_repl/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "8a3c6a1532c2cda1967b880e2a26474c04966c606d4cf5ef5a1fcbe65f2ccc7f";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/roslisp_repl/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "cefb6b7478f0354353b231bd85e2c31fa82dc803833acebb4038f4521e67507f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslisp-utilities/default.nix
+++ b/distros/melodic/roslisp-utilities/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslisp }:
 buildRosPackage {
   pname = "ros-melodic-roslisp-utilities";
-  version = "0.2.12-r1";
+  version = "0.2.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/roslisp_utilities/0.2.12-1.tar.gz";
-    name = "0.2.12-1.tar.gz";
-    sha256 = "285715fab6f8d3f65174fcc8eead6849d9f69e2c5870a454a96c879b7325f458";
+    url = "https://github.com/ros-gbp/roslisp_common-release/archive/release/melodic/roslisp_utilities/0.2.13-1.tar.gz";
+    name = "0.2.13-1.tar.gz";
+    sha256 = "d00d8ac04df0def12d8ff4a78bf4266bf0cc3b8c9259686f4d66a6368422e7cd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.0";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.0-0.tar.gz";
-    name = "0.5.0-0.tar.gz";
-    sha256 = "c35584b4ef0c7fed1e90a35bfeb17ad63ec36a9a86ba1aaf74547cdcbd1cea37";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "b36a7d65ebfbcd2abfa303e366c45f9fb4cc6c2321aca1c6eac36fb7715464f9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz-imu-plugin/default.nix
+++ b/distros/melodic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-rviz-imu-plugin";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "d9e0540473495ab3f625d54fe3e7dd3e2e62663540504e9c524f1cb7c8c4bec1";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "8d9af7ecde2407f571f97f6d3fd6f89d67b6cd0c3cb7732f5be3c6979b570db5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sick-tim/default.nix
+++ b/distros/melodic/sick-tim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-sick-tim";
-  version = "0.0.16-r1";
+  version = "0.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/sick_tim-release/archive/release/melodic/sick_tim/0.0.16-1.tar.gz";
-    name = "0.0.16-1.tar.gz";
-    sha256 = "21cbe180b6016b00a94db9fdcaca49ef8d560608c041bb975b5babb0e8f9aaf3";
+    url = "https://github.com/uos-gbp/sick_tim-release/archive/release/melodic/sick_tim/0.0.17-1.tar.gz";
+    name = "0.0.17-1.tar.gz";
+    sha256 = "876226df215f9fc5731e719a33b70dae58a197dfd11b48dbb2830dbdc23cc5b3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slime-ros/default.nix
+++ b/distros/melodic/slime-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-slime-ros";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_ros/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "6bfbb259a012cdddcccf9a39af143ba7468decfddb79d77b76be096b31b7a358";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_ros/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "043cf95acd112b9349ef2ba71360677a7dc501f1e42b17d647f497b647b2b293";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slime-wrapper/default.nix
+++ b/distros/melodic/slime-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, emacs }:
 buildRosPackage {
   pname = "ros-melodic-slime-wrapper";
-  version = "0.4.13";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_wrapper/0.4.13-0.tar.gz";
-    name = "0.4.13-0.tar.gz";
-    sha256 = "e2a2cbbdcc477518699369b9a35fdfb1dd21ca3e9fed2615fe87c1a5fea1eea5";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_wrapper/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "246f8018e61b66b887d4f86b1c39f3b4fd50d7369896b3e93bb9fd850439008e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-gps/default.nix
+++ b/distros/melodic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-gps";
-  version = "1.3.1-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "7b213073545194fc7cb4d1cefb3057536b99643f0c3566d20625f799a7dd47ee";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2c70f260827cb329a5525ecb937b45ede6a358967c461d91cafd8f4bf06f0f13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-msgs/default.nix
+++ b/distros/melodic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-msgs";
-  version = "1.3.1-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "20c42f29aeaa71e8e64de505e4c409757f22a96ff00e0c36814d8f0d5090787a";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "234745d45a3a493de4ec69bfa596b94ee0a05dfc31fea9b37ddefbd139a07ac1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-serialization/default.nix
+++ b/distros/melodic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-serialization";
-  version = "1.3.1-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "9d1b442a0d36838ab40081565a45e9ad4e736691bee01fe271a457c58601eff8";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "d2a4284c8f6d7839a3ea99253e1792d035f086265009620e9d4d24f2b4e264e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox/default.nix
+++ b/distros/melodic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox";
-  version = "1.3.1-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "cdf68577cfb07dd68049c6c8b924420a1c2c9d68feb3ca773e0a922dfea43ec1";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "8ce5719dd22959546e0e2464e3ca942560c6ced30c677f4c1780943b096a02b1";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic'] from nix-ros-overlay commit 759625cba90cb19990d7b1ce1c77c5cbf02101bc.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *joint-state-publisher 2.0.0-r1 --> 2.0.1-r1*
* *joint-state-publisher-gui 2.0.0-r1 --> 2.0.1-r1*

Eloquent Changes:
-----------------
* *kobuki-firmware 1.2.0-r2*

Kinetic Changes:
----------------
* *actionlib-lisp 0.2.12-r1 --> 0.2.13-r1*
* *audio-capture 0.3.5-r1 --> 0.3.6-r1*
* *audio-common 0.3.5-r1 --> 0.3.6-r1*
* *audio-common-msgs 0.3.5-r1 --> 0.3.6-r1*
* *audio-play 0.3.5-r1 --> 0.3.6-r1*
* *cl-tf 0.2.12-r1 --> 0.2.13-r1*
* *cl-tf2 0.2.12-r1 --> 0.2.13-r1*
* *cl-transforms 0.2.12-r1 --> 0.2.13-r1*
* *cl-transforms-stamped 0.2.12-r1 --> 0.2.13-r1*
* *cl-urdf 0.2.12-r1 --> 0.2.13-r1*
* *cl-utils 0.2.12-r1 --> 0.2.13-r1*
* *cob-extern 0.6.15-r1 --> 0.6.17-r1*
* *hebi-cpp-api 3.2.0-r1 --> 3.2.0-r2*
* *imu-complementary-filter 1.1.7-r1 --> 1.1.8-r1*
* *imu-filter-madgwick 1.1.7-r1 --> 1.1.8-r1*
* *imu-tools 1.1.7-r1 --> 1.1.8-r1*
* *libdlib 0.6.15-r1 --> 0.6.17-r1*
* *libntcan 0.6.15-r1 --> 0.6.17-r1*
* *libpcan 0.6.15-r1 --> 0.6.17-r1*
* *libphidgets 0.6.15-r1 --> 0.6.17-r1*
* *mbf-abstract-core 0.3.1-r1 --> 0.3.2-r1*
* *mbf-abstract-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-costmap-core 0.3.1-r1 --> 0.3.2-r1*
* *mbf-costmap-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-msgs 0.3.1-r1 --> 0.3.2-r1*
* *mbf-simple-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-utility 0.3.1-r1 --> 0.3.2-r1*
* *mcl-3dl 0.2.4-r1 --> 0.2.5-r1*
* *move-base-flex 0.3.1-r1 --> 0.3.2-r1*
* *opengm 0.6.15-r1 --> 0.6.17-r1*
* *plotjuggler 2.6.4-r1 --> 2.8.1-r2*
* *rosapi 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-library 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-msgs 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-server 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-suite 0.11.8-r1 --> 0.11.9-r1*
* *roslisp-common 0.2.12-r1 --> 0.2.13-r1*
* *roslisp-utilities 0.2.12-r1 --> 0.2.13-r1*
* *rospy-message-converter 0.5.0 --> 0.5.1-r1*
* *rviz-imu-plugin 1.1.7-r1 --> 1.1.8-r1*
* *sick-tim 0.0.16-r1 --> 0.0.17-r1*

Melodic Changes:
----------------
* *actionlib-lisp 0.2.12-r1 --> 0.2.13-r1*
* *audio-capture 0.3.5-r1 --> 0.3.6-r1*
* *audio-common 0.3.5-r1 --> 0.3.6-r1*
* *audio-common-msgs 0.3.5-r1 --> 0.3.6-r1*
* *audio-play 0.3.5-r1 --> 0.3.6-r1*
* *cl-tf 0.2.12-r1 --> 0.2.13-r1*
* *cl-tf2 0.2.12-r1 --> 0.2.13-r1*
* *cl-transforms 0.2.12-r1 --> 0.2.13-r1*
* *cl-transforms-stamped 0.2.12-r1 --> 0.2.13-r1*
* *cl-urdf 0.2.12-r1 --> 0.2.13-r1*
* *cl-utils 0.2.12-r1 --> 0.2.13-r1*
* *cob-extern 0.6.15-r1 --> 0.6.17-r1*
* *fadecandy-driver 0.1.0-r1*
* *fadecandy-msgs 0.1.0-r1*
* *geometric-shapes 0.6.2-r1 --> 0.6.3-r1*
* *hebi-cpp-api 3.2.0-r1 --> 3.2.0-r2*
* *imu-complementary-filter 1.2.1-r1 --> 1.2.2-r1*
* *imu-filter-madgwick 1.2.1-r1 --> 1.2.2-r1*
* *imu-tools 1.2.1-r1 --> 1.2.2-r1*
* *libdlib 0.6.15-r1 --> 0.6.17-r1*
* *libntcan 0.6.15-r1 --> 0.6.17-r1*
* *libpcan 0.6.15-r1 --> 0.6.17-r1*
* *libphidgets 0.6.15-r1 --> 0.6.17-r1*
* *mbf-abstract-core 0.3.1-r1 --> 0.3.2-r1*
* *mbf-abstract-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-costmap-core 0.3.1-r1 --> 0.3.2-r1*
* *mbf-costmap-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-msgs 0.3.1-r1 --> 0.3.2-r1*
* *mbf-simple-nav 0.3.1-r1 --> 0.3.2-r1*
* *mbf-utility 0.3.1-r1 --> 0.3.2-r1*
* *mcl-3dl 0.2.4-r1 --> 0.2.5-r1*
* *move-base-flex 0.3.1-r1 --> 0.3.2-r1*
* *opengm 0.6.15-r1 --> 0.6.17-r1*
* *plotjuggler 2.6.4-r1 --> 2.8.1-r1*
* *ros-emacs-utils 0.4.13 --> 0.4.14-r1*
* *rosapi 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-library 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-msgs 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-server 0.11.8-r1 --> 0.11.9-r1*
* *rosbridge-suite 0.11.8-r1 --> 0.11.9-r1*
* *rosemacs 0.4.13 --> 0.4.14-r1*
* *roslisp-common 0.2.12-r1 --> 0.2.13-r1*
* *roslisp-repl 0.4.13 --> 0.4.14-r1*
* *roslisp-utilities 0.2.12-r1 --> 0.2.13-r1*
* *rospy-message-converter 0.5.0 --> 0.5.1-r1*
* *rviz-imu-plugin 1.2.1-r1 --> 1.2.2-r1*
* *sick-tim 0.0.16-r1 --> 0.0.17-r1*
* *slime-ros 0.4.13 --> 0.4.14-r1*
* *slime-wrapper 0.4.13 --> 0.4.14-r1*
* *ublox 1.3.1-r1 --> 1.4.0-r1*
* *ublox-gps 1.3.1-r1 --> 1.4.0-r1*
* *ublox-msgs 1.3.1-r1 --> 1.4.0-r1*
* *ublox-serialization 1.3.1-r1 --> 1.4.0-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

