### PR TITLE
rosdistro sync, Fri Jun  5 12:54:26 2020

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -156,8 +156,6 @@ self: super: {
 
  can-msgs = self.callPackage ./can-msgs {};
 
- cartographer = self.callPackage ./cartographer {};
-
  cartographer-ros = self.callPackage ./cartographer-ros {};
 
  cartographer-ros-msgs = self.callPackage ./cartographer-ros-msgs {};
@@ -475,6 +473,8 @@ self: super: {
  lex-common-msgs = self.callPackage ./lex-common-msgs {};
 
  lex-node = self.callPackage ./lex-node {};
+
+ lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
 

--- a/distros/dashing/lgsvl-msgs/default.nix
+++ b/distros/dashing/lgsvl-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-lgsvl-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/dashing/lgsvl_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "9db29920ced9ee14bd86be0d3a80db012aecd6558c112f04173905f250c24326";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = ''The lgsvl_msgs package for ground truth data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/libphidget22/default.nix
+++ b/distros/dashing/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-dashing-libphidget22";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/libphidget22/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "24f2c220738f1468bad2072dfcaab8471fc5fd9ca12d3fb8180ad294335ddb37";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/libphidget22/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "54c1005187ec33ed78736b756fc9ab37ff0b8b900e99932c700a65ba89573a1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-accelerometer/default.nix
+++ b/distros/dashing/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-accelerometer";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_accelerometer/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "32b61cba5750fd07baa2d0a08e43b7e9fc3f642091c5d2cfdb48487beae87733";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_accelerometer/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "45f6902446f68e48746440ba393019a6f556abc2d2a7b95372369fd6ab1aa703";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-analog-inputs/default.nix
+++ b/distros/dashing/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-analog-inputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_analog_inputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "812990ac8228071fd50f06add6b4c8234ca75c2558f5fae35bec4071d918f20f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_analog_inputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "a605876102915b72c5293a8b0bde9000ff27c0168a6e67eeb0e59dcfc1e8ad7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-api/default.nix
+++ b/distros/dashing/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-api";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_api/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "45f5a5fac73054a7a1aa180ac1e03009d158064a8748c16650045d22982f795f";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_api/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "d67766d1e51666b96e4d7f6d81ae8fb234bdc16bb201c6e202c8316956ede855";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-digital-inputs/default.nix
+++ b/distros/dashing/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-digital-inputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_inputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "300ce16fa46296560431d8b3c489f6cc8db3b955bc3c30c4a9ffc0b5d1ac9144";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_inputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "cad25c68957f0cfa207493eb757e17233528bca4b45e0c04165966a180290da7";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-digital-outputs/default.nix
+++ b/distros/dashing/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-digital-outputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_outputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ce1d5f67aca42b09eefbc87b7ea8dee287e6ce2f62482c929350251868d438b9";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_digital_outputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "531295970d65cfd174f4fa89bbe5e855fc3bb3dcf0e90d35e7031c21f0657b77";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-drivers/default.nix
+++ b/distros/dashing/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-drivers";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_drivers/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5fc6c2c23d39bbacaeac470646e7b66d279a2d439abcb2d08aeb36ac8072806e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_drivers/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "9d9dc93e1d85aa43f06a455e5086757cd86ad29779820e0744c1e86f78927fc1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-gyroscope/default.nix
+++ b/distros/dashing/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-gyroscope";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_gyroscope/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "385bbfab6f93ed22993d429902a1f8ca7a4bb8d61c12c5bac2d0d7678495a251";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_gyroscope/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c906686bbe55c375636df3b9109ea82a92f8e44f27e50a0b151328cf958329ce";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-high-speed-encoder/default.nix
+++ b/distros/dashing/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-high-speed-encoder";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_high_speed_encoder/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "6fd632d74a4e6f11faed8eeb4987f6cc359085b762e5618a70c813bf2c34505d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_high_speed_encoder/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8acc4203fad88630b4d508b08bab535e49e011f6c52dc9df6a6b243cca514bd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-ik/default.nix
+++ b/distros/dashing/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-ik";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_ik/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c4ee37d6e820426cf5144485067a721deab44a279bd76daf1d72d94a25173865";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_ik/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8df8114115b0b7af318b6fc3fceaa5d317e3310c6c16cd3be9f5f91522efacb7";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-magnetometer/default.nix
+++ b/distros/dashing/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-magnetometer";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_magnetometer/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "21848f0d79f0f67eac5f1542f918df38d07390b761cfa14b308dcf9e7d777bd1";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_magnetometer/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8b14e06286fb306d3e6a026e4c5ac3266ff18637a26673c5569e56a940be30e3";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-motors/default.nix
+++ b/distros/dashing/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-motors";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_motors/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5f8ef698074e708c161ceaf431f90bd7e5f979931419dd8967fba645ea189fc6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_motors/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "841b85829c189763ff06b8c746de20a154e0dbeed0156154b5f6161fe4813a3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-msgs/default.nix
+++ b/distros/dashing/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "bbe7c95a1bc8533078b3914a63a2dba0ad754db6215b2a4c7e12296884110e6c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4c221eedab73d184895348c7309a76131e8ce6c8fe79cb8701fc1b6ea68a5cfa";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-spatial/default.nix
+++ b/distros/dashing/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-spatial";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_spatial/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "648e62d4392289d5f254d77ade082c4a87721e5c589cbcb9a78f8628ab799f0d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_spatial/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "9a11af943c9b1465f922cd7c73a777e7890aed96af1ec367ad7e0386988648d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/phidgets-temperature/default.nix
+++ b/distros/dashing/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-phidgets-temperature";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_temperature/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "08ac6d66bc1fc87d5f4bbae0e69764d5eb19c9224e19f16930b2a308670fe6de";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/dashing/phidgets_temperature/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "50ee03e42048ebbdc7173ca1a54a7928d5204bb30f3d49eb39cacefa29551e6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -148,8 +148,6 @@ self: super: {
 
  can-msgs = self.callPackage ./can-msgs {};
 
- cartographer = self.callPackage ./cartographer {};
-
  cartographer-ros = self.callPackage ./cartographer-ros {};
 
  cartographer-ros-msgs = self.callPackage ./cartographer-ros-msgs {};
@@ -444,6 +442,8 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
+
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
 
  libg2o = self.callPackage ./libg2o {};
@@ -541,6 +541,10 @@ self: super: {
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
+
+ novatel-gps-driver = self.callPackage ./novatel-gps-driver {};
+
+ novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
@@ -847,6 +851,8 @@ self: super: {
  rqt-gui-py = self.callPackage ./rqt-gui-py {};
 
  rqt-image-view = self.callPackage ./rqt-image-view {};
+
+ rqt-moveit = self.callPackage ./rqt-moveit {};
 
  rqt-msg = self.callPackage ./rqt-msg {};
 

--- a/distros/eloquent/kobuki-firmware/default.nix
+++ b/distros/eloquent/kobuki-firmware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros }:
 buildRosPackage {
   pname = "ros-eloquent-kobuki-firmware";
-  version = "1.2.0-r2";
+  version = "1.2.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/stonier/kobuki_firmware-release/archive/release/eloquent/kobuki_firmware/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "c485bd3d61f7e81af7e2d73969b8d8fdc7a6e2963231d12aa3988e2b77a38a16";
+    url = "https://github.com/stonier/kobuki_firmware-release/archive/release/eloquent/kobuki_firmware/1.2.0-3.tar.gz";
+    name = "1.2.0-3.tar.gz";
+    sha256 = "741d43d789454761689a26697b4f4e96df693201e155f64100e3903e05cf9e84";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/lgsvl-msgs/default.nix
+++ b/distros/eloquent/lgsvl-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-lgsvl-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/eloquent/lgsvl_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "1b8ae59b70461bedf65ee3d33497abf4c210a47ea5b16fa96f61f449dd5b9124";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = ''The lgsvl_msgs package for ground truth data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/libphidget22/default.nix
+++ b/distros/eloquent/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-eloquent-libphidget22";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/libphidget22/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f59ffeedfd7a92c71f2acf37d660f3be468ceca87aceaa23409fa31f3d2d67fe";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/libphidget22/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "f6d4e1bdc3a4952506a399afec09b6e51ae0b2abebfb27d707f1e4ff7147b9e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/novatel-gps-driver/default.nix
+++ b/distros/eloquent/novatel-gps-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, boost, diagnostic-msgs, diagnostic-updater, gps-msgs, libpcap, nav-msgs, novatel-gps-msgs, rclcpp, rclcpp-components, sensor-msgs, std-msgs, swri-math-util, swri-roscpp, swri-serial-util, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-novatel-gps-driver";
+  version = "4.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/eloquent/novatel_gps_driver/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "774c2153e9eea0fc45f09de942fad5afeafb9754d0b563406a212622d1155ff6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater gps-msgs libpcap nav-msgs novatel-gps-msgs rclcpp rclcpp-components sensor-msgs std-msgs swri-math-util swri-roscpp swri-serial-util tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver for NovAtel receivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/novatel-gps-msgs/default.nix
+++ b/distros/eloquent/novatel-gps-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-novatel-gps-msgs";
+  version = "4.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/novatel_gps_driver-release/archive/release/eloquent/novatel_gps_msgs/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "82e60f744deca17ef12a2bcc65ec362ce9e474a8b510e8fbd65a56c7a0bea827";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for proprietary (non-NMEA) sentences from Novatel GPS receivers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/phidgets-accelerometer/default.nix
+++ b/distros/eloquent/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-accelerometer";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_accelerometer/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "d0c2e55b13fe23735c74262ff82a55c2d432d3cd32c25468447fd331d052f07a";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_accelerometer/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "420dc002ddf015843b536f0a97c1d9fd2290b94dd4965c698996c98b77e2bdc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-analog-inputs/default.nix
+++ b/distros/eloquent/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-analog-inputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_analog_inputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "c4da97bfcb1ebac9a829505fb9840a4e960a97be7c3c6c9b88a192377f914df6";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_analog_inputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "853d93ebc5dfa3ddbd010f517bd700e1bc10e67df4e6f8308a48de13666e9038";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-api/default.nix
+++ b/distros/eloquent/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-api";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_api/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "e6565674037558aaa185c9863febbf5c2f68b58224baf8d2393f1fd8a22e9b3d";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_api/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8a357c4d42862aab47f283bca2644678cd7323271c19a64f97addb727115558c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-digital-inputs/default.nix
+++ b/distros/eloquent/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-digital-inputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_digital_inputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "20b05dbe5ef02ffd14f4fe04cf07a8cbe617d318ce03db652e912faa7b3fbc95";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_digital_inputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "948611f7f2b5cf8a9ade8b8b8751b7b2b1939eb058d91340cdf2987504614332";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-digital-outputs/default.nix
+++ b/distros/eloquent/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-digital-outputs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_digital_outputs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ab5ab6c260f73517d8eb3cfdbb495c5292badac90cebf26128e7e3a8de4917bc";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_digital_outputs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "d537364f051cc83f0ee578410898dd7a0dfb78a91f12fdee8bdd492bd051b5b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-drivers/default.nix
+++ b/distros/eloquent/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-drivers";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_drivers/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "51414d2cef20070c9f770567f5b39658f41f18de018537c1371c9ebca02c4074";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_drivers/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "de4253f76fbaa5aa2b38f665704e7d3e5b6e2ad7f9b27e9e68c1bacb35414df6";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-gyroscope/default.nix
+++ b/distros/eloquent/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-gyroscope";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_gyroscope/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "91f8832e91d6b19b4e9c27baa8041b951069832214a5a60ecbd9a6ba218a26a7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_gyroscope/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6738890fd259aaf53311d5590749399d89881f0ee1ed5c209e198cd66da7f0f3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-high-speed-encoder/default.nix
+++ b/distros/eloquent/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-high-speed-encoder";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_high_speed_encoder/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "91543e4cb7621824cc342b63c3a8bfbed9bfe11eee2597eb98664ef4520fa2ee";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_high_speed_encoder/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4a43ced82e5cfe0bf635112dd1e6db237524c0ae7baf3f1a12f72f82fcd6572d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-ik/default.nix
+++ b/distros/eloquent/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-ik";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_ik/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a72c67f9888c0b02f066bb4e3ff944dd728b61d1ba77c559b33bb7737cc87deb";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_ik/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4c411b678c4d35dcaf37e44315ea96296aa85ec31e48f4cc163a5e4232229f8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-magnetometer/default.nix
+++ b/distros/eloquent/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-magnetometer";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_magnetometer/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "6e5b2633c025a8352d767470b550833859b05e9986c583d03a52984d41bb67ca";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_magnetometer/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "322e9a99473b7ac23f9e42afc4d0c81fd33bc48cb9c7b356db2f732659237d30";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-motors/default.nix
+++ b/distros/eloquent/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-motors";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_motors/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a13190951f789509da9ce31e8db09280fdac65d49bb3d8d8f116b3c71e658020";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_motors/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "d82532286ec787ac6322489859e284d55b444f1e4491ac2279f7d5a5fca69122";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-msgs/default.nix
+++ b/distros/eloquent/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "bec235d8dfcb620a9850eb9f0d9ddadb2b25153ff964e13aaf0830424461a586";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "8ab73dcfdffb5b5471dde46a9ce54ab6b13ea154cc43037481828ee224114ee3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-spatial/default.nix
+++ b/distros/eloquent/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-spatial";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_spatial/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "abe1818d7490cac3dc27e3ae221c8951bd83c78d67556b89fd9dd2bddbbb2238";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_spatial/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "bb2baa1c767565f3de6052f58f27ba861e64beb6249423d75d58b86cd059c603";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/phidgets-temperature/default.nix
+++ b/distros/eloquent/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-phidgets-temperature";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_temperature/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "aab7e7465b6d9d34b524b5a2fff1117eb5ac364da5645aafa0b6764a6bdb8ed5";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/eloquent/phidgets_temperature/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "5a129d5f126e58a3a47367484f2106246144afddf60bd39490a409f36a189066";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rqt-moveit/default.nix
+++ b/distros/eloquent/rqt-moveit/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rosidl-default-generators, rqt-gui, rqt-gui-py, rqt-py-common, rqt-topic, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-rqt-moveit";
+  version = "1.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_moveit-release/archive/release/eloquent/rqt_moveit/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "5818b4ef447d1b8c97d16ac4be1980645cdb09037b9daa64f14e5336821de8c4";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ python-qt-binding rclpy rqt-gui rqt-gui-py rqt-py-common rqt-topic sensor-msgs ];
+  nativeBuildInputs = [ python3Packages.setuptools rosidl-default-generators ];
+
+  meta = {
+    description = ''An rqt-based tool that assists monitoring tasks
+   for <a href="http://ros.org/wiki/moveit">MoveIt!</a> motion planner
+   developers and users. Currently the following items are monitored if they
+   are either running, existing or published:
+   <ul>
+   <li>Node: /move_group</li>
+   <li>Parameter: [/robot_description, /robot_description_semantic]</li>
+   <li>Topic: Following types are monitored. Published &quot;names&quot; are ignored.<br/>
+       [sensor_msgs/PointCloud, sensor_msgs/PointCloud2,
+        sensor_msgs/Image, sensor_msgs/CameraInfo]</li>
+   </ul>
+   Since this package is not made by the MoveIt! development team (although with
+   assistance from the them), please post issue reports to the designated
+   tracker (not MoveIt!'s main tracker).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2966,6 +2966,8 @@ self: super: {
 
  phidgets-imu = self.callPackage ./phidgets-imu {};
 
+ phidgets-msgs = self.callPackage ./phidgets-msgs {};
+
  pid = self.callPackage ./pid {};
 
  piksi-multi-rtk = self.callPackage ./piksi-multi-rtk {};

--- a/distros/kinetic/lgsvl-msgs/default.nix
+++ b/distros/kinetic/lgsvl-msgs/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-lgsvl-msgs";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/kinetic/lgsvl_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "7adfcbaad0a60937c98b32d07fbf2e6fcc27656fbde4f460079bb4d2f825d870";
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/kinetic/lgsvl_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "d9698108249845d93e3354402e02db811b80324ec224e5bc2eedcabf149a3968";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
-  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The lgsvl_msgs package for ground truth data.'';

--- a/distros/kinetic/libphidget21/default.nix
+++ b/distros/kinetic/libphidget21/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-kinetic-libphidget21";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/libphidget21/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "936ad040bd0caebc715bac37f4faf68598debec5dc1041a80a42286d340ca6d4";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/libphidget21/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "cb19859d7275598b9bf33f5cdf35397ef394275a7f427f30f94f7ff324ab33ac";
   };
 
   buildType = "catkin";
+  buildInputs = [ libusb1 ];
   propagatedBuildInputs = [ libusb ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/phidgets-api/default.nix
+++ b/distros/kinetic/phidgets-api/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, catkin, libphidget21 }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-api";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_api/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "d0e31229e64bcac2b1e57f5516d2be520dcf6295d9014117a03b2a8ff640b034";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_api/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "ed886454294daed65b07f850a23c9c6c74a9141bb47216e5f3e159ba140cd411";
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libphidget21 libusb ];
+  propagatedBuildInputs = [ libphidget21 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/phidgets-drivers/default.nix
+++ b/distros/kinetic/phidgets-drivers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-imu }:
+{ lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-ik, phidgets-imu, phidgets-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-drivers";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_drivers/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "22a3125649e36a9a00b1afaec1374b2ea9b9e0b11b846ad2d946a6a95dcd9e44";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_drivers/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "6145d09441e835743fd3bee6a61aac26c1eea54f930a982b1f07ffd7316b4028";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ libphidget21 phidgets-api phidgets-high-speed-encoder phidgets-imu ];
+  propagatedBuildInputs = [ libphidget21 phidgets-api phidgets-high-speed-encoder phidgets-ik phidgets-imu phidgets-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/kinetic/phidgets-high-speed-encoder/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, message-generation, message-runtime, phidgets-api, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-high-speed-encoder";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_high_speed_encoder/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "4b312550ad9a97d33c8ebee17973fcfb6d93c1aebe8aa557ab5729c7d41e3768";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_high_speed_encoder/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "3e35b666024fe2b84ea72090ece93da72c88b3d5d75bc41e5c030a46b0af1c85";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ libphidget21 message-runtime phidgets-api roscpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs pluginlib roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/phidgets-ik/default.nix
+++ b/distros/kinetic/phidgets-ik/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nodelet, phidgets-api, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-ik";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_ik/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "7fdf740d366819c5058e0b1257e1e8758b3a8df9dfdcedf0d2d00a392586cae4";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_ik/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1d2d1441024d5dd1df4c5eaed1572809dd9637d74200f3fbb804f3c47d5a5c80";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime nodelet phidgets-api roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs pluginlib roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/phidgets-imu/default.nix
+++ b/distros/kinetic/phidgets-imu/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-imu";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_imu/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "94eb73ddd1e44e4887f2938447167510af531e27cb91e3b49611d14b070800da";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_imu/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "e9e92853b8863c01a6786cf26872f2d251e2f20ddef21ac511c38138b2eaea79";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater imu-filter-madgwick nodelet phidgets-api pluginlib roscpp sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater imu-filter-madgwick nodelet phidgets-api pluginlib roscpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/phidgets-msgs/default.nix
+++ b/distros/kinetic/phidgets-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phidgets-msgs";
+  version = "0.7.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_msgs/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "1f29e1a7cd91a7fb43ce1fd496d3096bd05aa4c9676b24e2ded69bafc9c5d4dd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Custom ROS messages for Phidgets drivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/pinocchio/default.nix
+++ b/distros/kinetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-kinetic-pinocchio";
-  version = "2.4.0-r2";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/kinetic/pinocchio/2.4.0-2.tar.gz";
-    name = "2.4.0-2.tar.gz";
-    sha256 = "a45e01bd57b0c66e4889ce7ccf68f0b2f1fd48cb88dc53191caa9dec461fde91";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/kinetic/pinocchio/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "19ddf7f783e6de44b4851de1d246f689bb34003c4e65e472a2e79c631d299aec";
   };
 
   buildType = "cmake";

--- a/distros/melodic/catkin/default.nix
+++ b/distros/melodic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-catkin";
-  version = "0.7.23-r1";
+  version = "0.7.26-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/melodic/catkin/0.7.23-1.tar.gz";
-    name = "0.7.23-1.tar.gz";
-    sha256 = "038975826eb49cf92a07fb7d35622da90b1ccb9ebbf0894d87ca6bd4dee53238";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/melodic/catkin/0.7.26-1.tar.gz";
+    name = "0.7.26-1.tar.gz";
+    sha256 = "745b4763eb6d20b5474fe58211d24ce3530fdc106175afc9c22697a87eac75d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "153d8a79f12f963bf0db013834ce4c32d518b9cc0faf6ef8552a042a0d69e352";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "2224b38f8413b5a765d7c3cd3e213d7ab168ee25291124be2a543ac318ed9afa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/control-toolbox/default.nix
+++ b/distros/melodic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-control-toolbox";
-  version = "1.18.0-r1";
+  version = "1.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.18.0-1.tar.gz";
-    name = "1.18.0-1.tar.gz";
-    sha256 = "ad00adfd593adb29204950fe83ae50e9fedd279851b6fa37b2a281c6fbb7b345";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/melodic/control_toolbox/1.18.2-1.tar.gz";
+    name = "1.18.2-1.tar.gz";
+    sha256 = "35b286163116a3ba5e016f9e970ece963de8711cb3fae2b1cccb7dcb1c32f55a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/csm/default.nix
+++ b/distros/melodic/csm/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, gsl }:
+buildRosPackage {
+  pname = "ros-melodic-csm";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/csm-release/archive/release/melodic/csm/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "16d77496d6da844ded1a368e4b723938d9c8cbc481a73c535c3eb266e3b23860";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ catkin gsl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This is a ROS 3rd-party wrapper <a href="http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
+
+    From <a href="http://censi.mit.edu/software/csm/">the official website</a>:
+    <ul>
+      The C(anonical) Scan Matcher (CSM) is a pure C implementation of a very fast variation of ICP using a point-to-line metric optimized for range-finder scan matching.
+
+      It is robust enough to be used in industrial prototypes of autonomous mobile robotics, for example at Kuka. CSM is used by a variety of people, though it is hard to keep track because of the open source distribution, especially as packaged in ROS. If you use this software for something cool, let me know.
+    </ul>'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -500,6 +500,8 @@ self: super: {
 
  criutils = self.callPackage ./criutils {};
 
+ csm = self.callPackage ./csm {};
+
  cv-bridge = self.callPackage ./cv-bridge {};
 
  cv-camera = self.callPackage ./cv-camera {};
@@ -1634,6 +1636,8 @@ self: super: {
 
  marti-visualization-msgs = self.callPackage ./marti-visualization-msgs {};
 
+ marvelmind-nav = self.callPackage ./marvelmind-nav {};
+
  master-discovery-fkie = self.callPackage ./master-discovery-fkie {};
 
  master-sync-fkie = self.callPackage ./master-sync-fkie {};
@@ -2177,6 +2181,8 @@ self: super: {
  phidgets-ik = self.callPackage ./phidgets-ik {};
 
  phidgets-imu = self.callPackage ./phidgets-imu {};
+
+ phidgets-msgs = self.callPackage ./phidgets-msgs {};
 
  photo = self.callPackage ./photo {};
 

--- a/distros/melodic/genmsg/default.nix
+++ b/distros/melodic/genmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genmsg";
-  version = "0.5.15-r1";
+  version = "0.5.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genmsg-release/archive/release/melodic/genmsg/0.5.15-1.tar.gz";
-    name = "0.5.15-1.tar.gz";
-    sha256 = "305bf8208b91e7921b7d186e9185f6c579e0e07ffb1d3487b35d76e6bd5f9504";
+    url = "https://github.com/ros-gbp/genmsg-release/archive/release/melodic/genmsg/0.5.16-1.tar.gz";
+    name = "0.5.16-1.tar.gz";
+    sha256 = "8f9ec18a26b026d0eeb1ae55d7da9c3f3edcf0968cadff6799fc11da62415fef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/genpy/default.nix
+++ b/distros/melodic/genpy/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genpy";
-  version = "0.6.9-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.9-1.tar.gz";
-    name = "0.6.9-1.tar.gz";
-    sha256 = "c34ac21b89413514766134f7f7c44b2f59902b0f8cc7c0c751455da86696348b";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "ed736b2ad7fad21b829983576a2a14ac1ccd302b0cd63cf4e24298183ae046ee";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ genmsg pythonPackages.pyyaml ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python ROS message and service generators.'';

--- a/distros/melodic/laser-filters/default.nix
+++ b/distros/melodic/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, dynamic-reconfigure, filters, laser-geometry, message-filters, pluginlib, roscpp, rostest, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters";
-  version = "1.8.10-r1";
+  version = "1.8.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/melodic/laser_filters/1.8.10-1.tar.gz";
-    name = "1.8.10-1.tar.gz";
-    sha256 = "ba6f7fb5e189985d2762f35b8806a6ec29c44da06ba3554437d34c11b6262ec9";
+    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/melodic/laser_filters/1.8.11-1.tar.gz";
+    name = "1.8.11-1.tar.gz";
+    sha256 = "c04a129db4b21ae1524e819d9f080826d7410449f843a4f3b915a62b4a72e970";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lgsvl-msgs/default.nix
+++ b/distros/melodic/lgsvl-msgs/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lgsvl-msgs";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/melodic/lgsvl_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "7e1a65d3443fa3de6cd21ff95f163ed74b9bf315eb322b2c55c0219dad523d20";
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/melodic/lgsvl_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "7565fcaab3b463b9350cd8469741b3a38e777b5934ea6acc36ed85494220c9e2";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ message-generation ros-environment ];
   propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
-  nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The lgsvl_msgs package for ground truth data.'';

--- a/distros/melodic/libphidget21/default.nix
+++ b/distros/melodic/libphidget21/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-libphidget21";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/libphidget21/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "5c5acae522f6e58661d819125794697d8de28be1409b98304ee8752ff724faa7";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/libphidget21/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "b493f61274d99ad205a18a6c841f140e54789361fdaccb2cc59f79ef2cfde9e1";
   };
 
   buildType = "catkin";
+  buildInputs = [ libusb1 ];
   propagatedBuildInputs = [ libusb ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/marvelmind-nav/default.nix
+++ b/distros/melodic/marvelmind-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-marvelmind-nav";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarvelmindRobotics/marvelmind_nav-release/archive/release/melodic/marvelmind_nav/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "abc7758576fda1b1cf6f3b49d084bd6f9c9e8333f4e622bd3683fa4fa0e843db";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Marvelmind local navigation system'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/message-filters/default.nix
+++ b/distros/melodic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-message-filters";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "5a24340fa66ecbd6a7d2ad52274499592f6dee34605ea173f2f0017688a3e9ad";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "4e46fdbd52aedb5c8208a39d63a55dcb01d388e3ad08845974881c5e3504dbac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mk/default.nix
+++ b/distros/melodic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-mk";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/mk/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "76bb52b899c88fe560e7a7b897f3bea0053afab89ff99b73233895e440d7bf92";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/mk/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "0c1e3e41d69fbd30193f1c231e9d0e452c2395512f9081c3e48077d039eff00a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "8fb1d0d33df9a57feaf8d3fd529b948f46d4dc915e7dc1e53993e400237178d9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "000acaeaf53f74d81b565dc2e42a88f3e8eb3234cde04fded31114b6da56bb7b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "e62906b7f9ab4e5cf65c6d43cb4139335c1fae7e8ca22732686f3d770ac0f977";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "0d62051fc967e5bb92c523bb86cf904f7eccca7fe88d77633871eef36cdbae06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-experimental/default.nix
+++ b/distros/melodic/moveit-experimental/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-experimental";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_experimental/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "e190eb9b55f5c626a308d5666f0fb668fa4db91ca965eb81f71f71f0b0f257e0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_experimental/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "3d0a02fde649793e89cff21d629c0ebcb74f864714084bab6bc49895aa39e712";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "d401c9fce5789c2ac1e772247330c762169487ef9d07adff5f58ce748b2c1c8f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "1f7feefa5884b7f2a4299bb4df48164f130a09073eb103bab9abdc6dcf90c048";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "cd987af131360fdc327814593634712222a737c98fc86962ce68e9e44d8636d8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "f198d6a837c63f94ad7bb0ee0d490bd8fc2abce1e70d044ae8ee1cf2f4b21a68";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "e5511388a2fc552cde9b005d6499179cb9a4bae9528108d04437f5e0501c3922";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "ba4b086bde240d7bb134715761d8079f4ab533ff3eb641e10a3191c24d7de389";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "d227e3d845246b39a128d484459933a3ab94de35cd45bf3cf318f68dc0ae1fac";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "eac77ce7ecece47dc3b9c3c301830ab281533b3ec578a4d55038fe26c528c110";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "64bf18b4e525c88b0f58d2773265145dbbc8a156503ca87f232a1893b6c36501";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "547543d86aafe00698991a8c93e6f1d48fdb5ca3c30471bf0641efead444d92c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "f1006e772d6bbeb56b89ea7ff5c4f8c208090c78491d54a8476c096d394c29be";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9b302f534ff8980927d0f02e1e7846168438e7045250b9205ead7c6986f870bb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "79f40a97093eb0be0703290346e212737d4713420834516fc3386520a92df0d9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "68eccb4d52c73395d0a0b1fd14632757a61e7bc58e31c57bfea776682614b465";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "d85299f39ee21f1ad34d5e9dfa031a760a05cdc3ff9c5f7c04435fda7300b64c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "86f51712fef6308ec700345b468be3ca094320362cd07cab72adf9c89217170c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "b294d0dce3b01473b2a38a28fd41fa4ded0f8da5abcdb44e35f63cb44dd53449";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "60ebd2266a1fd32df6b935f8a3d9e9fef350f15faa6d8a7975921c81d25c49d7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "84d6e721e0c286ca8895bb4509cf17da26d3334899f2009d04289521cf544d0f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "dc44ae4e8f512f3d32e4bc83f4cac096b414a2d1d142edb3c51998bd9d26357e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "d5dae1ae2579cb36e079012e30ff83d894eb16e5b0c3a171e924a55ab527bb67";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "88e331c73ae8481aa96aea9e193efa888d2114ec5354f29662061c04bfd947be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "2d8c5f25f8a211ac3cb47548bd48366ba318a408e63690e11fee5e4e294faee7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "c4f4928ac27a6a69aeda2f0e4539e92e299d8579aebc0d3291c9d373dc5d5e3b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "211cfc07cba0a114fdb54ee6ff2939e9dd22d5f6b336ad4b69dc2745f916904e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "f652004ec1003945b933ec3efe53dff095136817a3674eb525c7968f573409d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "06bc30b72ce32f3bfe35c736ae79b17c60411a5378f1c5a146585a9e0801ba9e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "de1389300435535c314721f75a9201b6cd8ce9e594ce811fa8f4ef55c62f679e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "bc9cfbbe671543cd62980ebda44de721c9e8e535158514a7e291d2534d359b1f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "c19096e9aa75f78adfe5dc32ba5de6359ba3f4e92b397ef59cf6bc2c95a4787f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "d5d8a13def50004da86f5fe4523086eae412fa67c268549a1aff42f2df31277c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "dfa6bf99363798a3be585f35be0f98ce43e7ef1bad93dd3df504dbc213895b3c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "4ade914f0a1261e8b0326bd6ff96b89acad5a1b774887661b41311bea8a67765";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "7af8a9eb7715671578a06554c6c02ae3ad5a9c315fd12d354257a0c6873774c6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "1b4ff1c14e32d97c81a48d2a6a84a5db25510e695263ba15bfc6c7d0c4f93705";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "3b5648d93088fab229febc1d0e74cc9da57c4cb5b6aa0084bc083ac0dad59878";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "835395c63e5b9a9504f1230dd89b1f019818e2d075a1e6aee9bf352c3d919f71";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "85c5f93107c37e8a97659bd43e92a7e2587801168fce0e99c16d4ddab74abb6f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "ad91800be3f51848a367d9b79b91476ee58b56dbca39fbc6428bd5f978b9c70b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "1e23726919235ba613a9a764245094d633e4f26d15e86a3359ea85fc2644cac5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "17279df23dadd10afe22d00bf93e1991b369f48c9725ad8e1d9210d762cd9304";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "ad2ec0bfb1a46c154f023ffc6076c7013f4ce0a8b61e101b66fcbec05d079db7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "ce38602900aca0b81cf1598a3fa21f935930834bd309176e901bfc4300310d5d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "e36c58bf4f0ddaea4772108cacd3c3f8d77ff237d9117da763c27b73e851f6d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mrt-cmake-modules/default.nix
+++ b/distros/melodic/mrt-cmake-modules/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mrt-cmake-modules";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/melodic/mrt_cmake_modules/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b3c261212810a999320a2a4398e8337cf801e89cf4a448a98d62e09ebbc1a29c";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/melodic/mrt_cmake_modules/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "77d17c502c1b98dd71fe09652979c234d379fee343a48646a0d1c1a1ec3e6a56";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python pythonPackages.pyyaml ];
-  nativeBuildInputs = [ catkin ];
+  propagatedBuildInputs = [ lcov pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
 
   meta = {
     description = ''CMake Functions and Modules for automating CMake'';

--- a/distros/melodic/phidgets-api/default.nix
+++ b/distros/melodic/phidgets-api/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, catkin, libphidget21 }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-api";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_api/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "c3f33f14fcfc032dddcb02b6a7938265972b7133804823a5cae8c9d51c30a46f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_api/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "4fc49e7bad1c3bf5a165f144a18d0c3a2af76ec27a2d1cf70eb6ce98b0281ee3";
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libphidget21 libusb ];
+  propagatedBuildInputs = [ libphidget21 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/phidgets-drivers/default.nix
+++ b/distros/melodic/phidgets-drivers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-imu }:
+{ lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-ik, phidgets-imu, phidgets-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-drivers";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_drivers/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "1fa07e01b428610e87697521a0b1f0b8b543b0f44a0e8ce34e08c6424f025a78";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_drivers/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "6f72628611a85e25175c1ae86266adbf5dec38e276c1ca2f19602f30dc8837f8";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ libphidget21 phidgets-api phidgets-high-speed-encoder phidgets-imu ];
+  propagatedBuildInputs = [ libphidget21 phidgets-api phidgets-high-speed-encoder phidgets-ik phidgets-imu phidgets-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/phidgets-high-speed-encoder/default.nix
+++ b/distros/melodic/phidgets-high-speed-encoder/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libphidget21, message-generation, message-runtime, phidgets-api, roscpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-high-speed-encoder";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_high_speed_encoder/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "d8b29845e8756bb602a1f63c030a3efee27fed46755d94574d696952ecdc05ef";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_high_speed_encoder/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "5878e35c9e46f6be29b4b9d3641fc308b1c8fb50b3ce6d36b48ab8fdc0b374b8";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ libphidget21 message-runtime phidgets-api roscpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs pluginlib roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/phidgets-ik/default.nix
+++ b/distros/melodic/phidgets-ik/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nodelet, phidgets-api, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-ik";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_ik/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "f7b6b527e58c2e93b61612f57ca708a383e6082de8774ea467a33eea0fae3e25";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_ik/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "efde9126efa41df2e088958b1047afa402bc04dff2bc8e0cfe07aeeb7e8c698f";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime nodelet phidgets-api roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs pluginlib roscpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/phidgets-imu/default.nix
+++ b/distros/melodic/phidgets-imu/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-imu";
-  version = "0.7.9-r1";
+  version = "0.7.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_imu/0.7.9-1.tar.gz";
-    name = "0.7.9-1.tar.gz";
-    sha256 = "43c322e37f15a5ae31b5a0695c9243f134528a31e8ebefe92f6022eecd5d3fe5";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_imu/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "03325987c440379ef8e1d00656aff251eff1a7ba10da092948c131fb06c26014";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater imu-filter-madgwick nodelet phidgets-api pluginlib roscpp sensor-msgs std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ diagnostic-aggregator diagnostic-msgs diagnostic-updater imu-filter-madgwick nodelet phidgets-api pluginlib roscpp sensor-msgs std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/phidgets-msgs/default.nix
+++ b/distros/melodic/phidgets-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-phidgets-msgs";
+  version = "0.7.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_msgs/0.7.10-1.tar.gz";
+    name = "0.7.10-1.tar.gz";
+    sha256 = "e05ec181840e85efc5a58351b799ab9cb9143901070c3542c750b5dbb45c316a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Custom ROS messages for Phidgets drivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.4.0-r2";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.4.0-2.tar.gz";
-    name = "2.4.0-2.tar.gz";
-    sha256 = "5758cc693407113362d721eeb5f981e1b699187ef009ad1ddedd61487d0f9774";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "18540457cbad5beb19e100db8303eb16ada0e78457cd663824872314e153e484";
   };
 
   buildType = "cmake";

--- a/distros/melodic/python-qt-binding/default.nix
+++ b/distros/melodic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-melodic-python-qt-binding";
-  version = "0.4.0-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c73766a7ab4e05e6b82e83a12c802bba2c56a552dcc6268ec6989326289eb6aa";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "a293ccc5315ae546199fb25dfd59f5a6fb8f9e4adb9da59780cf1aeb49f7a358";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qt-dotgraph/default.nix
+++ b/distros/melodic/qt-dotgraph/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-qt-dotgraph";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_dotgraph/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4de129ca721b664fa79136c817abbb2f8186a65b5eb5535fdffd9db00f6b4fff";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_dotgraph/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "527e75497946fd166abe67941bfd0ce7959fbd15d014b1ee2647b1f013e32d07";
   };
 
   buildType = "catkin";
   checkInputs = [ pythonPackages.pygraphviz ];
   propagatedBuildInputs = [ python-qt-binding pythonPackages.pydot ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_dotgraph provides helpers to work with dot graphs.'';

--- a/distros/melodic/qt-gui-app/default.nix
+++ b/distros/melodic/qt-gui-app/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qt-gui }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt-gui }:
 buildRosPackage {
   pname = "ros-melodic-qt-gui-app";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_app/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "575d3d34a7c88dea8843b67b44e73ed44c87288f7c846d28110fd57d064bda7f";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_app/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "3e8af4c946dba2b93089300199671da92a88d8b986c572a7d81ed9e10f48e881";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ qt-gui ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_app provides the main to start an instance of the integrated graphical user interface provided by qt_gui.'';

--- a/distros/melodic/qt-gui-core/default.nix
+++ b/distros/melodic/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-melodic-qt-gui-core";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_core/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "679f8c531728ed4a774b49422066643ad36a02cb4f3e8a8e80348b28398ba0f0";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_core/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "0a93acea73be2df4fac02c9aa931f8cc3aa133406796d59f3260ba1c5ff11ac4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qt-gui-cpp/default.nix
+++ b/distros/melodic/qt-gui-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, pythonPackages, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-qt-gui-cpp";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_cpp/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "082280e3d38a1dcc5b1127f180b65d6d6e35595f6b502a81d83f334dd79397db";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_cpp/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "9e18a570d02cfc1aa43a41462c4445f2fdb3593d3d545eaa6018f655ee533bf7";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules pkg-config python-qt-binding qt5.qtbase ];
   propagatedBuildInputs = [ pluginlib qt-gui tinyxml ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_cpp provides the foundation for C++-bindings for qt_gui and creates bindings for every generator available.

--- a/distros/melodic/qt-gui-py-common/default.nix
+++ b/distros/melodic/qt-gui-py-common/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-qt-gui-py-common";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_py_common/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b7071d863395099b3cd984ba2ea710a40ce50844159385989f2ee2817100e41b";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui_py_common/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "647f72cff8177a125fe01cb940095cc45dafa2e321ad57654f1588a0396381fc";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_py_common provides common functionality for GUI plugins written in Python.'';

--- a/distros/melodic/qt-gui/default.nix
+++ b/distros/melodic/qt-gui/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-melodic-qt-gui";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "68962c3131bdc6cead56978ab42270af51ae2546e78c4d6fa654b13376acbf2d";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/melodic/qt_gui/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5a3d2a1b4ce728bd94af6e0562f6a91439d9f0ebd0141277a8df67976d2dd796";
   };
 
   buildType = "catkin";
   buildInputs = [ pythonPackages.pyqt5 qt5.qtbase ];
   propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg tango-icon-theme ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui provides the infrastructure for an integrated graphical user interface based on Qt.

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.6-r1";
+  version = "2.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.6-1.tar.gz";
-    name = "2.6.6-1.tar.gz";
-    sha256 = "8ebb61da8246a0ed2dd7b5cdbc7b917e29b6d654f1209f21ad58b5126fc9b411";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.7-1.tar.gz";
+    name = "2.6.7-1.tar.gz";
+    sha256 = "c733708e1948f514cb94cad3942715980fdca0b073ead8ddad7ac9664375d5fa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-comm/default.nix
+++ b/distros/melodic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-ros-comm";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "fb2171682f4d084f3c8bf122be93decb5729eee0f9c145cfd3c7b3404ec8a416";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "036283a7f93b0c87a8da3fa9eb2bcaf559a08b60a1a53331ab17debc8ed5c80e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros/default.nix
+++ b/distros/melodic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-ros";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/ros/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "9d5e2945b00960586de7b7f2a52b02db6c0627695f22bbb38030558170070ac7";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/ros/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "925ce4054a71f0a39d6692ce8d8a52abbcc977b33dd77a4249ad9264b48ef164";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-storage/default.nix
+++ b/distros/melodic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-storage";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "e64d43dd0f9f4e2fab0d6eb6df1cd4b6dedec6bf934063474b8b9d64579e6410";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "2f563a481350c0c7e520d411cb66790c61a2c3c34f50d66087e4f53e5faeae12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag/default.nix
+++ b/distros/melodic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "642cb2b16b92366f8deaad9ec65d148e29f4ca550194fc2010a49670925610d9";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "11304483fd71a6f7928bef6ce8f5f427b1ca70d910154be18e348b7d36060930";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbash/default.nix
+++ b/distros/melodic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-melodic-rosbash";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosbash/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "59eb7db316cc956a64fd4962967330edba75a04cb65178da9a9c3b8521719e44";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosbash/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "6a46f7fa9ddd7a2122e55dc4b4998650375c4814f7fb8539f7719ebb6e62a046";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosboost-cfg/default.nix
+++ b/distros/melodic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosboost-cfg";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosboost_cfg/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "18805bb70e204afa454230063143482757097a80e2f4efc009a9c34e7d2c3bf8";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosboost_cfg/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "042fd5681840c37a41a7642ebdea54882c0c49dbbd71c241760f5eea71175b92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbuild/default.nix
+++ b/distros/melodic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-rosbuild";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosbuild/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "8a2cc14f6920e21643b7663c6b71e669c1b8572300324e488fba75b202c19f87";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosbuild/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "34effeb0596f1cc1fb841b7e399fc8fda0f38c8ed3ea1c021172b68a38d5eeec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosclean/default.nix
+++ b/distros/melodic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosclean";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosclean/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "cc9ecd24ad157822bbdff1ecd7ff1155e57853cb8868f12072c3acd2f963f51a";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosclean/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "69d89a7d3199d11214c208c177f56e7cbcc42fb349fe76df6992c869ceca5bbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roscpp/default.nix
+++ b/distros/melodic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-roscpp";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "cfd1297d7d46a60b5ff0620808294b408e44441499237ad80388d2dce0976004";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "041c3d384598732ccd68e24d5125917be9d73ced411ebde2c62f8d717e9b001f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roscreate/default.nix
+++ b/distros/melodic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-melodic-roscreate";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roscreate/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "4e7344a5f38437c4e6f498b97404b8b0194965edb877536b6d9c5c0c5a4bbfc5";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roscreate/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "5be3e124f93f53ad14096e6ae8d58bea596b7fe9850ed94e33295604a4987b26";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosgraph/default.nix
+++ b/distros/melodic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosgraph";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "13f5d55c64d54e8684ac8a82b4b7c8df84520dde89b145afe785639b6e867fd6";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "4b58a690d74e90fcbcbbedcd43ef2c85675abaa5f614c1b16ad106eb8d10488f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslang/default.nix
+++ b/distros/melodic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-melodic-roslang";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roslang/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "73b0567012d70f058745243e1ebb3ace80a83ddbdfa06280e735e592dbca04a5";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roslang/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "320b5d85852833da8a3aa3bcd48125aed8e9354cb4785ce760084a0cab84b48f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslaunch/default.nix
+++ b/distros/melodic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslaunch";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "98c1723ad727bee6e0cde2290683a4242f47a12b779a19772280660979051d71";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "5255e1ddf9aacd42f0361c1290bf99acdb7b1c762863d8e0b32a3ab4283a4083";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslib/default.nix
+++ b/distros/melodic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pythonPackages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-melodic-roslib";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roslib/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "b85d1a9f33ec7618c04a419d0402895cd7d2472e41243d231f1c6bde45ad4ea8";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/roslib/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "5d88106ad4dc7cf82a698e7a7ff86afa17c87ba2d994ea6caf5248cca727d6eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslz4/default.nix
+++ b/distros/melodic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslz4";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "c4641789f93152d33263e333988001e8f6e49327870c42c57540391e524d818b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "3123979d075d5e50454e8676bd1eaafe60253ce046ab9d5feb2381ba79e364de";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmake/default.nix
+++ b/distros/melodic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosmake";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosmake/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "3eb943466e1858f81e9be26b741d6035c65f8c45b29f45d165e75102ccf66de6";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosmake/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "a67c86505fa7edb380511dfb3e9021f6bbab44a11835af67117aa980af88e35a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmaster/default.nix
+++ b/distros/melodic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosmaster";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "7866b79124969719d512b3ef46d2e2b795542a477a056f04607a8881a746135e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "419655da12740e168e6ade947e2562f38e2303e0065348c3f167e252cff1668a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmon-core/default.nix
+++ b/distros/melodic/rosmon-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python, pythonPackages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-rosmon-core";
-  version = "2.2.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon_core/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "6bea6d7cce29cd3b2b77b1f26a06e9b7052aea9fbb5fcbec280711fbdb87687a";
+    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon_core/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9e919083967cc7d7859ede0342cb2a26d19ce8c01504b047f6688bff640835c9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmon-msgs/default.nix
+++ b/distros/melodic/rosmon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosmon-msgs";
-  version = "2.2.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon_msgs/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "03fbf2130f728808cc6eed9eb770b6e9674befdcad75a0a6677f874d3857c463";
+    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "2ae3bb5ebf044c4c74720afb8df5c6fd04070d1477b4e12e13fb10dfea84ac47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmon/default.nix
+++ b/distros/melodic/rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosmon-core, rqt-rosmon }:
 buildRosPackage {
   pname = "ros-melodic-rosmon";
-  version = "2.2.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "7294462ecc50fb638016cefea6f43c40fe45799bbb9088e8b3c7d71aaf7905ec";
+    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rosmon/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "a27ecc9867d2130a7fedc83d531bc182cae7ad0e88b6fe34a2a2fc5bb05fa39d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmsg/default.nix
+++ b/distros/melodic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosmsg";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "d039d629202ea7100ef81533bb6787b45debc529f103cefa23fe88f625c31b49";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "b99cd01fea89031eff02263c3394b64e6be010e03ecb2b1ba3a915fc086d5498";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosnode/default.nix
+++ b/distros/melodic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-rosnode";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "0ff95b420d2206c246092bf9f776a3cf02e3b91c29bd77d44ea0bf5297e20240";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "65ab957fe9895a78ac50c27d5cdc5f736f88aa24599edcc6f4629366fb363e59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosout/default.nix
+++ b/distros/melodic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosout";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "364440c03fbc6835577b9dc710a7e9eacd246bc11424ecbe75ac2d8c8db605e5";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "1dba19423ee6a4782e0725d024f97fa4d3bd0de2df58fa704993d11d4ed8307f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospack/default.nix
+++ b/distros/melodic/rospack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, gtest, pkg-config, python, pythonPackages, ros-environment, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-rospack";
-  version = "2.5.5-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rospack-release/archive/release/melodic/rospack/2.5.5-1.tar.gz";
-    name = "2.5.5-1.tar.gz";
-    sha256 = "f3e8b07388ee8214a6dd22aec23cb2b6014829df8a446ddefc61db6dfba9f74c";
+    url = "https://github.com/ros-gbp/rospack-release/archive/release/melodic/rospack/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "5d348a4428f344ecbde8d0ceed9d38b4326d45538d5875ead0b5498804d8f30e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosparam/default.nix
+++ b/distros/melodic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosparam";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "7bfa5fb9c39c0d3a627bfdfa683ddd3b2b1dbc400adec23b791e2e427e2109ed";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "2a7b9f228194d71a7e707c74cd84dc1b682ce5eedaaab575a0a77cc3516070d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy/default.nix
+++ b/distros/melodic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospy";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "1d4ffc44a7a048e2df92a40675a89ec597c5d98c6d4f5ddb34763f0bdd8953c1";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "af893893c5abb2ed4ef41ad5ae6b954b02fb887ef3709782520681f7883b710f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosservice/default.nix
+++ b/distros/melodic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosservice";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "bab389b8331b0f16d55658660750f53f1d9657b0b76384e5ee5531fc086fc64b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "a7464a4e2b38d77ea607add12ddae6157d794f5b8a5cda4191d696d52cbbbf5b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostest/default.nix
+++ b/distros/melodic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-rostest";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "923c0eac3a633ea26435c69044cf52e25aca4ce5eb559e43bf98b6eeb51c10e2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "23e9bc593f717f2003ae79d1e26e22a1a15196760b1939c2a853e7d09e05592a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostopic/default.nix
+++ b/distros/melodic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rostopic";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "671feff9f65d4ef61ee1508805c1defba40223b28bdcfd6329d95ecaf025802e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "ec8336961fc8d95d0ad709b8c5570e71dd9cba8c4af880aa76a478a6a7f2344e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosunit/default.nix
+++ b/distros/melodic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-melodic-rosunit";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosunit/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "e9e8baee4230ce1d3291c91cbda2c089eaaaefc2540c3ea6f38584263678c95e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/melodic/rosunit/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "4d2b0afb40e4967f16c1c7f1dd37938f0ea8a3e00c0e2bcc58b23e8ec63de772";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswtf/default.nix
+++ b/distros/melodic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-roswtf";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "4e84d669372890c3dad667d66eae1ceb594c0e02f1d21e7d2a0fabb4b4e8e2f5";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "50c1a09cbfb758b240f588c03fd37d7db48e9e38fd688db36c389d3ad7d45027";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-rosmon/default.nix
+++ b/distros/melodic/rqt-rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, roscpp, rosmon-msgs, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-melodic-rqt-rosmon";
-  version = "2.2.1-r1";
+  version = "2.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rqt_rosmon/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "5c36fe953743b65dbd9f9f59ea29f158f62a37316c14afdd6d5dee214f9c35aa";
+    url = "https://github.com/xqms/rosmon-release/archive/release/melodic/rqt_rosmon/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "9769d8e7d864db419856c498157f0bb6d41913049802afbc22f7bc229f173ec5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/topic-tools/default.nix
+++ b/distros/melodic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-topic-tools";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "bc58ba5173aed4ee21f8a6524a642d2415d6360585f631b224273d0b5feeb249";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "52450490ec59dfbdb18cb1366192e599bce89636eececa6a832f75d8f8ef1167";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-mux/default.nix
+++ b/distros/melodic/twist-mux/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-twist-mux";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "aa2888069d0ed77dbab6759a450cef52d03b6f64b09514c006bd2f49384732bd";
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/melodic/twist_mux/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "be81c02f14eddcb14a8e4195b2c6318953efcfa2c92ff7cf7963ff616e0b3a8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xmlrpcpp/default.nix
+++ b/distros/melodic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-melodic-xmlrpcpp";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "b766cdf6c839a83ecd29b87eaf615dae5e6f482d23c1b05615b99a3c4300ca00";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "7be348f760273091a360fc2d4a15167e9938a1cb1cd6ec5422cc0c4156a02be2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "746f069448936c7a1544d05990d40a75c3a44dcbccd85dc7062e8bd4e93d8ea8";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "ba3fa2ff00ff59ce5e840c284020c5b00a17315a483834e5689926c1537a5269";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "52cf9a18835b92ab878e11bb8348df0a485d2eb23e0351a75cf5a0e3f442c3d9";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "3e290786d9851e648a9b3712f71ef39ad89e09b32951697e344be4632174f0d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "abbe10eb4dc989441c1c5f5dc544401c43476076b7cbdc281d7ca2d6deb95168";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "62b55a8412d709e6cc5bc9aca1f78f0b6fd73575bdd085d4a74cc522b3e3c7a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.5-r1";
+  version = "0.3.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.5-1.tar.gz";
-    name = "0.3.5-1.tar.gz";
-    sha256 = "594522f643639bb0f8db94709f754d0ff25ff66bc055eacf1ef0aa5653224d94";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "501418fdced03167c403cc9faf0c6aed5f4afd6b1dd66551bd16a98e8fe3f8fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/behaviortree-cpp-v3/default.nix
+++ b/distros/noetic/behaviortree-cpp-v3/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
+buildRosPackage {
+  pname = "ros-noetic-behaviortree-cpp-v3";
+  version = "3.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/noetic/behaviortree_cpp_v3/3.5.0-1.tar.gz";
+    name = "3.5.0-1.tar.gz";
+    sha256 = "7650489692bdf82b407cbf0b70db2f598465e4b97b236fa861624f3f71550dc3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cppzmq ncurses roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides the Behavior Trees core library.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/cartesian-msgs/default.nix
+++ b/distros/noetic/cartesian-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/cartesian_msgs-release/archive/release/noetic/cartesian_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "427c2c1230df05e280ed460acc844e45c32f3cb64cc1d6b868d14d75848b7afe";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Stream cartesian commands'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/catch-ros/default.nix
+++ b/distros/noetic/catch-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-catch-ros";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AIS-Bonn/catch_ros-release/archive/release/noetic/catch_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "90889dd3dc2c5b6d0065ee5db36dc7d6540bf14e7d3b219db5a34824155d12af";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS integration for the Catch unit test framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
-  version = "0.8.5-r1";
+  version = "0.8.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.5-1.tar.gz";
-    name = "0.8.5-1.tar.gz";
-    sha256 = "3ab8eaec0c1d7a1d2a8746faabe657c900858188e0faa942a727f787d1fa7969";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "2f1a36f2666c735509055696b4cf81b4b7256270b445008a91d6ff6c0caff572";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-extern/default.nix
+++ b/distros/noetic/cob-extern/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libdlib, libntcan, libpcan, libphidgets, opengm }:
+buildRosPackage {
+  pname = "ros-noetic-cob-extern";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/cob_extern/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "19c8711acff2bcaee5b6cd917a43fbf2ac953af44d18ef9609fd13fe84cde14b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libdlib libntcan libpcan libphidgets opengm ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_extern stack contains third party libraries needed for operating Care-O-bot. The packages are downloaded from the manufactorers website and not changed in any way.'';
+    license = with lib.licenses; [ lgpl2 "proprietary" ];
+  };
+}

--- a/distros/noetic/control-toolbox/default.nix
+++ b/distros/noetic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-control-toolbox";
-  version = "1.18.0-r1";
+  version = "1.18.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.0-1.tar.gz";
-    name = "1.18.0-1.tar.gz";
-    sha256 = "22af8464ea59e77e430a8dc5539e977ffad9544d77932dc5a1df2a89725df7de";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.1-1.tar.gz";
+    name = "1.18.1-1.tar.gz";
+    sha256 = "12636c8385116b81e608f70e811112c849f192c1dde1653d7d98e4b56892c748";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-queue/default.nix
+++ b/distros/noetic/costmap-queue/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav-core2, roscpp, roslint, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-costmap-queue";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/costmap_queue/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "f500e0fa9d62496b20cc05bf993c687fe429f28eb259ec20d30fcc4ce12bce48";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rosunit ];
+  propagatedBuildInputs = [ nav-core2 roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tool for iterating through the cells of a costmap to find the closest distance to a subset of cells.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cpp-common/default.nix
+++ b/distros/noetic/cpp-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-cpp-common";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "381fc00674f632f524c062a68efb3bae210229f46b759fb63b598c649ab9a686";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/cpp_common/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "28a7892680c8c40eb4e77cd9c962abd22a0459fa9e69d73730ed3ebe3be5b9b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/csm/default.nix
+++ b/distros/noetic/csm/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, gsl }:
+buildRosPackage {
+  pname = "ros-noetic-csm";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/csm-release/archive/release/noetic/csm/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "fe2a7259863aa1f3761ce799b35dedfb332cd0a877a9710c3817ae410cd95e23";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ catkin gsl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This is a ROS 3rd-party wrapper <a href="http://www.ros.org/reps/rep-0136.html">(see REP-136 for more detail)</a> of Andrea Censi's CSM package. 
+
+    From <a href="http://censi.mit.edu/software/csm/">the official website</a>:
+    <ul>
+      The C(anonical) Scan Matcher (CSM) is a pure C implementation of a very fast variation of ICP using a point-to-line metric optimized for range-finder scan matching.
+
+      It is robust enough to be used in industrial prototypes of autonomous mobile robotics, for example at Kuka. CSM is used by a variety of people, though it is hard to keep track because of the open source distribution, especially as packaged in ROS. If you use this software for something cool, let me know.
+    </ul>'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/cv-camera/default.nix
+++ b/distros/noetic/cv-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, image-transport, nodelet, opencv3, roscpp, roslint, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cv-camera";
+  version = "0.5.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/OTL/cv_camera-release/archive/release/noetic/cv_camera/0.5.0-3.tar.gz";
+    name = "0.5.0-3.tar.gz";
+    sha256 = "d28ff8d89e6f26235c50b2bc1a60d712378bd2b5085b71ff2b21f5a330dc15f8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge image-transport nodelet opencv3 roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''cv_camera uses OpenCV capture object to capture camera image.
+  This supports camera_image and nodelet.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ddynamic-reconfigure/default.nix
+++ b/distros/noetic/ddynamic-reconfigure/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gmock, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-ddynamic-reconfigure";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure/archive/release/noetic/ddynamic_reconfigure/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "68e903ec0a816737a7c736bdc833be8a06861d4fe3f9c2aab818ec1c6fac82c0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gmock rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ddynamic_reconfigure package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dlux-global-planner/default.nix
+++ b/distros/noetic/dlux-global-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid, nav-grid-pub-sub, nav-msgs, pluginlib, roscpp, roslint, rostest, rosunit, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dlux-global-planner";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dlux_global_planner/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "37181821471bc8a04d130319876b5aa6122632971cac7e9b6870812f10913d1f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest rosunit ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-msgs nav-2d-utils nav-core2 nav-grid nav-grid-pub-sub nav-msgs pluginlib roscpp visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Plugin based global planner implementing the nav_core2::GlobalPlanner interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dlux-plugins/default.nix
+++ b/distros/noetic/dlux-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dlux-global-planner, global-planner-tests, nav-core2, nav-grid, pluginlib, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-dlux-plugins";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dlux_plugins/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "44592d2b8b60300cd4cb323354628e6fbf0b1bca75f5dcfb7e12ff3c3f811128";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ global-planner-tests roslint rostest ];
+  propagatedBuildInputs = [ dlux-global-planner nav-core2 nav-grid pluginlib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of dlux_global_planner plugin interfaces.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dual-quaternions-ros/default.nix
+++ b/distros/noetic/dual-quaternions-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-dual-quaternions-ros";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/noetic/dual_quaternions_ros/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "ecaf4f689fa6bde65227f924c43e933bd8e1cf836e407a79c66f5efb88bcc66c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dual-quaternions geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS msgs from and to dual quaternions'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/dual-quaternions/default.nix
+++ b/distros/noetic/dual-quaternions/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pyquaternion }:
+buildRosPackage {
+  pname = "ros-noetic-dual-quaternions";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/noetic/dual_quaternions/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "63b1083575b5eff98c5defaa1906886fdf4182522a04e1c473adfddb81290c08";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pyquaternion ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''dual quaternion operations'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/dwb-critics/default.nix
+++ b/distros/noetic/dwb-critics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, roscpp, roslint, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dwb-critics";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dwb_critics/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "7bea9fad5b4bc9d97d8327529098a855c3f58097b39a5c1a857d63508bca3dc2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ angles costmap-queue dwb-local-planner geometry-msgs nav-2d-msgs nav-2d-utils nav-core2 nav-grid-iterators pluginlib roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementations for dwb_local_planner TrajectoryCritic interface'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dwb-local-planner/default.nix
+++ b/distros/noetic/dwb-local-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-msgs, pluginlib, roscpp, roslint, rostest, rosunit, sensor-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dwb-local-planner";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dwb_local_planner/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "5044163cb897175f82f32ba79bd555433fa8dcaf141929b4aa60888569ca39af";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest rosunit ];
+  propagatedBuildInputs = [ dwb-msgs geometry-msgs nav-2d-msgs nav-2d-utils nav-core2 nav-msgs pluginlib roscpp sensor-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Plugin based local planner implementing the nav_core2::LocalPlanner interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dwb-msgs/default.nix
+++ b/distros/noetic/dwb-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-2d-msgs, nav-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dwb-msgs";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dwb_msgs/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "859311b430c086b10d48098c92b460e9912db8ad835ffe113bf3342122c866c4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-2d-msgs nav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message/Service definitions specifically for the dwb_local_planner'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dwb-plugins/default.nix
+++ b/distros/noetic/dwb-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, dwb-local-planner, dynamic-reconfigure, nav-2d-msgs, nav-2d-utils, nav-core2, pluginlib, roscpp, roslint, rostest, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-dwb-plugins";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/dwb_plugins/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "1304ec4154ee011a5d8adcb1ef3dce0b6e4392bfc4c9fe22005b3b16f3c26549";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest rosunit ];
+  propagatedBuildInputs = [ angles dwb-local-planner dynamic-reconfigure nav-2d-msgs nav-2d-utils nav-core2 pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Standard implementations of the GoalChecker
+      and TrajectoryGenerators for dwb_local_planner'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-build/default.nix
+++ b/distros/noetic/ecl-build/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-build";
+  version = "0.61.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/noetic/ecl_build/0.61.8-1.tar.gz";
+    name = "0.61.8-1.tar.gz";
+    sha256 = "fcfb4bd6e729545b04448786a1ab50b1496fc868391ae760d356561a852227e5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Collection of cmake/make build tools primarily for ecl development itself, but also
+     contains a few cmake modules useful outside of the ecl.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-license/default.nix
+++ b/distros/noetic/ecl-license/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-license";
+  version = "0.61.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/noetic/ecl_license/0.61.8-1.tar.gz";
+    name = "0.61.8-1.tar.gz";
+    sha256 = "4e3a7c697758861f96edcbebec01a3c9bd24d04da7b045a01ca66e413977a478";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Maintains the ecl licenses and also provides an install
+     target for deploying licenses with the ecl libraries.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-tools/default.nix
+++ b/distros/noetic/ecl-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-tools";
+  version = "0.61.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/noetic/ecl_tools/0.61.8-1.tar.gz";
+    name = "0.61.8-1.tar.gz";
+    sha256 = "c19172914ff3bcf92704c93a082382294b7b815a145ef5bce9f9a00b05274e96";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools and utilities for ecl development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.3.2-r2";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.3.2-2.tar.gz";
-    name = "2.3.2-2.tar.gz";
-    sha256 = "242da6cb6ae35e9e3da98cb97faeb8b0668a42dbeb2ec3962f30e2cbf3db5c07";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "6d817f9c91c3b1727c3b9b733d461407bce4887af28fdc8837bc76f0c001a044";
   };
 
   buildType = "cmake";

--- a/distros/noetic/exotica-val-description/default.nix
+++ b/distros/noetic/exotica-val-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-val-description";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/wxmerkt/exotica_val_description-release/archive/release/noetic/exotica_val_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bef122656f23a0a64ed34867b445ee7e3ce6cbfec5bec7472fd8823bf8f08a73";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''val_description version including our updated meshes for unit testing and visualisation. Based on the OpenHumanoids fork of the val_description package by NASA JSC. The most current version of the original package can be found at http://gitlab.com/nasa-jsc-robotics/val_description'';
+    license = with lib.licenses; [ "NASA-1.3" ];
+  };
+}

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-fadecandy-driver";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "f02aa46caa568f14395046a873af254fd5af3403ff52099414091f908930ea48";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs pythonPackages.pyusb rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fadecandy-msgs";
+  version = "0.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.1-2.tar.gz";
+    name = "0.1.1-2.tar.gz";
+    sha256 = "98e9c1c9d95587620c9ef295a7a92417a8326fed1369dc873b57446b3f500590";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS msgs for fadecandy LED controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/find-object-2d/default.nix
+++ b/distros/noetic/find-object-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-transport, message-filters, message-generation, message-runtime, qt5, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-find-object-2d";
+  version = "0.6.3-r5";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/find_object_2d-release/archive/release/noetic/find_object_2d/0.6.3-5.tar.gz";
+    name = "0.6.3-5.tar.gz";
+    sha256 = "a8e5130cd08ff78be8b6837bf44e8474bd5637e58af118ff9b4f7f193119d25c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge image-transport message-filters message-runtime qt5.qtbase roscpp rospy sensor-msgs std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The find_object_2d package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -28,6 +28,8 @@ self: super: {
 
  base-local-planner = self.callPackage ./base-local-planner {};
 
+ behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
+
  bond = self.callPackage ./bond {};
 
  bond-core = self.callPackage ./bond-core {};
@@ -56,6 +58,10 @@ self: super: {
 
  carrot-planner = self.callPackage ./carrot-planner {};
 
+ cartesian-msgs = self.callPackage ./cartesian-msgs {};
+
+ catch-ros = self.callPackage ./catch-ros {};
+
  catkin = self.callPackage ./catkin {};
 
  class-loader = self.callPackage ./class-loader {};
@@ -63,6 +69,8 @@ self: super: {
  clear-costmap-recovery = self.callPackage ./clear-costmap-recovery {};
 
  cmake-modules = self.callPackage ./cmake-modules {};
+
+ cob-extern = self.callPackage ./cob-extern {};
 
  code-coverage = self.callPackage ./code-coverage {};
 
@@ -100,7 +108,15 @@ self: super: {
 
  costmap-cspace-msgs = self.callPackage ./costmap-cspace-msgs {};
 
+ costmap-queue = self.callPackage ./costmap-queue {};
+
  cpp-common = self.callPackage ./cpp-common {};
+
+ csm = self.callPackage ./csm {};
+
+ cv-camera = self.callPackage ./cv-camera {};
+
+ ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
 
@@ -122,11 +138,33 @@ self: super: {
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
+ dlux-global-planner = self.callPackage ./dlux-global-planner {};
+
+ dlux-plugins = self.callPackage ./dlux-plugins {};
+
+ dual-quaternions = self.callPackage ./dual-quaternions {};
+
+ dual-quaternions-ros = self.callPackage ./dual-quaternions-ros {};
+
  dwa-local-planner = self.callPackage ./dwa-local-planner {};
+
+ dwb-critics = self.callPackage ./dwb-critics {};
+
+ dwb-local-planner = self.callPackage ./dwb-local-planner {};
+
+ dwb-msgs = self.callPackage ./dwb-msgs {};
+
+ dwb-plugins = self.callPackage ./dwb-plugins {};
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
+
+ ecl-build = self.callPackage ./ecl-build {};
+
+ ecl-license = self.callPackage ./ecl-license {};
+
+ ecl-tools = self.callPackage ./ecl-tools {};
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
@@ -136,9 +174,17 @@ self: super: {
 
  executive-smach = self.callPackage ./executive-smach {};
 
+ exotica-val-description = self.callPackage ./exotica-val-description {};
+
+ fadecandy-driver = self.callPackage ./fadecandy-driver {};
+
+ fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
+
  fake-localization = self.callPackage ./fake-localization {};
 
  filters = self.callPackage ./filters {};
+
+ find-object-2d = self.callPackage ./find-object-2d {};
 
  fkie-message-filters = self.callPackage ./fkie-message-filters {};
 
@@ -182,6 +228,8 @@ self: super: {
 
  geographic-msgs = self.callPackage ./geographic-msgs {};
 
+ geometric-shapes = self.callPackage ./geometric-shapes {};
+
  geometry = self.callPackage ./geometry {};
 
  geometry2 = self.callPackage ./geometry2 {};
@@ -194,11 +242,23 @@ self: super: {
 
  global-planner = self.callPackage ./global-planner {};
 
+ global-planner-tests = self.callPackage ./global-planner-tests {};
+
+ gps-common = self.callPackage ./gps-common {};
+
+ gps-umd = self.callPackage ./gps-umd {};
+
+ gpsd-client = self.callPackage ./gpsd-client {};
+
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
 
+ hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
+
  hokuyo3d = self.callPackage ./hokuyo3d {};
+
+ ifm3d = self.callPackage ./ifm3d {};
 
  image-common = self.callPackage ./image-common {};
 
@@ -218,13 +278,21 @@ self: super: {
 
  image-view = self.callPackage ./image-view {};
 
+ imu-complementary-filter = self.callPackage ./imu-complementary-filter {};
+
+ imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
+
  imu-sensor-controller = self.callPackage ./imu-sensor-controller {};
+
+ imu-tools = self.callPackage ./imu-tools {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
  interactive-markers = self.callPackage ./interactive-markers {};
 
  ivcon = self.callPackage ./ivcon {};
+
+ jderobot-assets = self.callPackage ./jderobot-assets {};
 
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
 
@@ -258,9 +326,29 @@ self: super: {
 
  laser-proc = self.callPackage ./laser-proc {};
 
+ lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
+
+ libdlib = self.callPackage ./libdlib {};
+
  libg2o = self.callPackage ./libg2o {};
 
+ libmavconn = self.callPackage ./libmavconn {};
+
+ libntcan = self.callPackage ./libntcan {};
+
+ libpcan = self.callPackage ./libpcan {};
+
+ libphidget22 = self.callPackage ./libphidget22 {};
+
+ libphidgets = self.callPackage ./libphidgets {};
+
  librviz-tutorial = self.callPackage ./librviz-tutorial {};
+
+ locomotor = self.callPackage ./locomotor {};
+
+ locomotor-msgs = self.callPackage ./locomotor-msgs {};
+
+ locomove-base = self.callPackage ./locomove-base {};
 
  map-laser = self.callPackage ./map-laser {};
 
@@ -272,7 +360,43 @@ self: super: {
 
  map-server = self.callPackage ./map-server {};
 
+ marti-can-msgs = self.callPackage ./marti-can-msgs {};
+
+ marti-common-msgs = self.callPackage ./marti-common-msgs {};
+
+ marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
+
+ marti-perception-msgs = self.callPackage ./marti-perception-msgs {};
+
+ marti-sensor-msgs = self.callPackage ./marti-sensor-msgs {};
+
+ marti-status-msgs = self.callPackage ./marti-status-msgs {};
+
+ marti-visualization-msgs = self.callPackage ./marti-visualization-msgs {};
+
+ marvelmind-nav = self.callPackage ./marvelmind-nav {};
+
  mavlink = self.callPackage ./mavlink {};
+
+ mavros = self.callPackage ./mavros {};
+
+ mavros-extras = self.callPackage ./mavros-extras {};
+
+ mavros-msgs = self.callPackage ./mavros-msgs {};
+
+ mbf-abstract-core = self.callPackage ./mbf-abstract-core {};
+
+ mbf-abstract-nav = self.callPackage ./mbf-abstract-nav {};
+
+ mbf-costmap-core = self.callPackage ./mbf-costmap-core {};
+
+ mbf-costmap-nav = self.callPackage ./mbf-costmap-nav {};
+
+ mbf-msgs = self.callPackage ./mbf-msgs {};
+
+ mbf-simple-nav = self.callPackage ./mbf-simple-nav {};
+
+ mbf-utility = self.callPackage ./mbf-utility {};
 
  mcl-3dl = self.callPackage ./mcl-3dl {};
 
@@ -290,13 +414,31 @@ self: super: {
 
  move-base = self.callPackage ./move-base {};
 
+ move-base-flex = self.callPackage ./move-base-flex {};
+
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
+ mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ nav-2d-msgs = self.callPackage ./nav-2d-msgs {};
+
+ nav-2d-utils = self.callPackage ./nav-2d-utils {};
+
  nav-core = self.callPackage ./nav-core {};
+
+ nav-core2 = self.callPackage ./nav-core2 {};
+
+ nav-core-adapter = self.callPackage ./nav-core-adapter {};
+
+ nav-grid = self.callPackage ./nav-grid {};
+
+ nav-grid-iterators = self.callPackage ./nav-grid-iterators {};
+
+ nav-grid-pub-sub = self.callPackage ./nav-grid-pub-sub {};
 
  nav-msgs = self.callPackage ./nav-msgs {};
 
@@ -338,6 +480,8 @@ self: super: {
 
  open-karto = self.callPackage ./open-karto {};
 
+ opengm = self.callPackage ./opengm {};
+
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
@@ -350,9 +494,43 @@ self: super: {
 
  perception-pcl = self.callPackage ./perception-pcl {};
 
+ phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
+
+ phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
+
+ phidgets-api = self.callPackage ./phidgets-api {};
+
+ phidgets-digital-inputs = self.callPackage ./phidgets-digital-inputs {};
+
+ phidgets-digital-outputs = self.callPackage ./phidgets-digital-outputs {};
+
+ phidgets-drivers = self.callPackage ./phidgets-drivers {};
+
+ phidgets-gyroscope = self.callPackage ./phidgets-gyroscope {};
+
+ phidgets-high-speed-encoder = self.callPackage ./phidgets-high-speed-encoder {};
+
+ phidgets-ik = self.callPackage ./phidgets-ik {};
+
+ phidgets-magnetometer = self.callPackage ./phidgets-magnetometer {};
+
+ phidgets-motors = self.callPackage ./phidgets-motors {};
+
+ phidgets-msgs = self.callPackage ./phidgets-msgs {};
+
+ phidgets-spatial = self.callPackage ./phidgets-spatial {};
+
+ phidgets-temperature = self.callPackage ./phidgets-temperature {};
+
+ pinocchio = self.callPackage ./pinocchio {};
+
  planner-cspace = self.callPackage ./planner-cspace {};
 
  planner-cspace-msgs = self.callPackage ./planner-cspace-msgs {};
+
+ plotjuggler = self.callPackage ./plotjuggler {};
+
+ plotjuggler-msgs = self.callPackage ./plotjuggler-msgs {};
 
  pluginlib = self.callPackage ./pluginlib {};
 
@@ -363,6 +541,8 @@ self: super: {
  posedetection-msgs = self.callPackage ./posedetection-msgs {};
 
  position-controllers = self.callPackage ./position-controllers {};
+
+ pybind11-catkin = self.callPackage ./pybind11-catkin {};
 
  pyquaternion = self.callPackage ./pyquaternion {};
 
@@ -394,9 +574,17 @@ self: super: {
 
  realtime-tools = self.callPackage ./realtime-tools {};
 
+ remote-rosbag-record = self.callPackage ./remote-rosbag-record {};
+
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ rgbd-launch = self.callPackage ./rgbd-launch {};
+
  robot = self.callPackage ./robot {};
+
+ robot-localization = self.callPackage ./robot-localization {};
+
+ robot-navigation = self.callPackage ./robot-navigation {};
 
  ros = self.callPackage ./ros {};
 
@@ -412,9 +600,13 @@ self: super: {
 
  ros-core = self.callPackage ./ros-core {};
 
+ ros-emacs-utils = self.callPackage ./ros-emacs-utils {};
+
  ros-environment = self.callPackage ./ros-environment {};
 
  ros-tutorials = self.callPackage ./ros-tutorials {};
+
+ rosapi = self.callPackage ./rosapi {};
 
  rosauth = self.callPackage ./rosauth {};
 
@@ -427,6 +619,14 @@ self: super: {
  rosbash = self.callPackage ./rosbash {};
 
  rosboost-cfg = self.callPackage ./rosboost-cfg {};
+
+ rosbridge-library = self.callPackage ./rosbridge-library {};
+
+ rosbridge-msgs = self.callPackage ./rosbridge-msgs {};
+
+ rosbridge-server = self.callPackage ./rosbridge-server {};
+
+ rosbridge-suite = self.callPackage ./rosbridge-suite {};
 
  rosbuild = self.callPackage ./rosbuild {};
 
@@ -450,6 +650,10 @@ self: super: {
 
  rosdiagnostic = self.callPackage ./rosdiagnostic {};
 
+ rosemacs = self.callPackage ./rosemacs {};
+
+ rosfmt = self.callPackage ./rosfmt {};
+
  rosgraph = self.callPackage ./rosgraph {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
@@ -464,11 +668,19 @@ self: super: {
 
  roslisp = self.callPackage ./roslisp {};
 
+ roslisp-repl = self.callPackage ./roslisp-repl {};
+
  roslz4 = self.callPackage ./roslz4 {};
 
  rosmake = self.callPackage ./rosmake {};
 
  rosmaster = self.callPackage ./rosmaster {};
+
+ rosmon = self.callPackage ./rosmon {};
+
+ rosmon-core = self.callPackage ./rosmon-core {};
+
+ rosmon-msgs = self.callPackage ./rosmon-msgs {};
 
  rosmsg = self.callPackage ./rosmsg {};
 
@@ -480,7 +692,11 @@ self: super: {
 
  rosparam = self.callPackage ./rosparam {};
 
+ rosparam-shortcuts = self.callPackage ./rosparam-shortcuts {};
+
  rospy = self.callPackage ./rospy {};
+
+ rospy-message-converter = self.callPackage ./rospy-message-converter {};
 
  rospy-tutorials = self.callPackage ./rospy-tutorials {};
 
@@ -554,6 +770,8 @@ self: super: {
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
+ rqt-rosmon = self.callPackage ./rqt-rosmon {};
+
  rqt-runtime-monitor = self.callPackage ./rqt-runtime-monitor {};
 
  rqt-rviz = self.callPackage ./rqt-rviz {};
@@ -572,7 +790,11 @@ self: super: {
 
  rqt-web = self.callPackage ./rqt-web {};
 
+ rtabmap-ros = self.callPackage ./rtabmap-ros {};
+
  rviz = self.callPackage ./rviz {};
+
+ rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
 
  rviz-plugin-tutorials = self.callPackage ./rviz-plugin-tutorials {};
 
@@ -588,9 +810,15 @@ self: super: {
 
  shape-msgs = self.callPackage ./shape-msgs {};
 
+ sick-tim = self.callPackage ./sick-tim {};
+
  simulators = self.callPackage ./simulators {};
 
  slam-karto = self.callPackage ./slam-karto {};
+
+ slime-ros = self.callPackage ./slime-ros {};
+
+ slime-wrapper = self.callPackage ./slime-wrapper {};
 
  smach = self.callPackage ./smach {};
 
@@ -620,7 +848,13 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ swri-console = self.callPackage ./swri-console {};
+
+ teb-local-planner = self.callPackage ./teb-local-planner {};
+
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
+
+ test-mavros = self.callPackage ./test-mavros {};
 
  tf = self.callPackage ./tf {};
 
@@ -662,6 +896,18 @@ self: super: {
 
  turtlesim = self.callPackage ./turtlesim {};
 
+ twist-mux = self.callPackage ./twist-mux {};
+
+ twist-mux-msgs = self.callPackage ./twist-mux-msgs {};
+
+ ublox = self.callPackage ./ublox {};
+
+ ublox-gps = self.callPackage ./ublox-gps {};
+
+ ublox-msgs = self.callPackage ./ublox-msgs {};
+
+ ublox-serialization = self.callPackage ./ublox-serialization {};
+
  unique-id = self.callPackage ./unique-id {};
 
  unique-identifier = self.callPackage ./unique-identifier {};
@@ -678,7 +924,11 @@ self: super: {
 
  urdfdom-py = self.callPackage ./urdfdom-py {};
 
+ urg-c = self.callPackage ./urg-c {};
+
  urg-stamped = self.callPackage ./urg-stamped {};
+
+ usb-cam = self.callPackage ./usb-cam {};
 
  uuid-msgs = self.callPackage ./uuid-msgs {};
 

--- a/distros/noetic/genpy/default.nix
+++ b/distros/noetic/genpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-genpy";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "1b4fb32adf1a2a62a0320ee282a88f51bc1e7a8cf9b89372b7fa9c52f013b88a";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "a7b6d5508b33b37a27e6e6ffa770b6835f3a51cb964dddba11b6da487c3df7d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometric-shapes/default.nix
+++ b/distros/noetic/geometric-shapes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-geometric-shapes";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/noetic/geometric_shapes/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "d9c37665e4e427ca554f71c1a56afe6e3585996a22d10421094877ff3e9dd757";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pkg-config ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ assimp boost console-bridge eigen eigen-stl-containers octomap qhull random-numbers resource-retriever shape-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains generic definitions of geometric shapes and bodies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/global-planner-tests/default.nix
+++ b/distros/noetic/global-planner-tests/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, map-server, nav-core2, nav-msgs, pluginlib, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-global-planner-tests";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/global_planner_tests/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "c462f9fda089a5e0533506ac0de665a520a58407acafd379e97edcf100f754b7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ libyamlcpp map-server nav-core2 nav-msgs pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A collection of tests for checking the validity and completeness of global planners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/gps-common/default.nix
+++ b/distros/noetic/gps-common/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-filters, message-generation, message-runtime, nav-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-gps-common";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_common/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a1b84a930406a1c806565f9360dd80980f47af90943d0bb3f6e5d166662eed8f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-filters message-runtime nav-msgs roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''GPS messages and common routines for use in GPS drivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/gps-umd/default.nix
+++ b/distros/noetic/gps-umd/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd-client }:
+buildRosPackage {
+  pname = "ros-noetic-gps-umd";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gps_umd/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "ca6c1d82ea1f9ac94136000f14477f0e71c6db70e568ba42113d6e89255a30aa";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gps-common gpsd-client ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''gps_umd metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/gpsd-client/default.nix
+++ b/distros/noetic/gpsd-client/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gps-common, gpsd, pkg-config, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-gpsd-client";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/gps_umd-release/archive/release/noetic/gpsd_client/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "be0044d18339e3a92478f87448d84b8364e491389bacd071825e70ee26ed070a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gps-common gpsd pkg-config roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''connects to a GPSd server and broadcasts GPS fixes 
+   using the NavSatFix message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hebi-cpp-api/default.nix
+++ b/distros/noetic/hebi-cpp-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-hebi-cpp-api";
+  version = "3.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/HebiRobotics/hebi_cpp_api_ros-release/archive/release/noetic/hebi_cpp_api/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "2979c3467c126931c36aa7a0a662ccddc15447159eed6e568a4cbf446e2f1d55";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS package providing access to the HEBI C++ API.'';
+    license = with lib.licenses; [ "HEBI C++ Software License (https://www.hebirobotics.com/softwarelicense)" ];
+  };
+}

--- a/distros/noetic/ifm3d/default.nix
+++ b/distros/noetic/ifm3d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ifm3d-core, image-transport, message-generation, nodelet, pcl-ros, roscpp, rospy, rostest, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-ifm3d";
+  version = "0.6.2-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-ros-release/archive/release/noetic/ifm3d/0.6.2-3.tar.gz";
+    name = "0.6.2-3.tar.gz";
+    sha256 = "491b816559556b3274cd25f3c926ca00335f646f9016cd39c1950f62a3ed9984";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ cv-bridge ifm3d-core image-transport message-generation nodelet pcl-ros roscpp rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ifm pmd-based 3D ToF Camera ROS package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/imu-complementary-filter/default.nix
+++ b/distros/noetic/imu-complementary-filter/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-imu-complementary-filter";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "765a085424e8c978c3731e7ccd0a604cbfe2180313ad9022fc81b499f480895f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ message-filters roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into a quaternion to represent the orientation of the device wrt the global frame. Based on the algorithm by Roberto G. Valenti etal. described in the paper &quot;Keeping a Good Attitude: A Quaternion-Based Orientation Filter for IMUs and MARGs&quot; available at http://www.mdpi.com/1424-8220/15/8/19302 .'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/imu-filter-madgwick/default.nix
+++ b/distros/noetic/imu-filter-madgwick/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-imu-filter-madgwick";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1aaed50ea8d450c79d6a1d5ee821f2d0c907702ceb33d243dbc142df24528194";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs message-filters nodelet pluginlib roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filter which fuses angular velocities, accelerations, and (optionally) magnetic readings from a generic IMU device into an orientation. Based on code by Sebastian Madgwick, http://www.x-io.co.uk/node/8#open_source_ahrs_and_imu_algorithms.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/imu-tools/default.nix
+++ b/distros/noetic/imu-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
+buildRosPackage {
+  pname = "ros-noetic-imu-tools";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "ffbb383013e7396a60c056533ec89c69ddf3b61577bb8e9bee0b059678d083f9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ imu-complementary-filter imu-filter-madgwick rviz-imu-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various tools for IMU devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jderobot-assets/default.nix
+++ b/distros/noetic/jderobot-assets/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-noetic-jderobot-assets";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/assets-release/archive/release/noetic/jderobot_assets/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "18f0a42e849e660c34cbf137c92486d632ad7b28536cca0bc67b5e21559749db";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
+
+  meta = {
+    description = ''The jderobot_assets package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/lgsvl-msgs/default.nix
+++ b/distros/noetic/lgsvl-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, message-generation, message-runtime, ros-environment, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-lgsvl-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/lgsvl_msgs-release/archive/release/noetic/lgsvl_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c51758323666169dd4cbcfbcebcf0ef340f9355818243903089134a79dba40ba";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
+
+  meta = {
+    description = ''The lgsvl_msgs package for ground truth data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libdlib/default.nix
+++ b/distros/noetic/libdlib/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-libdlib";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libdlib/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "704258cc1b7c08346fb6a622edfeac3a1575bfdf2d586039f83baa2d65a792f0";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the external c++ library dlib (http://dlib.net/) in a ROS package, so other packages can use it. The code was obtained from https://github.com/davisking/dlib . For further descriptions and tutorials see the Makefile.tarball and http://dlib.net/ .'';
+    license = with lib.licenses; [ boost ];
+  };
+}

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-libmavconn";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2cca748e7442735b0ffe0e511e2251a1fd52d1962660bde0a5802f504b25c65e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ boost console-bridge mavlink ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MAVLink communication library.
+    This library provide unified connection handling classes
+    and URL to connection object mapper.
+
+    This library can be used in standalone programs.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/noetic/libntcan/default.nix
+++ b/distros/noetic/libntcan/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dpkg }:
+buildRosPackage {
+  pname = "ros-noetic-libntcan";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libntcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "98ea696c9ecf7b235e565db4b6f2f7a85112ad2e61f5128eb3776214b73f5192";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dpkg ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the libntcan to use it as a ros dependency.'';
+    license = with lib.licenses; [ "proprietary" ];
+  };
+}

--- a/distros/noetic/libpcan/default.nix
+++ b/distros/noetic/libpcan/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-libpcan";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libpcan/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "2fe5ad3a5608e48eedb6c3e4bbcd846635f5193cd634dd45e3a1df902a00eaeb";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the libpcan to use it as a ros dependency'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
+buildRosPackage {
+  pname = "ros-noetic-libphidget22";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ec2332c2e545ede5a2ade74049e4b43ae60499112f0938cdf624649086371432";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ libusb1 ];
+  propagatedBuildInputs = [ libusb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the libphidget22 to use it as a ROS dependency'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/libphidgets/default.nix
+++ b/distros/noetic/libphidgets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libusb }:
+buildRosPackage {
+  pname = "ros-noetic-libphidgets";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/libphidgets/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "29fbbbf43e53763c863dedcec0390465376f129591ec58870312be669e462462";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libusb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the libphidgets to use it as a ros dependency'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/locomotor-msgs/default.nix
+++ b/distros/noetic/locomotor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, nav-2d-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-locomotor-msgs";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/locomotor_msgs/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "16aff17501fa3618374445e22d5ae689fbd4f823f8adf089a333074c0222aef6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime nav-2d-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Action definition for Locomotor'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/locomotor/default.nix
+++ b/distros/noetic/locomotor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, locomotor-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-msgs, pluginlib, roscpp, roslint, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-locomotor";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/locomotor/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "e0e82b68112e782b5dc8dd76f386db72bd94fc55bfed500ae21b38eb06b8f174";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ actionlib geometry-msgs locomotor-msgs nav-2d-msgs nav-2d-utils nav-core2 nav-msgs pluginlib roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Locomotor is an extensible path planning coordination engine that replaces move_base. The goal is to provide a mechanism for controlling what happens when the global and local planners succeed and fail. It leverages ROS callback queues to coordinate multiple threads.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/locomove-base/default.nix
+++ b/distros/noetic/locomove-base/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, locomotor, move-base-msgs, nav-2d-utils, nav-core, nav-core-adapter, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-locomove-base";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/locomove_base/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "0149e67caf75a3044563bc816ad903adde38955271e52469d2a50feeff264c53";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ locomotor move-base-msgs nav-2d-utils nav-core nav-core-adapter ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extension of locomotor that implements move_base's functionality.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-can-msgs/default.nix
+++ b/distros/noetic/marti-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-can-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ca2114bcc44c43653c2f105168857c2c6633f3d378be13b5823b3520d91ec467";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_can_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-common-msgs/default.nix
+++ b/distros/noetic/marti-common-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-common-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ad93af25c1967f060d6e6a84b9588126df613fcc268306791cf37b31b9390879";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_common_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-nav-msgs/default.nix
+++ b/distros/noetic/marti-nav-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-nav-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "55d43845ac2386b890a32fcedeea86406b20a5a88837c54a01184932ee34e646";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs marti-common-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_nav_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-perception-msgs/default.nix
+++ b/distros/noetic/marti-perception-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-perception-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "1944d3fcb1a0a6649bab94aaaffaf28df99b47403930867772e39488b3472fd8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_perception_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-sensor-msgs/default.nix
+++ b/distros/noetic/marti-sensor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-marti-sensor-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "22c38f24be40f7e5b7df95cdb415ff1b412044fbb83952c15f7c3fd5c96a7554";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_sensor_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-status-msgs/default.nix
+++ b/distros/noetic/marti-status-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-status-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "d644f0e040f3d69b391558b6d884d5fd89b33a4ed5f7dde1f6438e06bf9d2b9a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_status_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-visualization-msgs/default.nix
+++ b/distros/noetic/marti-visualization-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-visualization-msgs";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "7a8091457a208eded51d3ce82347279115ac074b843eb74af6f850d8fc445b1b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_visualization_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marvelmind-nav/default.nix
+++ b/distros/noetic/marvelmind-nav/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marvelmind-nav";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarvelmindRobotics/marvelmind_nav-release/archive/release/noetic/marvelmind_nav/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "748200b168add3d97206337a2b9a6b434e050c24b6127253bd355918794153e5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Marvelmind local navigation system'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mavros-extras";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ad1b28d956843424b3a843f39c75aeef117d13142454640f3cd012e61fe4a13a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ geometry-msgs mavros mavros-msgs roscpp sensor-msgs std-msgs tf tf2-eigen urdf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extra nodes and plugins for <a href="http://wiki.ros.org/mavros">MAVROS</a>.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mavros-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a8f5afaf6584ecbd4ee97628ce7471be44afd65cf44c4b7bc8a944e9e07ad031";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''mavros_msgs defines messages for <a href="http://wiki.ros.org/mavros">MAVROS</a>.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mavros";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fa1193d3870528f478cc21dba5a159e25db5e64ae1736df92a97cc97742a1e58";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros-msgs message-runtime nav-msgs pluginlib rosconsole-bridge roscpp rospy sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MAVROS -- MAVLink extendable communication node for ROS
+    with proxy for Ground Control Station.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-abstract-core/default.nix
+++ b/distros/noetic/mbf-abstract-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-abstract-core";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "b53606d12bd6f5e4c761882d24185902d80d891225b8c2b7a9927a4ff99e8b45";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides common interfaces for navigation specific robot actions. It contains the AbstractPlanner, AbstractController and AbstractRecovery plugin interfaces. This interfaces have to be implemented by the plugins to make the plugin available for Move Base Flex. The abstract classes provides a meaningful interface enabling the planners, controllers and recovery behaviors to return information, e.g. why something went wrong. Derivided interfaces can, for example, provide methods to initialize the planner, controller or recovery with map representations like costmap_2d, grid_map or other representations.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-abstract-nav/default.nix
+++ b/distros/noetic/mbf-abstract-nav/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-abstract-nav";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "355985f9c150b0ac8022a6243e6757e862540141001cce4c10ac0612b7905652";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mbf-abstract-core mbf-msgs mbf-utility nav-msgs roscpp std-msgs std-srvs tf xmlrpcpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mbf_abstract_nav package contains the abstract navigation server implementation of Move Base Flex (MBF). The abstract navigation server is not bound to any map representation. It provides the actions for planning, controlling and recovering. MBF loads all defined plugins at the program start. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-costmap-core/default.nix
+++ b/distros/noetic/mbf-costmap-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-costmap-core";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_core/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "00cdd0d83ef0d1729d7de90f2b7c99b8f479a33536ac3e9e67968672110c5149";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ costmap-2d geometry-msgs mbf-abstract-core mbf-utility nav-core std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides common interfaces for navigation specific robot actions. It contains the CostmapPlanner, CostmapController and CostmapRecovery interfaces. The interfaces have to be implemented by the plugins to make them available for Move Base Flex using the mbf_costmap_nav navigation implementation. That implementation inherits the mbf_abstract_nav implementation and binds the system to a local and a global costmap.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-costmap-nav/default.nix
+++ b/distros/noetic/mbf-costmap-nav/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-costmap-nav";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "cd3b22be4bb0029ff9fb7bd83e910c3736d256784fc3f192716076e03bf94a10";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs costmap-2d dynamic-reconfigure geometry-msgs mbf-abstract-nav mbf-costmap-core mbf-msgs mbf-utility move-base move-base-msgs nav-core nav-msgs pluginlib roscpp std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mbf_costmap_nav package contains the costmap navigation server implementation of Move Base Flex (MBF). The costmap navigation server is bound to the <a href="wiki.ros.org/costmap_2d">costmap_2d</a> representation. It provides the Actions for planning, controlling and recovering. At the time of start MBF loads all defined plugins. Therefor, it loads all plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
+
+        Additionally the mbf_costmap_nav package comes with a wrapper for the old navigation stack and the plugins which inherits from the <a href="wiki.ros.org/nav_core">nav_core</a> base classes. Preferably it tries to load plugins for the new API. However, plugins could even support both <a href="wiki.ros.org/move_base">move_base</a> and <a href="wiki.ros.org/move_base_flex">move_base_flex</a> by inheriting both base class interfaces located in the <a href="wiki.ros.org/nav_core">nav_core</a> package and in the <a href="mbf_costmap_core">mbf_costmap_core</a> package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-msgs/default.nix
+++ b/distros/noetic/mbf-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-msgs";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_msgs/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "b619e01a59ab9a269f0f3bd220b616ec4af4a200dc0ed36b2a59955822766942";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ genmsg message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime nav-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_flex messages package providing the action definition files for the action GetPath, ExePath, Recovery and MoveBase. The action servers providing these action are implemented in <a href="http://wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a>.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-simple-nav/default.nix
+++ b/distros/noetic/mbf-simple-nav/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-simple-nav";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_simple_nav/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "70c38eb038a9a84f0aa2f22dfabc0157f820155385c74ffd4f2e219dca57a6fc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs mbf-abstract-core mbf-abstract-nav mbf-msgs nav-msgs pluginlib roscpp std-msgs std-srvs tf tf2 tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mbf_simple_nav package contains a simple navigation server implementation of Move Base Flex (MBF). The simple navigation server is bound to no map representation. It provides actions for planning, controlling and recovering. MBF loads all defined plugins which are defined in the lists *planners*, *controllers* and *recovery_behaviors*. Each list holds a pair of a *name* and a *type*. The *type* defines which kind of plugin to load. The *name* defines under which name the plugin should be callable by the actions. 
+
+        It tries to load the defined plugins which implements the defined interfaces in <a href="wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mbf-utility/default.nix
+++ b/distros/noetic/mbf-utility/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mbf-utility";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_utility/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "b5ce41cbc7a1cbfec9f797e8b5da24f640be3d4decb9eadf2b0d5f57aa447652";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp tf tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mbf_utility package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.2.4-r1";
+  version = "0.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.2.4-1.tar.gz";
-    name = "0.2.4-1.tar.gz";
-    sha256 = "4b4f1a000f9974cf5e164bd7bf7d5c24b0bf3cb15e15259bf0544d3f6b744c9a";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.2.5-1.tar.gz";
+    name = "0.2.5-1.tar.gz";
+    sha256 = "85b60493bae8cb00e2715f03d19f7ddd584d9dec53ddbb47faa37f48066a31d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-filters/default.nix
+++ b/distros/noetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-message-filters";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "e141b2c7d7464e217f1f93623196558c7a77a57cdeb10973c21699e2012426ba";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "1e38321ed1341969c525c8452aea10676b0657efd63cd7a85e1949842c009b06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "6cbb420a737b13c86bd8b87ca9af4742385e68c95ae0c154f81d326830a7f571";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "f54382a10e1c8d84f8ba0011493f6954c395c678a793f0df78ef62a1c182778b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-base-flex/default.nix
+++ b/distros/noetic/move-base-flex/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+buildRosPackage {
+  pname = "ros-noetic-move-base-flex";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/move_base_flex/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "81a8e991123c9157df111b97b276dcbde653c927bfc622b2da7c58c5d24d549c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Move Base Flex (MBF) is a backwards-compatible replacement for move_base. MBF can use existing plugins for move_base, and provides an enhanced version of the planner, controller and recovery plugin ROS interfaces. It exposes action servers for planning, controlling and recovering, providing detailed information of the current state and the plugin’s feedback. An external executive logic can use MBF and its actions to perform smart and flexible navigation strategies. Furthermore, MBF enables the use of other map representations, e.g. meshes or grid_map
+       
+       This package is a meta package and refers to the Move Base Flex stack packages.The abstract core of MBF – without any binding to a map representation – is represented by the <a href="http://wiki.ros.org/mbf_abstract_nav">mbf_abstract_nav</a> and the <a href="http://wiki.ros.org/mbf_abstract_core">mbf_abstract_core</a>. For navigation on costmaps see <a href="http://wiki.ros.org/mbf_costmap_nav">mbf_costmap_nav</a> and <a href="http://wiki.ros.org/mbf_costmap_core">mbf_costmap_core</a>.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mrt-cmake-modules/default.nix
+++ b/distros/noetic/mrt-cmake-modules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
+buildRosPackage {
+  pname = "ros-noetic-mrt-cmake-modules";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/noetic/mrt_cmake_modules/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "4ae6263deee53ca6992488b020a7affb3906dd8488d4d317475cd041c0ac1972";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lcov pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
+
+  meta = {
+    description = ''CMake Functions and Modules for automating CMake'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/nav-2d-msgs/default.nix
+++ b/distros/noetic/nav-2d-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav-2d-msgs";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_2d_msgs/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "757a7784db3f7c25021c1a898b42624875239250d7e5ef6fcaaf4d5db9c3e145";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Basic message types for two dimensional navigation, extending from geometry_msgs::Pose2D.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-2d-utils/default.nix
+++ b/distros/noetic/nav-2d-utils/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-2d-msgs, nav-core2, nav-grid, nav-msgs, pluginlib, roscpp, roslint, rostest, rosunit, std-msgs, tf, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+buildRosPackage {
+  pname = "ros-noetic-nav-2d-utils";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_2d_utils/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "d959640a5d0d9e8ae40dc13fa7cca407dadd13a682e86d48777d2a9a1524c92c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest rosunit ];
+  propagatedBuildInputs = [ geometry-msgs nav-2d-msgs nav-core2 nav-grid nav-msgs pluginlib roscpp std-msgs tf tf2-geometry-msgs tf2-ros xmlrpcpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A handful of useful utility functions for nav_core2 packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-core-adapter/default.nix
+++ b/distros/noetic/nav-core-adapter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, dwb-critics, dwb-local-planner, dwb-plugins, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core, nav-core2, nav-grid, nav-msgs, pluginlib, roslint, rostest, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nav-core-adapter";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_core_adapter/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "752d744a559e57210fdfa7137f9e4e3d6b6dba76611c0c0ced759718032a3381";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ dwb-critics dwb-local-planner dwb-plugins roslint rostest ];
+  propagatedBuildInputs = [ costmap-2d geometry-msgs nav-2d-msgs nav-2d-utils nav-core nav-core2 nav-grid nav-msgs pluginlib tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains adapters for using `nav_core` plugins as `nav_core2` plugins and vice versa (more or less).
+      See README.md for more information.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-core2/default.nix
+++ b/distros/noetic/nav-core2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav-2d-msgs, nav-grid, roslint, rosunit, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-nav-core2";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_core2/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "d3d6c85b14aa60aa7c0c75518fbad88d106a9b60b24b36c963a6008abb7ac030";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rosunit ];
+  propagatedBuildInputs = [ nav-2d-msgs nav-grid tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Interfaces for Costmap, LocalPlanner and GlobalPlanner. Replaces nav_core.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-grid-iterators/default.nix
+++ b/distros/noetic/nav-grid-iterators/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nav-2d-msgs, nav-2d-utils, nav-grid, nav-msgs, roscpp, roslint, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-nav-grid-iterators";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_grid_iterators/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "a64ae6f71d047ca140fa84d2c0de528ac43edcae2db173516719186d16932cf0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rosunit ];
+  propagatedBuildInputs = [ nav-2d-msgs nav-2d-utils nav-grid nav-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Iterator implementations for moving around the cells of a nav_grid in a number of common patterns.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-grid-pub-sub/default.nix
+++ b/distros/noetic/nav-grid-pub-sub/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, map-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid, nav-grid-iterators, nav-msgs, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-nav-grid-pub-sub";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_grid_pub_sub/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "77f64c81727d050ed5ed9df7b08b6e8b9090455407738869558eb59e08a8cdf3";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs map-msgs nav-2d-msgs nav-2d-utils nav-core2 nav-grid nav-grid-iterators nav-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Publishers and Subscribers for nav_grid data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nav-grid/default.nix
+++ b/distros/noetic/nav-grid/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-nav-grid";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/nav_grid/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "a049756b3632aeb57553c441653ee75621d4f02fc748b640a064bc6b8237f336";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A templatized interface for overlaying a two dimensional grid on the world.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/opengm/default.nix
+++ b/distros/noetic/opengm/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-opengm";
+  version = "0.6.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_extern-release/archive/release/noetic/opengm/0.6.17-1.tar.gz";
+    name = "0.6.17-1.tar.gz";
+    sha256 = "016b0c5281f1a0207277774024c80ce74f2a08e858e409430a45a243151de243";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the external c++ library opengm in a ROS package, so other packages can use it. It downloads the source code of it and then unzips it. The library is a header-only library with command line interfaces, which aren't used, so it doesn't gets build. For further descriptions and tutorials see the Makefile.tarball and https://github.com/opengm/opengm .
+		Copyright (C) 2013 Bjoern Andres, Thorsten Beier and Joerg H.~Kappes.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-accelerometer";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5008d45d3b16f89ce6aadada1b27c800569fd78bf7aa109e1adb34d796378862";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Accelerometer devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-analog-inputs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "099a0800fa4a249d0586f19e7fce6a02b2a7faae5525d70ef1dc975c78e70e25";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Analog Input devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-api";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d72e7e5dc409ecb5130f27b62236f4b46dbbda55b330088e50c6f211f04043ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libphidget22 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A C++ Wrapper for the Phidgets C API'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-digital-inputs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "8f87cce624e7c7ca9bdc01cd95fd461e439c704d57e0b0eb3786de19f74e2d54";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Digital Input devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-digital-outputs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bafff84d6753bf01b485260dda8bfe5a0f95cb4a643413e84832a4062313da21";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Digital Output devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-drivers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dc86b023d5ae909b88264baf25f097a5efd485659035358c358fba739860994d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libphidget22 phidgets-accelerometer phidgets-analog-inputs phidgets-api phidgets-digital-inputs phidgets-digital-outputs phidgets-gyroscope phidgets-high-speed-encoder phidgets-ik phidgets-magnetometer phidgets-motors phidgets-msgs phidgets-spatial phidgets-temperature ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''API and ROS drivers for Phidgets devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-gyroscope";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6aab07cbe881807fbab88b010733c8f75d8d0380cf5d4ac56e835d9620fc8ab8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Gyroscope devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-high-speed-encoder";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5eb9c8b942edaff8409ddcb71d3588be324ca4ad9bf99f5dae56098f4e4577e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs pluginlib roscpp roslaunch sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets high speed encoder devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-ik";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "665601946428b0ff625a6b17e9e25e957f3492d25de18946667e81da225cc56b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-analog-inputs phidgets-digital-inputs phidgets-digital-outputs roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets InterfaceKit devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-magnetometer";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "83af2e0fb01bdc88b0107f169aaa9e74c66eb1f09dc6bbcd1d2f5fe3eeea1784";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Magnetometer devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-motors";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d23de5f3c6880db3ba8ed1366c6326182116f9fc9064ed614f1f5b14df80a197";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Motor devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ca943bb50346e7b31dec9dece76eae2abd584bd2f5d724b91b11225261899bbc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Custom ROS messages for Phidgets drivers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-spatial";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "60e0b44f3bafdd0b668e4d498d5983867c77af2d27984d48a98090846b233e14";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ imu-filter-madgwick nodelet phidgets-api pluginlib roscpp roslaunch sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Spatial 3/3/3 devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-temperature";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "98ec563d8ba833ce027d04554bb630d65e0f32acaef05ef064401989ddb89db9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Temperature devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
+buildRosPackage {
+  pname = "ros-noetic-pinocchio";
+  version = "2.4.5-r5";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.4.5-5.tar.gz";
+    name = "2.4.5-5.tar.gz";
+    sha256 = "9c5ddbf173290c34c4c9fdbee34428648200f7658ebb893c00eb91d7aaddbab8";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost eigen eigenpy python pythonPackages.numpy urdfdom ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/plotjuggler-msgs/default.nix
+++ b/distros/noetic/plotjuggler-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-plotjuggler-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/noetic/plotjuggler_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "400aab24ff30654a6c55e81d6b6739b9cc86bf2caefa5343a10dfbf92958351a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Special Messages for PlotJuggler'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-plotjuggler";
+  version = "2.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/2.8.0-1.tar.gz";
+    name = "2.8.0-1.tar.gz";
+    sha256 = "f215819553015d48da273217039f844a0c2f206317d430d8df2f28622f9f0895";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''PlotJuggler: juggle with data'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/pybind11-catkin/default.nix
+++ b/distros/noetic/pybind11-catkin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, python, pythonPackages }:
+buildRosPackage {
+  pname = "ros-noetic-pybind11-catkin";
+  version = "2.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/wxmerkt/pybind11_catkin-release/archive/release/noetic/pybind11_catkin/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "7504356d8938e0eaa880204ce834e03dcba505c73de7f83164110857ba0ad7cb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen python pythonPackages.numpy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pybind11 package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/python-qt-binding/default.nix
+++ b/distros/noetic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-noetic-python-qt-binding";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "23f9602d86c54d8adc0b0ff8d3b5d44dd7fcc54da8a48894678f472ef8d8f8e8";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "c4b1abeadfac51d34f01b5268a399b54681ba3fca44efd1775c04e25899663c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-dotgraph/default.nix
+++ b/distros/noetic/qt-dotgraph/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-qt-dotgraph";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "19bacb8b6df52c55c43fc0b90910de239ba43a3e4ff44e6da10cd4a02396ec8a";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "e3093cafe6cbdbdc0f4a2dfa9605337ceac4282522ef07aabd8c31228c43a091";
   };
 
   buildType = "catkin";
   checkInputs = [ pythonPackages.pygraphviz ];
   propagatedBuildInputs = [ python-qt-binding pythonPackages.pydot ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_dotgraph provides helpers to work with dot graphs.'';

--- a/distros/noetic/qt-gui-app/default.nix
+++ b/distros/noetic/qt-gui-app/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qt-gui }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt-gui }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-app";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "47aee409ecd4405715720b14a5c024fe020f9f8b28b45683906fcd0999faa4b1";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "0f1e6ba6eca18e5e5084ca6d34756af91baf3cfacb4247d7861abb87479f2303";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ qt-gui ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_app provides the main to start an instance of the integrated graphical user interface provided by qt_gui.'';

--- a/distros/noetic/qt-gui-core/default.nix
+++ b/distros/noetic/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-core";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "ead85c48b23541fa5c9cd598bfc43d2dad512c25a9710b156e2a22cc35ce212e";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "021c8ec1f3f4641abae8da00e9735a7464f8e0617cae45d2f08a7e0e34f93d2a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-cpp/default.nix
+++ b/distros/noetic/qt-gui-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, pythonPackages, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-cpp";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c253b6dd2fa58f5bb6a0d2bf7544dc3047c8460ec56e1d5df48e9adb8cb4bdca";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "806e9096994b81cc881e0a8bfded1d829573dfdc56c0a2cb8cd6e30fb43948f5";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules pkg-config python-qt-binding qt5.qtbase ];
   propagatedBuildInputs = [ pluginlib qt-gui tinyxml ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_cpp provides the foundation for C++-bindings for qt_gui and creates bindings for every generator available.

--- a/distros/noetic/qt-gui-py-common/default.nix
+++ b/distros/noetic/qt-gui-py-common/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-py-common";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "0e99e1f9b5075fddd8809ec0cc4441840a8c2efafb4a347d7e32391952c6f894";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "974b4ad8ac44f6666f9f23880479f5912839bef52d158f7cbbbefb8022da3e4c";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_py_common provides common functionality for GUI plugins written in Python.'';

--- a/distros/noetic/qt-gui/default.nix
+++ b/distros/noetic/qt-gui/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d5020bbb2db4c674cf9b9d153f50d3c5727f8dc4b34c37e73d9bb2064da2184d";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "a9d64ebc5adde5d914b9019cac696a7e337246f5e275e139a501d91d9e90a4c7";
   };
 
   buildType = "catkin";
   buildInputs = [ pythonPackages.pyqt5 qt5.qtbase ];
   propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg tango-icon-theme ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui provides the infrastructure for an integrated graphical user interface based on Qt.

--- a/distros/noetic/remote-rosbag-record/default.nix
+++ b/distros/noetic/remote-rosbag-record/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosbag, roscpp, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-remote-rosbag-record";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/noetic/remote_rosbag_record/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "2ee39861317e8d326b59c9c5e9df703ba2b648e2b49269690c603e509c1ee49b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosbag roscpp sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The remote_rosbag_record package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/rgbd-launch/default.nix
+++ b/distros/noetic/rgbd-launch/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, rostest, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-rgbd-launch";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rgbd_launch-release/archive/release/noetic/rgbd_launch/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3068bc034a4ccf0aa8810a9b825b43e4c300e7ed7bb9626ae1ea97ffcda41b40";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ depth-image-proc image-proc nodelet tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files to open an RGBD device and load all nodelets to 
+     convert raw depth/RGB/IR streams to depth images, disparity images, 
+     and (registered) point clouds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+buildRosPackage {
+  pname = "ros-noetic-robot-localization";
+  version = "2.6.8-r2";
+
+  src = fetchurl {
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.6.8-2.tar.gz";
+    name = "2.6.8-2.tar.gz";
+    sha256 = "fc11542b1c95dbd4cd7670c083f17354691d842ca4225ecb0dbc287e45db9115";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation pythonPackages.catkin-pkg roslint ];
+  checkInputs = [ rosbag rostest rosunit ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides nonlinear state estimation through sensor fusion of an abritrary number of sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-navigation/default.nix
+++ b/distros/noetic/robot-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-queue, dlux-global-planner, dlux-plugins, dwb-critics, dwb-local-planner, dwb-msgs, dwb-plugins, global-planner-tests, locomotor, locomotor-msgs, locomove-base, nav-2d-msgs, nav-2d-utils, nav-core-adapter, nav-core2, nav-grid, nav-grid-iterators, nav-grid-pub-sub }:
+buildRosPackage {
+  pname = "ros-noetic-robot-navigation";
+  version = "0.2.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/robot_navigation-release/archive/release/noetic/robot_navigation/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "4046b74c02d3a10d59141aa919dbbdd06c1fb2af9f69731d1da09dbe1e353013";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ costmap-queue dlux-global-planner dlux-plugins dwb-critics dwb-local-planner dwb-msgs dwb-plugins global-planner-tests locomotor locomotor-msgs locomove-base nav-2d-msgs nav-2d-utils nav-core-adapter nav-core2 nav-grid nav-grid-iterators nav-grid-pub-sub ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robot_navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros-comm/default.nix
+++ b/distros/noetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-ros-comm";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "fd6c6161ee4313f31635953364e052154dfa7bf7e67951b9ee31db9a2e7a7981";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "e554fe5cbbe36ecefd7c8c3744cae74d6680822a2dd5117f12dc73fd456e6f9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-emacs-utils/default.nix
+++ b/distros/noetic/ros-emacs-utils/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp-repl, slime-ros, slime-wrapper }:
+buildRosPackage {
+  pname = "ros-noetic-ros-emacs-utils";
+  version = "0.4.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/noetic/ros_emacs_utils/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "9eaa7ec1b09685c7c7006a155e56372e9cd8fdc21055228f7f6d8b5dc15729b5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosemacs roslisp-repl slime-ros slime-wrapper ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A metapackage of Emacs utils for ROS.
+    Only there for simplifying the release process.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "cf179df8b0c79e17be6250ef4842eadf64e4588b877c08695595b34e08201255";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "20b0bd750d975fbf728b0270691dae4f83d16aa2debce70eca6c10f46356f004";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosapi/default.nix
+++ b/distros/noetic/rosapi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbridge-library, rosgraph, rosnode, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-rosapi";
+  version = "0.11.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosapi/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "74053978b919ede8083cebac5be795d4b07c799753178654575044e5ea366c9b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosbridge-library rosgraph rosnode rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides service calls for getting ros meta-information, like list of
+    topics, services, params, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbag-storage/default.nix
+++ b/distros/noetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-storage";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "e20e610fa0be4e264388045bd620fa13767ed9eb8ed52ff21e65fb3f56ff7b77";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "f6893769241c0595c8305adc19efcc34bed4ab895b3389be067337e7ed7d654e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag/default.nix
+++ b/distros/noetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-rosbag";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "0c26833cc470ad39df6911c661a6a1300cd3c40ea689a8805985e26a90c32509";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "2c4650300776d33f616f122645638a44e0c1e98f4405fe22e28e0fdd7d5cb6e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "518f87b3b45c2656cd283495f9e32994d67f12d80c4c658371fa8e211f4d0212";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "5746cf5cc86ee06aa065e5507475690734fb0e8af661d15d5b15e17992d5f1bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "b42893c7b5b9b5dacbc179d35c10aaa72700b490a7791309201443bfacf1475a";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "944de8426dd933dd91962b85d3563840b4f014008582eb8b26ea427ca5385c3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbridge-library/default.nix
+++ b/distros/noetic/rosbridge-library/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rosbridge-library";
+  version = "0.11.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_library/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "2b73a44880f5525c50545fe549d87eba47079c86cdf7f787abe8005fdf6a5636";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pythonPackages.bson pythonPackages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The core rosbridge package, responsible for interpreting JSON and performing
+    the appropriate ROS action, like subscribe, publish, call service, and
+    interact with params.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbridge-msgs/default.nix
+++ b/distros/noetic/rosbridge-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rosbridge-msgs";
+  version = "0.11.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_msgs/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "4e481540ec971bfe380f1c5b5ab6b06a5ea0bce86b8146275f2b9e44d5c920f5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package containing message files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbridge-server/default.nix
+++ b/distros/noetic/rosbridge-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-rosbridge-server";
+  version = "0.11.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_server/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "a30d3b450f73bcec182cbaf041dcd25ab082b8e29944fb65eb4db3cf54976f9c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A WebSocket interface to rosbridge.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbridge-suite/default.nix
+++ b/distros/noetic/rosbridge-suite/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosapi, rosbridge-library, rosbridge-server }:
+buildRosPackage {
+  pname = "ros-noetic-rosbridge-suite";
+  version = "0.11.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/rosbridge_suite-release/archive/release/noetic/rosbridge_suite/0.11.9-1.tar.gz";
+    name = "0.11.9-1.tar.gz";
+    sha256 = "eea5d3fa8fb06e8e9c3ba20edc65c62b6b70367bfe4ac1486976af092abc7a99";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.
+    There are a variety of front ends that interface with rosbridge, including
+    a WebSocket server for web browsers to interact with.
+
+    Rosbridge_suite is a meta-package containing rosbridge, various front end
+    packages for rosbridge like a WebSocket package, and helper packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "58ba69f0a603aa09c2ad828fbaf88473b591e87894cf3940d995b17dcd291873";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "9b62ec7307ba7981898db9bc639dccdafd53db8ba3a1127d1824939168b5d161";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "47928b0d4ab5a669d7ded587194267cc61ff89f3d97941c9f9e1ae896bc23405";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "d020d768c46a33a3892a3fd64a11a8a6a5ab9207888e6a74d1f5f491729dfb1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-core/default.nix
+++ b/distros/noetic/roscpp-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-serialization, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-core";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e8cfe369833f0bb43c0d17f5a5bac1a90b4253c258efa763e1c20c457c8a9e07";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_core/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "d40d836804305c723cddab20b673c74bcdae047064a5f342b266b162830474e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-serialization/default.nix
+++ b/distros/noetic/roscpp-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, roscpp-traits, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-serialization";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "96b3cf1eb1c300973acfe4948b859b31e5c4bab973237cb089a6f00d68c71b24";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_serialization/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "ddbc65e42b525bdb29ec8795e05470984cec6c90839d16d577e6b752017e355a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp-traits/default.nix
+++ b/distros/noetic/roscpp-traits/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-roscpp-traits";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "6714f4f38a04669ecff9cfa49c6af5e7a17cc5b3b5d433cbdaca0b8bbfaad28f";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/roscpp_traits/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "4393d3b11553d92ae6044533a06583b40ffa8914b08ccf8127d0cb49ee1dbddf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp/default.nix
+++ b/distros/noetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-roscpp";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "b1e411ff5f188d408a0f6308943a661ed3f93be9e28d93e543323b8ae2e7782f";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "085de823d239af05dfe37a15c84be52e3f4c115fa405d86f69e798070c23e3b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "f8a4841462a1e41be5366498052055442ab9990dfe0b8a9208052f16b4d11b71";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "ed7dd2564d4f249bec2a811c028774ce4cd6c96e8d88ab5dcc5236fe79b1ac8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosemacs/default.nix
+++ b/distros/noetic/rosemacs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, emacs }:
+buildRosPackage {
+  pname = "ros-noetic-rosemacs";
+  version = "0.4.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/noetic/rosemacs/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "00df88d295329f832fcb84be69639f7e81eef42198301c10f323c0aa77ee9baf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ emacs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS tools for those who live in Emacs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosfmt/default.nix
+++ b/distros/noetic/rosfmt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosconsole, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-rosfmt";
+  version = "6.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/xqms/rosfmt-release/archive/release/noetic/rosfmt/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "be52a461360a5d459c3794a4f167a4b9dc4d8032d952978fccb2f54eca2e51c0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosconsole roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''fmt is an open-source formatting library for C++.
+		It can be used as a safe and fast alternative to (s)printf and IOStreams.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosgraph/default.nix
+++ b/distros/noetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "b8a4127fdb1eef1eaaae9e85e0c42d594d68c29825849d0b960fbdf7664a1106";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "4ad4a471be1afacc01c4507e394a4ea23ff61dc10a2f3ef9afd2f9b14180124a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "8c38a3e5459feaa17f9071a14e279712b2743fd1da3bad5a10e819b96615fdb5";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "057f6f50542b02361a0158f482d2f490ce5943a65c9086c13a36b44a0d512cf1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslaunch/default.nix
+++ b/distros/noetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslaunch";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "3ac52af2ebf5db417b8c7f17e590c083767a7872a55e772c82d53cc7324977d1";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "9191adb1cf8ec5d93c6b00a11cee802a2352cd035d0c30e237d743c3027bc8cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, pythonPackages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "2ec5a8ea96fc4ccee2b3858a3c49ed266dfe69b0bd58353d4456c4e24efd57ba";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "a823579f6a06906bf1be3fe2b41697c75854178448b23e237eb83eb179449236";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslisp-repl/default.nix
+++ b/distros/noetic/roslisp-repl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-ros, slime-wrapper }:
+buildRosPackage {
+  pname = "ros-noetic-roslisp-repl";
+  version = "0.4.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/noetic/roslisp_repl/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "e4f3cce9f9fab5757e030e3b2f62823aa548aca633284d677be17078ca6d9805";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosemacs roslisp sbcl slime-ros slime-wrapper ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a script that launches Emacs with Slime (the
+    Superior Lisp Interaction Mode) ready for Lisp development and
+    roslisp.'';
+    license = with lib.licenses; [ publicDomain ];
+  };
+}

--- a/distros/noetic/roslz4/default.nix
+++ b/distros/noetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslz4";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "d2f700006232a663a1add55254dd7c8c909552f18188891335e15cae9ce74676";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "1826944df6726d437c62a53bfeee216e21b98cbc078e43d0fcde65f2f7d17879";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "3b5a9f7bb22b17436bd67b56ce5a8c16d8f4836c41c7615bfa1f2750ef006bed";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "8887dedc14b16a0e9c9a2f5d01712344cebc667ebf29b298c6b0d9172648dde4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmaster/default.nix
+++ b/distros/noetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosmaster";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "63a11328445b9029ca1bfd87858b190b837d324a1b7a271d5dce895f13ff038f";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "b1291c70b6c0ea64e0f8112355cbd6ce315140c6038556c2e4c3dabc5fa7ad6d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon-core/default.nix
+++ b/distros/noetic/rosmon-core/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python, pythonPackages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
+buildRosPackage {
+  pname = "ros-noetic-rosmon-core";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_core/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "1a28b4662b9ef7ec6f67801801c03892c68888cc8f1e0bf92c7d87da04ec454e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python ];
+  checkInputs = [ catch-ros pythonPackages.rospkg rostest ];
+  propagatedBuildInputs = [ boost cmake-modules diagnostic-msgs libyamlcpp ncurses rosbash roscpp rosfmt roslib rosmon-msgs rospack std-msgs tinyxml ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node launcher and monitor for ROS. rosmon is a replacement
+		for the roslaunch tool, focused on performance, remote
+		monitoring, and usability.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosmon-msgs/default.nix
+++ b/distros/noetic/rosmon-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rosmon-msgs";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_msgs/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "8b9a71c387ab6dd04e35bf38d424eaaee017ba59c646674c5e8c5b0be242e0eb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-generation std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for rosmon, the node launcher and monitor for ROS.
+		rosmon is a replacement for the roslaunch tool, focused on performance,
+		remote monitoring, and usability.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosmon/default.nix
+++ b/distros/noetic/rosmon/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosmon-core, rqt-rosmon }:
+buildRosPackage {
+  pname = "ros-noetic-rosmon";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "f6a257b51d9f6fc0e1e4db30e590d4cbb32ddaf23a1ca5667a49d214e9d9bc69";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosmon-core rqt-rosmon ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node launcher and monitor for ROS. rosmon is a replacement
+		for the roslaunch tool, focused on performance, remote
+		monitoring, and usability.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosmsg/default.nix
+++ b/distros/noetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosmsg";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "c88c5be34e6ab334c8c0190c7469f63a33927185cc83fcd63adc8177702d7f6e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "a7e94bdbddd95e04e779dbe98d521aeef16b34e2dc7822d60561cf0771749a7b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosnode/default.nix
+++ b/distros/noetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-rosnode";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "b596564a996c5e6cfe1b975a76cd7ada3efb606625564f67c2c2d2a57d09544c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "d3c650c4b61dff991b97394fc3594363675d715c18bee27f96db97cbd836b81e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosout/default.nix
+++ b/distros/noetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosout";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "edcfe252192acf34ae9008a39f54f7ad51e4c64698c34596c9712e76ff5169a7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "35295be808290750efa22a08b9dea63e2db155eb787e32c217fb5bfd570b6601";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosparam-shortcuts/default.nix
+++ b/distros/noetic/rosparam-shortcuts/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, eigen-conversions, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rosparam-shortcuts";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/rosparam_shortcuts-release/archive/release/noetic/rosparam_shortcuts/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "620eb7c2013dac4e8b2ebb9704e36e702482639ffa6af293058870c6001d8ab7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules eigen roslint ];
+  propagatedBuildInputs = [ eigen-conversions roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Quickly load variables from rosparam with good command line error checking.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosparam/default.nix
+++ b/distros/noetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosparam";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "b355a1c23076ca762d541802954dc3fa8d409bc148bde9b21434b4cd37cdbed7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "a485aeb5aa3d291212987f0807c80c31d2b14a9582a87157a98f28233b679fab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-rospy-message-converter";
+  version = "0.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "a355bffe44bf9b82f9aad47ad704d0e11667df66daa9f81c8112458be18f5408";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ rosunit std-srvs ];
+  propagatedBuildInputs = [ message-runtime roslib rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts between Python dictionaries and JSON to rospy messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rospy/default.nix
+++ b/distros/noetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "029119bf173c328f9baade935660fb4c0d51dde299392d019cf7862bf3848cb9";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "821ab132e25d18ceb7ee90f2a65a3570ce945cb96d8d1f19e59c30dafcb73285";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosservice/default.nix
+++ b/distros/noetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosservice";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "b55ab9db8ab7e58fe8417686dd03acbd92e4749ce0be737f862a54ab8356a741";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "667123f16a6a2c13640d94281a795a8fdf5b9643e863065499aa5d9203642f48";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostest/default.nix
+++ b/distros/noetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rostest";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "c7fd0ff32e088dd34fa45f9c4acebe3bfc49b42f2927dd937978597895be793e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "060d801dbaabaca8ec8c27222796cd5be6924a7f1d77e6f7e0f68a84397a802e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostime/default.nix
+++ b/distros/noetic/rostime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common }:
 buildRosPackage {
   pname = "ros-noetic-rostime";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "85f9a8987b25140c89de123b434d19ab331b8d15524e54f7d849b66b1e148232";
+    url = "https://github.com/ros-gbp/roscpp_core-release/archive/release/noetic/rostime/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "7111aa9956e9e8ec623edd54c59b344c6488b65aed8b1d768a5a7a55b467c47c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostopic/default.nix
+++ b/distros/noetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rostopic";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "7cb372cb60845a5ceb3d7bafdff3717bdd06bc5e0d09b431f234729b7874e091";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "f4bb6e4caf58ea8a7e0fdf7d6519ca3255b78200ef1a1bb62a7b28c1832c3825";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.1-r1";
+  version = "1.15.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.1-1.tar.gz";
-    name = "1.15.1-1.tar.gz";
-    sha256 = "3c0025475094e240e2bbec9bda49241909b8f7e684001417da7de9f4e42cdd00";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.4-1.tar.gz";
+    name = "1.15.4-1.tar.gz";
+    sha256 = "8f94af7481f9c1ab894de78e65a72a75b6a8282ead882365935b9ca037cc347f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roswtf/default.nix
+++ b/distros/noetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-roswtf";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "02bb579466258fe706a207818457debfc3d9f11896a1d2a47eb0cb32881e4ef2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "f5177fdbda944e73e015f20f4385c8f1b478d3638b2bc85f6cc4b9cf7605c983";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-moveit/default.nix
+++ b/distros/noetic/rqt-moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosnode, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, rqt-topic, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-moveit";
-  version = "0.5.8-r1";
+  version = "0.5.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_moveit-release/archive/release/noetic/rqt_moveit/0.5.8-1.tar.gz";
-    name = "0.5.8-1.tar.gz";
-    sha256 = "d05252513947250337ce502ac45a9bcd114e8cf411991cfcb59d9880a012cb87";
+    url = "https://github.com/ros-gbp/rqt_moveit-release/archive/release/noetic/rqt_moveit/0.5.9-3.tar.gz";
+    name = "0.5.9-3.tar.gz";
+    sha256 = "6b85bd683e75127057f735a46326c4bd71baac6a3b0d09bfbcdcc79c2c9cc3bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-rosmon/default.nix
+++ b/distros/noetic/rqt-rosmon/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, roscpp, rosmon-msgs, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-rosmon";
+  version = "2.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rqt_rosmon/2.3.2-1.tar.gz";
+    name = "2.3.2-1.tar.gz";
+    sha256 = "828d7c361bb2134b8c188756cb51af94cee9129d741da2233726d877fd05542a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase ];
+  propagatedBuildInputs = [ pluginlib roscpp rosmon-msgs rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt GUI for rosmon, the node launcher and monitor for ROS.
+		rosmon is a replacement for the roslaunch tool, focused on performance,
+		remote monitoring, and usability.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rtabmap-ros";
+  version = "0.20.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.0-3.tar.gz";
+    name = "0.20.0-3.tar.gz";
+    sha256 = "f01101e3f851e0da82c56d306fcbe7808d05531760e5fb94aa85ab45473429d4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation pcl ];
+  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin genmsg ];
+
+  meta = {
+    description = ''RTAB-Map's ros-pkg. RTAB-Map is a RGB-D SLAM approach with real-time constraints.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rviz-imu-plugin/default.nix
+++ b/distros/noetic/rviz-imu-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-imu-plugin";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "8541afeb218d867cff4f3ab02461a87006333db6913ae74b642dabebd6f11d7f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt5.qtbase roscpp rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RVIZ plugin for IMU visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sick-tim/default.nix
+++ b/distros/noetic/sick-tim/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-sick-tim";
+  version = "0.0.17-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/sick_tim-release/archive/release/noetic/sick_tim/0.0.17-1.tar.gz";
+    name = "0.0.17-1.tar.gz";
+    sha256 = "9bd217db019fea42671703198dc50adffe67b1ad94c7902244fea03e20de606a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libusb libusb1 robot-state-publisher roscpp sensor-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS driver for the SICK TiM and the SICK MRS 1000 laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/slime-ros/default.nix
+++ b/distros/noetic/slime-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-wrapper }:
+buildRosPackage {
+  pname = "ros-noetic-slime-ros";
+  version = "0.4.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/noetic/slime_ros/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "f5c490a4f15902c50345bf41af5214421014b5847df8a0fa7a9dd27aa0ceecbf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosemacs roslisp sbcl slime-wrapper ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extensions for slime to assist in working with ROS packages'';
+    license = with lib.licenses; [ publicDomain ];
+  };
+}

--- a/distros/noetic/slime-wrapper/default.nix
+++ b/distros/noetic/slime-wrapper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, emacs }:
+buildRosPackage {
+  pname = "ros-noetic-slime-wrapper";
+  version = "0.4.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/noetic/slime_wrapper/0.4.15-1.tar.gz";
+    name = "0.4.15-1.tar.gz";
+    sha256 = "b8eb1de5c2845d5b177173c6d6ad7e060044f327cf0da9711ba30eff11bb2ff1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ emacs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS wrapper for slime'';
+    license = with lib.licenses; [ publicDomain ];
+  };
+}

--- a/distros/noetic/swri-console/default.nix
+++ b/distros/noetic/swri-console/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, qt5, rosbag-storage, roscpp, rosgraph-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-swri-console";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/swri_console-release/archive/release/noetic/swri_console/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a4d06a2b1af47088c200a94adcc12a38c7108e63cacc3e354fac93782e983ff8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost qt5.qtbase rosbag-storage roscpp rosgraph-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A rosout GUI viewer developed at Southwest Research Insititute as an
+     alternative to rqt_console.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/teb-local-planner/default.nix
+++ b/distros/noetic/teb-local-planner/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, costmap-2d, costmap-converter, dynamic-reconfigure, geometry-msgs, interactive-markers, libg2o, mbf-costmap-core, mbf-msgs, message-generation, message-runtime, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-teb-local-planner";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/teb_local_planner-release/archive/release/noetic/teb_local_planner/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "c435f9715885fbe7e9ae79250d8fd829949c76818d2a10c7a3182bf69656ef31";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules message-generation tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ base-local-planner costmap-2d costmap-converter dynamic-reconfigure geometry-msgs interactive-markers libg2o mbf-costmap-core mbf-msgs message-runtime nav-core nav-msgs pluginlib roscpp std-msgs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The teb_local_planner package implements a plugin
+    to the base_local_planner of the 2D navigation stack.
+    The underlying method called Timed Elastic Band locally optimizes
+    the robot's trajectory with respect to trajectory execution time,
+    separation from obstacles and compliance with kinodynamic constraints at runtime.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-test-mavros";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8333852256cb662e7d7b7219aefa709f6049ed8cc38b958bcc38fb6629fc030a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles cmake-modules ];
+  propagatedBuildInputs = [ control-toolbox eigen eigen-conversions geometry-msgs mavros mavros-extras roscpp std-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tests for MAVROS package'';
+    license = with lib.licenses; [ bsdOriginal gpl3 lgpl2 ];
+  };
+}

--- a/distros/noetic/topic-tools/default.nix
+++ b/distros/noetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-topic-tools";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "d41e99b215496e58e73ea6061491bd82367393e4bd6b9784964d3022d701d4c1";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "667ae42f21d555b5b08dde6b39d1ffd8c574695b97fb7ac734728049e51a1757";
   };
 
   buildType = "catkin";

--- a/distros/noetic/twist-mux-msgs/default.nix
+++ b/distros/noetic/twist-mux-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-twist-mux-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/twist_mux_msgs-release/archive/release/noetic/twist_mux_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "782864dff4f4c569eab485e232f3e00785b6c7dc1b6dc1702f6492ab577b73de";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The twist_mux msgs and actions package'';
+    license = with lib.licenses; [ cc-by-nc-sa-40 ];
+  };
+}

--- a/distros/noetic/twist-mux/default.nix
+++ b/distros/noetic/twist-mux/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, geometry-msgs, roscpp, rospy, rostest, rostopic, std-msgs, twist-mux-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-twist-mux";
+  version = "3.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/noetic/twist_mux/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "8e34204ea1a225e4bf0610fb0ce3d0df6a107fa57d4a90111edee495367bce81";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  checkInputs = [ rospy rostopic ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs roscpp std-msgs twist-mux-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Twist multiplexer, which multiplex several velocity commands (topics) and
+      allows to priorize or disable them (locks).'';
+    license = with lib.licenses; [ cc-by-nc-sa-40 ];
+  };
+}

--- a/distros/noetic/ublox-gps/default.nix
+++ b/distros/noetic/ublox-gps/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
+buildRosPackage {
+  pname = "ros-noetic-ublox-gps";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_gps/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "a2c10e5abab19013e7676686dfe5b12651ebb5e631927a0f1e843178e4ad8acf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-updater roscpp roscpp-serialization tf ublox-msgs ublox-serialization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for u-blox GPS devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ublox-msgs/default.nix
+++ b/distros/noetic/ublox-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
+buildRosPackage {
+  pname = "ros-noetic-ublox-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2ea427a899457d133eb6b91b137f45f838e7dfa7df435cc0c8cbc17dd9a15690";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime sensor-msgs std-msgs ublox-serialization ];
+  nativeBuildInputs = [ catkin message-generation ];
+
+  meta = {
+    description = ''ublox_msgs contains raw messages for u-blox GNSS devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ublox-serialization/default.nix
+++ b/distros/noetic/ublox-serialization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
+buildRosPackage {
+  pname = "ros-noetic-ublox-serialization";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_serialization/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "a133c6b45e255e0ea78a960329bc0dc65874121e2fecd08eddc1e927f21d8a67";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp roscpp-serialization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ublox_serialization provides header files for serialization of ROS messages to and from u-blox message format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ublox/default.nix
+++ b/distros/noetic/ublox/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
+buildRosPackage {
+  pname = "ros-noetic-ublox";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "89816ed65b672b6513617166e6c264a54de40ad662e028177af280fa379aec6a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ublox-gps ublox-msgs ublox-serialization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a ublox_gps node for u-blox GPS receivers, messages, and serialization packages for the binary UBX protocol.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/urdf-sim-tutorial/default.nix
+++ b/distros/noetic/urdf-sim-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, gazebo-ros, gazebo-ros-control, joint-state-controller, position-controllers, robot-state-publisher, rqt-robot-steering, rviz, urdf-tutorial, xacro }:
 buildRosPackage {
   pname = "ros-noetic-urdf-sim-tutorial";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/noetic/urdf_sim_tutorial/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "b7315898efb1689c164dc6738d611baa0826e27f9df47828a591a3055ede1ce0";
+    url = "https://github.com/ros-gbp/urdf_sim_tutorial-release/archive/release/noetic/urdf_sim_tutorial/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "e3d91a593655e47ed8dea7296e26bc63d7d30d425dc6ee10511dc25fea71132d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-c/default.nix
+++ b/distros/noetic/urg-c/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-urg-c";
+  version = "1.0.405-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urg_c-release/archive/release/noetic/urg_c/1.0.405-1.tar.gz";
+    name = "1.0.405-1.tar.gz";
+    sha256 = "c2af896d06b72140f91876cdc806f1d43015c872b50693a0303ec93b0d7a3750";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The urg_c package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/usb-cam/default.nix
+++ b/distros/noetic/usb-cam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, ffmpeg, image-transport, roscpp, sensor-msgs, std-msgs, std-srvs, v4l_utils }:
+buildRosPackage {
+  pname = "ros-noetic-usb-cam";
+  version = "0.3.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/noetic/usb_cam/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "7b03e9cd278dce5cd3c97057c87beb4f13da3089055efab56cb8f7dac80397c2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-info-manager ffmpeg image-transport roscpp sensor-msgs std-msgs std-srvs v4l_utils ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS Driver for V4L USB Cameras'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/xmlrpcpp/default.nix
+++ b/distros/noetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-xmlrpcpp";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "ca311afd6d1619cd62f4e190130c8ff3973e9cde079b0cbdd2fbf75c7ccdb5cb";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "193951b33b8b4e77c03c8d96bb1e223372505251b99ff76512ba0b076f3f7c77";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit d1f41bd290d7721f134bece70fc3115d6834c92a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *lgsvl-msgs 0.0.3-r1*
* *libphidget22 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-accelerometer 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-analog-inputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-api 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-digital-inputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-digital-outputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-drivers 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-gyroscope 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-high-speed-encoder 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-ik 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-magnetometer 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-motors 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-msgs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-spatial 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-temperature 2.0.1-r1 --> 2.0.2-r1*

Eloquent Changes:
-----------------
* *kobuki-firmware 1.2.0-r2 --> 1.2.0-r3*
* *lgsvl-msgs 0.0.3-r1*
* *libphidget22 2.0.1-r1 --> 2.0.2-r1*
* *novatel-gps-driver 4.0.3-r1*
* *novatel-gps-msgs 4.0.3-r1*
* *phidgets-accelerometer 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-analog-inputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-api 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-digital-inputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-digital-outputs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-drivers 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-gyroscope 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-high-speed-encoder 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-ik 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-magnetometer 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-motors 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-msgs 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-spatial 2.0.1-r1 --> 2.0.2-r1*
* *phidgets-temperature 2.0.1-r1 --> 2.0.2-r1*
* *rqt-moveit 1.0.1-r2*

Kinetic Changes:
----------------
* *lgsvl-msgs 0.0.2-r1 --> 0.0.3-r1*
* *libphidget21 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-api 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-drivers 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-high-speed-encoder 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-ik 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-imu 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-msgs 0.7.10-r1*
* *pinocchio 2.4.0-r2 --> 2.4.5-r1*

Melodic Changes:
----------------
* *catkin 0.7.23-r1 --> 0.7.26-r1*
* *chomp-motion-planner 1.0.3-r2 --> 1.0.4-r1*
* *control-toolbox 1.18.0-r1 --> 1.18.2-r1*
* *csm 1.0.2-r2*
* *genmsg 0.5.15-r1 --> 0.5.16-r1*
* *genpy 0.6.9-r1 --> 0.6.12-r1*
* *laser-filters 1.8.10-r1 --> 1.8.11-r1*
* *lgsvl-msgs 0.0.2-r1 --> 0.0.3-r1*
* *libphidget21 0.7.9-r1 --> 0.7.10-r1*
* *marvelmind-nav 1.0.11-r1*
* *message-filters 1.14.5-r1 --> 1.14.6-r1*
* *mk 1.14.8-r1 --> 1.14.9-r1*
* *moveit 1.0.3-r2 --> 1.0.4-r1*
* *moveit-chomp-optimizer-adapter 1.0.3-r2 --> 1.0.4-r1*
* *moveit-controller-manager-example 1.0.3-r2 --> 1.0.4-r1*
* *moveit-experimental 1.0.3-r2 --> 1.0.4-r1*
* *moveit-fake-controller-manager 1.0.3-r2 --> 1.0.4-r1*
* *moveit-kinematics 1.0.3-r2 --> 1.0.4-r1*
* *moveit-planners 1.0.3-r2 --> 1.0.4-r1*
* *moveit-planners-chomp 1.0.3-r2 --> 1.0.4-r1*
* *moveit-planners-ompl 1.0.3-r2 --> 1.0.4-r1*
* *moveit-plugins 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-benchmarks 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-control-interface 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-manipulation 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-move-group 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-occupancy-map-monitor 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-perception 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-planning 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-planning-interface 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-robot-interaction 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-visualization 1.0.3-r2 --> 1.0.4-r1*
* *moveit-ros-warehouse 1.0.3-r2 --> 1.0.4-r1*
* *moveit-runtime 1.0.3-r2 --> 1.0.4-r1*
* *moveit-setup-assistant 1.0.3-r2 --> 1.0.4-r1*
* *moveit-simple-controller-manager 1.0.3-r2 --> 1.0.4-r1*
* *mrt-cmake-modules 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-api 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-drivers 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-high-speed-encoder 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-ik 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-imu 0.7.9-r1 --> 0.7.10-r1*
* *phidgets-msgs 0.7.10-r1*
* *pinocchio 2.4.0-r2 --> 2.4.5-r1*
* *python-qt-binding 0.4.0-r1 --> 0.4.2-r1*
* *qt-dotgraph 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-app 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-core 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-cpp 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-py-common 0.4.0-r1 --> 0.4.1-r1*
* *robot-localization 2.6.6-r1 --> 2.6.7-r1*
* *ros 1.14.8-r1 --> 1.14.9-r1*
* *ros-comm 1.14.5-r1 --> 1.14.6-r1*
* *rosbag 1.14.5-r1 --> 1.14.6-r1*
* *rosbag-storage 1.14.5-r1 --> 1.14.6-r1*
* *rosbash 1.14.8-r1 --> 1.14.9-r1*
* *rosboost-cfg 1.14.8-r1 --> 1.14.9-r1*
* *rosbuild 1.14.8-r1 --> 1.14.9-r1*
* *rosclean 1.14.8-r1 --> 1.14.9-r1*
* *roscpp 1.14.5-r1 --> 1.14.6-r1*
* *roscreate 1.14.8-r1 --> 1.14.9-r1*
* *rosgraph 1.14.5-r1 --> 1.14.6-r1*
* *roslang 1.14.8-r1 --> 1.14.9-r1*
* *roslaunch 1.14.5-r1 --> 1.14.6-r1*
* *roslib 1.14.8-r1 --> 1.14.9-r1*
* *roslz4 1.14.5-r1 --> 1.14.6-r1*
* *rosmake 1.14.8-r1 --> 1.14.9-r1*
* *rosmaster 1.14.5-r1 --> 1.14.6-r1*
* *rosmon 2.2.1-r1 --> 2.3.2-r1*
* *rosmon-core 2.2.1-r1 --> 2.3.2-r1*
* *rosmon-msgs 2.2.1-r1 --> 2.3.2-r1*
* *rosmsg 1.14.5-r1 --> 1.14.6-r1*
* *rosnode 1.14.5-r1 --> 1.14.6-r1*
* *rosout 1.14.5-r1 --> 1.14.6-r1*
* *rospack 2.5.5-r1 --> 2.5.6-r1*
* *rosparam 1.14.5-r1 --> 1.14.6-r1*
* *rospy 1.14.5-r1 --> 1.14.6-r1*
* *rosservice 1.14.5-r1 --> 1.14.6-r1*
* *rostest 1.14.5-r1 --> 1.14.6-r1*
* *rostopic 1.14.5-r1 --> 1.14.6-r1*
* *rosunit 1.14.8-r1 --> 1.14.9-r1*
* *roswtf 1.14.5-r1 --> 1.14.6-r1*
* *rqt-rosmon 2.2.1-r1 --> 2.3.2-r1*
* *topic-tools 1.14.5-r1 --> 1.14.6-r1*
* *twist-mux 3.1.0-r1 --> 3.1.1-r1*
* *xmlrpcpp 1.14.5-r1 --> 1.14.6-r1*

Noetic Changes:
---------------
* *audio-capture 0.3.5-r1 --> 0.3.6-r1*
* *audio-common 0.3.5-r1 --> 0.3.6-r1*
* *audio-common-msgs 0.3.5-r1 --> 0.3.6-r1*
* *audio-play 0.3.5-r1 --> 0.3.6-r1*
* *behaviortree-cpp-v3 3.5.0-r1*
* *cartesian-msgs 0.0.3-r1*
* *catch-ros 0.4.0-r1*
* *catkin 0.8.5-r1 --> 0.8.6-r1*
* *cob-extern 0.6.17-r1*
* *control-toolbox 1.18.0-r1 --> 1.18.1-r1*
* *costmap-queue 0.2.6-r1*
* *cpp-common 0.7.1-r1 --> 0.7.2-r1*
* *csm 1.0.2-r2*
* *cv-camera 0.5.0-r3*
* *ddynamic-reconfigure 0.3.0-r1*
* *dlux-global-planner 0.2.6-r1*
* *dlux-plugins 0.2.6-r1*
* *dual-quaternions 0.3.1-r1*
* *dual-quaternions-ros 0.1.3-r1*
* *dwb-critics 0.2.6-r1*
* *dwb-local-planner 0.2.6-r1*
* *dwb-msgs 0.2.6-r1*
* *dwb-plugins 0.2.6-r1*
* *ecl-build 0.61.8-r1*
* *ecl-license 0.61.8-r1*
* *ecl-tools 0.61.8-r1*
* *eigenpy 2.3.2-r2 --> 2.4.0-r1*
* *exotica-val-description 1.0.0-r1*
* *fadecandy-driver 0.1.1-r2*
* *fadecandy-msgs 0.1.1-r2*
* *find-object-2d 0.6.3-r5*
* *genpy 0.6.11-r1 --> 0.6.12-r1*
* *geometric-shapes 0.7.0-r1*
* *global-planner-tests 0.2.6-r1*
* *gps-common 0.3.2-r1*
* *gps-umd 0.3.2-r1*
* *gpsd-client 0.3.2-r1*
* *hebi-cpp-api 3.2.0-r1*
* *ifm3d 0.6.2-r3*
* *imu-complementary-filter 1.2.2-r1*
* *imu-filter-madgwick 1.2.2-r1*
* *imu-tools 1.2.2-r1*
* *jderobot-assets 1.0.3-r1*
* *lgsvl-msgs 0.0.3-r1*
* *libdlib 0.6.17-r1*
* *libmavconn 1.2.0-r1*
* *libntcan 0.6.17-r1*
* *libpcan 0.6.17-r1*
* *libphidget22 1.0.0-r1*
* *libphidgets 0.6.17-r1*
* *locomotor 0.2.6-r1*
* *locomotor-msgs 0.2.6-r1*
* *locomove-base 0.2.6-r1*
* *marti-can-msgs 0.8.0-r1*
* *marti-common-msgs 0.8.0-r1*
* *marti-nav-msgs 0.8.0-r1*
* *marti-perception-msgs 0.8.0-r1*
* *marti-sensor-msgs 0.8.0-r1*
* *marti-status-msgs 0.8.0-r1*
* *marti-visualization-msgs 0.8.0-r1*
* *marvelmind-nav 1.0.11-r1*
* *mavros 1.2.0-r1*
* *mavros-extras 1.2.0-r1*
* *mavros-msgs 1.2.0-r1*
* *mbf-abstract-core 0.3.2-r1*
* *mbf-abstract-nav 0.3.2-r1*
* *mbf-costmap-core 0.3.2-r1*
* *mbf-costmap-nav 0.3.2-r1*
* *mbf-msgs 0.3.2-r1*
* *mbf-simple-nav 0.3.2-r1*
* *mbf-utility 0.3.2-r1*
* *mcl-3dl 0.2.4-r1 --> 0.2.5-r1*
* *message-filters 1.15.6-r1 --> 1.15.7-r1*
* *mk 1.15.1-r1 --> 1.15.4-r1*
* *move-base-flex 0.3.2-r1*
* *mrt-cmake-modules 1.0.3-r1*
* *nav-2d-msgs 0.2.6-r1*
* *nav-2d-utils 0.2.6-r1*
* *nav-core-adapter 0.2.6-r1*
* *nav-core2 0.2.6-r1*
* *nav-grid 0.2.6-r1*
* *nav-grid-iterators 0.2.6-r1*
* *nav-grid-pub-sub 0.2.6-r1*
* *opengm 0.6.17-r1*
* *phidgets-accelerometer 1.0.0-r1*
* *phidgets-analog-inputs 1.0.0-r1*
* *phidgets-api 1.0.0-r1*
* *phidgets-digital-inputs 1.0.0-r1*
* *phidgets-digital-outputs 1.0.0-r1*
* *phidgets-drivers 1.0.0-r1*
* *phidgets-gyroscope 1.0.0-r1*
* *phidgets-high-speed-encoder 1.0.0-r1*
* *phidgets-ik 1.0.0-r1*
* *phidgets-magnetometer 1.0.0-r1*
* *phidgets-motors 1.0.0-r1*
* *phidgets-msgs 1.0.0-r1*
* *phidgets-spatial 1.0.0-r1*
* *phidgets-temperature 1.0.0-r1*
* *pinocchio 2.4.5-r5*
* *plotjuggler 2.8.0-r1*
* *plotjuggler-msgs 0.1.1-r1*
* *pybind11-catkin 2.5.0-r1*
* *python-qt-binding 0.4.1-r1 --> 0.4.2-r1*
* *qt-dotgraph 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-app 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-core 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-cpp 0.4.0-r1 --> 0.4.1-r1*
* *qt-gui-py-common 0.4.0-r1 --> 0.4.1-r1*
* *remote-rosbag-record 0.0.2-r1*
* *rgbd-launch 2.3.0-r1*
* *robot-localization 2.6.8-r2*
* *robot-navigation 0.2.6-r1*
* *ros 1.15.1-r1 --> 1.15.4-r1*
* *ros-comm 1.15.6-r1 --> 1.15.7-r1*
* *ros-emacs-utils 0.4.15-r1*
* *rosapi 0.11.9-r1*
* *rosbag 1.15.6-r1 --> 1.15.7-r1*
* *rosbag-storage 1.15.6-r1 --> 1.15.7-r1*
* *rosbash 1.15.1-r1 --> 1.15.4-r1*
* *rosboost-cfg 1.15.1-r1 --> 1.15.4-r1*
* *rosbridge-library 0.11.9-r1*
* *rosbridge-msgs 0.11.9-r1*
* *rosbridge-server 0.11.9-r1*
* *rosbridge-suite 0.11.9-r1*
* *rosbuild 1.15.1-r1 --> 1.15.4-r1*
* *rosclean 1.15.1-r1 --> 1.15.4-r1*
* *roscpp 1.15.6-r1 --> 1.15.7-r1*
* *roscpp-core 0.7.1-r1 --> 0.7.2-r1*
* *roscpp-serialization 0.7.1-r1 --> 0.7.2-r1*
* *roscpp-traits 0.7.1-r1 --> 0.7.2-r1*
* *roscreate 1.15.1-r1 --> 1.15.4-r1*
* *rosemacs 0.4.15-r1*
* *rosfmt 6.2.0-r1*
* *rosgraph 1.15.6-r1 --> 1.15.7-r1*
* *roslang 1.15.1-r1 --> 1.15.4-r1*
* *roslaunch 1.15.6-r1 --> 1.15.7-r1*
* *roslib 1.15.1-r1 --> 1.15.4-r1*
* *roslisp-repl 0.4.15-r1*
* *roslz4 1.15.6-r1 --> 1.15.7-r1*
* *rosmake 1.15.1-r1 --> 1.15.4-r1*
* *rosmaster 1.15.6-r1 --> 1.15.7-r1*
* *rosmon 2.3.2-r1*
* *rosmon-core 2.3.2-r1*
* *rosmon-msgs 2.3.2-r1*
* *rosmsg 1.15.6-r1 --> 1.15.7-r1*
* *rosnode 1.15.6-r1 --> 1.15.7-r1*
* *rosout 1.15.6-r1 --> 1.15.7-r1*
* *rosparam 1.15.6-r1 --> 1.15.7-r1*
* *rosparam-shortcuts 0.4.0-r1*
* *rospy 1.15.6-r1 --> 1.15.7-r1*
* *rospy-message-converter 0.5.1-r1*
* *rosservice 1.15.6-r1 --> 1.15.7-r1*
* *rostest 1.15.6-r1 --> 1.15.7-r1*
* *rostime 0.7.1-r1 --> 0.7.2-r1*
* *rostopic 1.15.6-r1 --> 1.15.7-r1*
* *rosunit 1.15.1-r1 --> 1.15.4-r1*
* *roswtf 1.15.6-r1 --> 1.15.7-r1*
* *rqt-moveit 0.5.8-r1 --> 0.5.9-r3*
* *rqt-rosmon 2.3.2-r1*
* *rtabmap-ros 0.20.0-r3*
* *rviz-imu-plugin 1.2.2-r1*
* *sick-tim 0.0.17-r1*
* *slime-ros 0.4.15-r1*
* *slime-wrapper 0.4.15-r1*
* *swri-console 1.1.0-r1*
* *teb-local-planner 0.9.1-r1*
* *test-mavros 1.2.0-r1*
* *topic-tools 1.15.6-r1 --> 1.15.7-r1*
* *twist-mux 3.1.1-r1*
* *twist-mux-msgs 2.1.0-r1*
* *ublox 1.4.0-r1*
* *ublox-gps 1.4.0-r1*
* *ublox-msgs 1.4.0-r1*
* *ublox-serialization 1.4.0-r1*
* *urdf-sim-tutorial 0.5.0-r1 --> 0.5.1-r1*
* *urg-c 1.0.405-r1*
* *usb-cam 0.3.6-r1*
* *xmlrpcpp 1.15.6-r1 --> 1.15.7-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gazebo11
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libgazebo11-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-dev-qt5
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libqglviewer2-qt5
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rospkg-modules
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3
 * [ ] python3-babeltrace
 * [ ] python3-catkin-pkg
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-sphinx
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

