### PR TITLE
rosdistro sync, Fri Jun 12 13:17:24 2020

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -676,6 +676,10 @@ self: super: {
 
  radar-msgs = self.callPackage ./radar-msgs {};
 
+ raspimouse = self.callPackage ./raspimouse {};
+
+ raspimouse-msgs = self.callPackage ./raspimouse-msgs {};
+
  rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
 
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
@@ -905,6 +909,8 @@ self: super: {
  rqt-py-console = self.callPackage ./rqt-py-console {};
 
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
+
+ rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 

--- a/distros/dashing/raspimouse-msgs/default.nix
+++ b/distros/dashing/raspimouse-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-dashing-raspimouse-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net/raspimouse2-release/archive/release/dashing/raspimouse_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "f28f8eb19da3983c1164aafec7fa1fcd8d39160272e74822000de4c8a47c3c25";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''RaspiMouse messages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/raspimouse/default.nix
+++ b/distros/dashing/raspimouse/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, raspimouse-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-raspimouse";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net/raspimouse2-release/archive/release/dashing/raspimouse/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "480d14a5c319b7c24ecbddde14c3e6d9324a75feac52562ed7d28aad3cc2ae66";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs raspimouse-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RaspiMouse ROS 2 node'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/rqt-robot-monitor/default.nix
+++ b/distros/dashing/rqt-robot-monitor/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rclpy, rosidl-default-generators, rqt-gui, rqt-gui-py, rqt-py-common }:
+buildRosPackage {
+  pname = "ros-dashing-rqt-robot-monitor";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_robot_monitor-release/archive/release/dashing/rqt_robot_monitor/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ec45e643620df143ff22a8a0bb7ded41eb9f4cf3106f7aa4732974aba1cc91a9";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''rqt_robot_monitor displays diagnostics_agg topics messages that
+   are published by <a href="http://www.ros.org/wiki/diagnostic_aggregator">diagnostic_aggregator</a>.
+   rqt_robot_monitor is a direct port to rqt of
+   <a href="http://www.ros.org/wiki/robot_monitor">robot_monitor</a>. All
+   diagnostics are fall into one of three tree panes depending on the status of
+   diagnostics (normal, warning, error/stale). Status are shown in trees to
+   represent their hierarchy. Worse status dominates the higher level status.<br/>
+   <ul>
+    Ex. 'Computer' category has 3 sub devices. 2 are green but 1 is error. Then
+        'Computer' becomes error.
+   </ul>
+  You can look at the detail of each status by double-clicking the tree nodes.<br/>
+
+  Currently re-usable API to other pkgs are not explicitly provided.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/ament-package/default.nix
+++ b/distros/eloquent/ament-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-eloquent-ament-package";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/eloquent/ament_package/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "15d7727a71a534342a8881486050f01ac9f3f775a30dbe8cddc9a491570045f4";
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/eloquent/ament_package/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "8b97a1bb5815cf6596cf88a738cf226f8d78e75675678919c8b5314eee90a9e9";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/behaviortree-cpp-v3/default.nix
+++ b/distros/eloquent/behaviortree-cpp-v3/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cppzmq, ncurses, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cppzmq, ncurses, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-behaviortree-cpp-v3";
-  version = "3.5.0-r1";
+  version = "3.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/eloquent/behaviortree_cpp_v3/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "9f85d3b92b116badb013e199a90b42380d2a04d37844b0a2da947618f04c0207";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/eloquent/behaviortree_cpp_v3/3.5.1-1.tar.gz";
+    name = "3.5.1-1.tar.gz";
+    sha256 = "9df335c6a7574b7cb4efc7d3781764f72e9a33e91b7bfaf0c80a37e969061db4";
   };
 
   buildType = "catkin";
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ cppzmq ncurses rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -470,6 +470,8 @@ self: super: {
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
 
+ marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
+
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
  marti-perception-msgs = self.callPackage ./marti-perception-msgs {};

--- a/distros/eloquent/marti-can-msgs/default.nix
+++ b/distros/eloquent/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-can-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_can_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "88c6824ec6ba70daad632d4e6adb4981f1d4d7480e86a38b82d14d02fc6ae6e6";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_can_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ccedfc8964ef08fa5062f3514aaacdf431855f61c9fe62e9a2ed8da9f72d2bb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-common-msgs/default.nix
+++ b/distros/eloquent/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-common-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_common_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c01ce669f8dcc877924654a73bc84d4fb8aa20fa20995a4aef60800b90c020f9";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_common_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "12679a6cbb358a39a89f33d0ff97ff45173b0038b0fabb63ffd84df58b803793";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-dbw-msgs/default.nix
+++ b/distros/eloquent/marti-dbw-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-marti-dbw-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_dbw_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2a13b934ec61979b959963f7edc5f4b40036b8849295569c77105c352bddd58a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''marti_dbw_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/marti-nav-msgs/default.nix
+++ b/distros/eloquent/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-nav-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_nav_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "402681359601a802524c474bcaa717425889f1d23fb4a946e7f0337ef702a1df";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_nav_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a12ada84848b6433272e3f0858bd78f0037880bec997d89c415d51ae5ed57b56";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-perception-msgs/default.nix
+++ b/distros/eloquent/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-perception-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_perception_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7d190f762383d9a31908e5f76b65283092c65d42bb4f80a645845e1ffa40d2b6";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_perception_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ef09ae2a5b306caad6e76a131140d7589d1633fc10fd37b1cb315483a2f4e1cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-sensor-msgs/default.nix
+++ b/distros/eloquent/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-eloquent-marti-sensor-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_sensor_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "fed9127a9a8758bd8943d801346d46fee0825f78b8f88bc98039c74674cd8324";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_sensor_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "40755705f8f1f0ded4d5523dc15fb6ad7e224259861835ae9903a39f0654b233";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-status-msgs/default.nix
+++ b/distros/eloquent/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-status-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_status_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "b956d01ba6cb90145245a2c580be63ffa291f0a3827a60d0bf7986744cda7153";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_status_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "098179146cc8ff5ff69f0f4fff2926b4706a85efb1bea562763214ee125d86fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/marti-visualization-msgs/default.nix
+++ b/distros/eloquent/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-marti-visualization-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_visualization_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0bfe262d7c7a444f64a7e24ec532d7ca07c8a378a5111a4587a4e10cd8907797";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/eloquent/marti_visualization_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5a4b4c73057bf58aae8bdd842b0c05857dd0d35e8c94df1d626122f7cf0bd79f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/ros-workspace/default.nix
+++ b/distros/eloquent/ros-workspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-package, cmake }:
 buildRosPackage {
   pname = "ros-eloquent-ros-workspace";
-  version = "0.8.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/eloquent/ros_workspace/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "e9c26a514ee1e7f4963b421c74f159c67b71b62e9b439dc97fb9fa72593170b4";
+    url = "https://github.com/ros2-gbp/ros_workspace-release/archive/release/eloquent/ros_workspace/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9cf0163411a2d0fc4866b6f3a25b9b669b4b8f37c43fa2b77d1ec43c0cc2d969";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/urg-node/default.nix
+++ b/distros/eloquent/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, diagnostic-updater, laser-proc, rclcpp, rclcpp-components, rosidl-default-generators, sensor-msgs, std-srvs, urg-c, urg-node-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-urg-node";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/urg_node-release/archive/release/eloquent/urg_node/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "c7f102a5a0be9953f64c6d52c34e7caaf28f35248bd34a68db123d1bef46dc18";
+    url = "https://github.com/ros2-gbp/urg_node-release/archive/release/eloquent/urg_node/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "e52d647c539ceec13161fa8caba32113d8ec1d47247077c4561c7db999345ca7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/dual-quaternions/default.nix
+++ b/distros/kinetic/dual-quaternions/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pyquaternion }:
+buildRosPackage {
+  pname = "ros-kinetic-dual-quaternions";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/kinetic/dual_quaternions/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "75c484d00dffea7bd617ff271800da2955d80e364a49937d9973c4386e87ecfa";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pyquaternion ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''dual quaternion operations'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -798,6 +798,8 @@ self: super: {
 
  dsr-msgs = self.callPackage ./dsr-msgs {};
 
+ dual-quaternions = self.callPackage ./dual-quaternions {};
+
  dwa-local-planner = self.callPackage ./dwa-local-planner {};
 
  dwb-critics = self.callPackage ./dwb-critics {};
@@ -4069,6 +4071,8 @@ self: super: {
  rr-openrover-driver = self.callPackage ./rr-openrover-driver {};
 
  rr-openrover-driver-msgs = self.callPackage ./rr-openrover-driver-msgs {};
+
+ rr-openrover-simulation = self.callPackage ./rr-openrover-simulation {};
 
  rr-openrover-stack = self.callPackage ./rr-openrover-stack {};
 

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2020.5.21-r1";
+  version = "2020.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.5.21-1.tar.gz";
-    name = "2020.5.21-1.tar.gz";
-    sha256 = "5e8fa0bd5a8364d25f37ab8ae1020af491c82fe0316c78cb6f669c5f145a6065";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.6.6-1.tar.gz";
+    name = "2020.6.6-1.tar.gz";
+    sha256 = "dd720763cc59f0d343329b11787dc8a6c6567aefa59bc1d053e0bea831265226";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/py-trees-ros/default.nix
+++ b/distros/kinetic/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, py-trees, py-trees-msgs, python-qt-binding, pythonPackages, rosbag, rospy, rostest, rosunit, sensor-msgs, std-msgs, unique-id, uuid-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-py-trees-ros";
-  version = "0.5.20-r1";
+  version = "0.5.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/kinetic/py_trees_ros/0.5.20-1.tar.gz";
-    name = "0.5.20-1.tar.gz";
-    sha256 = "987000d9d17c3d9a612cf8da17804f5d1c9fbad492e2bdcb0603df6d6ba50c99";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/kinetic/py_trees_ros/0.5.21-1.tar.gz";
+    name = "0.5.21-1.tar.gz";
+    sha256 = "cb89987a85f261118cd15c86654f68bd54b123aceac8ef2a2f25c7b12c67d72e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-control-input-manager/default.nix
+++ b/distros/kinetic/rr-control-input-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-control-input-manager";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "c11d051886f20e1c46964a08cfbe9a32ff060e8d842f207a995e02b2f561350f";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "d074f1819b190341a0566c9d9b25cdaf5ea3ab77d9fda674c91a431c877c7de7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-description/default.nix
+++ b/distros/kinetic/rr-openrover-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-description";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_description/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "70237118a29c25548d7f5427ed5d3ef15521b8088e88397c568fe352c5126f07";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_description/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "ebc8e2f9c4e01fcfa4a306539b2ecce5259f23c7f0d7f76f94723c05e01a5878";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-driver-msgs/default.nix
+++ b/distros/kinetic/rr-openrover-driver-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver-msgs";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "3765595e41e50bc5a4848bd4fbd1ea24f69bf453c26374d25dff4eadb6745956";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "e74a34407ce7bf9bcca81b6bc9a9c940a7b8f75b0b74ca33c51f91b9ffdb594e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-driver/default.nix
+++ b/distros/kinetic/rr-openrover-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "d719aad57bf8aba8211724164ded8c049546763b6a30e41fefdf238017eb7d41";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "fde6c2041b88a10025bfaaec0622a0d3f9f88dc6802b1159ae3c1d377fc6e2a7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-simulation/default.nix
+++ b/distros/kinetic/rr-openrover-simulation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rr-openrover-simulation";
+  version = "1.0.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_simulation/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "19d32ca6996f2d77edee8c07f56fb492e86011e876d36faf54bb48a7fac0bd04";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-msgs gazebo-plugins gazebo-ros gazebo-ros-control gazebo-ros-pkgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rr_openrover_simulation package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/kinetic/rr-openrover-stack/default.nix
+++ b/distros/kinetic/rr-openrover-stack/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-driver, rr-openrover-driver-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-description, rr-openrover-driver, rr-openrover-driver-msgs, rr-openrover-simulation, rr-rover-zero-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-stack";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "6c49b9746d05ffc33617e9cdeca0bf5a996d1008254caf44c706fba06b26a8e2";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "a4bca04c9788a72c7cfe9301ee214a0eeeab18e97c383e41ad37727f8bbdfdb8";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rr-control-input-manager rr-openrover-driver rr-openrover-driver-msgs ];
+  propagatedBuildInputs = [ rr-control-input-manager rr-openrover-description rr-openrover-driver rr-openrover-driver-msgs rr-openrover-simulation rr-rover-zero-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rr-rover-zero-driver/default.nix
+++ b/distros/kinetic/rr-rover-zero-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-rr-rover-zero-driver";
-  version = "0.8.0-r1";
+  version = "1.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_rover_zero_driver/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "bb847129135a965be1516312b96a08e794e98011335f33db083208bf8559517c";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_rover_zero_driver/1.0.0-3.tar.gz";
+    name = "1.0.0-3.tar.gz";
+    sha256 = "3bb1b4baa627602b3f7724c5833ca6f646acde6cc6b9f06e52f8df731ac681f9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.13-r1";
+  version = "0.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "9b65f9cfc1bb5eb6faf82404c4853ec3ea9625c9b8be8c15144d91bb4e32f949";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "0bc507ce57d98ea3741301823fc5db80f521187f589944ea29d83bffe6b184d0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/avt-vimba-camera/default.nix
+++ b/distros/melodic/avt-vimba-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, polled-camera, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-avt-vimba-camera";
-  version = "0.0.11-r1";
+  version = "0.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/0.0.11-1.tar.gz";
-    name = "0.0.11-1.tar.gz";
-    sha256 = "2ef59b4dcd0006486e9a68b469485bd13f54d6cc9f1d76a2b01ae229c8a1a6a4";
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/melodic/avt_vimba_camera/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "8902143fcf7f83538d426f6577edfd34e0324eb22ffb37ecc4ff99541d2750af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1324,8 +1324,6 @@ self: super: {
 
  jderobot-camviz = self.callPackage ./jderobot-camviz {};
 
- jderobot-color-tuner = self.callPackage ./jderobot-color-tuner {};
-
  jderobot-drones = self.callPackage ./jderobot-drones {};
 
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
@@ -3017,6 +3015,20 @@ self: super: {
  rqt-virtual-joy = self.callPackage ./rqt-virtual-joy {};
 
  rqt-web = self.callPackage ./rqt-web {};
+
+ rr-control-input-manager = self.callPackage ./rr-control-input-manager {};
+
+ rr-openrover-description = self.callPackage ./rr-openrover-description {};
+
+ rr-openrover-driver = self.callPackage ./rr-openrover-driver {};
+
+ rr-openrover-driver-msgs = self.callPackage ./rr-openrover-driver-msgs {};
+
+ rr-openrover-simulation = self.callPackage ./rr-openrover-simulation {};
+
+ rr-openrover-stack = self.callPackage ./rr-openrover-stack {};
+
+ rr-rover-zero-driver = self.callPackage ./rr-rover-zero-driver {};
 
  rslidar = self.callPackage ./rslidar {};
 

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2020.5.21-r1";
+  version = "2020.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.5.21-1.tar.gz";
-    name = "2020.5.21-1.tar.gz";
-    sha256 = "f7abeb7789efb15d6072cb4ef9e394d95abd26e18fd999604e4556a5b5728a7c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.6.6-1.tar.gz";
+    name = "2020.6.6-1.tar.gz";
+    sha256 = "295c071126d132007c586ddc4b5eaced67ceded52def43ffa1458fc9ded14263";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mpc-local-planner-examples/default.nix
+++ b/distros/melodic/mpc-local-planner-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, map-server, move-base, mpc-local-planner, mpc-local-planner-msgs, stage-ros }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner-examples";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_examples/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "cd714dbefccd4740cc76657dc09776e1a243664df04c01f46b7434f4abc5aaaf";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_examples/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "79549b550d571485d31da57e740d6d35eda56544939da69caf2c521543705430";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mpc-local-planner-msgs/default.nix
+++ b/distros/melodic/mpc-local-planner-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner-msgs";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "ee9966e8bd7b011c4f2f44d7aaf71bb61cf781fcb76b04b694c95b8063758823";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "802a95c12ab6588105f018277842d85b4325d5ef06bf0fda584beb319126a4b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mpc-local-planner/default.nix
+++ b/distros/melodic/mpc-local-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, base-local-planner, catkin, control-box-rst, costmap-2d, costmap-converter, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, mbf-costmap-core, mbf-msgs, mpc-local-planner-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, teb-local-planner, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mpc-local-planner";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "3bd8496e1c349125dbdc73f1db4c3003d2d294f3387cc369944f502ed6621e45";
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/melodic/mpc_local_planner/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "0b22647c9eb78beee9582b7f3b4c1bc9b0e1041340482b82c34a09fe4e9090aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/py-trees-ros/default.nix
+++ b/distros/melodic/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, py-trees, py-trees-msgs, python-qt-binding, pythonPackages, rosbag, rospy, rostest, rosunit, sensor-msgs, std-msgs, unique-id, uuid-msgs }:
 buildRosPackage {
   pname = "ros-melodic-py-trees-ros";
-  version = "0.5.18";
+  version = "0.5.21-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/melodic/py_trees_ros/0.5.18-0.tar.gz";
-    name = "0.5.18-0.tar.gz";
-    sha256 = "1bc3f54d395458994329b16c3e3abff63702270a44e1443c5cafafe85a7362ac";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/melodic/py_trees_ros/0.5.21-1.tar.gz";
+    name = "0.5.21-1.tar.gz";
+    sha256 = "d74455aaa4da3ca549de5950044da474e75293c666a3bc0c89bf3f00d2484a54";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-control-input-manager/default.nix
+++ b/distros/melodic/rr-control-input-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rr-control-input-manager";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_control_input_manager/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "13312611f0a08c552c84b8526764cb270c162ad63e94506f205b3bc99960d03e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filter velocity commands by ensuring that message time stamps do not exceed given timeout thresholds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rr-openrover-description/default.nix
+++ b/distros/melodic/rr-openrover-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rr-openrover-description";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_description/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "6cc2c409ac518fb0de7888468111770d0f44017e2b52682f25c4f969f504dd03";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rr_openrover_description package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/melodic/rr-openrover-driver-msgs/default.nix
+++ b/distros/melodic/rr-openrover-driver-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rr-openrover-driver-msgs";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver_msgs/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "cd4e6202631bed70d3831fd1bfea78e82ad9b8eb5181b619302efb484f512009";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rr_openrover_driver_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rr-openrover-driver/default.nix
+++ b/distros/melodic/rr-openrover-driver/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, twist-mux }:
+buildRosPackage {
+  pname = "ros-melodic-rr-openrover-driver";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "00be302ddb8b762e9c8828755143409e72ed3702db77728f39dbdde369527a96";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation tf2-geometry-msgs ];
+  propagatedBuildInputs = [ geometry-msgs joy message-runtime nav-msgs roscpp rospy rr-openrover-driver-msgs sensor-msgs std-msgs tf2 twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides an interface between ros and Rover Robotics rover hardware. Inputs to rr_openrover_driver
+    include emergency stop and velocity commands.  It outputs diagnostic data such as encoder
+    readings and battery charge.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rr-openrover-simulation/default.nix
+++ b/distros/melodic/rr-openrover-simulation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rr-openrover-simulation";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_simulation/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "ad3b243af2d65da484f820bd5447dcfed3bd791f9aa19296dac256d4b379d546";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-msgs gazebo-plugins gazebo-ros gazebo-ros-control gazebo-ros-pkgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rr_openrover_simulation package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/melodic/rr-openrover-stack/default.nix
+++ b/distros/melodic/rr-openrover-stack/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-description, rr-openrover-driver, rr-openrover-driver-msgs, rr-openrover-simulation, rr-rover-zero-driver }:
+buildRosPackage {
+  pname = "ros-melodic-rr-openrover-stack";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_stack/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "984a5f86e45762f6ac53e710cbb726b41acaf1cc8965b988facb5bfa66e84db1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rr-control-input-manager rr-openrover-description rr-openrover-driver rr-openrover-driver-msgs rr-openrover-simulation rr-rover-zero-driver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Packages related to the operation of Rover Robotics rover hardware.  This includes a client
+    for interfacing with the hardware (rr_openrover_driver) and a tool for filtering time stamped
+    velocity commands (rr_control_input_manager).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rr-rover-zero-driver/default.nix
+++ b/distros/melodic/rr-rover-zero-driver/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-rr-rover-zero-driver";
+  version = "1.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_rover_zero_driver/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "0e65f093ae110e078bdcca4b8e958006b8ce4aea30f38101dd427d7f1ac1e81e";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rover_zero_driver package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/melodic/slam-toolbox-msgs/default.nix
+++ b/distros/melodic/slam-toolbox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-slam-toolbox-msgs";
-  version = "1.1.3-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/melodic/slam_toolbox_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "2b6ffe7c9ac01d4df3f75d289befcd09c72b9ef5e32bc2e68b4423f959860131";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/melodic/slam_toolbox_msgs/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "9b72a259b2d29b84c80cbedfd01faab555414e19c1d861f2b950e64176428b44";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slam-toolbox/default.nix
+++ b/distros/melodic/slam-toolbox/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, rviz, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, rostest, rosunit, rviz, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-slam-toolbox";
-  version = "1.1.3-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/melodic/slam_toolbox/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ff4ad2fe6af0fe83f2def7b3fe525713311a0aa86db16cda3e3033dc2731afec";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/melodic/slam_toolbox/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "73c76ea13e65f47d6a6a3e5d2beb39130cd8a1d8f769517e44c52e5f2578ee65";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ ceres-solver eigen interactive-markers libg2o liblapack map-server message-filters message-runtime nav-msgs pluginlib qt5.qtbase rosconsole roscpp rviz sensor-msgs slam-toolbox-msgs sparse-bundle-adjustment std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  checkInputs = [ rostest rosunit ];
+  propagatedBuildInputs = [ ceres-solver eigen interactive-markers libg2o liblapack map-server message-filters message-runtime nav-msgs pluginlib qt5.qtbase rosconsole roscpp rostest rviz sensor-msgs slam-toolbox-msgs sparse-bundle-adjustment std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/tf2-server/default.nix
+++ b/distros/melodic/tf2-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gtest, message-generation, message-runtime, nodelet, roscpp, rospy, rostest, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-tf2-server";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c3d98a499738325ecbf1dbfbaa21efdcdb20b8387387df3de7af09657088e402";
+    url = "https://github.com/peci1/tf2_server-release/archive/release/melodic/tf2_server/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c67256a38cfb77de988fe3a67334caf05eaab0b13108cf526d109c65e94dd63a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-gps/default.nix
+++ b/distros/melodic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-gps";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2c70f260827cb329a5525ecb937b45ede6a358967c461d91cafd8f4bf06f0f13";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "a55576ce6b61e9a6b3d08bff772d646169aaed410be63fbe8be6acad2b3e53c5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-msgs/default.nix
+++ b/distros/melodic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "234745d45a3a493de4ec69bfa596b94ee0a05dfc31fea9b37ddefbd139a07ac1";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "f8f9b32a80cb9f7c1e1beee8ceface2b8ad0cd77abeb80493d2cd3eeb26a8e74";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-serialization/default.nix
+++ b/distros/melodic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-serialization";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "d2a4284c8f6d7839a3ea99253e1792d035f086265009620e9d4d24f2b4e264e1";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "6c7f0f6d3715245ad583814a58e636106b37cf5e33e4a9452c931ad42930b4ae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox/default.nix
+++ b/distros/melodic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "8ce5719dd22959546e0e2464e3ca942560c6ced30c677f4c1780943b096a02b1";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "88fc16b1221df1f68aecbf5f0edfc0a763fe28055442f5f730c8c7c648a240a8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-node/default.nix
+++ b/distros/melodic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-melodic-urg-node";
-  version = "0.1.13-r1";
+  version = "0.1.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.13-1.tar.gz";
-    name = "0.1.13-1.tar.gz";
-    sha256 = "d7af4323e1d394519ee0fc519284a6b19400492c8a449089860649f44a8e23b6";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "931f78afd03357bcaea2960c6e6c66a9e9d433d569b27551546ebb7b14dee0c9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/avt-vimba-camera/default.nix
+++ b/distros/noetic/avt-vimba-camera/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, diagnostic-updater, dynamic-reconfigure, image-geometry, image-proc, image-transport, message-filters, nodelet, polled-camera, roscpp, sensor-msgs, std-msgs, stereo-image-proc }:
+buildRosPackage {
+  pname = "ros-noetic-avt-vimba-camera";
+  version = "0.0.12-r2";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/avt_vimba_camera-release/archive/release/noetic/avt_vimba_camera/0.0.12-2.tar.gz";
+    name = "0.0.12-2.tar.gz";
+    sha256 = "ff2a92ae2d911bb50b0d589f3e2730f58f59a28078fe5fbef6c897f448455736";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-geometry image-proc image-transport message-filters nodelet polled-camera roscpp sensor-msgs std-msgs stereo-image-proc ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Wrapper of the Allied Vision Technologies (AVT) VIMBA Ethernet and Firewire SDK.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/control-toolbox/default.nix
+++ b/distros/noetic/control-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, control-msgs, dynamic-reconfigure, message-generation, message-runtime, realtime-tools, roscpp, rosunit, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-control-toolbox";
-  version = "1.18.1-r1";
+  version = "1.18.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.1-1.tar.gz";
-    name = "1.18.1-1.tar.gz";
-    sha256 = "12636c8385116b81e608f70e811112c849f192c1dde1653d7d98e4b56892c748";
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/noetic/control_toolbox/1.18.2-1.tar.gz";
+    name = "1.18.2-1.tar.gz";
+    sha256 = "f0cfd52a0e7ecb256997808fd3caa730e31ddfe2e9404174d875f13100caaae2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-ulc-can/default.nix
+++ b/distros/noetic/dataspeed-ulc-can/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-ulc-msgs, geometry-msgs, nodelet, roscpp, roslib, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-ulc-can";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release/archive/release/noetic/dataspeed_ulc_can/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "9ed384d5ba42a7471716ede8406852d1a3d9c4523f55ecae84e3138db42144e8";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslib rostest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-ulc-msgs geometry-msgs nodelet roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package to translate ROS messages to and from CAN messages to interact with the Universal Lat/Lon Controller (ULC) firmware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-ulc-msgs/default.nix
+++ b/distros/noetic/dataspeed-ulc-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-ulc-msgs";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release/archive/release/noetic/dataspeed_ulc_msgs/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "45476604a4303713789b69379dd049da0245107f6516439245398d1f6ac0c901";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS messages for interacting with the Universal Lat/Lon Controller (ULC)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-ulc/default.nix
+++ b/distros/noetic/dataspeed-ulc/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-ulc-can, dataspeed-ulc-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-ulc";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_ulc_ros-release/archive/release/noetic/dataspeed_ulc/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "3c25aaa2ad8856c22b3fb2e2e5278428fd59032614ae8f65bcc0da0f74362833";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dataspeed-ulc-can dataspeed-ulc-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''CAN interface to the Universal Lat/Lon Controller (ULC) firmware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-config/default.nix
+++ b/distros/noetic/ecl-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-config";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_config/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "a9ea24d6890c90bd24d88ad48b5423e9cb07e9d8e682459173c92fb0dc015ec6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These tools inspect and describe your system with macros, types 
+     and functions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-console/default.nix
+++ b/distros/noetic/ecl-console/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-console";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_console/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "63176776ff8c55b804b1e31c543b03ea03b4b1fa901aa65ff3cce40f06499fc8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Color codes for ansii consoles.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-converters-lite/default.nix
+++ b/distros/noetic/ecl-converters-lite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-converters-lite";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_converters_lite/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "dc53dde0c57b21b207c2d4fee29c7bacc566e401492b05e31e884f8876e43708";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These are a very simple version of some of the functions in ecl_converters 
+     suitable for firmware development. That is, there is no use of new, 
+     templates or exceptions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-errors/default.nix
+++ b/distros/noetic/ecl-errors/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-errors";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_errors/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "d653796a07f7e8491cd9426028c9a2e040c8f28eba489fef23c0b06085752d9a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This library provides lean and mean error mechanisms. 
+    It includes c style error functions as well as a few 
+    useful macros. For higher level mechanisms, 
+    refer to ecl_exceptions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-io/default.nix
+++ b/distros/noetic/ecl-io/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-io";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_io/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "9f99aa8e629d50743ff16d5fbcaa9a74b8af4a824b1c3250ed43a0cbb5dae588";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Most implementations (windows, posix, ...) have slightly different api for 
+     low level input-output functions. These are gathered here and re-represented 
+     with a cross platform set of functions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-lite/default.nix
+++ b/distros/noetic/ecl-lite/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-converters-lite, ecl-errors, ecl-io, ecl-sigslots-lite, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-lite";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_lite/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "f39f774a0b9ad3bf9d50e6854a5b354016559dfc7e111f4992f098ec415d5586";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-converters-lite ecl-errors ecl-io ecl-sigslots-lite ecl-time-lite ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Libraries and utilities for embedded and low-level linux development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-sigslots-lite/default.nix
+++ b/distros/noetic/ecl-sigslots-lite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-sigslots-lite";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_sigslots_lite/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "a39f77f28ffbde76c8d230b4c0b61261ed20b9c480220dd5c3db9a30cb472181";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This avoids use of dynamic storage (malloc/new) and thread safety (mutexes) to
+     provide a very simple sigslots implementation that can be used for *very*
+     embedded development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-time-lite/default.nix
+++ b/distros/noetic/ecl-time-lite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-time-lite";
+  version = "0.61.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/noetic/ecl_time_lite/0.61.6-1.tar.gz";
+    name = "0.61.6-1.tar.gz";
+    sha256 = "bffb469391c6ad528bba012ff940e0a8bc7530ed88b8b65b7dbdab686299626c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a portable set of time functions that are especially useful for 
+     porting other code or being wrapped by higher level c++ classes.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -26,6 +26,8 @@ self: super: {
 
  audio-play = self.callPackage ./audio-play {};
 
+ avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
+
  base-local-planner = self.callPackage ./base-local-planner {};
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
@@ -116,6 +118,12 @@ self: super: {
 
  cv-camera = self.callPackage ./cv-camera {};
 
+ dataspeed-ulc = self.callPackage ./dataspeed-ulc {};
+
+ dataspeed-ulc-can = self.callPackage ./dataspeed-ulc-can {};
+
+ dataspeed-ulc-msgs = self.callPackage ./dataspeed-ulc-msgs {};
+
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
  depth-image-proc = self.callPackage ./depth-image-proc {};
@@ -162,7 +170,23 @@ self: super: {
 
  ecl-build = self.callPackage ./ecl-build {};
 
+ ecl-config = self.callPackage ./ecl-config {};
+
+ ecl-console = self.callPackage ./ecl-console {};
+
+ ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-errors = self.callPackage ./ecl-errors {};
+
+ ecl-io = self.callPackage ./ecl-io {};
+
  ecl-license = self.callPackage ./ecl-license {};
+
+ ecl-lite = self.callPackage ./ecl-lite {};
+
+ ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-time-lite = self.callPackage ./ecl-time-lite {};
 
  ecl-tools = self.callPackage ./ecl-tools {};
 
@@ -250,6 +274,8 @@ self: super: {
 
  gpsd-client = self.callPackage ./gpsd-client {};
 
+ graph-msgs = self.callPackage ./graph-msgs {};
+
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
@@ -282,9 +308,15 @@ self: super: {
 
  imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
 
+ imu-pipeline = self.callPackage ./imu-pipeline {};
+
+ imu-processors = self.callPackage ./imu-processors {};
+
  imu-sensor-controller = self.callPackage ./imu-sensor-controller {};
 
  imu-tools = self.callPackage ./imu-tools {};
+
+ imu-transformer = self.callPackage ./imu-transformer {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
@@ -304,6 +336,8 @@ self: super: {
 
  joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
 
+ joy-teleop = self.callPackage ./joy-teleop {};
+
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
  jsk-common-msgs = self.callPackage ./jsk-common-msgs {};
@@ -313,6 +347,8 @@ self: super: {
  jsk-gui-msgs = self.callPackage ./jsk-gui-msgs {};
 
  jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
+
+ key-teleop = self.callPackage ./key-teleop {};
 
  laser-assembler = self.callPackage ./laser-assembler {};
 
@@ -350,6 +386,8 @@ self: super: {
 
  locomove-base = self.callPackage ./locomove-base {};
 
+ lusb = self.callPackage ./lusb {};
+
  map-laser = self.callPackage ./map-laser {};
 
  map-msgs = self.callPackage ./map-msgs {};
@@ -363,6 +401,8 @@ self: super: {
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
+
+ marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
 
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
 
@@ -412,6 +452,8 @@ self: super: {
 
  mk = self.callPackage ./mk {};
 
+ mouse-teleop = self.callPackage ./mouse-teleop {};
+
  move-base = self.callPackage ./move-base {};
 
  move-base-flex = self.callPackage ./move-base-flex {};
@@ -419,6 +461,12 @@ self: super: {
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
+
+ mpc-local-planner = self.callPackage ./mpc-local-planner {};
+
+ mpc-local-planner-examples = self.callPackage ./mpc-local-planner-examples {};
+
+ mpc-local-planner-msgs = self.callPackage ./mpc-local-planner-msgs {};
 
  mrpt2 = self.callPackage ./mrpt2 {};
 
@@ -478,9 +526,15 @@ self: super: {
 
  octomap-server = self.callPackage ./octomap-server {};
 
+ ompl = self.callPackage ./ompl {};
+
  open-karto = self.callPackage ./open-karto {};
 
  opengm = self.callPackage ./opengm {};
+
+ openni2-camera = self.callPackage ./openni2-camera {};
+
+ openni2-launch = self.callPackage ./openni2-launch {};
 
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
 
@@ -535,6 +589,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  pluginlib-tutorials = self.callPackage ./pluginlib-tutorials {};
+
+ pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
  polled-camera = self.callPackage ./polled-camera {};
 
@@ -810,11 +866,19 @@ self: super: {
 
  shape-msgs = self.callPackage ./shape-msgs {};
 
+ sick-scan = self.callPackage ./sick-scan {};
+
  sick-tim = self.callPackage ./sick-tim {};
 
  simulators = self.callPackage ./simulators {};
 
  slam-karto = self.callPackage ./slam-karto {};
+
+ slam-toolbox = self.callPackage ./slam-toolbox {};
+
+ slam-toolbox-msgs = self.callPackage ./slam-toolbox-msgs {};
+
+ slam-toolbox-rviz = self.callPackage ./slam-toolbox-rviz {};
 
  slime-ros = self.callPackage ./slime-ros {};
 
@@ -831,6 +895,8 @@ self: super: {
  socketcan-bridge = self.callPackage ./socketcan-bridge {};
 
  socketcan-interface = self.callPackage ./socketcan-interface {};
+
+ sophus = self.callPackage ./sophus {};
 
  sparse-bundle-adjustment = self.callPackage ./sparse-bundle-adjustment {};
 
@@ -851,6 +917,10 @@ self: super: {
  swri-console = self.callPackage ./swri-console {};
 
  teb-local-planner = self.callPackage ./teb-local-planner {};
+
+ teleop-tools = self.callPackage ./teleop-tools {};
+
+ teleop-tools-msgs = self.callPackage ./teleop-tools-msgs {};
 
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 

--- a/distros/noetic/geometry/default.nix
+++ b/distros/noetic/geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, eigen-conversions, kdl-conversions, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-geometry";
-  version = "1.13.1-r1";
+  version = "1.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/geometry/1.13.1-1.tar.gz";
-    name = "1.13.1-1.tar.gz";
-    sha256 = "d28bb57be01e2d33a1cbd87ac1673e7b1cc62a255c550bec00035de412d00c9f";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/geometry/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "45d3dd1724ca4416f16efbc51f6bb9e8fd1eb72db66cd0b7392b83d7d6eb9e1f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometry2/default.nix
+++ b/distros/noetic/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-noetic-geometry2";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "66592d019ee1d562349ad4d89bf8971254e871492164623a93fd141c7fa832da";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/geometry2/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "1b355b4045aa42ca6cf114421cfbab30186d421cf16c8056812c10bb3938be5f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graph-msgs/default.nix
+++ b/distros/noetic/graph-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-graph-msgs";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/graph_msgs-release/archive/release/noetic/graph_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "ce7125a86592674cfafa8ae3ba856c85fdf5359b0207a7537841f532679f0b25";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS messages for publishing graphs of different data types'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/imu-pipeline/default.nix
+++ b/distros/noetic/imu-pipeline/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, imu-processors, imu-transformer }:
+buildRosPackage {
+  pname = "ros-noetic-imu-pipeline";
+  version = "0.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/imu_pipeline-release/archive/release/noetic/imu_pipeline/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "946eec181c53278eb6e6dd0763beb3e9a654b76f825affe873dcb7afaf509242";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ imu-processors imu-transformer ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''imu_pipeline'';
+    license = with lib.licenses; [ bsdOriginal gpl1 ];
+  };
+}

--- a/distros/noetic/imu-processors/default.nix
+++ b/distros/noetic/imu-processors/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-imu-processors";
+  version = "0.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/imu_pipeline-release/archive/release/noetic/imu_processors/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "2414b4f4622a5e70115bfe13eaec88df83bfa0de8289cebcc2336128dae8a8e0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Processors for sensor_msgs::Imu data'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/imu-transformer/default.nix
+++ b/distros/noetic/imu-transformer/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-filters, nodelet, roscpp, roslaunch, sensor-msgs, tf, tf2, tf2-ros, tf2-sensor-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-imu-transformer";
+  version = "0.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/imu_pipeline-release/archive/release/noetic/imu_transformer/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "68cb06d8148e357063eefd74495f78328c6b0056ad7c88c75c0d9289b141ddb2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet roscpp sensor-msgs tf tf2 tf2-ros tf2-sensor-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node/nodelet combination to transform sensor_msgs::Imu data from one frame into another.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/jderobot-assets/default.nix
+++ b/distros/noetic/jderobot-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-jderobot-assets";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/assets-release/archive/release/noetic/jderobot_assets/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "18f0a42e849e660c34cbf137c92486d632ad7b28536cca0bc67b5e21559749db";
+    url = "https://github.com/JdeRobot/assets-release/archive/release/noetic/jderobot_assets/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3c11d5065095615c276e2e67a4b940545a0a8e7faf1208f7f678a688c1242cca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joy-teleop/default.nix
+++ b/distros/noetic/joy-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, rospy, rostopic, sensor-msgs, teleop-tools-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joy-teleop";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/noetic/joy_teleop/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8824c105187a12a47186db7ff08706673316d2aca3dae67ffa987eeaeb74d475";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib rospy rostopic sensor-msgs teleop-tools-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A (to be) generic joystick interface to control a robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/key-teleop/default.nix
+++ b/distros/noetic/key-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-key-teleop";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/noetic/key_teleop/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "eb2a780a6771f9f56569c9e7c5c186a1623ab6e1df367b8e06518363cd8a4639";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A text-based interface to send a robot movement commands'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-filters/default.nix
+++ b/distros/noetic/laser-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, dynamic-reconfigure, filters, laser-geometry, message-filters, pluginlib, roscpp, rostest, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-laser-filters";
-  version = "1.8.9-r1";
+  version = "1.8.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/noetic/laser_filters/1.8.9-1.tar.gz";
-    name = "1.8.9-1.tar.gz";
-    sha256 = "811dc73c7509a59a545bc8e2d417634a10ff1e3e9cbc7501894074265ed5f5d0";
+    url = "https://github.com/ros-gbp/laser_filters-release/archive/release/noetic/laser_filters/1.8.11-1.tar.gz";
+    name = "1.8.11-1.tar.gz";
+    sha256 = "d23908e302de876e438f93ae7cd6e770080a2d49a2194f48698865285f213353";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ec2332c2e545ede5a2ade74049e4b43ae60499112f0938cdf624649086371432";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cb3c5d6c110815d1352bb290d85763a34f9e304d1a7e37299eea27e75ebadf8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lusb/default.nix
+++ b/distros/noetic/lusb/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, libusb, libusb1 }:
+buildRosPackage {
+  pname = "ros-noetic-lusb";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/lusb-release/archive/release/noetic/lusb/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "65aeadc9a0f6e40009b2f8c5befeb581d7b83f954c40bf9bdf66847b9c9d53bc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ libusb1 ];
+  propagatedBuildInputs = [ boost libusb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Library for interfacing to USB devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-can-msgs/default.nix
+++ b/distros/noetic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-can-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ca2114bcc44c43653c2f105168857c2c6633f3d378be13b5823b3520d91ec467";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_can_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "62eba4a10e3fd9ee8f9a68501b48a2f1807051bf48fe61727c3e88c3b08ee852";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-common-msgs/default.nix
+++ b/distros/noetic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-common-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ad93af25c1967f060d6e6a84b9588126df613fcc268306791cf37b31b9390879";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_common_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "43512be3bc6dee5938d72d4cde1075df635610dd9abdbb7ec4dcbbc9420c0374";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-dbw-msgs/default.nix
+++ b/distros/noetic/marti-dbw-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marti-dbw-msgs";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_dbw_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "949bac75a1a06020d0f0b4ebb78b47ce740b6e1f715b75011f4a58f233f95fa4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_dbw_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/marti-nav-msgs/default.nix
+++ b/distros/noetic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-nav-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "55d43845ac2386b890a32fcedeea86406b20a5a88837c54a01184932ee34e646";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_nav_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "7ca31922df0a65183794ba94c53ff177cdb32910ab9ce423d3a5c49ea307fa8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-perception-msgs/default.nix
+++ b/distros/noetic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-perception-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "1944d3fcb1a0a6649bab94aaaffaf28df99b47403930867772e39488b3472fd8";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_perception_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "9a736e305d1bca6be998e944ab4cdc8a57bc2dfe044a11d3b2454a4d0864f4f7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-sensor-msgs/default.nix
+++ b/distros/noetic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-marti-sensor-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "22c38f24be40f7e5b7df95cdb415ff1b412044fbb83952c15f7c3fd5c96a7554";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_sensor_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "0167851877e863fd13f13723a5e5568ae27086fc5685126fb9a9d392b3a71da2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-status-msgs/default.nix
+++ b/distros/noetic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-status-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "d644f0e040f3d69b391558b6d884d5fd89b33a4ed5f7dde1f6438e06bf9d2b9a";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_status_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d9bedfb4a4b2ff12094d974fb2c1f09076c40d65c23df4967d0b575da1b42ef7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-visualization-msgs/default.nix
+++ b/distros/noetic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-marti-visualization-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7a8091457a208eded51d3ce82347279115ac074b843eb74af6f850d8fc445b1b";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/noetic/marti_visualization_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "6de761adac49b0634e86de126cd73029c47f5ec933ba72515203147d44b60de1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2020.5.21-r1";
+  version = "2020.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.5.21-1.tar.gz";
-    name = "2020.5.21-1.tar.gz";
-    sha256 = "1dbcc8a11a141ac9ae286ea7a66151fb7cc59769725cc227523b763576a1aeb1";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.6.6-1.tar.gz";
+    name = "2020.6.6-1.tar.gz";
+    sha256 = "42e149b8d0f0b1ee3b091f87e0e8d1932e493f3c0f56c1ff97d87d39fa2c6b70";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mouse-teleop/default.nix
+++ b/distros/noetic/mouse-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-mouse-teleop";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/noetic/mouse_teleop/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "503f0f74b7858db4eca3c48c5e8fa80d312964e5922bb40ae29d73af766e2c3f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.numpy pythonPackages.tkinter rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A mouse teleop tool for holonomic mobile robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mpc-local-planner-examples/default.nix
+++ b/distros/noetic/mpc-local-planner-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, map-server, move-base, mpc-local-planner, mpc-local-planner-msgs, stage-ros }:
+buildRosPackage {
+  pname = "ros-noetic-mpc-local-planner-examples";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/noetic/mpc_local_planner_examples/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "b0ef5b7b4bf1c078f9dc2aa977e465a8435c3c7640ea94afe6848e79467b849b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl map-server move-base mpc-local-planner mpc-local-planner-msgs stage-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mpc_local_planner_examples package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mpc-local-planner-msgs/default.nix
+++ b/distros/noetic/mpc-local-planner-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mpc-local-planner-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/noetic/mpc_local_planner_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "bf44761253edd16b87eaa7f092b82e3d36f95998b681cd8df831746804ed8033";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides message types that are used by the package mpc_local_planner'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/mpc-local-planner/default.nix
+++ b/distros/noetic/mpc-local-planner/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, control-box-rst, costmap-2d, costmap-converter, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, mbf-costmap-core, mbf-msgs, mpc-local-planner-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, teb-local-planner, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mpc-local-planner";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rst-tu-dortmund/mpc_local_planner-release/archive/release/noetic/mpc_local_planner/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "5ac9ee2b283c30626a85282071d60d083a1ec139e94ad4d6817359bcc1cb50d6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ tf2-eigen tf2-geometry-msgs ];
+  propagatedBuildInputs = [ base-local-planner control-box-rst costmap-2d costmap-converter dynamic-reconfigure eigen geometry-msgs interactive-markers mbf-costmap-core mbf-msgs mpc-local-planner-msgs nav-core nav-msgs pluginlib roscpp std-msgs teb-local-planner tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mpc_local_planner package implements a plugin
+    to the base_local_planner of the 2D navigation stack.
+    It provides a generic and versatile model predictive control implementation
+    with minimum-time and quadratic-form receding-horizon configurations.'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/ompl/default.nix
+++ b/distros/noetic/ompl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, eigen, pkg-config }:
+buildRosPackage {
+  pname = "ros-noetic-ompl";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ompl-release/archive/release/noetic/ompl/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c2c4fca9ef20e20dc1de4c243a5ff100ab9ceb49b2f42eb6bc38a2aa29422d97";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake pkg-config ];
+  propagatedBuildInputs = [ boost eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''OMPL is a free sampling-based motion planning library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/openni2-camera/default.nix
+++ b/distros/noetic/openni2-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, openni2, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-openni2-camera";
+  version = "1.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_camera/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "c1999fe5f544d9983e2edeb3db4fe197f54039ee907809621e13cd8d981a9bf6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ camera-info-manager dynamic-reconfigure image-transport message-runtime nodelet openni2 roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drivers for the Asus Xtion and Primesense Devices. For using a kinect
+  with ROS, try the <a href="http://wiki.ros.org/freenect_stack">freenect stack</a>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/openni2-launch/default.nix
+++ b/distros/noetic/openni2-launch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, pythonPackages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
+buildRosPackage {
+  pname = "ros-noetic-openni2-launch";
+  version = "1.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/openni2_camera-release/archive/release/noetic/openni2_launch/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "67a1cd7a2d3b9b667271d9297d412db970cca713e2075abd47d36993b3afb0f3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ depth-image-proc image-proc nodelet openni2-camera pythonPackages.catkin-pkg rgbd-launch rospy roswtf tf usbutils ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files to start the openni2_camera drivers using rgbd_launch.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5008d45d3b16f89ce6aadada1b27c800569fd78bf7aa109e1adb34d796378862";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2711b04fb49d94d74caba25cc6ce6dff6b755f84fd5f27215f098bd92cd55904";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "099a0800fa4a249d0586f19e7fce6a02b2a7faae5525d70ef1dc975c78e70e25";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "33695e7f1a90c9390da8363f144693740ef9024a9d60642fe45583fa94def41f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d72e7e5dc409ecb5130f27b62236f4b46dbbda55b330088e50c6f211f04043ad";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "20009c1554c652d1bb8ec9af96392dc94dedd4c52470e426101859b93556aeb9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "8f87cce624e7c7ca9bdc01cd95fd461e439c704d57e0b0eb3786de19f74e2d54";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d55a8c8962d4990cc76401536f7977ffb02bb037a26d37c58ce8c14ef39bd902";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "bafff84d6753bf01b485260dda8bfe5a0f95cb4a643413e84832a4062313da21";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "24267f25fd7866564d2bb5e6551eae348e7aa3abe2916ef374c9c6c15bb567e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "dc86b023d5ae909b88264baf25f097a5efd485659035358c358fba739860994d";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6d7897d4c1a1d91fe3e5e35fece4f517d2100c61ed833cfeb3c0df031fba99e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6aab07cbe881807fbab88b010733c8f75d8d0380cf5d4ac56e835d9620fc8ab8";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "25d3f37691542c6f371b970880ef2dc5bc6a1c876582e391c7fd0a3767084761";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5eb9c8b942edaff8409ddcb71d3588be324ca4ad9bf99f5dae56098f4e4577e4";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "efddecf8d7e49d2684f858143f6ea9e4f766d6b5d0194872604595b800acb08b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "665601946428b0ff625a6b17e9e25e957f3492d25de18946667e81da225cc56b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3e035d67786cb21822bc512aecc4464e932cfc2673e081e22895be8de2fddc58";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "83af2e0fb01bdc88b0107f169aaa9e74c66eb1f09dc6bbcd1d2f5fe3eeea1784";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "959e23d3cfa5768dab4dfb1a5ba4440585354dbc4dda2a823a4691f4ec8dbb9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d23de5f3c6880db3ba8ed1366c6326182116f9fc9064ed614f1f5b14df80a197";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6489d6a3c5947eb91203a86095e5341a7b870d97ead941e92cb68a524cbb5edd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ca943bb50346e7b31dec9dece76eae2abd584bd2f5d724b91b11225261899bbc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0c1ee6ed6227df2236e1fd0bfa0fe3df314e87a7be3fcdc8ac5b529c9876c4aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "60e0b44f3bafdd0b668e4d498d5983867c77af2d27984d48a98090846b233e14";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c4f675a64cce4931b95b19317f30d500d638dbb0869aacb0e185c815e1ed98ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "98ec563d8ba833ce027d04554bb630d65e0f32acaef05ef064401989ddb89db9";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "fcc58db08288de3212288902b3480bb0d505fa37a73d6d0bd77b9d2a9bd4ef6b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointcloud-to-laserscan/default.nix
+++ b/distros/noetic/pointcloud-to-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, message-filters, nodelet, roscpp, roslint, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pointcloud-to-laserscan";
+  version = "1.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/pointcloud_to_laserscan-release/archive/release/noetic/pointcloud_to_laserscan/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "acc561fc25b0b63f7eed1f56040bf2992e400e9bba6c22380d571c10478eeb40";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ laser-geometry message-filters nodelet roscpp sensor-msgs tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts a 3D Point Cloud into a 2D laser scan. This is useful for making devices like the Kinect appear like a laser scanner for 2D-based algorithms (e.g. laser-based SLAM).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/python-qt-binding/default.nix
+++ b/distros/noetic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-noetic-python-qt-binding";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "c4b1abeadfac51d34f01b5268a399b54681ba3fca44efd1775c04e25899663c3";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "743d59d0e39c3c139521050628ea45a0f2cef9b9e5e536d93eb04062974c3868";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan/default.nix
+++ b/distros/noetic/sick-scan/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sick-scan";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "dabe35907366de3a5a9f1445d24885c833d37f59beb2b4d742b6c5c6210f3f51";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime pcl-conversions pcl-ros roscpp sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS driver for the SICK TiM and SICK MRS series of laser scanners.
+    This package is based on the original sick_tim-repository of Martin Günther et al.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/slam-toolbox-msgs/default.nix
+++ b/distros/noetic/slam-toolbox-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-slam-toolbox-msgs";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "dae1e4189516139bd5c18e4e4ff17c9cbd1d526b6744a8c0111567b8d8f0814b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/slam-toolbox-rviz/default.nix
+++ b/distros/noetic/slam-toolbox-rviz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rviz, slam-toolbox-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-slam-toolbox-rviz";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "cc66bf855ac1a772da613702d0db9ec8792ec92e308b22091f91793ea5d27f4b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rviz slam-toolbox-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/slam-toolbox/default.nix
+++ b/distros/noetic/slam-toolbox/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-slam-toolbox";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "4f7c8dcd075d03764e2018b351f064bd2b8302a667cee9cc7c5ce3f2b5f697a6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ ceres-solver eigen interactive-markers libg2o liblapack map-server message-filters message-runtime nav-msgs pluginlib qt5.qtbase rosconsole roscpp sensor-msgs slam-toolbox-msgs sparse-bundle-adjustment std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/sophus/default.nix
+++ b/distros/noetic/sophus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-sophus";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/noetic/sophus/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c30680143378020b2b52ef83dfb48855b47ca7c894166649c34f01c00ee6dc04";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ implementation of Lie Groups using Eigen.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/teleop-tools-msgs/default.nix
+++ b/distros/noetic/teleop-tools-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, control-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-teleop-tools-msgs";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/noetic/teleop_tools_msgs/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8cc7640ebe831d44cbfed52384248636cb2dd9e54c142f70d5fa847143d521e8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs control-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The teleop_tools_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/teleop-tools/default.nix
+++ b/distros/noetic/teleop-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joy-teleop, key-teleop, mouse-teleop, teleop-tools-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-teleop-tools";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/noetic/teleop_tools/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f662b3bbf0d8350707ba9ca3547375564a8c2f5394e64663edc0368e0ee044b8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joy-teleop key-teleop mouse-teleop teleop-tools-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A set of generic teleoperation tools for any robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/tf/default.nix
+++ b/distros/noetic/tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geometry-msgs, graphviz, message-filters, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, roswtf, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf";
-  version = "1.13.1-r1";
+  version = "1.13.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf/1.13.1-1.tar.gz";
-    name = "1.13.1-1.tar.gz";
-    sha256 = "1aecdee491ea6efd8ad0f2901e4d7561ee06d8098a6584f3520e56da6dedaadb";
+    url = "https://github.com/ros-gbp/geometry-release/archive/release/noetic/tf/1.13.2-1.tar.gz";
+    name = "1.13.2-1.tar.gz";
+    sha256 = "e80444520026246b20a25f86f897cac53af73b3019b478d0abacaae5c46f480d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-bullet/default.nix
+++ b/distros/noetic/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bullet, catkin, geometry-msgs, pkg-config, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-bullet";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "b927d54fb0193c76936808c475ed9b1e7db1ea70500fa61dc06713f2f51353cf";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_bullet/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "0d2c420da3ddef86cd966327fe21d8e451372fbe9adb556d25da25852d3980e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-eigen/default.nix
+++ b/distros/noetic/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-eigen";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "9ba5b5696faf15ebe79e0af2dd443992181299443d6825539fbe2fa9ea9961ad";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_eigen/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "881e1f89630a4d837b41162e4c0a01380d6e6ed37d07c182b7c42d5997299159";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-msgs/default.nix
+++ b/distros/noetic/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation }:
 buildRosPackage {
   pname = "ros-noetic-tf2-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "17d3ddf62466da7b1909fb6d4a8e231e8cfb9d385784f85b67c05b3ea26e1d7a";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "b0dc57bf3b2dc84de60b8ac76c3d8c136a75b9808cbeec0d8184cbf15ac504a2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-py/default.nix
+++ b/distros/noetic/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-tf2-py";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "5d47f179e1def9396df0a7f41eecba1369f5eb4a9c79d9bf6fec2c118e530573";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_py/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "085338e6ebd735d223880ae9f0dd33f5cd034ff45e56ef59ba1625064d5e1adb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-ros/default.nix
+++ b/distros/noetic/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-filters, roscpp, rosgraph, rospy, rostest, std-msgs, tf2, tf2-msgs, tf2-py, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-tf2-ros";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "72a7b0b8a8cd4af364e481e468640a68a9549f37e9cad96ad9b9bb92bfe5b4cd";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_ros/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "d61a4b77a7effb253911b1fb8c6ea09e163f3528d694a24c666f3e8ea20d40bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2-tools/default.nix
+++ b/distros/noetic/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-tf2-tools";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e890ff721ab1374e392981faceda27f612764d91f18d52f03145a0092bf12bf5";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2_tools/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "9ebf883f15548745dad8b2f03d714fb1cada97007ce36242a8030f9c04d4da78";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tf2/default.nix
+++ b/distros/noetic/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, console-bridge, geometry-msgs, rostime, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-tf2";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "8f3a14bac0590976a76f776188c9222e33a6ba438d15dc77cdae25e118c57ace";
+    url = "https://github.com/ros-gbp/geometry2-release/archive/release/noetic/tf2/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "439de4e59dc0ee3a6de433fa9588d6baa4a7cdb7c40d3e3b0acbd2d46a83e94c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox-gps/default.nix
+++ b/distros/noetic/ublox-gps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-gps";
-  version = "1.4.0-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_gps/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "a2c10e5abab19013e7676686dfe5b12651ebb5e631927a0f1e843178e4ad8acf";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_gps/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "9424ea29b192475b9fea1fedfc744e5affffda51020fe3c48e914d57d99b4b9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox-msgs/default.nix
+++ b/distros/noetic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2ea427a899457d133eb6b91b137f45f838e7dfa7df435cc0c8cbc17dd9a15690";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_msgs/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "1ad2f25900e26c8d672d2d87eda24d430a0b02bad9c10467309e0d38ce56f401";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox-serialization/default.nix
+++ b/distros/noetic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-serialization";
-  version = "1.4.0-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_serialization/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "a133c6b45e255e0ea78a960329bc0dc65874121e2fecd08eddc1e927f21d8a67";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_serialization/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "99b1445d71dce681e50a7d50580a74bf104e1c09a549d30b46f6e18e1e8146cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox/default.nix
+++ b/distros/noetic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox";
-  version = "1.4.0-r1";
+  version = "1.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "89816ed65b672b6513617166e6c264a54de40ad662e028177af280fa379aec6a";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "5a4fed44385f67d457cc2bc6d2cc352cc59efc83e646fe1238ffb2dfe6088953";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 1aa4fdb475ec634b2b2620f547210e68368f870e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *raspimouse 1.0.1-r1*
* *raspimouse-msgs 1.0.1-r1*
* *rqt-robot-monitor 1.0.1-r1*

Eloquent Changes:
-----------------
* *ament-package 0.8.8-r1 --> 0.8.9-r1*
* *behaviortree-cpp-v3 3.5.0-r1 --> 3.5.1-r1*
* *marti-can-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-common-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-dbw-msgs 1.1.0-r1*
* *marti-nav-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-perception-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-sensor-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-status-msgs 1.0.0-r1 --> 1.1.0-r1*
* *marti-visualization-msgs 1.0.0-r1 --> 1.1.0-r1*
* *ros-workspace 0.8.0-r1 --> 1.0.1-r1*
* *urg-node 1.0.0-r1 --> 1.0.1-r1*

Kinetic Changes:
----------------
* *dual-quaternions 0.3.1-r1*
* *mavlink 2020.5.21-r1 --> 2020.6.6-r1*
* *py-trees-ros 0.5.20-r1 --> 0.5.21-r1*
* *rr-control-input-manager 0.8.0-r1 --> 1.0.0-r3*
* *rr-openrover-description 0.8.0-r1 --> 1.0.0-r3*
* *rr-openrover-driver 0.8.0-r1 --> 1.0.0-r3*
* *rr-openrover-driver-msgs 0.8.0-r1 --> 1.0.0-r3*
* *rr-openrover-simulation 1.0.0-r3*
* *rr-openrover-stack 0.8.0-r1 --> 1.0.0-r3*
* *rr-rover-zero-driver 0.8.0-r1 --> 1.0.0-r3*
* *urg-node 0.1.13-r1 --> 0.1.14-r1*

Melodic Changes:
----------------
* *avt-vimba-camera 0.0.11-r1 --> 0.0.12-r1*
* *mavlink 2020.5.21-r1 --> 2020.6.6-r1*
* *mpc-local-planner 0.0.2-r1 --> 0.0.3-r1*
* *mpc-local-planner-examples 0.0.2-r1 --> 0.0.3-r1*
* *mpc-local-planner-msgs 0.0.2-r1 --> 0.0.3-r1*
* *py-trees-ros 0.5.18 --> 0.5.21-r1*
* *rr-control-input-manager 1.1.0-r2*
* *rr-openrover-description 1.1.0-r2*
* *rr-openrover-driver 1.1.0-r2*
* *rr-openrover-driver-msgs 1.1.0-r2*
* *rr-openrover-simulation 1.1.0-r2*
* *rr-openrover-stack 1.1.0-r2*
* *rr-rover-zero-driver 1.1.0-r2*
* *slam-toolbox 1.1.3-r1 --> 1.1.6-r1*
* *slam-toolbox-msgs 1.1.3-r1 --> 1.1.6-r1*
* *tf2-server 1.0.5-r1 --> 1.0.6-r1*
* *ublox 1.4.0-r1 --> 1.4.1-r1*
* *ublox-gps 1.4.0-r1 --> 1.4.1-r1*
* *ublox-msgs 1.4.0-r1 --> 1.4.1-r1*
* *ublox-serialization 1.4.0-r1 --> 1.4.1-r1*
* *urg-node 0.1.13-r1 --> 0.1.14-r1*

Noetic Changes:
---------------
* *avt-vimba-camera 0.0.12-r2*
* *control-toolbox 1.18.1-r1 --> 1.18.2-r1*
* *dataspeed-ulc 0.0.5-r2*
* *dataspeed-ulc-can 0.0.5-r2*
* *dataspeed-ulc-msgs 0.0.5-r2*
* *ecl-config 0.61.6-r1*
* *ecl-console 0.61.6-r1*
* *ecl-converters-lite 0.61.6-r1*
* *ecl-errors 0.61.6-r1*
* *ecl-io 0.61.6-r1*
* *ecl-lite 0.61.6-r1*
* *ecl-sigslots-lite 0.61.6-r1*
* *ecl-time-lite 0.61.6-r1*
* *geometry 1.13.1-r1 --> 1.13.2-r1*
* *geometry2 0.7.1-r1 --> 0.7.2-r1*
* *graph-msgs 0.1.0-r2*
* *imu-pipeline 0.3.0-r2*
* *imu-processors 0.3.0-r2*
* *imu-transformer 0.3.0-r2*
* *jderobot-assets 1.0.3-r1 --> 1.1.0-r1*
* *joy-teleop 0.4.0-r1*
* *key-teleop 0.4.0-r1*
* *laser-filters 1.8.9-r1 --> 1.8.11-r1*
* *libphidget22 1.0.0-r1 --> 1.0.1-r1*
* *lusb 1.1.0-r1*
* *marti-can-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-common-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-dbw-msgs 0.9.0-r1*
* *marti-nav-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-perception-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-sensor-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-status-msgs 0.8.0-r1 --> 0.9.0-r1*
* *marti-visualization-msgs 0.8.0-r1 --> 0.9.0-r1*
* *mavlink 2020.5.21-r1 --> 2020.6.6-r1*
* *mouse-teleop 0.4.0-r1*
* *mpc-local-planner 0.0.3-r1*
* *mpc-local-planner-examples 0.0.3-r1*
* *mpc-local-planner-msgs 0.0.3-r1*
* *ompl 1.5.0-r1*
* *openni2-camera 1.4.2-r1*
* *openni2-launch 1.4.2-r1*
* *phidgets-accelerometer 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-analog-inputs 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-api 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-digital-inputs 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-digital-outputs 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-drivers 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-gyroscope 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-high-speed-encoder 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-ik 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-magnetometer 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-motors 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-msgs 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-spatial 1.0.0-r1 --> 1.0.1-r1*
* *phidgets-temperature 1.0.0-r1 --> 1.0.1-r1*
* *pointcloud-to-laserscan 1.4.1-r1*
* *python-qt-binding 0.4.2-r1 --> 0.4.3-r1*
* *sick-scan 1.6.0-r1*
* *slam-toolbox 1.5.0-r1*
* *slam-toolbox-msgs 1.5.0-r1*
* *slam-toolbox-rviz 1.5.0-r1*
* *sophus 1.1.0-r1*
* *teleop-tools 0.4.0-r1*
* *teleop-tools-msgs 0.4.0-r1*
* *tf 1.13.1-r1 --> 1.13.2-r1*
* *tf2 0.7.1-r1 --> 0.7.2-r1*
* *tf2-bullet 0.7.1-r1 --> 0.7.2-r1*
* *tf2-eigen 0.7.1-r1 --> 0.7.2-r1*
* *tf2-msgs 0.7.1-r1 --> 0.7.2-r1*
* *tf2-py 0.7.1-r1 --> 0.7.2-r1*
* *tf2-ros 0.7.1-r1 --> 0.7.2-r1*
* *tf2-tools 0.7.1-r1 --> 0.7.2-r1*
* *ublox 1.4.0-r1 --> 1.4.1-r2*
* *ublox-gps 1.4.0-r1 --> 1.4.1-r2*
* *ublox-msgs 1.4.0-r1 --> 1.4.1-r2*
* *ublox-serialization 1.4.0-r1 --> 1.4.1-r2*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gazebo11
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libgazebo11-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-dev-qt5
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libqglviewer2-qt5
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opencv2
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rospkg-modules
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3
 * [ ] python3-babeltrace
 * [ ] python3-catkin-pkg
 * [ ] python3-future
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-sphinx
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

