### PR TITLE
rosdistro sync, Fri Jun 19 12:54:43 2020

### DIFF
--- a/distros/dashing/osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "185f904f6e12b39cd031144ba279c08540bb5337960ecc2d9446e282281bcaa3";
+    sha256 = "8160416b8da311fc0b70bdf3a957453c68788a33982ca66eef7b03f20f45ce95";
   };
 
   buildType = "cmake";

--- a/distros/dashing/qt-dotgraph/default.nix
+++ b/distros/dashing/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-qt-dotgraph";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_dotgraph/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e76d05f8fc9980fe75079a36a3a8e5bbf48100cf46316093f63eeea272c33977";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_dotgraph/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "14a2d03f36a2d163a0b3d6080e9f8c54ddee8c4b3c654942134fcf96d4f3a2c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/qt-gui-app/default.nix
+++ b/distros/dashing/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-dashing-qt-gui-app";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_app/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "6dd19686823d2f5a2bbf36fead928fa02ba2b8384ef53db35cf97231311ceae0";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_app/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "4d29cd1664be1ee8397ed6f13848103ca1ef6fafd56b613e4460efee1ad59a08";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/qt-gui-core/default.nix
+++ b/distros/dashing/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-dashing-qt-gui-core";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3549aa1ec63b99aecf153019e26b0057f3277a940525569c1d967b7206163c3b";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "44a2c38afd83635b5bda249dd8c755254892fa65a434c2e21e873d320dbc71d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/qt-gui-cpp/default.nix
+++ b/distros/dashing/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-dashing-qt-gui-cpp";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_cpp/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0ec9a0be0a8a8705cd6bd8d2b0b8c018b204ecd537510479f37a8f497cbd84c1";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_cpp/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "43c1b4ddb8022b6fac87de0ebd0324b95e61ce4b67dc50fdd9987495eca1a6e6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/qt-gui-py-common/default.nix
+++ b/distros/dashing/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-dashing-qt-gui-py-common";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_py_common/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "59e2ea2f2a5a4af0fddf807332e2c4266d2b26c8648abf392f3f57ae762c623c";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui_py_common/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "ff3935f117200f14b8dd835f247fa8879909eecc7c53f58b75fdf89f5d78848c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/qt-gui/default.nix
+++ b/distros/dashing/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-dashing-qt-gui";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "5c89db11d107fc71ba81088b98507b14613d1b28930185d430985813d90b1964";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/dashing/qt_gui/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "2cd7188fe75e1407a1be3edb6f0b0128e00c67711e21978c7a069db86f51872e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/sros2-cmake/default.nix
+++ b/distros/dashing/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-dashing-sros2-cmake";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/dashing/sros2_cmake/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "5048c3e582a406fb776c1bbfc270dfa2dcd54b1bff49d5bbf4354b689da9915f";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/dashing/sros2_cmake/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "c64b7935e139fe0602e4155fd8dbf005afb97726ec8d946041accc9a10350571";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Cmake macros to configure security for nodes'';
+    description = ''CMake macros to configure security for nodes'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/dashing/sros2/default.nix
+++ b/distros/dashing/sros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, openssl, python3Packages, pythonPackages, rclpy, ros2cli }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, openssl, python3Packages, pythonPackages, rclpy, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-sros2";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/dashing/sros2/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e1f3418eb4f3500eb3c8603aab81c2315f248c1963efd4c808049b4778328612";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/dashing/sros2/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "f17d82cd80c3b0ac1ccfdc2d9d2c584c94bb80ab7de24b5876dbeb586180cb9a";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ openssl python3Packages.lxml rclpy ros2cli ];
+  propagatedBuildInputs = [ ament-index-python openssl python3Packages.lxml rclpy ros2cli ];
 
   meta = {
     description = ''Command line tools for managing SROS2 keys'';

--- a/distros/dashing/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "b5168ed927afbbeb3f17be5913baf27b4f34a3aed3a4c3f199012f2a68d44031";
+    sha256 = "1d496b46debc9b6155c316d3cc3519168aee512e107ee2d293dc484863548876";
   };
 
   buildType = "cmake";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/turtlesim/default.nix
+++ b/distros/dashing/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-turtlesim";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/dashing/turtlesim/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6b87baa51cee30307d4ca46aac1d6f3564fc50f68845a5f034603763893fc238";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/dashing/turtlesim/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f59ebbaa9e1231fa556f89581ec504119c91b1c2397695ebaf88d0bd02217b7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -872,6 +872,8 @@ self: super: {
 
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
 
+ rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
+
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
  rqt-service-caller = self.callPackage ./rqt-service-caller {};

--- a/distros/eloquent/osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "974bb61988443982d8760ab83213fe959b679a070f11f50ad93f3e92994ecc64";
+    sha256 = "3e281da144e292afee15fdcd4b85780ed0ae047129c16bb4c7147856961a3260";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/qt-dotgraph/default.nix
+++ b/distros/eloquent/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-eloquent-qt-dotgraph";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_dotgraph/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "40dca3461dc462e323303b6ae277203af0c2d2b7f9ab0fad0afaf6bec462b632";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_dotgraph/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "fec7b3ab9504bf0f84ac6e25b7bb0a58ec1a3a11495c8a9f71dc0da2a15ad61d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/qt-gui-app/default.nix
+++ b/distros/eloquent/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-eloquent-qt-gui-app";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_app/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "adbda60c1b7d7be9bd6011e23959216862b49ba43eb3db7c7e88ed00d1991163";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_app/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "dbb070b38a59d3e482e82717eee89bd589823cb997ada27b4124fc8f16b2ff99";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/qt-gui-core/default.nix
+++ b/distros/eloquent/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-eloquent-qt-gui-core";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_core/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "b6cb56a4ebd123263e0123ca6c88ed5bdd809494dd7c4c7d826cd9470ea14c0d";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "da648058e9c917d78d673286d08759d86a68c1ea0fc8323565eb04b2463fb4e4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/qt-gui-cpp/default.nix
+++ b/distros/eloquent/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-qt-gui-cpp";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_cpp/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "d893e98420d1ab751478aa4a260472ae456e157a329c21d891124f8b2c57e928";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_cpp/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "7023ae86ebcabf61279871ad1adfd7fd2a7b39ef222c09b676f1807dcd446194";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/qt-gui-py-common/default.nix
+++ b/distros/eloquent/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-eloquent-qt-gui-py-common";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_py_common/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "9fcbf780e45c026317601f5fe384b60f17dd6e79d8d1ef7c87e3114c90271aaa";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui_py_common/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "9046be3901b2c944896cac5b85b9ead179d4adeaadf2197f5e466e5ea962930d";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/qt-gui/default.nix
+++ b/distros/eloquent/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-eloquent-qt-gui";
-  version = "1.0.7-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "91c20b73850e0ac407f3e73448560f5161cd3097bebe3b7c49c8203a18627f24";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/eloquent/qt_gui/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "62cb2eb745c6b5f260728c62fb15babd113120c2cf7aec9c5649777f43e0c64a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rqt-robot-monitor/default.nix
+++ b/distros/eloquent/rqt-robot-monitor/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rclpy, rosidl-default-generators, rqt-gui, rqt-gui-py, rqt-py-common }:
+buildRosPackage {
+  pname = "ros-eloquent-rqt-robot-monitor";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_robot_monitor-release/archive/release/eloquent/rqt_robot_monitor/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "84054d6a03aba5e2dd9c3a08b2d00e3964df9c1801ddb65ccd2ba6a29a13b3f1";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''rqt_robot_monitor displays diagnostics_agg topics messages that
+   are published by <a href="http://www.ros.org/wiki/diagnostic_aggregator">diagnostic_aggregator</a>.
+   rqt_robot_monitor is a direct port to rqt of
+   <a href="http://www.ros.org/wiki/robot_monitor">robot_monitor</a>. All
+   diagnostics are fall into one of three tree panes depending on the status of
+   diagnostics (normal, warning, error/stale). Status are shown in trees to
+   represent their hierarchy. Worse status dominates the higher level status.<br/>
+   <ul>
+    Ex. 'Computer' category has 3 sub devices. 2 are green but 1 is error. Then
+        'Computer' becomes error.
+   </ul>
+  You can look at the detail of each status by double-clicking the tree nodes.<br/>
+
+  Currently re-usable API to other pkgs are not explicitly provided.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/sros2-cmake/default.nix
+++ b/distros/eloquent/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-eloquent-sros2-cmake";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/eloquent/sros2_cmake/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "200e5f0b960bd1ee7457e92dc6ad50d24553d28d0aed39c2961ebb38d0967ef8";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/eloquent/sros2_cmake/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "5bfc16a8300023d607b648d29c7b8eb2c81cab27bb6edcdff7f761ecd3dd6510";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Cmake macros to configure security for nodes'';
+    description = ''CMake macros to configure security for nodes'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/eloquent/sros2/default.nix
+++ b/distros/eloquent/sros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, pythonPackages, rclpy, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-sros2";
-  version = "0.8.1-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/eloquent/sros2/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9f8dabde33f6ab15c12d2320689600224e2f2410726ceec344137856b887627e";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/eloquent/sros2/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "f65acae55a5d8d8ed02698d83275bfb495e5585a7035c8d300a6adcc9e8435af";
   };
 
   buildType = "ament_python";

--- a/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "32ab5b5aec9f25fb7306bbdf5b61c593fbd85963b404c9967bbe3c5714dcd5e0";
+    sha256 = "3701c6297431bcbcb96a9e61ac4a25db8aa470df275889a79b7b1d38b0f62d78";
   };
 
   buildType = "cmake";

--- a/distros/foxy/apriltag/default.nix
+++ b/distros/foxy/apriltag/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-apriltag";
+  version = "3.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/foxy/apriltag/3.1.2-2.tar.gz";
+    name = "3.1.2-2.tar.gz";
+    sha256 = "f79e5ecb5aa78a3e008bc90b292998de17c294565e5b3008d546610bfd939ef1";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''AprilTag detector library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/cyclonedds/default.nix
+++ b/distros/foxy/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, maven, openjdk, openssl }:
 buildRosPackage {
   pname = "ros-foxy-cyclonedds";
-  version = "0.5.1-r2";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/foxy/cyclonedds/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "5b3edf7326843f994bc115d5291addede1a3f9d8592bb7cedc8122f1a4c637d1";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/foxy/cyclonedds/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "df843df67155e09abfff76236dffbc3424ee6bccc021487f8b818aea13157a6d";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -126,6 +126,8 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
+ apriltag = self.callPackage ./apriltag {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
@@ -650,6 +652,8 @@ self: super: {
 
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
 
+ rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
+
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
@@ -811,6 +815,26 @@ self: super: {
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ webots-ros2 = self.callPackage ./webots-ros2 {};
+
+ webots-ros2-abb = self.callPackage ./webots-ros2-abb {};
+
+ webots-ros2-demos = self.callPackage ./webots-ros2-demos {};
+
+ webots-ros2-desktop = self.callPackage ./webots-ros2-desktop {};
+
+ webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
+
+ webots-ros2-examples = self.callPackage ./webots-ros2-examples {};
+
+ webots-ros2-msgs = self.callPackage ./webots-ros2-msgs {};
+
+ webots-ros2-tiago = self.callPackage ./webots-ros2-tiago {};
+
+ webots-ros2-universal-robot = self.callPackage ./webots-ros2-universal-robot {};
+
+ webots-ros2-ur-e-description = self.callPackage ./webots-ros2-ur-e-description {};
 
  xacro = self.callPackage ./xacro {};
 

--- a/distros/foxy/osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "e45c6bfaaf2feb2cd5fdad1a85efc2219d7621db4adaaf8344ab69e9f292b8b3";
+    sha256 = "32179f190ed329ba1a47ba412c2762f047973a85a4baa25d69d1d530a8bdbafa";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rqt-robot-monitor/default.nix
+++ b/distros/foxy/rqt-robot-monitor/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rclpy, rosidl-default-generators, rqt-gui, rqt-gui-py, rqt-py-common }:
+buildRosPackage {
+  pname = "ros-foxy-rqt-robot-monitor";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_robot_monitor-release/archive/release/foxy/rqt_robot_monitor/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2174f343a27291f2f953ed740a0307e1339ac560cb1120d7e8d6e78cfd91da98";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''rqt_robot_monitor displays diagnostics_agg topics messages that
+   are published by <a href="http://www.ros.org/wiki/diagnostic_aggregator">diagnostic_aggregator</a>.
+   rqt_robot_monitor is a direct port to rqt of
+   <a href="http://www.ros.org/wiki/robot_monitor">robot_monitor</a>. All
+   diagnostics are fall into one of three tree panes depending on the status of
+   diagnostics (normal, warning, error/stale). Status are shown in trees to
+   represent their hierarchy. Worse status dominates the higher level status.<br/>
+   <ul>
+    Ex. 'Computer' category has 3 sub devices. 2 are green but 1 is error. Then
+        'Computer' becomes error.
+   </ul>
+  You can look at the detail of each status by double-clicking the tree nodes.<br/>
+
+  Currently re-usable API to other pkgs are not explicitly provided.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/test_osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "5a63a3c96ca015cc0ac3e9ba54d83320cd014fb0f67105a114c69a22b22f9bf3";
+    sha256 = "c4305d66ab841ea1a44618a15187e7d54fb4b3c6beb695f5c312e0f35dc8ed99";
   };
 
   buildType = "cmake";

--- a/distros/foxy/turtlesim/default.nix
+++ b/distros/foxy/turtlesim/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, geometry-msgs, qt5, rclcpp, rclcpp-action, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-turtlesim";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/foxy/turtlesim/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "cb94260f6d2540633d0219dc4105e433e7b82efdeba9c361ba8f1c135ed3b33b";
+    url = "https://github.com/ros2-gbp/ros_tutorials-release/archive/release/foxy/turtlesim/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "289d7d0565490d255ba88cbf7a88ecfaaeb153b4f69c5e24be19c7db2eae3b6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/v4l2-camera/default.nix
+++ b/distros/foxy/v4l2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-v4l2-camera";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.1.1-1";
+    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "328a8ecdee96b40f876a90560cc35a9037d6329d2c057fb064c34ebc2da18004";
+    sha256 = "327d72dc99df436b904a5aff7aaa96c41cb00e20aebd616a729810e426ed60b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-abb/default.nix
+++ b/distros/foxy/webots-ros2-abb/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-abb";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "3195a0b822005bb192d31797ae5b8f2cb9cd238dc6e4792819f70f32e2882b88";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs rclpy rosgraph-msgs sensor-msgs std-msgs trajectory-msgs webots-ros2-core ];
+
+  meta = {
+    description = ''ABB robots ROS2 interface for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-demos/default.nix
+++ b/distros/foxy/webots-ros2-demos/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-universal-robot }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-demos";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "7db1de5d04df6b529e55d369fdcbc9bdd09a092fade38b107f14da7fbad87ae0";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-universal-robot ];
+
+  meta = {
+    description = ''Various demos of the Webots-ROS2 interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-desktop/default.nix
+++ b/distros/foxy/webots-ros2-desktop/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, builtin-interfaces, rclpy, std-msgs, webots-ros2 }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-desktop";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_desktop/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "345687687ea0bbe2e8a6f9bacbfa366575140bd90c65ffe3823a1a670ac1615f";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2 ];
+
+  meta = {
+    description = ''Interface between Webots and ROS2 including the Webots package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-epuck";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "579958daf1961b8ba37f5ed1e890dab5653248d255d4c6a8b75fc10c24b8811e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs nav-msgs rclpy rviz2 sensor-msgs std-msgs tf2-ros webots-ros2-core webots-ros2-msgs ];
+
+  meta = {
+    description = ''E-puck2 driver for Webots simulated robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-examples/default.nix
+++ b/distros/foxy/webots-ros2-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, webots-ros2-core, webots-ros2-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-examples";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "4aab310a9cda0a12ee30c41778e7bddc5cea3f5ec7af0406fcb4ae1fd27d825c";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy sensor-msgs std-msgs webots-ros2-core webots-ros2-msgs ];
+
+  meta = {
+    description = ''Minimal example showing how to control a robot with ROS2 in Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "d125a708d27ce03ab57732872d0d6df0520a12b2d4e53525d075f7d18cb05a13";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Services and Messages of the webots_ros2 packages.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-tiago";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "80ddd1c285ca097bdf66391c8486da74c9fe8a64364d1fc1ef598e3f18a09e53";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclpy rviz2 webots-ros2-core ];
+
+  meta = {
+    description = ''TIAGo robots ROS2 interface for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-universal-robot";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "154b1903366864d85d7b63b213ccdaa14096634bc30b889e198b361a2419e982";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces control-msgs rclpy rosgraph-msgs rviz2 sensor-msgs std-msgs trajectory-msgs webots-ros2-core webots-ros2-ur-e-description ];
+
+  meta = {
+    description = ''Universal Robot ROS2 interface for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-ur-e-description/default.nix
+++ b/distros/foxy/webots-ros2-ur-e-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, urdf }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-ur-e-description";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c1fa4aeeebd232ab5ad2c2710c03da2c07f5f415a44be4477c0bb27736d0471d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ urdf ];
+
+  meta = {
+    description = ''Universal Robot description for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-examples, webots-ros2-importer, webots-ros2-tiago, webots-ros2-universal-robot }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "20dc0e9b93306f84c6d604e2706aff3d94b7fb5bf664fa51d218f80b763ca3c7";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-examples webots-ros2-importer webots-ros2-tiago webots-ros2-universal-robot ];
+
+  meta = {
+    description = ''Interface between Webots and ROS2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "fedc732fbd0e31ddedb51b26fd34d7d1f9fcdbf906e49467700b148cf4ec0331";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "26612878e6a1061937502b9839d4ad48c2ea882d935a0e27633d8556cdbd97ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dual-quaternions-ros/default.nix
+++ b/distros/kinetic/dual-quaternions-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-kinetic-dual-quaternions-ros";
+  version = "0.1.3-r3";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/kinetic/dual_quaternions_ros/0.1.3-3.tar.gz";
+    name = "0.1.3-3.tar.gz";
+    sha256 = "dc9076627c8cb54d1fc3e0d3c4eab854f2a48d0aa12bd261fc0a678ce794b85b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dual-quaternions geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS msgs from and to dual quaternions'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/dual-quaternions/default.nix
+++ b/distros/kinetic/dual-quaternions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pyquaternion }:
 buildRosPackage {
   pname = "ros-kinetic-dual-quaternions";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/kinetic/dual_quaternions/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "75c484d00dffea7bd617ff271800da2955d80e364a49937d9973c4386e87ecfa";
+    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/kinetic/dual_quaternions/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "392aaa2d3efbedc9d378f0ef673db93fb0a8f4fe83448ed933b9623574e5ccf6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-behavior-engine/default.nix
+++ b/distros/kinetic/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-behavior-engine";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e5a8377c035a016294841d07bfbf5dffd0a5a6eed10f77e34cc45f99adec803f";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "dd270872c43100381b5d978ccae06502e8f22a44a62b1133f9f842fab023b475";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-core/default.nix
+++ b/distros/kinetic/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, rostest, smach-ros, tf }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-core";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e740ab7e200c5fa294956666af8f6e311f941ddd2525371ecfa2550be8796def";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "3b1d29d34f7208f8772dfcf910f39bc0b0c53ba95a7c97bf49b224d972803f87";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-input/default.nix
+++ b/distros/kinetic/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, pythonPackages, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-input";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "406691bcca409ea9240110d29f6dc0c883510448dbb25a42b4a469d2d23a18bb";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "17b22061ee5bbe600f1632eeeefa3617b3a47c2ee3992a9959b592bc3a40a3be";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-mirror/default.nix
+++ b/distros/kinetic/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-mirror";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "0cae54cba828a22dbb2814eab51b75a15b3221e7e76595ae3360fe8105701b47";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "4c9464985cd2167304fbd00a71a72c17f45aa9e948fc5e672806853f1f969400";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-msgs/default.nix
+++ b/distros/kinetic/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-msgs";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "3664ada239ee3f4a1bf981bf0b8fb7d07d687ccd1d138fa17d8a0cd8eafad979";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "2a359eb5f21788b1db8404bc0a88c189895c59b1f290ee38582239c93e0ba4ed";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-onboard/default.nix
+++ b/distros/kinetic/flexbe-onboard/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-onboard";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "cf69794624279f0d9b58034fea4105d7e5fd3e963d7f8bc5899901e61ebd316e";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "47ba62809691d63df576f52be7b49af74c8df364c5ce7bdd7aab81476d8b8216";
   };
 
   buildType = "catkin";
+  buildInputs = [ rostest ];
   propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/flexbe-states/default.nix
+++ b/distros/kinetic/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-states";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "19ba3ae87bc1a98797ea7e7a1388abb91ce1dc5e04e86599cb35202ee04ba6a5";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "078d89131588b4d0e576a32ce54a4de6eca6dd86bd9189eaecfa641987e8f616";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-testing/default.nix
+++ b/distros/kinetic/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, smach-ros, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-testing";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "995b35f588514f78ce7ac963d7c5e2a45663b7e78303c4a44c9aba6334497336";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "bbe6b3471afe5fa5d0d05994113ea8d018d7c0c46a8a8858e63fe9087b79a888";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-widget/default.nix
+++ b/distros/kinetic/flexbe-widget/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-widget";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "1a90350f992f3baaeddbf1708422e89adb83bd597ba0f9d052219b0bce6dfaca";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "b5115fc90bd080d53fd9e0e8cd6d9e41a3e9a4d27d58c265f78eed8289cf1db3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -800,6 +800,8 @@ self: super: {
 
  dual-quaternions = self.callPackage ./dual-quaternions {};
 
+ dual-quaternions-ros = self.callPackage ./dual-quaternions-ros {};
+
  dwa-local-planner = self.callPackage ./dwa-local-planner {};
 
  dwb-critics = self.callPackage ./dwb-critics {};
@@ -2003,6 +2005,10 @@ self: super: {
  leap-motion = self.callPackage ./leap-motion {};
 
  leg-detector = self.callPackage ./leg-detector {};
+
+ leo-description = self.callPackage ./leo-description {};
+
+ leo-viz = self.callPackage ./leo-viz {};
 
  leuze-bringup = self.callPackage ./leuze-bringup {};
 
@@ -3769,6 +3775,10 @@ self: super: {
  rosbag-migration-rule = self.callPackage ./rosbag-migration-rule {};
 
  rosbag-pandas = self.callPackage ./rosbag-pandas {};
+
+ rosbag-snapshot = self.callPackage ./rosbag-snapshot {};
+
+ rosbag-snapshot-msgs = self.callPackage ./rosbag-snapshot-msgs {};
 
  rosbag-storage = self.callPackage ./rosbag-storage {};
 

--- a/distros/kinetic/graph-msgs/default.nix
+++ b/distros/kinetic/graph-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-graph-msgs";
-  version = "0.1.0";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/davetcoleman/graph_msgs-release/archive/release/kinetic/graph_msgs/0.1.0-0.tar.gz";
-    name = "0.1.0-0.tar.gz";
-    sha256 = "d72fb3ab3eac18e4669abdc4af66cecb565edd2275c039be2fe3d5d8ce9b5f8b";
+    url = "https://github.com/PickNikRobotics/graph_msgs-release/archive/release/kinetic/graph_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "544de30323529e0219a6eabe242809089ff285cf7e8b1911d6dbe5f27ac7dd77";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "811aafcbdcf3fc7998c50ab43f330d7903642fb14d7b0435e5c398c014c5e2d6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "aa905cca50e419ad995c65bfee470eb5e697f841a81648d2a57fd4cf69abb913";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/leo-description/default.nix
+++ b/distros/kinetic/leo-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-kinetic-leo-description";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_description-release/archive/release/kinetic/leo_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "15db55892ea9447b3c39aa2b5602edd8aec6809e5331f90e74eb3d1554bd90fc";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF Description package for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/leo-viz/default.nix
+++ b/distros/kinetic/leo-viz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, leo-description, robot-state-publisher, rviz }:
+buildRosPackage {
+  pname = "ros-kinetic-leo-viz";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_viz-release/archive/release/kinetic/leo_viz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5291c4ed64fd8648c692a68432060c47de61d58bbf5c25fdfb316bf6d1f042cc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "0553f5c72564e963cb9d013b428646004d61be0416aaba160a83167251697858";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "3642d991f410e5bb3674590529b6c59b8079c445d5b6e083a586eb2f94b244bc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "fd69ef38944d9226d1e4b13ad8559cff22f6810cd72da281ba1a4da66fd68328";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "8455e00574cecd079c262a95a2fde8a2250d98ed6a256097504b6b3aa6f9c170";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "6140c24f85bfde25e2e1e4bee98274c8f309b04fcd599ac1a396d3a8fd468547";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "6202de94f593b201d821bfef5e83f0d250bfc539a74a59d09dc45a122f4a9259";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "4fc679eb4bb5b8219b7a282503075f493bf208845449d7416f6b8d484ed7a8bd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "95046ccc3c348344dc3111d14590f1816ccbdd698d351f37ba391814042d4470";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "d8a7a3c6f3394a85986a4dcc8a61da0813121b1c1758766590eeed99a101dc95";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "27469ee208f106ff2bcef519b880212f2b9292a40e46389403ac0d082e2a95b7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "614f6cf59b21fea5130f8bb5d8ecaa49e857d86a23a12837cb91567f2fb4c2e3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "897974adbbbe51692e5e7b9c9810addd5aa259ca390dd9cdc74512d45039ab33";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.13-r1";
+  version = "2.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.13-1.tar.gz";
-    name = "2.2.13-1.tar.gz";
-    sha256 = "14b8c6820854fee2cb4a07dc24100efe7f6bd2ff0b9c6008759bd74b3f999512";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "19a9d9e6b6bec03b400abef04c150629fe3d750e34ae07030852130a304599c6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.13-r1";
+  version = "2.2.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.13-1.tar.gz";
-    name = "2.2.13-1.tar.gz";
-    sha256 = "21b79cfad078f38eba241dba892b47890e4b1976a2493065fbffa378aa18efd6";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.14-1.tar.gz";
+    name = "2.2.14-1.tar.gz";
+    sha256 = "0219bbedc5d2f55f653a87ac05c645bd9feccb66569603d9120fa0243f9d0564";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/kinetic/rosbag-snapshot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rosbag-snapshot-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c69e51f659b77b8e4f05805e7e7fc5444e55b6dffb12470aaeb1da58165c0333";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosgraph-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Service and message definitions for rosbag_snapshot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/rosbag-snapshot/default.nix
+++ b/distros/kinetic/rosbag-snapshot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
+buildRosPackage {
+  pname = "ros-kinetic-rosbag-snapshot";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "33a4255373aabdf3c8f2b6cfe618c5ffbaa40a0e5c3b339fa555ccf2e5ae68cf";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rospy rostest rostopic std-msgs ];
+  propagatedBuildInputs = [ rosbag rosbag-snapshot-msgs roscpp rosgraph-msgs std-srvs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rosbag_snapshot package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/rqt-reconfigure/default.nix
+++ b/distros/kinetic/rqt-reconfigure/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, pythonPackages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-reconfigure";
-  version = "0.5.1-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/kinetic/rqt_reconfigure/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "4d4ddccaba198e1867fd7283c27654fda2f7c8c783440c2fe16bf056bd6e5b4f";
+    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/kinetic/rqt_reconfigure/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "b07430674732837553702a73032da73f3c4744d03186c73e9401bea3083526f1";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure python-qt-binding pythonPackages.pyyaml rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''This rqt plugin succeeds former dynamic_reconfigure's GUI

--- a/distros/kinetic/rr-control-input-manager/default.nix
+++ b/distros/kinetic/rr-control-input-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-control-input-manager";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "d074f1819b190341a0566c9d9b25cdaf5ea3ab77d9fda674c91a431c877c7de7";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_control_input_manager/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "986e24afe587fc86dc3562d42b98f14c453df9c85369fff9e05fa01160fe8fe5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-description/default.nix
+++ b/distros/kinetic/rr-openrover-description/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-description";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_description/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "ebc8e2f9c4e01fcfa4a306539b2ecce5259f23c7f0d7f76f94723c05e01a5878";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "08e441ccf838829cbe86d38194b7a9dbbf96397ba9339878f85ce9dc14a10752";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  propagatedBuildInputs = [ gazebo-msgs gazebo-plugins gazebo-ros gazebo-ros-control gazebo-ros-pkgs roscpp rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The rr_openrover_description package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/rr-openrover-driver-msgs/default.nix
+++ b/distros/kinetic/rr-openrover-driver-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver-msgs";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "e74a34407ce7bf9bcca81b6bc9a9c940a7b8f75b0b74ca33c51f91b9ffdb594e";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cfb15d3aed0b691b9cfc2521e36d43b31cdf26e25ebc793e2a5129a27d044894";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-driver/default.nix
+++ b/distros/kinetic/rr-openrover-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-driver";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "fde6c2041b88a10025bfaaec0622a0d3f9f88dc6802b1159ae3c1d377fc6e2a7";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "082b40321712e51a6693eda24ec2ff62f61ea14ca1fd098e1487505d52c41205";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-openrover-simulation/default.nix
+++ b/distros/kinetic/rr-openrover-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-simulation";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_simulation/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "19d32ca6996f2d77edee8c07f56fb492e86011e876d36faf54bb48a7fac0bd04";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_simulation/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0baaa3a6fa47db7c904983de95a0f4825feb4bf7f2b19fc6cdf67d19b3a3df06";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The rr_openrover_simulation package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/rr-openrover-stack/default.nix
+++ b/distros/kinetic/rr-openrover-stack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-description, rr-openrover-driver, rr-openrover-driver-msgs, rr-openrover-simulation, rr-rover-zero-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rr-openrover-stack";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "a4bca04c9788a72c7cfe9301ee214a0eeeab18e97c383e41ad37727f8bbdfdb8";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_openrover_stack/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8ad3aec59ba2121d852b26226236021fa16d3f76f6023fabd2d51a9b8b98b759";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rr-rover-zero-driver/default.nix
+++ b/distros/kinetic/rr-rover-zero-driver/default.nix
@@ -2,22 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, python-orocos-kdl, pythonPackages, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rr-rover-zero-driver";
-  version = "1.0.0-r3";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_rover_zero_driver/1.0.0-3.tar.gz";
-    name = "1.0.0-3.tar.gz";
-    sha256 = "3bb1b4baa627602b3f7724c5833ca6f646acde6cc6b9f06e52f8df731ac681f9";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/kinetic/rr_rover_zero_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "0818a636dadba1bf9bbd45a78cf1c1c61deee283f043b1cd6d26fc5b3579c4fd";
   };
 
   buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs nav-msgs python-orocos-kdl pythonPackages.pyserial rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The rover_zero_driver package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "60b3d5e31a9607dbb84071bd20c46ec052b4b8ad6910b30269ba5ccea8f34f62";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "c60b302d1c57d34f80c2c5e16a08d25575a26900a00f55aa73defd4b91c665d0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-safetyscanners/default.nix
+++ b/distros/kinetic/sick-safetyscanners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, roscpp, rqt-reconfigure, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rqt-reconfigure, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-safetyscanners";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/kinetic/sick_safetyscanners/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "8529eb3a84bcdb79a11d4156bff66470bb0f9876b38ad4c7555c0e171e08c857";
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/kinetic/sick_safetyscanners/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "952ab90782dfa2e20d0d05358d34b906002c4826989d19c1b6f4b7b57ebc35e9";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rqt-reconfigure sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime roscpp rqt-reconfigure sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "61ae28d1dacebfe35df7a52e244815904b9a738d2a6a0ba3e42fd6e5de127a82";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "ac5d0fe1a655235412c2e7b5a6070a775f5f263e22b81e358bdcf077c4622328";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "0afadd54924c2b23d9abdc0c0dff9f7b29d9d28faa2199416c9fb1ac0723dc81";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "3b2323ce258fc8a14778a029a9e5e37808ad0739783d703ab39b65ab08246c25";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "c1b24185483c132c5e9cf11fe81e27ecca5bb51dd93c24b64728dc1ffc6a2472";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "de5c85ab68b8bfdc4b97e6ed0353ed8c3ea4b076cd61d445d62f505f1dc5e78b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/datmo/default.nix
+++ b/distros/melodic/datmo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, message-generation, message-runtime, nav-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-geometry-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-datmo";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/kostaskonkk/datmo-release/archive/release/melodic/datmo/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "7003a039dda59b01b5d934a090ea54ac289ef7653a975b1fda2063d429dee91b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules eigen message-generation nav-msgs sensor-msgs tf tf2-geometry-msgs visualization-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The LIDAR Detection and Tracking of Moving Objects package'';
+    license = with lib.licenses; [ bsdOriginal mit ];
+  };
+}

--- a/distros/melodic/dual-quaternions-ros/default.nix
+++ b/distros/melodic/dual-quaternions-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-dual-quaternions-ros";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/melodic/dual_quaternions_ros/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "93084d18038c68680ace921c976e5ea15f86072c59c40e1a0f61fb978a69c1ee";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dual-quaternions geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS msgs from and to dual quaternions'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/dual-quaternions/default.nix
+++ b/distros/melodic/dual-quaternions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pyquaternion }:
 buildRosPackage {
   pname = "ros-melodic-dual-quaternions";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/melodic/dual_quaternions/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "a2fc145187a3905c744d9b10f294fa4c013bd2940c899b3b88fd79d8d2f92ab0";
+    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/melodic/dual_quaternions/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "7a453c19f652fa6d610a8ae72fc585e71458d7f382c0f7328a4c78b8e63eaadf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-behavior-engine/default.nix
+++ b/distros/melodic/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-behavior-engine";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_behavior_engine/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "5ac6269d1b9703bed022a93e6d6a72ad9a25c55dca3d4fe1a2d101aebb2fdeb7";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_behavior_engine/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "22bbdba318a608e0f7005c9e2dd4eed5c141d3b3fccf6e122596c093ce8d6a6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-core/default.nix
+++ b/distros/melodic/flexbe-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, rostest, smach-ros, tf }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-core";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_core/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e3a50d2edad56f4f36fe8c85059477291893bb4404a254b9edfd067357e1a9bd";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_core/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "d4dffbd00d25778acb53b74ffc939b32605f877a9967a635247018e1556ea28a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-input/default.nix
+++ b/distros/melodic/flexbe-input/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, pythonPackages, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-input";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_input/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "ecf39da99d20decf8d7af6ec3e940de931ef29cee581316f7b36a341b5479536";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_input/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "39042d3ccf5c5a7bc479a6798d6bc3f7b16af6a2af8d980c6fddc734d576f4a8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-mirror/default.nix
+++ b/distros/melodic/flexbe-mirror/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-mirror";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_mirror/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "761cb9829c20c41866edb0dc392ccd3488eadc367ba02b471eb05ba3e0d56ce3";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_mirror/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "cd7dbe6b860fc6cf274082f0fda9bab349433427a7dc439eed3bdca1a77b8a49";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-msgs/default.nix
+++ b/distros/melodic/flexbe-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-msgs";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_msgs/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "1951e1bcf661a7de5fd77c3d4eef5ced678cb5982cdf7c324100cb9cc28f91f8";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_msgs/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "7dd54113fef83279bbb58892bd0ecc55b22ce9ee7689192e186a50773404f01b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-onboard/default.nix
+++ b/distros/melodic/flexbe-onboard/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-onboard";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_onboard/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "1f7891bc91b86f8abdc291e06412a0fc7d2573c8b999abae23e0e4efa2b193f5";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_onboard/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "926e4a4b604bb30319ec1250a35a8022936e2162bb7e1161fd033f12ac94e6ce";
   };
 
   buildType = "catkin";
+  buildInputs = [ rostest ];
   propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/flexbe-states/default.nix
+++ b/distros/melodic/flexbe-states/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-states";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_states/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "571ea74439c41acfdff956490bb56bb36a0128613f7332e5b0c21ebb49ce3171";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_states/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "b510d7f73d84c90bfab4b435fb89b46db79c413f09feea3523176de064733f8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-testing/default.nix
+++ b/distros/melodic/flexbe-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, smach-ros, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-testing";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_testing/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "0ba600e5b68a9863afeb30bbbeb04eb50d1d0f9da5e656376c13ffa375ecb626";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_testing/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "3203ddf405af11b8012ea96da0dc075674503f159bcd6ab4e1e59f793f59aea7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/flexbe-widget/default.nix
+++ b/distros/melodic/flexbe-widget/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy, smach-ros }:
 buildRosPackage {
   pname = "ros-melodic-flexbe-widget";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_widget/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "e4e76e721eaae3e451fa7cfb5dd8baf5e96c3a3619f261873462a93d74fb2832";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/melodic/flexbe_widget/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "b22acb599f15e67ee87f09bdd9d6fe8e235dc109aeeb2d6e83c9d97e9e5e2e43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -532,6 +532,8 @@ self: super: {
 
  dataspeed-ulc-msgs = self.callPackage ./dataspeed-ulc-msgs {};
 
+ datmo = self.callPackage ./datmo {};
+
  dbw-fca = self.callPackage ./dbw-fca {};
 
  dbw-fca-can = self.callPackage ./dbw-fca-can {};
@@ -633,6 +635,8 @@ self: super: {
  drone-wrapper = self.callPackage ./drone-wrapper {};
 
  dual-quaternions = self.callPackage ./dual-quaternions {};
+
+ dual-quaternions-ros = self.callPackage ./dual-quaternions-ros {};
 
  dwa-local-planner = self.callPackage ./dwa-local-planner {};
 
@@ -1506,6 +1510,10 @@ self: super: {
 
  leg-detector = self.callPackage ./leg-detector {};
 
+ leo-description = self.callPackage ./leo-description {};
+
+ leo-viz = self.callPackage ./leo-viz {};
+
  leuze-bringup = self.callPackage ./leuze-bringup {};
 
  leuze-description = self.callPackage ./leuze-description {};
@@ -1977,6 +1985,14 @@ self: super: {
  network-monitor-udp = self.callPackage ./network-monitor-udp {};
 
  network-traffic-control = self.callPackage ./network-traffic-control {};
+
+ nextage-description = self.callPackage ./nextage-description {};
+
+ nextage-gazebo = self.callPackage ./nextage-gazebo {};
+
+ nextage-ik-plugin = self.callPackage ./nextage-ik-plugin {};
+
+ nextage-moveit-config = self.callPackage ./nextage-moveit-config {};
 
  nlopt = self.callPackage ./nlopt {};
 
@@ -2948,8 +2964,6 @@ self: super: {
 
  rqt-ground-robot-teleop = self.callPackage ./rqt-ground-robot-teleop {};
 
- rqt-gui = self.callPackage ./rqt-gui {};
-
  rqt-gui-cpp = self.callPackage ./rqt-gui-cpp {};
 
  rqt-gui-py = self.callPackage ./rqt-gui-py {};
@@ -3049,6 +3063,8 @@ self: super: {
  rtmros-common = self.callPackage ./rtmros-common {};
 
  rtmros-hironx = self.callPackage ./rtmros-hironx {};
+
+ rtmros-nextage = self.callPackage ./rtmros-nextage {};
 
  rviz = self.callPackage ./rviz {};
 

--- a/distros/melodic/jderobot-assets/default.nix
+++ b/distros/melodic/jderobot-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-assets";
-  version = "1.0.2-r1";
+  version = "1.0.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "b19ca427101bbd076aa5a9c30e8f5f50f0d0c0cb9869079957d6287dd2791ffd";
+    url = "https://github.com/JdeRobot/assets-release/archive/release/melodic/jderobot_assets/1.0.4-3.tar.gz";
+    name = "1.0.4-3.tar.gz";
+    sha256 = "5a9b5d2b0f99b289689b9c3974f01ae01f653e0c662865c902f2722cd2f1311c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "7c299e40ae649e9d51d3a0216a836ba8362573a3a460225a06a8e3f36f55073f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "46cc7fd3cacf311aa0b09155c710772431e1e5af3f69c8d9f1aa17cc53b98978";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-description/default.nix
+++ b/distros/melodic/leo-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-leo-description";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_description-release/archive/release/melodic/leo_description/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2e6b81531ab0493e73e6083379a277d4ccd6f886879818f3a77261a74372876e";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF Description package for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/leo-viz/default.nix
+++ b/distros/melodic/leo-viz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, leo-description, robot-state-publisher, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-leo-viz";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_viz-release/archive/release/melodic/leo_viz/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "c4b64530476886266b2f97f50cf035a4b2a2612092fe2c955e412e2fbb143eca";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui leo-description robot-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Visualization launch files and RViz configurations for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "3ec0f6c29fbfdaaceeb0ba0b822ba6a836e9e64d68f73c32e4220f91f7e0ae0c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "817c94d6bacd5789a8058ab41fdf36492336e35a6942aef138d02b0c4af38bab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "cb10bc658bb0a4d0162e948828ed38c1868bed31e1373c5152820a5c17bb8885";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "68a7515ee383320e174a4b95decbe5244a742604b618f247d9cf14fcb940e2d0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "821786996545c5d6a86efdca5106409d6d1e81029056b396ddff4140ee1fa585";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "78b81d7ce119822aa9df6689502c60ae7c5a849d8eb00312f6aafc65f3fe82bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "7d60ccbbcae69b37ace90e5ff723f0ada6e55af625e79afecbc1d4dfd4c30afe";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "6d4a4687206276ca134e986d7458942e033f5c0cb17fbff21d1f15e76a7ad009";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-description/default.nix
+++ b/distros/melodic/nextage-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, urdf }:
+buildRosPackage {
+  pname = "ros-melodic-nextage-description";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_description/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "5d73e35355d25f5caa5137b793aabd2dd9daaa93e5e07b150b0e6baf3ab409cf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''As a part of rtmros_nextage package that is a ROS interface for <a href="http://nextage.kawada.jp/en/">Nextage</a> dual-armed robot from Kawada Robotics Inc, this package provides its 3D model that can be used in simulation and <a href="http://ros.org/wiki/moveit">MoveIt!</a>-based motion planning tasks.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/nextage-gazebo/default.nix
+++ b/distros/melodic/nextage-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, nextage-description, nextage-moveit-config, ros-controllers, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-nextage-gazebo";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_gazebo/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "b380d62da2f4ef14a1c1495b6e2d6df800382f5a0991bac4e61c88ae71dda04f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros-control nextage-description nextage-moveit-config ros-controllers ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo simulation for NEXTAGE Open'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/nextage-ik-plugin/default.nix
+++ b/distros/melodic/nextage-ik-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
+buildRosPackage {
+  pname = "ros-melodic-nextage-ik-plugin";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_ik_plugin/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "47d7cebb7911853af2cdd42960780ba71d46a067d0ad531b8e40555b52ec300f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ liblapack moveit-core pluginlib roscpp tf-conversions ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''IKFast package for NEXTAGE Open'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/nextage-moveit-config/default.nix
+++ b/distros/melodic/nextage-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hironx-moveit-config, joint-state-publisher, moveit-planners, moveit-ros, moveit-ros-move-group, moveit-ros-planning-interface, moveit-ros-visualization, moveit-simple-controller-manager, nextage-ros-bridge, robot-state-publisher, rostest, trac-ik-kinematics-plugin }:
+buildRosPackage {
+  pname = "ros-melodic-nextage-moveit-config";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_moveit_config/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "1df0434fc36ad651c69d1c94b92d1698e82c9e7fd4201c054ff1bd3fabb21bad";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ joint-state-publisher robot-state-publisher rostest ];
+  propagatedBuildInputs = [ hironx-moveit-config moveit-planners moveit-ros moveit-ros-move-group moveit-ros-planning-interface moveit-ros-visualization moveit-simple-controller-manager nextage-ros-bridge trac-ik-kinematics-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the NextageOpen with the MoveIt Motion Planning Framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "72c4cb9034e40884753c7d4f2c9df45f2df531367bb264ed5d140f85526196e4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "66a6e81cae08b7e418f05d849728b480b88907dd9b98bd1a386a5a499a6bcb16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "a427becff0aef722b77b224b801f07b046504c757144766b78b4b1d2d6bc2ed6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "6b159dcc73d268a38490e42ce63101671198fca706dd9a3af25ec844b678ffd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/python-qt-binding/default.nix
+++ b/distros/melodic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-melodic-python-qt-binding";
-  version = "0.4.2-r1";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "a293ccc5315ae546199fb25dfd59f5a6fb8f9e4adb9da59780cf1aeb49f7a358";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "e4da2117e4480a5f73a6cd256f7f66777bc95e90977c01450adb53befff30236";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-fancy/default.nix
+++ b/distros/melodic/rosbag-fancy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, ncurses, rosbag-storage, roscpp, rosfmt, topic-tools }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, ncurses, rosbag-storage, roscpp, rosfmt, tf2-ros, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-fancy";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/melodic/rosbag_fancy/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "1cb76b16313a6cde9bf2e39d3be308af886107c0553b1141caa6a306309a3002";
+    url = "https://github.com/xqms/rosbag_fancy-release/archive/release/melodic/rosbag_fancy/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "839e4c131c6da7f0ea872b61667ce56b81e6db21a3aa5e0c3145ed9e9097eb40";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost ncurses rosbag-storage roscpp rosfmt topic-tools ];
+  propagatedBuildInputs = [ boost ncurses rosbag-storage roscpp rosfmt tf2-ros topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rqt-gui-cpp/default.nix
+++ b/distros/melodic/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, qt-gui, qt-gui-cpp, qt5, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-rqt-gui-cpp";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "87b9fca3c031833debaa4a04e27c2470d34e242ff919198a34956ba5810052d5";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_cpp/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "2b1a17e25f960b71148a92baab5bfb19d8247788dbef53ec5bc9aa0c1d56832b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-gui-py/default.nix
+++ b/distros/melodic/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-gui, rospy, rqt-gui }:
 buildRosPackage {
   pname = "ros-melodic-rqt-gui-py";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_py/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "309447f09365e68cf299ddea67675149cba9d277ac06dd92d128814ee2172414";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_gui_py/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "19e890bbce211050398d6eacf2298a2bbb92fd47b7ed3e91278b45b8044ca596";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-py-common/default.nix
+++ b/distros/melodic/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, genmsg, genpy, python-qt-binding, qt-gui, rosbag, roslib, rospy, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-py-common";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_py_common/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d352ab8dc677872b068374d52888a61c2896e38252df659c1f61a789f30b3aa8";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt_py_common/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "8c59891fcdbf11af9c98cc0ad0b3248a35250d781bf855c3d0d48f27d67a70ff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-reconfigure/default.nix
+++ b/distros/melodic/rqt-reconfigure/default.nix
@@ -5,19 +5,19 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, pythonPackages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-melodic-rqt-reconfigure";
-  version = "0.5.1-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/melodic/rqt_reconfigure/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "718a1e266ce3af19b94bed5cf51f94df71be44070213e63940c57c1a908218f8";
+    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/melodic/rqt_reconfigure/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "54bf182c0c203226a0fd612ab16b5d3904f0be7272b45f05a49fe560eee197a7";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure python-qt-binding pythonPackages.pyyaml rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''This rqt plugin succeeds former dynamic_reconfigure's GUI

--- a/distros/melodic/rqt/default.nix
+++ b/distros/melodic/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rqt-gui, rqt-gui-cpp, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "1ed513439e34e85c1e1753637fcf442f9a9b605dc307f6655815246afbe64cb9";
+    url = "https://github.com/ros-gbp/rqt-release/archive/release/melodic/rqt/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "e3335ef566d7c61b9a4e7ae8c6c4b1a9d8b1c6958c281b81a594d58abfbb36a7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-control-input-manager/default.nix
+++ b/distros/melodic/rr-control-input-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rr-control-input-manager";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_control_input_manager/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "13312611f0a08c552c84b8526764cb270c162ad63e94506f205b3bc99960d03e";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_control_input_manager/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "db25b07273b106b589148f80502cb9e31e015c44c1038da30701e59c05665366";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-openrover-description/default.nix
+++ b/distros/melodic/rr-openrover-description/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, roscpp, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rr-openrover-description";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_description/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "6cc2c409ac518fb0de7888468111770d0f44017e2b52682f25c4f969f504dd03";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "0274774ac629b0db1ae649644177d38fc7c6a08d4b51bf448f45a25044a23adb";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  propagatedBuildInputs = [ gazebo-msgs gazebo-plugins gazebo-ros gazebo-ros-control gazebo-ros-pkgs roscpp rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The rr_openrover_description package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/rr-openrover-driver-msgs/default.nix
+++ b/distros/melodic/rr-openrover-driver-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rr-openrover-driver-msgs";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver_msgs/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "cd4e6202631bed70d3831fd1bfea78e82ad9b8eb5181b619302efb484f512009";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "809fd2071d04f447b256c6aa0cf07e1b9f83ee90b03e77a881e4388250891526";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-openrover-driver/default.nix
+++ b/distros/melodic/rr-openrover-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, joy, message-generation, message-runtime, nav-msgs, roscpp, rospy, rr-openrover-driver-msgs, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-rr-openrover-driver";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "00be302ddb8b762e9c8828755143409e72ed3702db77728f39dbdde369527a96";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d44e90740c1301be2451d7a739f42711563236f17e04e027363ed2c8140e4be8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-openrover-simulation/default.nix
+++ b/distros/melodic/rr-openrover-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, gazebo-plugins, gazebo-ros, gazebo-ros-control, gazebo-ros-pkgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rr-openrover-simulation";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_simulation/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "ad3b243af2d65da484f820bd5447dcfed3bd791f9aa19296dac256d4b379d546";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_simulation/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b08f5b97f14c600060f59a48f66c22f5b5233b6d11c130fea1a073184871eadf";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The rr_openrover_simulation package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/rr-openrover-stack/default.nix
+++ b/distros/melodic/rr-openrover-stack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rr-control-input-manager, rr-openrover-description, rr-openrover-driver, rr-openrover-driver-msgs, rr-openrover-simulation, rr-rover-zero-driver }:
 buildRosPackage {
   pname = "ros-melodic-rr-openrover-stack";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_stack/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "984a5f86e45762f6ac53e710cbb726b41acaf1cc8965b988facb5bfa66e84db1";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_openrover_stack/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b8c6b289d8b66c77cd4d55ce405038ea9ee68c772aca5d35d1f90eae916b5b38";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rr-rover-zero-driver/default.nix
+++ b/distros/melodic/rr-rover-zero-driver/default.nix
@@ -2,22 +2,23 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, python-orocos-kdl, pythonPackages, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rr-rover-zero-driver";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_rover_zero_driver/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "0e65f093ae110e078bdcca4b8e958006b8ce4aea30f38101dd427d7f1ac1e81e";
+    url = "https://github.com/RoverRobotics-release/rr_openrover_stack-release/archive/release/melodic/rr_rover_zero_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "50d742a89bea79ea48fdf795a04d2ce825d3fa2f01efa92dc1dcd6b175c4ebed";
   };
 
   buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs nav-msgs python-orocos-kdl pythonPackages.pyserial rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
     description = ''The rover_zero_driver package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/rtmros-nextage/default.nix
+++ b/distros/melodic/rtmros-nextage/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nextage-calibration, nextage-description, nextage-gazebo, nextage-ik-plugin, nextage-moveit-config, nextage-ros-bridge }:
+buildRosPackage {
+  pname = "ros-melodic-rtmros-nextage";
+  version = "0.8.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/rtmros_nextage/0.8.6-1.tar.gz";
+    name = "0.8.6-1.tar.gz";
+    sha256 = "1782ef9b7f29f11fcd1fd6f8c66dc6f65044e3f5b4343868678e6b6fd6ce4704";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nextage-calibration nextage-description nextage-gazebo nextage-ik-plugin nextage-moveit-config nextage-ros-bridge ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rtmros_nextage package is a ROS interface for <a href="http://nextage.kawada.jp/en/">Nextage</a> dual-armed robot from Kawada Robotics Inc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "426e935f21f92cc98d2ad8905d464d1892add1c461071ea4c5906c06a19862a6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "8c0c7e98d5060c900e369cf4f97b8a1002c70dc002010f71d79fd935bf36e692";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sick-safetyscanners/default.nix
+++ b/distros/melodic/sick-safetyscanners/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, roscpp, rqt-reconfigure, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rqt-reconfigure, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-safetyscanners";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/melodic/sick_safetyscanners/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "8da30184c80f0d43c3ad4657d63f3bda46087d165e8e8f6b00011be4dfe8660e";
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/melodic/sick_safetyscanners/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "6a68c960289587db1874f30044b13bf6b436b49c14f901185c0d55865ba6b48f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rqt-reconfigure sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime roscpp rqt-reconfigure sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "039566ea8196ad401c4da6cfae2db965730c6d5549154a00946b354644eaebe3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "498d3a4671cbfff4fe53165955156a5b9c9f24743eb915ef62e613232b539c8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "4b4eafdcf5efc620b2f23adba299bd56a457200616731bcf4aae83451a4ffd10";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "479bca4bc6a28810039e5843206b93266ad930210d5793d6a825b8246de5f24f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/apriltag/default.nix
+++ b/distros/noetic/apriltag/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-apriltag";
+  version = "3.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/noetic/apriltag/3.1.2-2.tar.gz";
+    name = "3.1.2-2.tar.gz";
+    sha256 = "cd865830edbf30f93b897b0b98c3b86d4c5273bceeb5db4e8beba4170d832a4c";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''AprilTag detector library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bondpy/default.nix
+++ b/distros/noetic/bondpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bond, catkin, python3Packages, rospy, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, bond, catkin, pythonPackages, rospy, smclib, utillinux }:
 buildRosPackage {
   pname = "ros-noetic-bondpy";
   version = "1.8.5-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ bond ];
   propagatedBuildInputs = [ rospy smclib utillinux ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python implementation of bond, a mechanism for checking when

--- a/distros/noetic/capabilities/default.nix
+++ b/distros/noetic/capabilities/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bondpy, catkin, geometry-msgs, message-generation, message-runtime, nodelet, python3Packages, roslaunch, rospy, rosservice, rostest, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, bondpy, catkin, geometry-msgs, message-generation, message-runtime, nodelet, pythonPackages, roslaunch, rospy, rosservice, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-capabilities";
   version = "0.3.1-r1";
@@ -15,8 +15,8 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ message-generation rostest ];
-  checkInputs = [ geometry-msgs python3Packages.coverage python3Packages.mock python3Packages.pep8 rosservice ];
-  propagatedBuildInputs = [ bondpy message-runtime nodelet python3Packages.pyyaml roslaunch rospy std-msgs std-srvs ];
+  checkInputs = [ geometry-msgs pythonPackages.coverage pythonPackages.mock pythonPackages.pep8 rosservice ];
+  propagatedBuildInputs = [ bondpy message-runtime nodelet pythonPackages.pyyaml roslaunch rospy std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
   version = "0.8.6-r1";
@@ -14,9 +14,9 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.mock python3Packages.nose ];
-  propagatedBuildInputs = [ cmake gmock gtest python3Packages.catkin-pkg python3Packages.empy python3Packages.nose python3Packages.setuptools ];
-  nativeBuildInputs = [ cmake python3Packages.setuptools ];
+  checkInputs = [ pythonPackages.mock pythonPackages.nose ];
+  propagatedBuildInputs = [ cmake gmock gtest python pythonPackages.catkin-pkg pythonPackages.empy pythonPackages.nose ];
+  nativeBuildInputs = [ cmake pythonPackages.setuptools ];
 
   meta = {
     description = ''Low-level build system macros and infrastructure for ROS.'';

--- a/distros/noetic/code-coverage/default.nix
+++ b/distros/noetic/code-coverage/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-code-coverage";
   version = "0.4.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ lcov python3Packages.coverage ];
+  propagatedBuildInputs = [ lcov pythonPackages.coverage ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/controller-manager-msgs/default.nix
+++ b/distros/noetic/controller-manager-msgs/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rospy, rosservice, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-msgs";
   version = "0.19.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ message-generation ];
   propagatedBuildInputs = [ message-runtime rospy rosservice std-msgs ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Messages and services for the controller manager.'';

--- a/distros/noetic/controller-manager-tests/default.nix
+++ b/distros/noetic/controller-manager-tests/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, rosbash, roscpp, rosnode, rospy, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, pythonPackages, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-tests";
   version = "0.19.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   checkInputs = [ rosbash rosnode rostest ];
   propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface pluginlib roscpp rospy ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Tests for the controller manager.'';

--- a/distros/noetic/controller-manager/default.nix
+++ b/distros/noetic/controller-manager/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, roscpp, rosparam, rospy, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, pythonPackages, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager";
   version = "0.19.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   checkInputs = [ rostest ];
   propagatedBuildInputs = [ controller-interface controller-manager-msgs hardware-interface pluginlib roscpp rosparam rospy std-msgs ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''The controller manager.'';

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "1fb9dbab7bbd99d9898fb556bb92a4877d55cba3ba43bd7d23feb4825b54d10e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "ad8f7a1dae2898dd94d59af08e33c89dbb8c2289efb062f1bb42921db87a3452";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dual-quaternions/default.nix
+++ b/distros/noetic/dual-quaternions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pyquaternion }:
 buildRosPackage {
   pname = "ros-noetic-dual-quaternions";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/noetic/dual_quaternions/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "63b1083575b5eff98c5defaa1906886fdf4182522a04e1c473adfddb81290c08";
+    url = "https://github.com/Achllle/dual_quaternions-release/archive/release/noetic/dual_quaternions/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "41c7d1914282dd7c9d27656d1a93088f30cefa8c95ec698b08c7d1a431230c28";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
   version = "2.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ doxygen git ];
-  propagatedBuildInputs = [ boost eigen python3 python3Packages.numpy ];
+  propagatedBuildInputs = [ boost eigen python pythonPackages.numpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
   version = "0.1.1-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs python3Packages.pyusb rospy ];
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs pythonPackages.pyusb rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/gencpp/default.nix
+++ b/distros/noetic/gencpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-gencpp";
   version = "0.6.5-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ genmsg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''C++ ROS message and service generators.'';

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -18,6 +18,8 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
+ apriltag = self.callPackage ./apriltag {};
+
  audio-capture = self.callPackage ./audio-capture {};
 
  audio-common = self.callPackage ./audio-common {};
@@ -404,6 +406,8 @@ self: super: {
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
 
+ marti-data-structures = self.callPackage ./marti-data-structures {};
+
  marti-dbw-msgs = self.callPackage ./marti-dbw-msgs {};
 
  marti-nav-msgs = self.callPackage ./marti-nav-msgs {};
@@ -505,6 +509,8 @@ self: super: {
  neonavigation-msgs = self.callPackage ./neonavigation-msgs {};
 
  neonavigation-rviz-plugins = self.callPackage ./neonavigation-rviz-plugins {};
+
+ nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nodelet = self.callPackage ./nodelet {};
 
@@ -656,6 +662,8 @@ self: super: {
 
  ros-control = self.callPackage ./ros-control {};
 
+ ros-control-boilerplate = self.callPackage ./ros-control-boilerplate {};
+
  ros-controllers = self.callPackage ./ros-controllers {};
 
  ros-core = self.callPackage ./ros-core {};
@@ -709,8 +717,6 @@ self: super: {
  roscreate = self.callPackage ./roscreate {};
 
  rosdiagnostic = self.callPackage ./rosdiagnostic {};
-
- rosdoc-lite = self.callPackage ./rosdoc-lite {};
 
  rosemacs = self.callPackage ./rosemacs {};
 
@@ -796,8 +802,6 @@ self: super: {
 
  rqt-graph = self.callPackage ./rqt-graph {};
 
- rqt-gui = self.callPackage ./rqt-gui {};
-
  rqt-gui-cpp = self.callPackage ./rqt-gui-cpp {};
 
  rqt-gui-py = self.callPackage ./rqt-gui-py {};
@@ -829,8 +833,6 @@ self: super: {
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
 
  rqt-robot-dashboard = self.callPackage ./rqt-robot-dashboard {};
-
- rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
 
  rqt-robot-plugins = self.callPackage ./rqt-robot-plugins {};
 
@@ -866,15 +868,21 @@ self: super: {
 
  rviz-python-tutorial = self.callPackage ./rviz-python-tutorial {};
 
+ rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
+
  safety-limiter = self.callPackage ./safety-limiter {};
 
  safety-limiter-msgs = self.callPackage ./safety-limiter-msgs {};
+
+ sbpl = self.callPackage ./sbpl {};
 
  self-test = self.callPackage ./self-test {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
  shape-msgs = self.callPackage ./shape-msgs {};
+
+ sick-safetyscanners = self.callPackage ./sick-safetyscanners {};
 
  sick-scan = self.callPackage ./sick-scan {};
 
@@ -926,11 +934,45 @@ self: super: {
 
  swri-console = self.callPackage ./swri-console {};
 
+ swri-console-util = self.callPackage ./swri-console-util {};
+
+ swri-dbw-interface = self.callPackage ./swri-dbw-interface {};
+
+ swri-geometry-util = self.callPackage ./swri-geometry-util {};
+
+ swri-image-util = self.callPackage ./swri-image-util {};
+
+ swri-math-util = self.callPackage ./swri-math-util {};
+
+ swri-nodelet = self.callPackage ./swri-nodelet {};
+
+ swri-opencv-util = self.callPackage ./swri-opencv-util {};
+
+ swri-prefix-tools = self.callPackage ./swri-prefix-tools {};
+
+ swri-roscpp = self.callPackage ./swri-roscpp {};
+
+ swri-rospy = self.callPackage ./swri-rospy {};
+
+ swri-route-util = self.callPackage ./swri-route-util {};
+
+ swri-serial-util = self.callPackage ./swri-serial-util {};
+
+ swri-string-util = self.callPackage ./swri-string-util {};
+
+ swri-system-util = self.callPackage ./swri-system-util {};
+
+ swri-transform-util = self.callPackage ./swri-transform-util {};
+
+ swri-yaml-util = self.callPackage ./swri-yaml-util {};
+
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 
  teleop-tools-msgs = self.callPackage ./teleop-tools-msgs {};
+
+ teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 
@@ -1006,6 +1048,8 @@ self: super: {
 
  urg-c = self.callPackage ./urg-c {};
 
+ urg-node = self.callPackage ./urg-node {};
+
  urg-stamped = self.callPackage ./urg-stamped {};
 
  usb-cam = self.callPackage ./usb-cam {};
@@ -1027,6 +1071,8 @@ self: super: {
  voxel-grid = self.callPackage ./voxel-grid {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ webkit-dependency = self.callPackage ./webkit-dependency {};
 
  xacro = self.callPackage ./xacro {};
 

--- a/distros/noetic/geneus/default.nix
+++ b/distros/noetic/geneus/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-geneus";
   version = "3.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ genmsg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''EusLisp ROS message and service generators.'';

--- a/distros/noetic/genlisp/default.nix
+++ b/distros/noetic/genlisp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-genlisp";
   version = "0.4.18-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ genmsg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Common-Lisp ROS message and service generators.'';

--- a/distros/noetic/genmsg/default.nix
+++ b/distros/noetic/genmsg/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-genmsg";
   version = "0.5.16-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ catkin python3Packages.empy ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ catkin pythonPackages.empy ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Standalone Python library for generating ROS message and service data structures for various languages.'';

--- a/distros/noetic/gennodejs/default.nix
+++ b/distros/noetic/gennodejs/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-gennodejs";
   version = "2.0.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ genmsg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Javascript ROS message and service generators.'';

--- a/distros/noetic/genpy/default.nix
+++ b/distros/noetic/genpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-genpy";
   version = "0.6.12-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ genmsg python3Packages.pyyaml ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ genmsg pythonPackages.pyyaml ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python ROS message and service generators.'';

--- a/distros/noetic/geodesy/default.nix
+++ b/distros/noetic/geodesy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, catkin, geographic-msgs, geometry-msgs, python3Packages, rosunit, sensor-msgs, tf, unique-id, uuid-msgs }:
+{ lib, buildRosPackage, fetchurl, angles, catkin, geographic-msgs, geometry-msgs, pythonPackages, rosunit, sensor-msgs, tf, unique-id, uuid-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geodesy";
   version = "0.5.5-r1";
@@ -14,10 +14,10 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ angles python3Packages.catkin-pkg ];
+  buildInputs = [ angles pythonPackages.catkin-pkg ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs python3Packages.pyproj sensor-msgs tf unique-id uuid-msgs ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs pythonPackages.pyproj sensor-msgs tf unique-id uuid-msgs ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python and C++ interfaces for manipulating geodetic coordinates.'';

--- a/distros/noetic/gl-dependency/default.nix
+++ b/distros/noetic/gl-dependency/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-gl-dependency";
   version = "1.1.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.pyqt5 ];
+  propagatedBuildInputs = [ pythonPackages.pyqt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/jderobot-assets/default.nix
+++ b/distros/noetic/jderobot-assets/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-jderobot-assets";
   version = "1.1.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''The jderobot_assets package'';

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "c9aa55dd7776126871d0467d96c79a6b282558f6a7044dfe8be1ef8990966749";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "1693c64cbee3a278ebf9563fef912b8a99c0d771d766d2f2914b67d427fdf744";
   };
 
   buildType = "catkin";

--- a/distros/noetic/laser-geometry/default.nix
+++ b/distros/noetic/laser-geometry/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, python3Packages, roscpp, rosunit, sensor-msgs, tf, tf2 }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, pythonPackages, roscpp, rosunit, sensor-msgs, tf, tf2 }:
 buildRosPackage {
   pname = "ros-noetic-laser-geometry";
   version = "1.6.5-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ angles boost eigen python3Packages.numpy roscpp sensor-msgs tf tf2 ];
+  propagatedBuildInputs = [ angles boost eigen pythonPackages.numpy roscpp sensor-msgs tf tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "2fb7a7b72387ab06461a608b25b97442e3b467242ce5cfac173b9696758e28d2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "0eb8d8ecd60f966c28958219638fff077f3103404597997652edd63040d935ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marti-data-structures/default.nix
+++ b/distros/noetic/marti-data-structures/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-marti-data-structures";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "b5ffcf3de02cc3e660751ab9df18049f20a9c5d2b446054a36566af5b4475555";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''marti_data_structures'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
   version = "2020.6.6-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ python3 python3Packages.future python3Packages.lxml ];
+  buildInputs = [ python pythonPackages.future pythonPackages.lxml ];
   propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/noetic/mouse-teleop/default.nix
+++ b/distros/noetic/mouse-teleop/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-mouse-teleop";
   version = "0.4.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs python3Packages.numpy python3Packages.tkinter rospy ];
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.numpy pythonPackages.tkinter rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mrt-cmake-modules/default.nix
+++ b/distros/noetic/mrt-cmake-modules/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, lcov, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-mrt-cmake-modules";
   version = "1.0.3-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ lcov python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ];
-  nativeBuildInputs = [ catkin python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ];
+  propagatedBuildInputs = [ lcov pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.pyyaml pythonPackages.rospkg pythonPackages.setuptools ];
 
   meta = {
     description = ''CMake Functions and Modules for automating CMake'';

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "f39d6be9bff83f6c24f507528852700a725c421169b68b43f89772250af0c175";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "46ef7f29747b87082a7021ee3f03b7c4c796aa5eab8268624d6869876a93c08c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "7d22d2969e73111f7c95f0b111cd88e7e32c788408d25a4dc7040654e4250d45";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "26c032ba4c96b767afe187f2e387bcc05c4a3b17c269ad4d629fa5d57c56723b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "e2cbc8032d5b68692c70f0437f147a25fa4da8b055ef4cd1cea458565c6d4112";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "232ecb889031db7c66af446699696fadbe821649a8e3072f852c0a579747a1d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nmea-msgs/default.nix
+++ b/distros/noetic/nmea-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nmea-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/nmea_msgs-release/archive/release/noetic/nmea_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "046f13505f846ccee51d939024546f06013295f74a09e2fe98c5b482fff70eac";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The nmea_msgs package contains messages related to data in the NMEA format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "b51c976cbb1f52513da76a1ddad58124b160a05ec2bc5e0c9efdd94e6492455c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "87bf224698821aaa124badd24e745fe1d95c004ed699d457fa57c3be7f153064";
   };
 
   buildType = "catkin";

--- a/distros/noetic/openni2-launch/default.nix
+++ b/distros/noetic/openni2-launch/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, python3Packages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
+{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, image-proc, nodelet, openni2-camera, pythonPackages, rgbd-launch, roslaunch, rospy, roswtf, tf, usbutils }:
 buildRosPackage {
   pname = "ros-noetic-openni2-launch";
   version = "1.4.2-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ depth-image-proc image-proc nodelet openni2-camera python3Packages.catkin-pkg rgbd-launch rospy roswtf tf usbutils ];
+  propagatedBuildInputs = [ depth-image-proc image-proc nodelet openni2-camera pythonPackages.catkin-pkg rgbd-launch rospy roswtf tf usbutils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
+{ lib, buildRosPackage, fetchurl, boost, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
   version = "2.4.5-r5";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ doxygen git ];
-  propagatedBuildInputs = [ boost eigen eigenpy python3 python3Packages.numpy urdfdom ];
+  propagatedBuildInputs = [ boost eigen eigenpy python pythonPackages.numpy urdfdom ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "c5b2d4335a9e5a6acec75c19fbfd5f450d01f212962b5e00e60e9135203a30ac";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "a6198e8a4f13b23f7d5219993d5c7cb2fe58e539f4e30ea3cf0e7c8ccfbf1583";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pybind11-catkin/default.nix
+++ b/distros/noetic/pybind11-catkin/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, python3, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-pybind11-catkin";
   version = "2.5.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen python3 python3Packages.numpy ];
+  propagatedBuildInputs = [ eigen python pythonPackages.numpy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/python-qt-binding/default.nix
+++ b/distros/noetic/python-qt-binding/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, qt5, rosbuild }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-noetic-python-qt-binding";
   version = "0.4.3-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ qt5.qtbase rosbuild ];
-  propagatedBuildInputs = [ catkin python3Packages.pyqt5 ];
+  propagatedBuildInputs = [ catkin pythonPackages.pyqt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/qt-dotgraph/default.nix
+++ b/distros/noetic/qt-dotgraph/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-qt-dotgraph";
   version = "0.4.1-r1";
@@ -14,9 +14,9 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.pygraphviz ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.pydot ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  checkInputs = [ pythonPackages.pygraphviz ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.pydot ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_dotgraph provides helpers to work with dot graphs.'';

--- a/distros/noetic/qt-gui-app/default.nix
+++ b/distros/noetic/qt-gui-app/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, qt-gui }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt-gui }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-app";
   version = "0.4.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ qt-gui ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_app provides the main to start an instance of the integrated graphical user interface provided by qt_gui.'';

--- a/distros/noetic/qt-gui-cpp/default.nix
+++ b/distros/noetic/qt-gui-cpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, python3Packages, qt-gui, qt5, tinyxml }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, pythonPackages, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-cpp";
   version = "0.4.1-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ cmake-modules pkg-config python-qt-binding qt5.qtbase ];
   propagatedBuildInputs = [ pluginlib qt-gui tinyxml ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_cpp provides the foundation for C++-bindings for qt_gui and creates bindings for every generator available.

--- a/distros/noetic/qt-gui-py-common/default.nix
+++ b/distros/noetic/qt-gui-py-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-py-common";
   version = "0.4.1-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui_py_common provides common functionality for GUI plugins written in Python.'';

--- a/distros/noetic/qt-gui/default.nix
+++ b/distros/noetic/qt-gui/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt5, tango-icon-theme }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui";
   version = "0.4.1-r1";
@@ -14,9 +14,9 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ python3Packages.pyqt5 qt5.qtbase ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg tango-icon-theme ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  buildInputs = [ pythonPackages.pyqt5 qt5.qtbase ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg tango-icon-theme ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''qt_gui provides the infrastructure for an integrated graphical user interface based on Qt.

--- a/distros/noetic/resource-retriever/default.nix
+++ b/distros/noetic/resource-retriever/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, curl, python3Packages, rosconsole, roslib }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, curl, pythonPackages, rosconsole, roslib }:
 buildRosPackage {
   pname = "ros-noetic-resource-retriever";
   version = "1.12.6-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost curl python3Packages.rospkg rosconsole roslib ];
+  propagatedBuildInputs = [ boost curl pythonPackages.rospkg rosconsole roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
   version = "2.6.8-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation python3Packages.catkin-pkg roslint ];
+  buildInputs = [ message-generation pythonPackages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
   propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/ros-control-boilerplate/default.nix
+++ b/distros/noetic/ros-control-boilerplate/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-ros-control-boilerplate";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/noetic/ros_control_boilerplate/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "008938614602fb9b50ad8bae0d0dc5a8526179bba7509f03d45d77e1fbf727fa";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules gflags ];
+  propagatedBuildInputs = [ actionlib control-msgs control-toolbox controller-manager hardware-interface joint-limits-interface roscpp rosparam-shortcuts sensor-msgs std-msgs trajectory-msgs transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple simulation interface and template for setting up a hardware interface for ros_control'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rosbag/default.nix
+++ b/distros/noetic/rosbag/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, python3Packages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-rosbag";
   version = "1.15.7-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ cpp-common python3Packages.pillow roscpp-serialization ];
-  propagatedBuildInputs = [ boost genmsg genpy python3Packages.pycryptodomex python3Packages.python-gnupg python3Packages.rospkg rosbag-storage rosconsole roscpp roslib rospy std-srvs topic-tools xmlrpcpp ];
+  buildInputs = [ cpp-common pythonPackages.pillow roscpp-serialization ];
+  propagatedBuildInputs = [ boost genmsg genpy pythonPackages.pycryptodomex pythonPackages.python-gnupg pythonPackages.rospkg rosbag-storage rosconsole roscpp roslib rospy std-srvs topic-tools xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
   version = "1.15.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Contains scripts used by the rosboost-cfg tool for determining cflags/lflags/etc. of boost on your system'';

--- a/distros/noetic/rosbridge-library/default.nix
+++ b/distros/noetic/rosbridge-library/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, python3Packages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, pythonPackages, roscpp, rosgraph, rospy, rospy-tutorials, rosservice, rostest, rostopic, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-library";
   version = "0.11.9-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ actionlib-msgs diagnostic-msgs nav-msgs rospy-tutorials rostest sensor-msgs std-srvs stereo-msgs tf2-msgs trajectory-msgs visualization-msgs ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime python3Packages.bson python3Packages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pythonPackages.bson pythonPackages.pillow roscpp rosgraph rospy rosservice rostopic std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosbridge-server/default.nix
+++ b/distros/noetic/rosbridge-server/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosapi, rosauth, rosbridge-library, rosbridge-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rosbridge-server";
   version = "0.11.9-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ python3Packages.autobahn python3Packages.tornado python3Packages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
+  propagatedBuildInputs = [ pythonPackages.autobahn pythonPackages.backports_ssl_match_hostname pythonPackages.tornado pythonPackages.twisted rosapi rosauth rosbridge-library rosbridge-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
   version = "1.15.4-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.rospkg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ pythonPackages.rospkg ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''rosclean: cleanup filesystem resources (e.g. log files).'';

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
   version = "1.15.4-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.rospkg roslib ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ pythonPackages.rospkg roslib ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''roscreate contains a tool that assists in the creation of ROS filesystem resources.

--- a/distros/noetic/rosgraph/default.nix
+++ b/distros/noetic/rosgraph/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph";
   version = "1.15.7-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.mock ];
-  propagatedBuildInputs = [ python3Packages.netifaces python3Packages.pyyaml python3Packages.rospkg ];
+  checkInputs = [ pythonPackages.mock ];
+  propagatedBuildInputs = [ pythonPackages.netifaces pythonPackages.pyyaml pythonPackages.rospkg ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/roslaunch/default.nix
+++ b/distros/noetic/roslaunch/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslaunch";
   version = "1.15.7-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ rosbuild ];
-  propagatedBuildInputs = [ python3Packages.paramiko python3Packages.pyyaml python3Packages.rospkg rosclean rosgraph-msgs roslib rosmaster rosout rosparam rosunit ];
+  propagatedBuildInputs = [ pythonPackages.paramiko pythonPackages.pyyaml pythonPackages.rospkg rosclean rosgraph-msgs roslib rosmaster rosout rosparam rosunit ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, pythonPackages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
   version = "1.15.4-r1";
@@ -16,8 +16,8 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ boost ];
   checkInputs = [ rosmake ];
-  propagatedBuildInputs = [ catkin python3Packages.rospkg ros-environment rospack ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ catkin pythonPackages.rospkg ros-environment rospack ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Base dependencies and support libraries for ROS.

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
   version = "1.15.4-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ catkin python3Packages.rospkg ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ catkin pythonPackages.rospkg ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''rosmake is a ros dependency aware build tool which can be used to

--- a/distros/noetic/rosmaster/default.nix
+++ b/distros/noetic/rosmaster/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosmaster";
   version = "1.15.7-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.defusedxml rosgraph ];
+  propagatedBuildInputs = [ pythonPackages.defusedxml rosgraph ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosmon-core/default.nix
+++ b/distros/noetic/rosmon-core/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python3, python3Packages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
+{ lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python, pythonPackages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-core";
   version = "2.3.2-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ python3 ];
-  checkInputs = [ catch-ros python3Packages.rospkg rostest ];
+  buildInputs = [ python ];
+  checkInputs = [ catch-ros pythonPackages.rospkg rostest ];
   propagatedBuildInputs = [ boost cmake-modules diagnostic-msgs libyamlcpp ncurses rosbash roscpp rosfmt roslib rosmon-msgs rospack std-msgs tinyxml ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/rosmsg/default.nix
+++ b/distros/noetic/rosmsg/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages, rosbag, roslib, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosmsg";
   version = "1.15.7-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ std-msgs ];
-  propagatedBuildInputs = [ catkin genmsg genpy python3Packages.rospkg rosbag roslib ];
+  propagatedBuildInputs = [ catkin genmsg genpy pythonPackages.rospkg rosbag roslib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rospack/default.nix
+++ b/distros/noetic/rospack/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, gtest, pkg-config, python3, python3Packages, ros-environment, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, gtest, pkg-config, python, pythonPackages, ros-environment, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-rospack";
   version = "2.6.2-r1";
@@ -15,8 +15,8 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules gtest ];
-  checkInputs = [ python3Packages.coverage ];
-  propagatedBuildInputs = [ boost pkg-config python3 python3Packages.catkin-pkg python3Packages.rosdep ros-environment tinyxml-2 ];
+  checkInputs = [ pythonPackages.coverage ];
+  propagatedBuildInputs = [ boost pkg-config python pythonPackages.catkin-pkg pythonPackages.rosdep ros-environment tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosparam/default.nix
+++ b/distros/noetic/rosparam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosparam";
   version = "1.15.7-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.pyyaml rosgraph ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml rosgraph ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rospy/default.nix
+++ b/distros/noetic/rospy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy";
   version = "1.15.7-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ genpy python3Packages.numpy python3Packages.pyyaml python3Packages.rospkg roscpp rosgraph rosgraph-msgs roslib std-msgs ];
+  propagatedBuildInputs = [ genpy pythonPackages.numpy pythonPackages.pyyaml pythonPackages.rospkg roscpp rosgraph rosgraph-msgs roslib std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
   version = "1.15.4-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.rospkg roslib ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ pythonPackages.rospkg roslib ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Unit-testing package for ROS. This is a lower-level library for rostest and handles unit tests, whereas rostest handles integration tests.'';

--- a/distros/noetic/roswtf/default.nix
+++ b/distros/noetic/roswtf/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, python3Packages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-roswtf";
   version = "1.15.7-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "catkin";
   buildInputs = [ rostest ];
   checkInputs = [ cmake-modules rosbag roslang std-srvs ];
-  propagatedBuildInputs = [ python3Packages.paramiko python3Packages.rospkg rosbuild rosgraph roslaunch roslib rosnode rosservice ];
+  propagatedBuildInputs = [ pythonPackages.paramiko pythonPackages.rospkg rosbuild rosgraph roslaunch roslib rosnode rosservice ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-bag-plugins/default.nix
+++ b/distros/noetic/rqt-bag-plugins/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag-plugins";
   version = "0.4.13-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs python3Packages.pillow python3Packages.pycairo rosbag roslib rospy rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.pillow pythonPackages.pycairo rosbag roslib rospy rqt-bag rqt-gui rqt-gui-py rqt-plot sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-bag/default.nix
+++ b/distros/noetic/rqt-bag/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag";
   version = "0.4.13-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rosbag rosgraph-msgs roslib rosnode rospy rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg rosbag rosgraph-msgs roslib rosnode rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-console/default.nix
+++ b/distros/noetic/rqt-console/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, rqt-logger-level, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-console";
   version = "0.4.11-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg roslib rospy rqt-gui rqt-gui-py rqt-logger-level rqt-py-common ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py rqt-logger-level rqt-py-common ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-controller-manager/default.nix
+++ b/distros/noetic/rqt-controller-manager/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, python3Packages, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, pythonPackages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-controller-manager";
   version = "0.19.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ controller-manager-msgs rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Graphical frontend for interacting with the controller manager.'';

--- a/distros/noetic/rqt-dep/default.nix
+++ b/distros/noetic/rqt-dep/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-dep";
   version = "0.4.10-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.mock ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph qt-gui qt-gui-py-common rqt-graph rqt-gui-py ];
+  checkInputs = [ pythonPackages.mock ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-dotgraph qt-gui qt-gui-py-common rqt-graph rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-graph/default.nix
+++ b/distros/noetic/rqt-graph/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rosgraph, rosgraph-msgs, roslib, rosnode, rospy, rosservice, rostopic, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-dotgraph, rosgraph, rosgraph-msgs, roslib, rosnode, rospy, rosservice, rostopic, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-graph";
   version = "0.4.14-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph rosgraph rosgraph-msgs roslib rosnode rospy rosservice rostopic rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-dotgraph rosgraph rosgraph-msgs roslib rosnode rospy rosservice rostopic rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-logger-level/default.nix
+++ b/distros/noetic/rqt-logger-level/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosnode, rospy, rosservice, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosnode, rospy, rosservice, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-logger-level";
   version = "0.4.11-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rosnode rospy rosservice rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg rosnode rospy rosservice rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-moveit/default.nix
+++ b/distros/noetic/rqt-moveit/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosnode, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, rqt-topic, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosnode, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, rqt-topic, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-moveit";
   version = "0.5.9-r3";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ python-qt-binding rosnode rospy rostopic rqt-gui rqt-gui-py rqt-py-common rqt-topic sensor-msgs ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''An rqt-based tool that assists monitoring tasks

--- a/distros/noetic/rqt-msg/default.nix
+++ b/distros/noetic/rqt-msg/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rosmsg, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, roslib, rosmsg, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-msg";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg roslib rosmsg rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg roslib rosmsg rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-plot/default.nix
+++ b/distros/noetic/rqt-plot/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-plot";
   version = "0.4.12-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.matplotlib python3Packages.numpy python3Packages.rospkg qt-gui-py-common qwt-dependency rosgraph rostopic rqt-gui rqt-gui-py rqt-py-common std-msgs ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.matplotlib pythonPackages.numpy pythonPackages.rospkg qt-gui-py-common qwt-dependency rosgraph rostopic rqt-gui rqt-gui-py rqt-py-common std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-pose-view/default.nix
+++ b/distros/noetic/rqt-pose-view/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gl-dependency, python-qt-binding, python3Packages, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gl-dependency, python-qt-binding, pythonPackages, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, tf }:
 buildRosPackage {
   pname = "ros-noetic-rqt-pose-view";
   version = "0.5.10-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs gl-dependency python-qt-binding python3Packages.pyopengl python3Packages.rospkg rospy rostopic rqt-gui rqt-gui-py rqt-py-common tf ];
+  propagatedBuildInputs = [ geometry-msgs gl-dependency python-qt-binding pythonPackages.pyopengl pythonPackages.rospkg rospy rostopic rqt-gui rqt-gui-py rqt-py-common tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-publisher/default.nix
+++ b/distros/noetic/rqt-publisher/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, roslib, rosmsg, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, roslib, rosmsg, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-publisher";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui-py-common roslib rosmsg rqt-gui rqt-gui-py rqt-py-common ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-gui-py-common roslib rosmsg rqt-gui rqt-gui-py rqt-py-common ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-py-console/default.nix
+++ b/distros/noetic/rqt-py-console/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui, qt-gui-py-common, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-console";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rospy rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-gui qt-gui-py-common rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-reconfigure/default.nix
+++ b/distros/noetic/rqt-reconfigure/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, python3Packages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python-qt-binding, pythonPackages, roslint, rospy, rostest, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-reconfigure";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "15b5d740bc62ac0e3838f02598bf1d97c455dc367ce228da9e4401605576dc47";
+    url = "https://github.com/ros-gbp/rqt_reconfigure-release/archive/release/noetic/rqt_reconfigure/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "53f478c46f7b0948ec5e1a5d55b441584016e31e51e76d8c2dc69132aa143c60";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure python-qt-binding python3Packages.pyyaml rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  propagatedBuildInputs = [ dynamic-reconfigure python-qt-binding pythonPackages.pyyaml rospy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''This rqt plugin succeeds former dynamic_reconfigure's GUI

--- a/distros/noetic/rqt-robot-dashboard/default.nix
+++ b/distros/noetic/rqt-robot-dashboard/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-nav-view, rqt-robot-monitor }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, pythonPackages, qt-gui, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-nav-view, rqt-robot-monitor }:
 buildRosPackage {
   pname = "ros-noetic-rqt-robot-dashboard";
   version = "0.5.8-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   propagatedBuildInputs = [ diagnostic-msgs python-qt-binding qt-gui rospy rqt-console rqt-gui rqt-gui-py rqt-nav-view rqt-robot-monitor ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''rqt_robot_dashboard provides an infrastructure for building robot dashboard plugins in rqt.'';

--- a/distros/noetic/rqt-robot-steering/default.nix
+++ b/distros/noetic/rqt-robot-steering/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python-qt-binding, python3Packages, rostopic, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python-qt-binding, pythonPackages, rostopic, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-robot-steering";
   version = "0.5.11-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs python-qt-binding python3Packages.rospkg rostopic rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ geometry-msgs python-qt-binding pythonPackages.rospkg rostopic rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-runtime-monitor/default.nix
+++ b/distros/noetic/rqt-runtime-monitor/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, pythonPackages, qt-gui, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-runtime-monitor";
   version = "0.5.8-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding pythonPackages.rospkg qt-gui rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-service-caller/default.nix
+++ b/distros/noetic/rqt-service-caller/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosservice, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosservice, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-service-caller";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python3Packages.rospkg rosservice rqt-gui rqt-gui-py rqt-py-common ];
+  propagatedBuildInputs = [ pythonPackages.rospkg rosservice rqt-gui rqt-gui-py rqt-py-common ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-shell/default.nix
+++ b/distros/noetic/rqt-shell/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-shell";
   version = "0.4.10-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-tf-tree/default.nix
+++ b/distros/noetic/rqt-tf-tree/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-dotgraph, rospy, rqt-graph, rqt-gui, rqt-gui-py, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rqt-tf-tree";
   version = "0.6.1-r1";
@@ -14,8 +14,8 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.mock ];
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-dotgraph rospy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
+  checkInputs = [ pythonPackages.mock ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-dotgraph rospy rqt-graph rqt-gui rqt-gui-py tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-top/default.nix
+++ b/distros/noetic/rqt-top/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-top";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.psutil rospy rqt-gui rqt-gui-py ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.psutil rospy rqt-gui rqt-gui-py ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-topic/default.nix
+++ b/distros/noetic/rqt-topic/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rostopic, rqt-gui, rqt-gui-py, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rostopic, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-topic";
   version = "0.4.12-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg rostopic rqt-gui rqt-gui-py std-msgs ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg rostopic rqt-gui rqt-gui-py std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-web/default.nix
+++ b/distros/noetic/rqt-web/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, webkit-dependency }:
+{ lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui, rospy, rqt-gui, rqt-gui-py, webkit-dependency }:
 buildRosPackage {
   pname = "ros-noetic-rqt-web";
   version = "0.4.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ python-qt-binding python3Packages.rospkg qt-gui rospy rqt-gui rqt-gui-py webkit-dependency ];
+  propagatedBuildInputs = [ python-qt-binding pythonPackages.rospkg qt-gui rospy rqt-gui rqt-gui-py webkit-dependency ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rviz-visual-tools/default.nix
+++ b/distros/noetic/rviz-visual-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-stl-containers, geometry-msgs, graph-msgs, ogre1_9, qt5, roscpp, roslint, rostest, rosunit, rviz, sensor-msgs, shape-msgs, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-ros, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-visual-tools";
+  version = "3.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/noetic/rviz_visual_tools/3.9.0-1.tar.gz";
+    name = "3.9.0-1.tar.gz";
+    sha256 = "3ca4c817e553412b8159064691a3cfa64c7929a885b456e90a5fdea621201738";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest rosunit ];
+  propagatedBuildInputs = [ eigen-stl-containers geometry-msgs graph-msgs ogre1_9 qt5.qtx11extras roscpp roslint rviz sensor-msgs shape-msgs std-msgs tf2-eigen tf2-geometry-msgs tf2-ros trajectory-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Utility functions for displaying and debugging data in Rviz via published markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "d70c8d2b88876c3b93675e74594d3c924316f6a96d25e668d901bcd34ee863ea";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "30452fb5d3b4e30f17e6ff64685cf1368d423f0414840e85d69d17179f29dd0f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sbpl/default.nix
+++ b/distros/noetic/sbpl/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-sbpl";
+  version = "1.3.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/sbpl-release/archive/release/noetic/sbpl/1.3.1-3.tar.gz";
+    name = "1.3.1-3.tar.gz";
+    sha256 = "b9a0c52ebc5d5e5beace383c1fc2be3d1be1596135b3857c7812ebbffde9d706";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Search-based planning library (SBPL).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sensor-msgs/default.nix
+++ b/distros/noetic/sensor-msgs/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, python3Packages, rosbag, rosunit, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, pythonPackages, rosbag, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sensor-msgs";
   version = "1.13.0-r1";
@@ -17,7 +17,7 @@ buildRosPackage {
   buildInputs = [ message-generation ];
   checkInputs = [ rosbag rosunit ];
   propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''This package defines messages for commonly used sensors, including

--- a/distros/noetic/sick-safetyscanners/default.nix
+++ b/distros/noetic/sick-safetyscanners/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rqt-reconfigure, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sick-safetyscanners";
+  version = "1.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/noetic/sick_safetyscanners/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
+    sha256 = "a5e6f363233d779c720ffd27e83018044a003e4bbb2f91186be77b2ceea1e4b7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime roscpp rqt-reconfigure sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides an Interface to read the sensor output of a SICK
+  Safety Scanner'';
+    license = with lib.licenses; [ "ALv2" ];
+  };
+}

--- a/distros/noetic/slam-toolbox-msgs/default.nix
+++ b/distros/noetic/slam-toolbox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-msgs";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "dae1e4189516139bd5c18e4e4ff17c9cbd1d526b6744a8c0111567b8d8f0814b";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "45cb93c32033ae6ad690a66848f06fe5044bfca57286f25177652773bce9db2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox-rviz/default.nix
+++ b/distros/noetic/slam-toolbox-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rviz, slam-toolbox-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-rviz";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "cc66bf855ac1a772da613702d0db9ec8792ec92e308b22091f91793ea5d27f4b";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "f7429c87f5352b5aa19a9a89c231a5b33a9170276573135055639ff1a2b90787";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox/default.nix
+++ b/distros/noetic/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "4f7c8dcd075d03764e2018b351f064bd2b8302a667cee9cc7c5ce3f2b5f697a6";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "a9de8886b830e18968be0a31b50d16afcd47b4b776c5063e3db6a9d9837f74d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/smclib/default.nix
+++ b/distros/noetic/smclib/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-noetic-smclib";
   version = "1.8.5-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/

--- a/distros/noetic/swri-console-util/default.nix
+++ b/distros/noetic/swri-console-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
+buildRosPackage {
+  pname = "ros-noetic-swri-console-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "c56e7d5948db8c381633b9bf0e56f3369fc1f5ea7edc37da9bffae6e0e8bb2d3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp swri-math-util ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_console_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-dbw-interface/default.nix
+++ b/distros/noetic/swri-dbw-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-swri-dbw-interface";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "3c1088947e1bf269c6cccf92faa0134dee72d6941db88b20745289c32e3550d9";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides documentation on common interface conventions for
+    drive-by-wire systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-geometry-util/default.nix
+++ b/distros/noetic/swri-geometry-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
+buildRosPackage {
+  pname = "ros-noetic-swri-geometry-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "96a4a007883796a911c68bd84866c5159b8b8e312501ca6267f201c39c5398e9";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ cmake-modules cv-bridge eigen geos roscpp tf ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''swri_geometry_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-image-util/default.nix
+++ b/distros/noetic/swri-image-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
+buildRosPackage {
+  pname = "ros-noetic-swri-image-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "51bf66350371319eddf3f856faffee6d2d82597cefe351875be86921003d6d8a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ swri-nodelet ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge eigen geometry-msgs image-geometry image-transport message-filters nav-msgs nodelet roscpp rospy std-msgs swri-geometry-util swri-math-util swri-opencv-util swri-roscpp tf ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''swri_image_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-math-util/default.nix
+++ b/distros/noetic/swri-math-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-swri-math-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "18cf33c15222382ecff6679202bdb3bef77c6441fbaabec589312ff1e389535d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_math_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-nodelet/default.nix
+++ b/distros/noetic/swri-nodelet/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-swri-nodelet";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "d37f7c2b36a8e6a61c2a25f14bd6200ae837b587b7e58030edc1f966002dd008";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosbash rostest ];
+  propagatedBuildInputs = [ nodelet rosbash roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a simple script to write simple launch files
+    that can easily switch between running nodelets together or as
+    standalone nodes.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-opencv-util/default.nix
+++ b/distros/noetic/swri-opencv-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, swri-math-util }:
+buildRosPackage {
+  pname = "ros-noetic-swri-opencv-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "9c5f7574224b4607ddb00556b616fe557f7c37cfe03be1c4abfd3a9667aacc63";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge swri-math-util ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_opencv_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-prefix-tools/default.nix
+++ b/distros/noetic/swri-prefix-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-noetic-swri-prefix-tools";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "d9b5768ad76bf8a23336ad61072768caa8a96edcd1da15c224269a5f17834809";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.psutil ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains scripts that are useful as prefix commands for nodes
+    started by roslaunch.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-roscpp/default.nix
+++ b/distros/noetic/swri-roscpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-swri-roscpp";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "8901afbc94f2d039a568e8ba7c97aa3951a99b110608f2aeacf81043d8aaa652";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest message-generation message-runtime rostest rosunit ];
+  propagatedBuildInputs = [ boost diagnostic-updater dynamic-reconfigure libyamlcpp marti-common-msgs nav-msgs roscpp std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''swri_roscpp'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-rospy/default.nix
+++ b/distros/noetic/swri-rospy/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-swri-rospy";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "ba7dcc6302cd1cd9d243b8b041151b3a03fa4180514a96696a8f42fb477e627c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rospy std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
+
+  meta = {
+    description = ''This package provides added functionality on top of rospy, including a
+  single-threaded callback queue.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-route-util/default.nix
+++ b/distros/noetic/swri-route-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-swri-route-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "47a3cc2f1dcb447481321d018978a11d75ab861bf1fb39d24974178c76147754";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ marti-common-msgs marti-nav-msgs roscpp swri-geometry-util swri-math-util swri-transform-util visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This library provides functionality to simplify working with the
+    navigation messages defined in marti_nav_msgs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-serial-util/default.nix
+++ b/distros/noetic/swri-serial-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-swri-serial-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "11f2ba6744576a435b38dcee7fd7d5137b34e866322b8dbdd8da537f04c68285";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_serial_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-string-util/default.nix
+++ b/distros/noetic/swri-string-util/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-swri-string-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "db4d54adf6026757e1f31e611bc1b75cb2def3e63e13ee8580713131d5852427";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_string_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-system-util/default.nix
+++ b/distros/noetic/swri-system-util/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-swri-system-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "6162f6ae8d708b123379a8fc7ea9798625f63a73a688fce5602ebe470def74d5";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''swri_system_util'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-transform-util/default.nix
+++ b/distros/noetic/swri-transform-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, pythonPackages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-swri-transform-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "831822878a7f6c37633e1b70844e5617a6a291d1d6cd5f41af77526e43655b29";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
+  nativeBuildInputs = [ catkin pkg-config pythonPackages.setuptools ];
+
+  meta = {
+    description = ''The swri_transform_util package contains utility functions and classes for
+     transforming between coordinate frames.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/swri-yaml-util/default.nix
+++ b/distros/noetic/swri-yaml-util/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
+buildRosPackage {
+  pname = "ros-noetic-swri-yaml-util";
+  version = "2.13.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.13.5-1.tar.gz";
+    name = "2.13.5-1.tar.gz";
+    sha256 = "083d2bd3c75a48352e2e4c44be5d3e768c7e44a83291675492f7b254b56da81d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost libyamlcpp ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''Provides wrappers around the yaml-cpp library for various utility functions
+    and to abstract out the API changes made to yaml-cpp between ubuntu:precise
+    and ubuntu:trusty.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/teleop-twist-keyboard/default.nix
+++ b/distros/noetic/teleop-twist-keyboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-teleop-twist-keyboard";
+  version = "0.6.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/teleop_twist_keyboard-release/archive/release/noetic/teleop_twist_keyboard/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "f88b1bfe22c7df202673dab7e7a4d95e3708a23b1fd2b9e6e810cb12e75fac00";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic keyboard teleop for twist robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "ba2f6c245482d954241c0345cccad85c0d9bcb234d2f60bd28ae6b96078d38da";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "bc6709cb9873c8d200f1401869183f43ed2bd2696012a98b35345bc7f6c4fab3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.8.7-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.8.7-1.tar.gz";
-    name = "0.8.7-1.tar.gz";
-    sha256 = "62a7a6fb90d8d2f67162f4cbe01e037dfc538eb490045fefc7d8f0a1116241a1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "f3b9b80de2fb851f85600453e1fc182dda26466cee997f929635a120bbfebe63";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urdfdom-py/default.nix
+++ b/distros/noetic/urdfdom-py/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-urdfdom-py";
   version = "0.4.3-r1";
@@ -14,9 +14,9 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ python3Packages.mock ];
-  propagatedBuildInputs = [ python3Packages.pyyaml rospy ];
-  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+  checkInputs = [ pythonPackages.mock ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml rospy ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Python implementation of the URDF parser.'';

--- a/distros/noetic/urg-node/default.nix
+++ b/distros/noetic/urg-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
+buildRosPackage {
+  pname = "ros-noetic-urg-node";
+  version = "0.1.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/noetic/urg_node/0.1.14-1.tar.gz";
+    name = "0.1.14-1.tar.gz";
+    sha256 = "c49e047ac49d8e1e9c56f49d9be92f796c9342250596d1fbe00245d9aa4998ab";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure laser-proc message-generation message-runtime nodelet rosconsole roscpp sensor-msgs std-msgs std-srvs tf urg-c ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''urg_node'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit d049127a2f874f3a2bba27fb799ec6f6ee268e9c.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *qt-dotgraph 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-app 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-core 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-cpp 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-py-common 1.0.7-r1 --> 1.0.9-r1*
* *sros2 0.7.1-r1 --> 0.7.2-r1*
* *sros2-cmake 0.7.1-r1 --> 0.7.2-r1*
* *turtlesim 1.0.1-r1 --> 1.0.2-r1*

Eloquent Changes:
-----------------
* *qt-dotgraph 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-app 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-core 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-cpp 1.0.7-r1 --> 1.0.9-r1*
* *qt-gui-py-common 1.0.7-r1 --> 1.0.9-r1*
* *rqt-robot-monitor 1.0.1-r1*
* *sros2 0.8.1-r1 --> 0.8.2-r1*
* *sros2-cmake 0.8.1-r1 --> 0.8.2-r1*

Foxy Changes:
-------------
* *apriltag 3.1.2-r2*
* *cyclonedds 0.5.1-r2 --> 0.6.0-r1*
* *rqt-robot-monitor 1.0.1-r1*
* *turtlesim 1.2.3-r1 --> 1.2.4-r1*
* *v4l2-camera 0.1.1-r1 --> 0.2.0-r1*
* *webots-ros2 0.0.3-r1*
* *webots-ros2-abb 0.0.3-r1*
* *webots-ros2-demos 0.0.3-r1*
* *webots-ros2-desktop 0.0.3-r1*
* *webots-ros2-epuck 0.0.3-r1*
* *webots-ros2-examples 0.0.3-r1*
* *webots-ros2-msgs 0.0.3-r1*
* *webots-ros2-tiago 0.0.3-r1*
* *webots-ros2-universal-robot 0.0.3-r1*
* *webots-ros2-ur-e-description 0.0.3-r1*

Kinetic Changes:
----------------
* *costmap-cspace 0.8.7-r1 --> 0.8.8-r1*
* *dual-quaternions 0.3.1-r1 --> 0.3.2-r1*
* *dual-quaternions-ros 0.1.3-r3*
* *flexbe-behavior-engine 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-core 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-input 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-mirror 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-msgs 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-onboard 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-states 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-testing 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-widget 1.2.4-r1 --> 1.2.5-r1*
* *graph-msgs 0.1.0 --> 0.1.0-r1*
* *joystick-interrupt 0.8.7-r1 --> 0.8.8-r1*
* *leo-description 0.3.0-r1*
* *leo-viz 0.1.1-r1*
* *map-organizer 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-common 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-launch 0.8.7-r1 --> 0.8.8-r1*
* *obj-to-pointcloud 0.8.7-r1 --> 0.8.8-r1*
* *planner-cspace 0.8.7-r1 --> 0.8.8-r1*
* *realsense2-camera 2.2.13-r1 --> 2.2.14-r1*
* *realsense2-description 2.2.13-r1 --> 2.2.14-r1*
* *rosbag-snapshot 1.0.0-r1*
* *rosbag-snapshot-msgs 1.0.0-r1*
* *rqt-reconfigure 0.5.1-r1 --> 0.5.3-r1*
* *rr-control-input-manager 1.0.0-r3 --> 1.0.1-r1*
* *rr-openrover-description 1.0.0-r3 --> 1.0.1-r1*
* *rr-openrover-driver 1.0.0-r3 --> 1.0.1-r1*
* *rr-openrover-driver-msgs 1.0.0-r3 --> 1.0.1-r1*
* *rr-openrover-simulation 1.0.0-r3 --> 1.0.1-r1*
* *rr-openrover-stack 1.0.0-r3 --> 1.0.1-r1*
* *rr-rover-zero-driver 1.0.0-r3 --> 1.0.1-r1*
* *safety-limiter 0.8.7-r1 --> 0.8.8-r1*
* *sick-safetyscanners 1.0.4-r1 --> 1.0.5-r1*
* *track-odometry 0.8.7-r1 --> 0.8.8-r1*
* *trajectory-tracker 0.8.7-r1 --> 0.8.8-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.8.7-r1 --> 0.8.8-r1*
* *datmo 0.1.2-r2*
* *dual-quaternions 0.3.1-r1 --> 0.3.2-r1*
* *dual-quaternions-ros 0.1.3-r1*
* *flexbe-behavior-engine 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-core 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-input 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-mirror 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-msgs 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-onboard 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-states 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-testing 1.2.4-r1 --> 1.2.5-r1*
* *flexbe-widget 1.2.4-r1 --> 1.2.5-r1*
* *jderobot-assets 1.0.2-r1 --> 1.0.4-r3*
* *joystick-interrupt 0.8.7-r1 --> 0.8.8-r1*
* *leo-description 0.3.0-r1*
* *leo-viz 0.1.1-r1*
* *map-organizer 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-common 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-launch 0.8.7-r1 --> 0.8.8-r1*
* *nextage-description 0.8.6-r1*
* *nextage-gazebo 0.8.6-r1*
* *nextage-ik-plugin 0.8.6-r1*
* *nextage-moveit-config 0.8.6-r1*
* *obj-to-pointcloud 0.8.7-r1 --> 0.8.8-r1*
* *planner-cspace 0.8.7-r1 --> 0.8.8-r1*
* *python-qt-binding 0.4.2-r1 --> 0.4.3-r1*
* *rosbag-fancy 0.1.1-r1 --> 0.2.0-r1*
* *rqt 0.5.1-r1 --> 0.5.2-r1*
* *rqt-gui-cpp 0.5.1-r1 --> 0.5.2-r1*
* *rqt-gui-py 0.5.1-r1 --> 0.5.2-r1*
* *rqt-py-common 0.5.1-r1 --> 0.5.2-r1*
* *rqt-reconfigure 0.5.1-r1 --> 0.5.3-r1*
* *rr-control-input-manager 1.1.0-r2 --> 1.1.1-r1*
* *rr-openrover-description 1.1.0-r2 --> 1.1.1-r1*
* *rr-openrover-driver 1.1.0-r2 --> 1.1.1-r1*
* *rr-openrover-driver-msgs 1.1.0-r2 --> 1.1.1-r1*
* *rr-openrover-simulation 1.1.0-r2 --> 1.1.1-r1*
* *rr-openrover-stack 1.1.0-r2 --> 1.1.1-r1*
* *rr-rover-zero-driver 1.1.0-r2 --> 1.1.1-r1*
* *rtmros-nextage 0.8.6-r1*
* *safety-limiter 0.8.7-r1 --> 0.8.8-r1*
* *sick-safetyscanners 1.0.4-r1 --> 1.0.5-r1*
* *track-odometry 0.8.7-r1 --> 0.8.8-r1*
* *trajectory-tracker 0.8.7-r1 --> 0.8.8-r1*

Noetic Changes:
---------------
* *apriltag 3.1.2-r2*
* *costmap-cspace 0.8.7-r1 --> 0.8.8-r1*
* *dual-quaternions 0.3.1-r1 --> 0.3.2-r1*
* *joystick-interrupt 0.8.7-r1 --> 0.8.8-r1*
* *map-organizer 0.8.7-r1 --> 0.8.8-r1*
* *marti-data-structures 2.13.5-r1*
* *neonavigation 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-common 0.8.7-r1 --> 0.8.8-r1*
* *neonavigation-launch 0.8.7-r1 --> 0.8.8-r1*
* *nmea-msgs 1.1.0-r1*
* *obj-to-pointcloud 0.8.7-r1 --> 0.8.8-r1*
* *planner-cspace 0.8.7-r1 --> 0.8.8-r1*
* *ros-control-boilerplate 0.6.0-r1*
* *rqt-reconfigure 0.5.2-r1 --> 0.5.3-r1*
* *rviz-visual-tools 3.9.0-r1*
* *safety-limiter 0.8.7-r1 --> 0.8.8-r1*
* *sbpl 1.3.1-r3*
* *sick-safetyscanners 1.0.5-r2*
* *slam-toolbox 1.5.0-r1 --> 1.5.1-r1*
* *slam-toolbox-msgs 1.5.0-r1 --> 1.5.1-r1*
* *slam-toolbox-rviz 1.5.0-r1 --> 1.5.1-r1*
* *swri-console-util 2.13.5-r1*
* *swri-dbw-interface 2.13.5-r1*
* *swri-geometry-util 2.13.5-r1*
* *swri-image-util 2.13.5-r1*
* *swri-math-util 2.13.5-r1*
* *swri-nodelet 2.13.5-r1*
* *swri-opencv-util 2.13.5-r1*
* *swri-prefix-tools 2.13.5-r1*
* *swri-roscpp 2.13.5-r1*
* *swri-rospy 2.13.5-r1*
* *swri-route-util 2.13.5-r1*
* *swri-serial-util 2.13.5-r1*
* *swri-string-util 2.13.5-r1*
* *swri-system-util 2.13.5-r1*
* *swri-transform-util 2.13.5-r1*
* *swri-yaml-util 2.13.5-r1*
* *teleop-twist-keyboard 0.6.2-r1*
* *track-odometry 0.8.7-r1 --> 0.8.8-r1*
* *trajectory-tracker 0.8.7-r1 --> 0.8.8-r1*
* *urg-node 0.1.14-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gazebo11
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libflann-dev
 * [ ] libftdipp-dev
 * [ ] libgazebo11-dev
 * [ ] libmongoclient-dev
 * [ ] libnlopt0
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opencv2
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rospkg-modules
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-transforms3d-pip
 * [ ] python3-babeltrace
 * [ ] python3-collada-pip
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pandas
 * [ ] python3-pycodestyle
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] turtlebot_description
 * [ ] ueye_cam
 * [ ] urdf2webots-pip
 * [ ] xdot
 * [ ] xpath-perl

