### PR TITLE
rosdistro sync, Fri Jun 26 12:52:25 2020

### DIFF
--- a/distros/dashing/osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "185f904f6e12b39cd031144ba279c08540bb5337960ecc2d9446e282281bcaa3";
+    sha256 = "8160416b8da311fc0b70bdf3a957453c68788a33982ca66eef7b03f20f45ce95";
   };
 
   buildType = "cmake";

--- a/distros/dashing/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "b5168ed927afbbeb3f17be5913baf27b4f34a3aed3a4c3f199012f2a68d44031";
+    sha256 = "1d496b46debc9b6155c316d3cc3519168aee512e107ee2d293dc484863548876";
   };
 
   buildType = "cmake";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "974bb61988443982d8760ab83213fe959b679a070f11f50ad93f3e92994ecc64";
+    sha256 = "3e281da144e292afee15fdcd4b85780ed0ae047129c16bb4c7147856961a3260";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "32ab5b5aec9f25fb7306bbdf5b61c593fbd85963b404c9967bbe3c5714dcd5e0";
+    sha256 = "3701c6297431bcbcb96a9e61ac4a25db8aa470df275889a79b7b1d38b0f62d78";
   };
 
   buildType = "cmake";

--- a/distros/foxy/gazebo-msgs/default.nix
+++ b/distros/foxy/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-msgs";
-  version = "3.5.0-r1";
+  version = "3.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_msgs/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "aa86da755af3456385ba0b7c87dbcefa20436fa52b71943e71e15124733712e6";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_msgs/3.5.0-2.tar.gz";
+    name = "3.5.0-2.tar.gz";
+    sha256 = "fe98b39c011ecea31f4ccc6c29f32b052d3db10beb7f7f97dcd39d15843bf29f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-plugins/default.nix
+++ b/distros/foxy/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-plugins";
-  version = "3.5.0-r1";
+  version = "3.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_plugins/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "18a9f027d4bd5361a7a4888df200da28c79bedeb32003b898add980d42f6da47";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_plugins/3.5.0-2.tar.gz";
+    name = "3.5.0-2.tar.gz";
+    sha256 = "0befc30d6a8c54b0c9321172af8e4dfeee31b39050cb96ede3fd9c6b58e1a8e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros-pkgs/default.nix
+++ b/distros/foxy/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros-pkgs";
-  version = "3.5.0-r1";
+  version = "3.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros_pkgs/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "b9848b02cd21aee7229464710345008f64a4b25338ae10b87d6bbd8ecae5c7fd";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros_pkgs/3.5.0-2.tar.gz";
+    name = "3.5.0-2.tar.gz";
+    sha256 = "5196df0bb0229e704c1745f927fa83d628326f5348189bb33af6bfcb3eccee49";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros/default.nix
+++ b/distros/foxy/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, gazebo-dev, gazebo-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, rcl, rclcpp, rclpy, rmw, ros2run, sensor-msgs, std-msgs, std-srvs, tinyxml-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros";
-  version = "3.5.0-r1";
+  version = "3.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "7c57b01bedbc2ac8a81b97fd14d752ca4fbcfb77d2204ddeae20b88c33cc77ea";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros/3.5.0-2.tar.gz";
+    name = "3.5.0-2.tar.gz";
+    sha256 = "a552e1cfd0ba2ad5908a390c2819554a03c4c3061ab41b1e0a7b1a81eb93c3b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "e45c6bfaaf2feb2cd5fdad1a85efc2219d7621db4adaaf8344ab69e9f292b8b3";
+    sha256 = "32179f190ed329ba1a47ba412c2762f047973a85a4baa25d69d1d530a8bdbafa";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "0d0c050945691eb325ff889e968bae4ac6f4db9c4b1acb7aae8218c91243bd3d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "20ef52a351c5d0aec0358e400d6b95975320e901e6bdfa59fe19cae53cc8a73f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "e604ad50033bda45d3072956ebfda2558446f21f5ca9048bc43e87889c519188";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "a1c942d86a09a787755cf83485f85260a1eee92a35872eac7584ee97eead812f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "dbb2da2cd98fde947c6b01f28a80d4de651cb8c1b0a2f6f16ad9e13f3e164310";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "53566b6fc8a687fb4f023cc7613fac23676242dee98429e82e351a4f272377c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "609d965cfbb8abc62d321c31ea672ae13f4d40b93b76dcabc59315b02f3e43b5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "3c6e893c1bcb3677cdd37a9c06fd61737a95f58e59b7ace86b7ecfa0ca2f2889";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "92cb1f609edfff4f77dd610b53ac46fead90d017f5e9e69f34d1da0b250f3966";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "e6bb9e2c3c3bf9219c8fa8745f3817c79d7881e14168a7e7273eaaa66bfbf118";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "bf420c8c6f89e412f50672376f7ca7c6c8d84dee8cf5c544f076ff22cce604b2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "89c689ffa97aca59d4c4e91b4b36829feeda7aba245f98026e0f64ecc09574d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "b8f3ea8371c6b06c4cca8b1e48a6ec78fa50473e23d4f031fb3a5fa0fc71fbd8";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "1b0224d6b81b166b91bb38fcd626f633da683de914340220a7827a9f2a256e41";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.1.1-r1";
+  version = "8.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.1.1-1.tar.gz";
-    name = "8.1.1-1.tar.gz";
-    sha256 = "f608366b5537586ab2a61faf5e99895e74165a5c4733c38daf112aa28c816a49";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.0-1.tar.gz";
+    name = "8.2.0-1.tar.gz";
+    sha256 = "b0244eaad9eddafa87ea11ccc07f394fbed82678da8c4d7c3ae75401e5237376";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/test_osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "5a63a3c96ca015cc0ac3e9ba54d83320cd014fb0f67105a114c69a22b22f9bf3";
+    sha256 = "c4305d66ab841ea1a44618a15187e7d54fb4b3c6beb695f5c312e0f35dc8ed99";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb1, linuxHeaders, openssl, pkg-config, udev }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.33.1-r2";
+  version = "2.35.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.33.1-2.tar.gz";
-    name = "2.33.1-2.tar.gz";
-    sha256 = "9c755cf1d0f4301d48d86f67ec1a7d159c513471f06b8f95de7bb4c5a4b304e4";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.35.2-2.tar.gz";
+    name = "2.35.2-2.tar.gz";
+    sha256 = "87a3e6ee46cada6c2122abc5ff71fa52811ea34c69b6f35c78453e45515d66c2";
   };
 
   buildType = "cmake";
   buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ libusb1 linuxHeaders openssl udev ];
+  propagatedBuildInputs = [ libusb1 openssl udev ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/soem/default.nix
+++ b/distros/kinetic/soem/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-soem";
-  version = "1.4.0-r1";
+  version = "1.4.1000-r1";
 
   src = fetchurl {
-    url = "https://github.com/mgruhler/soem-gbp/archive/release/kinetic/soem/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "67e40cc25126e41f9cba65b6ff7e342531e893ea6f1e4666a97de09fba5baff4";
+    url = "https://github.com/mgruhler/soem-gbp/archive/release/kinetic/soem/1.4.1000-1.tar.gz";
+    name = "1.4.1000-1.tar.gz";
+    sha256 = "95fd563d3325a03a62544bf7b975f5df7225b7e98e463acf1df5977507b51104";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-stamped/default.nix
+++ b/distros/kinetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-urg-stamped";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "d803529a50f64c8291d82296a7675a6a7457f650059839534bd2cfe9cd897d43";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "02fd52ce8598710fce6a88287dcc64253e8ea64b719b3905405501143db3adbb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.12-r1";
+  version = "1.13.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.12-1.tar.gz";
-    name = "1.13.12-1.tar.gz";
-    sha256 = "f446d50353caf457b1c9406df0c407e832f18e265f8914584247eef0313d4932";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.13-1.tar.gz";
+    name = "1.13.13-1.tar.gz";
+    sha256 = "a5990e3514fb281e91d834328cb5da8cf45f528eed3ad5320c586cea55701ba0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/soem/default.nix
+++ b/distros/melodic/soem/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-soem";
-  version = "1.4.0-r1";
+  version = "1.4.1002-r1";
 
   src = fetchurl {
-    url = "https://github.com/mgruhler/soem-gbp/archive/release/melodic/soem/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "cc03d89d73e3fc1a7914451e6f890065a30b74d6aed49983b743f57db73c4a80";
+    url = "https://github.com/mgruhler/soem-gbp/archive/release/melodic/soem/1.4.1002-1.tar.gz";
+    name = "1.4.1002-1.tar.gz";
+    sha256 = "1f9dcfda3ff941a9d8d5a346fe03c8b880f6aae2f50d23ea5bb57e1233d7b1c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ur-msgs/default.nix
+++ b/distros/melodic/ur-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ur-msgs";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/melodic/ur_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "58d71795b39665a7ec502a993e055064b5359ca0f8d8c7683246ded59c7d7531";
+    url = "https://github.com/ros-industrial-release/ur_msgs-release/archive/release/melodic/ur_msgs/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "851d00a37896990a63c221d2a17f7a946c0380d9193b7c33574f54b5c20f7e13";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.5-r1";
+  version = "0.0.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "65514384ea118ceacd685cb5533af68148989fdb3fdea2c5e885743811870053";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.6-2.tar.gz";
+    name = "0.0.6-2.tar.gz";
+    sha256 = "cadca2704bcdaa8c81e7b435543b6cae659c6bf57aed2d85e323b9eb55b45892";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.0-r2";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.0-2.tar.gz";
-    name = "1.14.0-2.tar.gz";
-    sha256 = "a96afc5cf9382de6f64c7e782e00b9beb2ae6701a687fdabd179ebf0b08c5c72";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "409240cebbf10ef14bc053a374b245998785190717211422d14a6b685bd06ba1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/soem/default.nix
+++ b/distros/noetic/soem/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-soem";
-  version = "1.4.1001-r1";
+  version = "1.4.1002-r1";
 
   src = fetchurl {
-    url = "https://github.com/mgruhler/soem-gbp/archive/release/noetic/soem/1.4.1001-1.tar.gz";
-    name = "1.4.1001-1.tar.gz";
-    sha256 = "18a758a4886a013161dbb0a874c3ecfb151fc6ca0cc39156545d9aa5d3be77f4";
+    url = "https://github.com/mgruhler/soem-gbp/archive/release/noetic/soem/1.4.1002-1.tar.gz";
+    name = "1.4.1002-1.tar.gz";
+    sha256 = "5fab12cec09557010dead08ba8985f5bc6d8c6e8b5d02bac3ff05138a20f82ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "ab75df5a31e1c4a6eccf8c51f3bd93ea337f8a2331692aca8e64c657f30a3858";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "1572e20184419f3fab30e0574436ecef721a303789ff39cc3fee4e9d83414bce";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 9d7a6c25ba4f06a07d18cb2964a117131abf358a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Foxy Changes:
-------------
* *gazebo-msgs 3.5.0-r1 --> 3.5.0-r2*
* *gazebo-plugins 3.5.0-r1 --> 3.5.0-r2*
* *gazebo-ros 3.5.0-r1 --> 3.5.0-r2*
* *gazebo-ros-pkgs 3.5.0-r1 --> 3.5.0-r2*
* *rviz-assimp-vendor 8.1.1-r1 --> 8.2.0-r1*
* *rviz-common 8.1.1-r1 --> 8.2.0-r1*
* *rviz-default-plugins 8.1.1-r1 --> 8.2.0-r1*
* *rviz-ogre-vendor 8.1.1-r1 --> 8.2.0-r1*
* *rviz-rendering 8.1.1-r1 --> 8.2.0-r1*
* *rviz-rendering-tests 8.1.1-r1 --> 8.2.0-r1*
* *rviz-visual-testing-framework 8.1.1-r1 --> 8.2.0-r1*
* *rviz2 8.1.1-r1 --> 8.2.0-r1*

Kinetic Changes:
----------------
* *librealsense2 2.33.1-r2 --> 2.35.2-r2*
* *soem 1.4.0-r1 --> 1.4.1000-r1*
* *urg-stamped 0.0.5-r1 --> 0.0.6-r1*

Melodic Changes:
----------------
* *rviz 1.13.12-r1 --> 1.13.13-r1*
* *soem 1.4.0-r1 --> 1.4.1002-r1*
* *ur-msgs 1.3.0-r1 --> 1.3.1-r1*
* *urg-stamped 0.0.5-r1 --> 0.0.6-r2*

Noetic Changes:
---------------
* *rviz 1.14.0-r2 --> 1.14.1-r1*
* *soem 1.4.1001-r1 --> 1.4.1002-r1*
* *urg-stamped 0.0.5-r1 --> 0.0.6-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gazebo11
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libgazebo11-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-transforms3d-pip
 * [ ] python3-babeltrace
 * [ ] python3-collada-pip
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] turtlebot_description
 * [ ] ueye_cam
 * [ ] urdf2webots-pip
 * [ ] xdot
 * [ ] xpath-perl

