### PR TITLE
rosdistro sync, Fri Jul 10 12:58:21 2020

### DIFF
--- a/distros/dashing/osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "185f904f6e12b39cd031144ba279c08540bb5337960ecc2d9446e282281bcaa3";
+    sha256 = "8160416b8da311fc0b70bdf3a957453c68788a33982ca66eef7b03f20f45ce95";
   };
 
   buildType = "cmake";

--- a/distros/dashing/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/dashing/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/dashing/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "b5168ed927afbbeb3f17be5913baf27b4f34a3aed3a4c3f199012f2a68d44031";
+    sha256 = "1d496b46debc9b6155c316d3cc3519168aee512e107ee2d293dc484863548876";
   };
 
   buildType = "cmake";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_launch/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "d2001368f6c4949a7512227b12ee7afb3448009bd66547434805a2ef6dc823f5";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/dashing/tracetools_test/0.2.8-1";
     name = "archive.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "a9450bbafff2fa4e1f269e4168418831dfad4a8cdca940ea2fc1fd998730acb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/mavlink/default.nix
+++ b/distros/eloquent/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-eloquent-mavlink";
-  version = "2020.6.6-r1";
+  version = "2020.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/eloquent/mavlink/2020.6.6-1.tar.gz";
-    name = "2020.6.6-1.tar.gz";
-    sha256 = "31e1d88e0d7c69a141eb96803acec292ef7479f48c70c1ffc72f96b49eedc2d4";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/eloquent/mavlink/2020.7.7-1.tar.gz";
+    name = "2020.7.7-1.tar.gz";
+    sha256 = "eed6a8fde1724155fb2c5685aac8a8d3c768069992a4cd9664a1b53c7ebff222";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "974bb61988443982d8760ab83213fe959b679a070f11f50ad93f3e92994ecc64";
+    sha256 = "3e281da144e292afee15fdcd4b85780ed0ae047129c16bb4c7147856961a3260";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/plansys2-bringup/default.nix
+++ b/distros/eloquent/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-bringup";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "3658724d47117dceac8d53de25e0448685fe3ff51db06f50abb2063bfd8b3cc8";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "7e566d92231d8cb62dad358ef231a7ff046b72a3ffd07c8d985051887a055d3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-domain-expert/default.nix
+++ b/distros/eloquent/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-domain-expert";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "d939daa00679218b0a43bd7b52127be62fb06c62119373cbdeb8b6ad663800a5";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "e6986f6631bd7c7ed891b545cffd90988acf4dac2695f07a5d1e1346f248eb03";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-executor/default.nix
+++ b/distros/eloquent/plansys2-executor/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, boost, geometry-msgs, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-executor";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "3a21002efeb15f192be61af018f3bdd24b94d56cf66ad34b1d45db34a32aabf4";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "99b542f9454cf8229cc63ef2901e4d508b606c71854f5ed2b10a862828960653";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ boost ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs test-msgs ];
   propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/eloquent/plansys2-lifecycle-manager/default.nix
+++ b/distros/eloquent/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-lifecycle-manager";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "169f444bb3c82279284797ceede2a7a7a77db4d51ca6e611750a130e9dcaf52d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "c476594144516b5758f7e82545522e765a79690dbc8e567970367df42b9cb803";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-msgs/default.nix
+++ b/distros/eloquent/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-msgs";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "1522ec1e86a383a0c962e9b6122f195f9718f8a24057c58ec537df207e74494f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "0a9e90eb31f013c8c8a46b41061024b6377b24460b9b8c01524d372c76873640";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-pddl-parser/default.nix
+++ b/distros/eloquent/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-pddl-parser";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "3025da371b62b657884a238503e37daf422079e6d5b9931dba56f1d15007384c";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "425ac3f46c65940ff68934fd3baa12889002f0d99b213112859044b4093ebbe5";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-planner/default.nix
+++ b/distros/eloquent/plansys2-planner/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-planner";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "057369581aa895668b42cffb928a6171ecd5f26445b1b61f06b0f5fe632f75cc";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "f023c0467cd297b2653be4e50f745cb33b7b41114de7bf46fce61a7467095f48";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ boost ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
   propagatedBuildInputs = [ ament-index-cpp plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/eloquent/plansys2-problem-expert/default.nix
+++ b/distros/eloquent/plansys2-problem-expert/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-problem-expert";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "1ca07d2203e28d9800faf2ccf5ad2627fb2fd1d8a2a4feb0f2d5f62acd0d10de";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "eeac6dfed607a757fb01165e4a9b5a05f3245132f960b820ab6448ef47bce0e5";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ boost ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp plansys2-domain-expert plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/eloquent/plansys2-terminal/default.nix
+++ b/distros/eloquent/plansys2-terminal/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-terminal";
-  version = "0.0.8-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.8-1.tar.gz";
-    name = "0.0.8-1.tar.gz";
-    sha256 = "d4ffabf66cabf56c2bc7f92c5f782cbd25821b8721f58f9f2c2e64126cf441f9";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "ad6d7d3c39bd6a984c8d8f723daa6443b211d79ea82715e6133d900644829879";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ boost ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-index-cpp plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/eloquent/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/eloquent/test_osrf_testing_tools_cpp/1.2.2-1.tar.gz";
     name = "1.2.2-1.tar.gz";
-    sha256 = "32ab5b5aec9f25fb7306bbdf5b61c593fbd85963b404c9967bbe3c5714dcd5e0";
+    sha256 = "3701c6297431bcbcb96a9e61ac4a25db8aa470df275889a79b7b1d38b0f62d78";
   };
 
   buildType = "cmake";

--- a/distros/foxy/control-msgs/default.nix
+++ b/distros/foxy/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-control-msgs";
-  version = "2.3.0-r3";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_msgs-release/archive/release/foxy/control_msgs/2.3.0-3.tar.gz";
-    name = "2.3.0-3.tar.gz";
-    sha256 = "17f734f73c7ec0aeca2e968c2713f81cf5a6fea2f50babad8666e0147160c928";
+    url = "https://github.com/ros-gbp/control_msgs-release/archive/release/foxy/control_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "451027f891a840b4fb503d23472ffeec82aa40a0fd3ea609508d99e6c6afb9f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/costmap-queue/default.nix
+++ b/distros/foxy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-costmap-queue";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "5c4b9bc9b6317b75db9dc83f483c3a7fb71d4187e28537fe4185cf9b31676c43";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "d0fffb15a940c4ba6b238251c57b11e22f183b6c3f3b3e6ac18cf9368ec3fec3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/desktop/default.nix
+++ b/distros/foxy/desktop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials-cpp, action-tutorials-interfaces, action-tutorials-py, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclcpp-multithreaded-executor, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor }:
+{ lib, buildRosPackage, fetchurl, action-tutorials-cpp, action-tutorials-interfaces, action-tutorials-py, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclcpp-multithreaded-executor, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-desktop";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/desktop/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "f350caf4d25c32ebf7126fad65b2a67d52bc97e768e7e0971656b634a610c9f6";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/desktop/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "d9a3e5eb1b3e87409a9850e420ec7667a539120808c5696292a6540ac2788b9a";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ action-tutorials-cpp action-tutorials-interfaces action-tutorials-py angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclcpp-multithreaded-executor examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor ];
+  propagatedBuildInputs = [ action-tutorials-cpp action-tutorials-interfaces action-tutorials-py angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclcpp-multithreaded-executor examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/dwb-core/default.nix
+++ b/distros/foxy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-core";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6814ce436588cffa779a2595a697aaee8d2762b9cf4b588e5be25e4ae71efa1e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "aff9c01a907bd1bcd28101275f1944698e6b6e7b0f47fa4dbb91f14309773db6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-critics/default.nix
+++ b/distros/foxy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-critics";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "64477324af1580114ce302c7bc0190da0e35330814e7b1331ef9ad4606028340";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "3c145a436e66f254f5aa3728df875ef0aeafa957b38cc14aa4a6f08c3a30495c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-msgs/default.nix
+++ b/distros/foxy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1bd10eba1df27d2dce9ad0f95b9b838760510c5e45e3a16efc128e05e4b52583";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "c01296decff1eca700ff805e3c02508a6e5dde672cfbd992bfe94de21958c87c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-plugins/default.nix
+++ b/distros/foxy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dwb-plugins";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "750eb9ebac19a9f77ec2360c5a193a90408732b43f6a83ad344f7a4b107c89c3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "dd322122df9fbf7149f4cea980e9d4f607a45f245a7586d2c184ccd5549fd523";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -558,6 +558,8 @@ self: super: {
 
  realsense-ros = self.callPackage ./realsense-ros {};
 
+ realtime-tools = self.callPackage ./realtime-tools {};
+
  resource-retriever = self.callPackage ./resource-retriever {};
 
  rmw = self.callPackage ./rmw {};
@@ -820,6 +822,8 @@ self: super: {
 
  system-modes-examples = self.callPackage ./system-modes-examples {};
 
+ tango-icons-vendor = self.callPackage ./tango-icons-vendor {};
+
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
@@ -902,6 +906,8 @@ self: super: {
 
  webots-ros2-abb = self.callPackage ./webots-ros2-abb {};
 
+ webots-ros2-core = self.callPackage ./webots-ros2-core {};
+
  webots-ros2-demos = self.callPackage ./webots-ros2-demos {};
 
  webots-ros2-desktop = self.callPackage ./webots-ros2-desktop {};
@@ -909,6 +915,8 @@ self: super: {
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
 
  webots-ros2-examples = self.callPackage ./webots-ros2-examples {};
+
+ webots-ros2-importer = self.callPackage ./webots-ros2-importer {};
 
  webots-ros2-msgs = self.callPackage ./webots-ros2-msgs {};
 

--- a/distros/foxy/nav-2d-msgs/default.nix
+++ b/distros/foxy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6f2ef3a0efaef3e1aafc6a4acc562b0ae8fe31ae581c83d5f3b3fe38141a97e9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "510dd13e886fd8883cfa93249effeab001c3a493b4770fea8274b22527135486";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav-2d-utils/default.nix
+++ b/distros/foxy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-utils";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "37175d12ce791791ef17d83b51558147f91d6769e88a64bcb61704780d43dd34";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "f38060ee7415053dda686269d44dc1f1005a1334d8c36fb3bdd1158909f2fdd9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-amcl/default.nix
+++ b/distros/foxy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-amcl";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "04b1fd2cdbaf660db133af720c84eb6116c4b527d80bd233cc569e160626afde";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "7f53399027c594755fbbbc2b0c83d22fc3019effc39c7e70dfa0274efc532fe4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-behavior-tree/default.nix
+++ b/distros/foxy/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-behavior-tree";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4c2c12e932f0b8ce1c1f59159359c2be107c36f4b7eeecb7df6d2d552b25ef1e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "b6df3746c76ce7c7e1b334053301c57c683a5dea2835a0cc852990ef6d757872";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-bringup/default.nix
+++ b/distros/foxy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2 }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bringup";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "0364bf5acd296cd0905320d7fcc798a1dee81e58b46bff306328a99e0f54a3f0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "1742b28a3ed4f99931880bbd94c3677898f6e9b0f0c4b2bbc1c70e7c3ffbb6ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-bt-navigator/default.nix
+++ b/distros/foxy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bt-navigator";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "08f4620c6b38eead9c123a48d3142e416e28341bad234619fa7213920fedaea6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "602649f18787cc40f6fd47168210d4e8ca8506a8ef13bddd5d25652d41bb01fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-common/default.nix
+++ b/distros/foxy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-nav2-common";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "71102419aa3b68f4ee06277da02bbd73dc90a47ff69d378a10a12987de10e3a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "4a96da159a361d6008820931c4bc8ebd0c197f871d830b861f9a2661f8f5f769";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-controller/default.nix
+++ b/distros/foxy/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "a3aa130cb2f73be25f601a7c1127c82a705c8c3250c29670fc60e8c635055e46";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "580324c767ed39c62966d44ea7afab321c198138cdd285881634acd0893de1fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-core/default.nix
+++ b/distros/foxy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-core";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d0324ebebc766cc230277e04ce9e74fcf9c601346baaf813b4b21ff5a398984c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "fac7fe8936940006f5f821a6f7224915424ef3962e5c1a5cc7879180aa521b2c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-costmap-2d/default.nix
+++ b/distros/foxy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-costmap-2d";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4b063350110b5645f3e01f6513c20f9d75cad0ebe8124b210e02b6b142eaea0e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "a10bd9e12afd6c3fea2895cb2a3cbc91221ba7ae279222bc487632edc6ba88eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-dwb-controller/default.nix
+++ b/distros/foxy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-foxy-nav2-dwb-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "e1f3ccd131b2f5cfd653696a007412e5636f1536e02d2525a5a84698e32e2eb0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "619abb9815a64a663cc575e217286a983a7f33a78f61d00539d2a0e847f287c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-gazebo-spawner/default.nix
+++ b/distros/foxy/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-gazebo-spawner";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "52f8dbbe1c1dba622358e9890496239d7ec219d133b7455e1e581fe82014c6a6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "2e1ff29286fd05db374d5cf7669f6bbeaddf9585ce6b0a9384ff8e28b35fd644";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/nav2-lifecycle-manager/default.nix
+++ b/distros/foxy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-lifecycle-manager";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "5e139fb6882685aefb05903d845355cb1d319ba473c50890a2072a8573ee30dc";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "e40f763e2f005fe735263b15320b09717710ea386b7bb06e4c79e4cea236ec69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-map-server/default.nix
+++ b/distros/foxy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-nav2-map-server";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "a0f79a0147581e73bca3d535a2a4972b5841893d2e3c8c448bba79c6e9bad22d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "36b4db547156b523cfb668aae659f81af85cfd1b5322daca097a81878687e075";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-msgs/default.nix
+++ b/distros/foxy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-msgs";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "edd383efe0f01594f363c8311dc6061ce3f9eed0e42e8a7e3329e6c5197f84e5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "9610bb5b0b1b329d61e5b142f802c37659333f248d4b243349cf51ef28870891";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-navfn-planner/default.nix
+++ b/distros/foxy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-navfn-planner";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "38452bf55a6b6340b1b1fb5db6b92bf7d8dfb38a7b03b38f70e21655a07f4d8d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "0e52ff2b63aa46b158a9038e643c3065ea89eb22d105dbd0c846985fa4ae6c3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-planner/default.nix
+++ b/distros/foxy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-planner";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "66e5f61b6be73404edd07c11fd8559c0ee13d7b0963950a3ff4c0275c5fe533b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "29b4d9e7f93273905beff0649a367d3e19a04a15e668cc5c93c5c87007b10793";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-recoveries/default.nix
+++ b/distros/foxy/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-recoveries";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "253882c140de6a2fa4b9be7ff259aa9cd890b4ca4470689e9c7d9792c9e3935f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "580d80e33735959792e343ccefeac4e7e4a33237b162727ca1fd99d75b03ff82";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-rviz-plugins/default.nix
+++ b/distros/foxy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-rviz-plugins";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "b881ab414687db43ab376ac365b1309b77d2872220e37ee21e5debbcfe8d5242";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "36022eb819a5a6afeb60a23c09a8fea32b4546fc1f738cbddbe0beb741d0c944";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-system-tests/default.nix
+++ b/distros/foxy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-system-tests";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "168828cc7bd3da5ca28106c483bd5a49ede2c47e9fb154ea0c16044d92eefd6b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "6b4316d8448800e0005d60a717cbde8f137646740592b67a7f8fefdb2211b13c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-util/default.nix
+++ b/distros/foxy/nav2-util/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, launch, launch-testing-ament-cmake, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-util";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "409cff9e0515bdfceba1796114415489405b4d2e44dd73af4dee7eb1fd73e219";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "1fd187da7ca109b8daea333c5e2e5bd20e816452758fb33493f187aaddd1f25c";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common std-srvs ];
-  propagatedBuildInputs = [ boost geometry-msgs lifecycle-msgs nav-msgs nav2-common nav2-msgs rclcpp rclcpp-action rclcpp-lifecycle test-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch launch-testing-ament-cmake std-srvs ];
+  propagatedBuildInputs = [ boost geometry-msgs launch launch-testing-ament-cmake lifecycle-msgs nav-msgs nav2-common nav2-msgs rclcpp rclcpp-action rclcpp-lifecycle test-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/nav2-voxel-grid/default.nix
+++ b/distros/foxy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-nav2-voxel-grid";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "d5fe55230ef42968ae59bae89efba3cd30fd7e1005408f2e0df920df41d330d3";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "434ad5aba1a7d6b5e446d4e326546e13cc064f22a8cfa7c6abf02bb514c96255";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-waypoint-follower/default.nix
+++ b/distros/foxy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-waypoint-follower";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "c9d43860cfc75c3e71fa7082a02e7faaa5a1f1bf7e882aacb2844067a29bb6f6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "f18f064224d1b8f5c47a7c2d3fa446a483790e6b301b5372c8d4df5102318917";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/navigation2/default.nix
+++ b/distros/foxy/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-foxy-navigation2";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4606f2ddc3f2f89b9a5625dce35a3d31fe4530c51ba39fca3b731402ac756711";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "846b86ac086abd3faf20ec7464629d2d2138ea55eb9ded0eb9cc85358ca5c323";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "e45c6bfaaf2feb2cd5fdad1a85efc2219d7621db4adaaf8344ab69e9f292b8b3";
+    sha256 = "32179f190ed329ba1a47ba412c2762f047973a85a4baa25d69d1d530a8bdbafa";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "ddcffae278a2280716252d088b950d2c40c30f023de5c6bc43af7d9082a7e54f";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "80016ef180a08297c1988e46eb9a8337fab54256d8bba07926d1f73366550d81";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "6f68ab322635dfc1fa0e309aae1ccfc4b6b1754b9617c0e7b69b055c4bf477c3";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "a7e4aee36582843f294d0c8babf36967526b58f720d22f3fcf96badeccc9f433";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, osrf-testing-tools-cpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "682edd79f026bf6ce5d881f893187d29aa6d7bf3a9164e4c25219929c00d0a4d";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "13816a6d5f4e6b064b7d20ada7f21869654d159b142724ad499cf906145d57c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.5-r1";
+  version = "1.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.5-1.tar.gz";
-    name = "1.1.5-1.tar.gz";
-    sha256 = "a8f48ba0a7fa114a3a2b1289448b484471c10e8d2bc43eae147f0169588cb344";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.6-1.tar.gz";
+    name = "1.1.6-1.tar.gz";
+    sha256 = "09f64c3a32290fda5c20850be8b0640b480a362b449791191de94f2357b43d3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-action/default.nix
+++ b/distros/foxy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcl-action, rclcpp, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-action";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "55030395a014f664156110c0cdf04dded4834f4bcfffef6265a9713c307e9dca";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4e0a1467f31fb98d72866923066238271fe5f4ca3c877d8d9d791028adcb2f2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-components/default.nix
+++ b/distros/foxy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-components";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "7dc52d6f2cd4d4dcbcd5a43c4848e96b0cdcc58f106ff7b3bfa0384b5f5a4b66";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "87399b62eda379e8c2c43b4c22fa7a294dedc59128d7ab51b2aef9001d68529c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, rcl-lifecycle, rclcpp, rmw, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-lifecycle";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "dea818702bfaafbe7e021a596bbe7f0331032505e4f921365ef23ae6b2db6528";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4f11909f030671a0709f7c84a94978211704343d977e7bad7bb020ab599f181c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp/default.nix
+++ b/distros/foxy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "f162f4566d6f8441eae0db155926bec1537cdfcae58f6cc42a9c15dc81786d60";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "94fe45b874b56d26b7c6658662ad2ef84147c9a3878ece4ca77089b1ccf36ef8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclpy/default.nix
+++ b/distros/foxy/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclpy";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "9caaeb37567c33878669e28d08fb5f41066b9e7bdcd3cfc4839ff93bfece71dd";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "93a460530df5e1e51d17b599bc17e0cd8651f409d949eb8f30a5d797d69b0fc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realtime-tools/default.nix
+++ b/distros/foxy/realtime-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-action, test-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-realtime-tools";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/realtime_tools-release/archive/release/foxy/realtime_tools/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6de798d45d133a7771505cc92c8dce2630dc9c089cefad1d4f6f057d3f1cda5a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common rclcpp-action test-msgs ];
+  propagatedBuildInputs = [ ament-cmake rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains a set of tools that can be used from a hard
+    realtime thread, without breaking the realtime behavior.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rmw-connext-cpp/default.nix
+++ b/distros/foxy/rmw-connext-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rmw-connext-shared-cpp, rosidl-cmake, rosidl-generator-dds-idl, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-connext-c, rosidl-typesupport-connext-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-connext-cpp";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/foxy/rmw_connext_cpp/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "d96348702d130bcc2fa69d892a3134e4a4a764e799a58c2cada27ac754a14879";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/foxy/rmw_connext_cpp/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ed72595965752f2def9b6ea00439169fcbfb034c6981ac01acfc71e5ae2e0671";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-connext-shared-cpp/default.nix
+++ b/distros/foxy/rmw-connext-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, connext-cmake-module, rcpputils, rcutils, rmw, rosidl-cmake }:
 buildRosPackage {
   pname = "ros-foxy-rmw-connext-shared-cpp";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/foxy/rmw_connext_shared_cpp/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7f2ec782a646e772693816359b5bc9610fe97dc64ecb93b5b53242aed0dc874d";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/foxy/rmw_connext_shared_cpp/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "dae0ca4e6263b72e3ebad1ef8c5e634e98f27df2515e5d33cadf3f51ee645407";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "2b4252adb62a7e2669632431f095579a6a51219b058c9263e1d3ec44d4be5a8a";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "9e2e01744e4d0b45c61ff7eefac15e8469f4aa3c675f270b895b4c4e9a2df760";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "69e4adae712efbb2b283533d09d82992f09cad4665fd90c6c269225a27f0b7eb";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "712fcd630599b9fe7508896b241a300e99ea7a8c70963072ef86c4121cc5785c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c1bcc9b0656d7bc55564c3c7830a152f690415cf1837333b6599cd4ce1d836ca";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "38a0c3016ceab92ba4258ebc38639986f2b512b4c30a13259d3f55b23d46d2a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "59a6b396e30fb1958e3277fefc93e65e4c27a832c2ddbf7bc55f867005914319";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "2ebfef3dd6b3a1fb25c11778fd2b650d67c3fcd6dfd31e8568e1dcfff37b6bda";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros-base/default.nix
+++ b/distros/foxy/ros-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry2, kdl-parser, robot-state-publisher, ros-core, rosbag2, urdf }:
 buildRosPackage {
   pname = "ros-foxy-ros-base";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/ros_base/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "307b0bae688ee0546174a4d142f5cea8a2c4852b6a59a4776d69010303719be6";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/ros_base/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "17b2a81b60bdf088408d1a349ca4c558ea69f70a90f30598dde5daae74786f23";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros-core/default.nix
+++ b/distros/foxy/ros-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, class-loader, common-interfaces, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, launch-xml, launch-yaml, pluginlib, rcl-lifecycle, rclcpp, rclcpp-lifecycle, rclpy, ros-environment, ros2action, ros2component, ros2doctor, ros2interface, ros2launch, ros2lifecycle, ros2multicast, ros2node, ros2param, ros2pkg, ros2run, ros2service, ros2topic, rosidl-default-generators, rosidl-default-runtime, sros2, sros2-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ros-core";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/ros_core/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "2d80ef421305967a5e2af31df2c6d1065e37a4095716ed235cfd08ddf5b8f380";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/foxy/ros_core/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "9ed6646dd29039eae6e11622bd07a88457e628f46526186b6359101752bf212c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros1-bridge/default.nix
+++ b/distros/foxy/ros1-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, demo-nodes-cpp, diagnostic-msgs, example-interfaces, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, pkg-config, python3Packages, rclcpp, rcutils, rmw-implementation-cmake, ros2run, rosidl-cmake, rosidl-parser, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros1-bridge";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/foxy/ros1_bridge/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "d70611190cb1c2642368e7d5b581fe3a1d5ba66633302c8c4a9f6df4bbbcca17";
+    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/foxy/ros1_bridge/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "26dae33cdf282bdb52187e20702ed326a2acd3552748ca038606cfec32cdb922";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2action/default.nix
+++ b/distros/foxy/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2action";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2action/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "4539afa07060b1c473f7576ad5c76baaff06341c3d304dbf1515c283b80ab261";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2action/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "f76374655bef4866fb2de795c76fdec890b7f21fc3cbbba7f878ba9dfd582d62";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2cli/default.nix
+++ b/distros/foxy/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2cli";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2cli/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "749770ec083d35ec4b16b9c63554527256af4593e1896e4024cccd8e24c4a0b8";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2cli/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "fc5c7ffe370f71b63eded6c30bc13084d3a18a9d9de8cd5b43ad56c5cc846bfa";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2component/default.nix
+++ b/distros/foxy/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2component";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2component/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "ecd58d1ad3ebc6497077b2ac689529032b80c5b3f9af9b2948bde4430ae138ab";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2component/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "92787e7e1c4beb22b6e852e0ad5f9693e9929650092441dec8b57cb0dcc563c7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2interface/default.nix
+++ b/distros/foxy/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2interface";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2interface/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "eae37653d5e3b0dccce29285be9df5bc793e6e49d6dfc896b1268aa828185fa5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2interface/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "39908fd466f02ed6058f45e1bdae6bd989067811da8bcdb4b4a151ea6ab9096a";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/foxy/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-ros2lifecycle-test-fixtures";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle_test_fixtures/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "6aa2ae33bf2e6fca215bb8ddd7ccb6056f924bd35b1cd1dc18ce0d9c2538b4ea";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle_test_fixtures/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "48e5d804a7726adcfed6438aa46216aaf06284ba24ef9a4bd5ec5f232a68129a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2lifecycle/default.nix
+++ b/distros/foxy/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros-testing, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-foxy-ros2lifecycle";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "e6182fee73e0f609b794d6c6fe15eab6e54e5c5e6e3f8ab00f31154303868949";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "7e407a3efe7629e4f7dc4deebb2e451c1b0cc7d75648859e101d07088c4fbbd4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2multicast/default.nix
+++ b/distros/foxy/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-foxy-ros2multicast";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2multicast/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "eedcb1d448c8d77d6547a9baaa26aebe78f1b33b38f3224d74663b7bce1fee15";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2multicast/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "a88997a9a5ee191f860466fdc81a4c4d28aacf26e771d677562e46c7eafe8f88";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2node/default.nix
+++ b/distros/foxy/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2node";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2node/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "5b6b2698b70dde249c2d38c514348c7873af55f95592fc5d1afec543367ecde6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2node/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "5c82958697a730851e58a1db566a89513144f2cb6b4193806c6da608f71c7aba";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2param/default.nix
+++ b/distros/foxy/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-foxy-ros2param";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2param/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "6f0cdf14879e3f7d0ef5705ce598ff652b61302aedf2723b426a73429bf02165";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2param/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "f752c64383fc8aa0cedcb4b8e12a0c8ba8dc779f734ff8798945797e0aeafb2b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2pkg/default.nix
+++ b/distros/foxy/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
 buildRosPackage {
   pname = "ros-foxy-ros2pkg";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2pkg/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "b7eeae5f6b985e2be2a1a4e7bf4810f935569c04b944178637ec33263072858e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2pkg/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "ca9038293d2a9b5eff20fc33e0fea21ea725b6e9c3dd01e0750fbc97a1e695c7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2run/default.nix
+++ b/distros/foxy/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2run";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2run/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "4a64e7d221b247c6e5c83c9716f2203a3b50e1d2b9854a4bc2ba5b33c1edbc3f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2run/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "e475eab0fd78154524bd0ef653b0cb006144729ac229c802979e5ae221a14048";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2service/default.nix
+++ b/distros/foxy/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2service";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2service/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "d1d3005a3df71d65bae738cbaa4bec098519cfc919728e54e8c24bdaaf6f4673";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2service/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "7b4368cc30fa22301344a15cc1a7cc08343732903b7b87eb1a44aed4bb3a5769";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2topic/default.nix
+++ b/distros/foxy/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2topic";
-  version = "0.9.6-r1";
+  version = "0.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2topic/0.9.6-1.tar.gz";
-    name = "0.9.6-1.tar.gz";
-    sha256 = "cf2f32315cc555a798093615e821a759d325b5a1e9f6fbe78924d00ac5d46176";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2topic/0.9.7-1.tar.gz";
+    name = "0.9.7-1.tar.gz";
+    sha256 = "cd878f8f5e2a99656bc2ebcfe11d29addae45cfddab76ff2471ab4872a023416";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/tango-icons-vendor/default.nix
+++ b/distros/foxy/tango-icons-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-tango-icons-vendor";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/tango_icons_vendor-release/archive/release/foxy/tango_icons_vendor/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "90d9bbe7a9e1ad18345098ec72b7b24aec9ef6b4d7b21dbf7da0d62756e15132";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''tango_icons_vendor provides the public domain Tango icons for non-linux systems (<a href="http://tango-project.org/Tango_Icon_Library/">Tango Icon Library</a>) from the <a href="http://tango-project.org/Tango_Desktop_Project/">Tango Desktop Project</a>'';
+    license = with lib.licenses; [ asl20 publicDomain ];
+  };
+}

--- a/distros/foxy/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/test_osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "5a63a3c96ca015cc0ac3e9ba54d83320cd014fb0f67105a114c69a22b22f9bf3";
+    sha256 = "c4305d66ab841ea1a44618a15187e7d54fb4b3c6beb695f5c312e0f35dc8ed99";
   };
 
   buildType = "cmake";

--- a/distros/foxy/webots-ros2-abb/default.nix
+++ b/distros/foxy/webots-ros2-abb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-abb";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "3195a0b822005bb192d31797ae5b8f2cb9cd238dc6e4792819f70f32e2882b88";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "11773593128609bd854b4d39a24b25a19e8e7bc8ecc00d4b9e26a3b9f5795bdc";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-core";
+  version = "0.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "b278404fb5c9d39eb4a6f2be838c6a07e56d99bc25231ee4c0940fa01eb6abd9";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-msgs ];
+
+  meta = {
+    description = ''Core interface between Webots and ROS2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-demos/default.nix
+++ b/distros/foxy/webots-ros2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-demos";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "7db1de5d04df6b529e55d369fdcbc9bdd09a092fade38b107f14da7fbad87ae0";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "826924dedfa09347b96f698a3b2a7dbb8075a7668e4dde5d55f9e1f463a01048";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-desktop/default.nix
+++ b/distros/foxy/webots-ros2-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, builtin-interfaces, rclpy, std-msgs, webots-ros2 }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-desktop";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_desktop/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "345687687ea0bbe2e8a6f9bacbfa366575140bd90c65ffe3823a1a670ac1615f";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_desktop/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "d0b3240769e8d71c93adc66e72dd8f640951a1c62a17ea10a37972a564ddcd8e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "579958daf1961b8ba37f5ed1e890dab5653248d255d4c6a8b75fc10c24b8811e";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "b62a5b38418f3e49f1d70ac5e85911f0e583d55fc37675fe9a47d60d9a8ed167";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-examples/default.nix
+++ b/distros/foxy/webots-ros2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-examples";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "4aab310a9cda0a12ee30c41778e7bddc5cea3f5ec7af0406fcb4ae1fd27d825c";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "cd38e4b467ae6247017619a75c4c59269df1a54c943633312b5aa9ffa853e84f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-importer/default.nix
+++ b/distros/foxy/webots-ros2-importer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-importer";
+  version = "0.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_importer/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "6998c661c5c297e77a5c34388da601e7f2a548494f09d11d604977c8b7ed7ecc";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces xacro ];
+
+  meta = {
+    description = ''This package allows to convert URDF and XACRO files into Webots PROTO files.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "d125a708d27ce03ab57732872d0d6df0520a12b2d4e53525d075f7d18cb05a13";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "a456a598507af6d27c441ac9023336dca5214c5ec1787af594853610646c53f2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "80ddd1c285ca097bdf66391c8486da74c9fe8a64364d1fc1ef598e3f18a09e53";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "a50145dec7dbb338cbb95b76a3ce4055a944d7b5727dccd748c3257838bcb353";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "154b1903366864d85d7b63b213ccdaa14096634bc30b889e198b361a2419e982";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "b63014175205c26f1c611523d12b1545f9a7713642a70841d2e57288c3215159";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-ur-e-description/default.nix
+++ b/distros/foxy/webots-ros2-ur-e-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, urdf }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-ur-e-description";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "c1fa4aeeebd232ab5ad2c2710c03da2c07f5f415a44be4477c0bb27736d0471d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "ebee89b03a39a738cb383b248a2b3ddf5c8003e1f5732455a04d8025d372675b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-examples, webots-ros2-importer, webots-ros2-tiago, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "20dc0e9b93306f84c6d604e2706aff3d94b7fb5bf664fa51d218f80b763ca3c7";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "8152eec99ddba48749936248e08ca81413d0399f990dbd3cc4d08ec29dc54b6d";
   };
 
   buildType = "ament_python";

--- a/distros/kinetic/auv-msgs/default.nix
+++ b/distros/kinetic/auv-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-auv-msgs";
-  version = "0.1.0";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oceansystemslab/auv_msgs-release/archive/release/kinetic/auv_msgs/0.1.0-0.tar.gz";
-    name = "0.1.0-0.tar.gz";
-    sha256 = "2e110447ae64991a7e8488fd076f2ff5bb7d32e426152d233ba77420041fa619";
+    url = "https://github.com/oceansystemslab/auv_msgs-release/archive/release/kinetic/auv_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "32cace62288e30f83779400b442940ff2daaea913956dfd91d3bf5ca849069dd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/carla-msgs/default.nix
+++ b/distros/kinetic/carla-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-carla-msgs";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/kinetic/carla_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c287805a87b147fd52c225ae811c6f935ae2600d2ff21bd14ae799b8402ac0aa";
+    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/kinetic/carla_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5a84c1211bee6e57aab7c116ffaed102d9f35001fc6b249b1f301504628cbe49";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "26612878e6a1061937502b9839d4ad48c2ea882d935a0e27633d8556cdbd97ce";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d21e09117bd6ae019e39cfaa3a540b7e6c47c4360b5473dfa0d09a1a43603aca";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-msg-filters/default.nix
+++ b/distros/kinetic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-msg-filters";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "a5c03ec73256b4998b53a84268e767a3d29e7798a9a87b87698b2cc02d6bf918";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_msg_filters/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "f0bd3fac873a161c3598f72f0655760df8ff59f29137f20cf1aa09ed8dfadcae";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-tools/default.nix
+++ b/distros/kinetic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-tools";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "2856ed287059e3419b3ce5f6cb58b7a4f37658ea40a7356625e245b345360c93";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_tools/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "590726c88044213bc0d2b3e3913a84b5d0052e5268d88201619bd925123ccb1f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can-usb/default.nix
+++ b/distros/kinetic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can-usb";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "81ee8019c72050458123c0491f199f42df0864668e76aa1a74733dacbd9ac647";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can_usb/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "ecb70c4c1c90c079fe0b1e785874d9590801e248b58135585e6f82eb2004aa95";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dataspeed-can/default.nix
+++ b/distros/kinetic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-kinetic-dataspeed-can";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "d1b1c7623f4db15399b3f03f2ca32d14db310a088cc9bc21e08f32fba7cb218c";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/kinetic/dataspeed_can/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "9432a7bc47d98722fa4055a96ff784e82f9aee308d7523438510e611cb27ca48";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dual-quaternions-ros/default.nix
+++ b/distros/kinetic/dual-quaternions-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-dual-quaternions-ros";
-  version = "0.1.3-r3";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/kinetic/dual_quaternions_ros/0.1.3-3.tar.gz";
-    name = "0.1.3-3.tar.gz";
-    sha256 = "dc9076627c8cb54d1fc3e0d3c4eab854f2a48d0aa12bd261fc0a678ce794b85b";
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/kinetic/dual_quaternions_ros/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "ce4160460c0a993ddfcef5d5d72ab1228be1f75a0d65cb07cbef8436499d7d5b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "aa905cca50e419ad995c65bfee470eb5e697f841a81648d2a57fd4cf69abb913";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "4cc21bf33da327cadc600521074976af71d12a4c0d3d5face321cb6a668b3535";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "3642d991f410e5bb3674590529b6c59b8079c445d5b6e083a586eb2f94b244bc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2fab816333736e6d551817a1b6d15dfa4756e4e4ee68277c2f5c9187783b69cb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2020.6.6-r1";
+  version = "2020.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.6.6-1.tar.gz";
-    name = "2020.6.6-1.tar.gz";
-    sha256 = "dd720763cc59f0d343329b11787dc8a6c6567aefa59bc1d053e0bea831265226";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.7.7-1.tar.gz";
+    name = "2020.7.7-1.tar.gz";
+    sha256 = "ac0fc92b4d50581cfd89ba37ecb57b8d003a1b321d554935853609f9868ce2ef";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "8455e00574cecd079c262a95a2fde8a2250d98ed6a256097504b6b3aa6f9c170";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f3feecd5f6023049ff48a56ae3a6f0a3e0831f64853cfa16a6396aa6f4364805";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "6202de94f593b201d821bfef5e83f0d250bfc539a74a59d09dc45a122f4a9259";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "483957df163d485cf9cc74c272b7dc6f43d2778e4bd4b32c010b9a7ee164bcec";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "95046ccc3c348344dc3111d14590f1816ccbdd698d351f37ba391814042d4470";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "7efb24f4caf7f580254d31f1eb07db5b2cab4b9e60a3aef01bc73045598aea8a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "27469ee208f106ff2bcef519b880212f2b9292a40e46389403ac0d082e2a95b7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e59775d28cc1d2477dcc55695f370a2098c9f606d9319695fc24bb08bf465bb2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/oxford-gps-eth/default.nix
+++ b/distros/kinetic/oxford-gps-eth/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gps-common, nav-msgs, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gps-common, nav-msgs, pythonPackages, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-oxford-gps-eth";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/oxford_gps_eth-release/archive/release/kinetic/oxford_gps_eth/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "467a0a5ed41975eb74e7a677418bb9c150114ee934f0f51668b18eac1bcff43b";
+    url = "https://github.com/DataspeedInc-release/oxford_gps_eth-release/archive/release/kinetic/oxford_gps_eth/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "76b70486cb6c3360da88e2b8e059f376dc4fa01d1d20aec239a99b192df1a3f0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
   propagatedBuildInputs = [ geometry-msgs gps-common nav-msgs roscpp roslaunch rospy sensor-msgs std-msgs tf ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Ethernet interface to OxTS GPS receivers (NCOM packet structure)'';

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "897974adbbbe51692e5e7b9c9810addd5aa259ca390dd9cdc74512d45039ab33";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "bbd288c97c22d03d2d04c18a016f4c1023ce34cb0fceaae979da7991b9968bdf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.8.1-r2";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.8.1-2.tar.gz";
-    name = "2.8.1-2.tar.gz";
-    sha256 = "364648b8dd1ee2159b05c1429f7a114763f06adde8ddd6e663a3f5e9b2e451eb";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "c5f377d38abb12e3dc0550e725d9f97f8fdbac6000e5a723fcdb9de8194b1a1f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rospy-message-converter/default.nix
+++ b/distros/kinetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy-message-converter";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "78e098de065db3aa6f8c4c8e2ce594e2e4ae728798d60d9598bfae7ade95ffb9";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "e306f9b91dff3d9d23e1c79fc0e644762ff3593808b1b6dd9dfe3cb3b71c551a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "c60b302d1c57d34f80c2c5e16a08d25575a26900a00f55aa73defd4b91c665d0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "2de20f780ed7b7d1d09383b5e08b1cf862bbaf2dd90a3b2cd212261e320f21e5";
   };
 
   buildType = "catkin";
   checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
-  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/sick-scan/default.nix
+++ b/distros/kinetic/sick-scan/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-scan";
-  version = "1.6.0-r1";
+  version = "1.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "f88728990fc8d21ea6106cc0483812ac53bc177888a10eda782769ea24e8444d";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.7.6-1.tar.gz";
+    name = "1.7.6-1.tar.gz";
+    sha256 = "e738ee00e2332a00bd7185d0c725e59c3515f038c70d38353396b25a9c21388e";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime pcl-conversions pcl-ros roscpp sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''A ROS driver for the SICK TiM and SICK MRS series of laser scanners.
+    description = ''A ROS driver for the SICK TiM and SICK MRS series of lidars.
     This package is based on the original sick_tim-repository of Martin Günther et al.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "ac5d0fe1a655235412c2e7b5a6070a775f5f263e22b81e358bdcf077c4622328";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "979ae27cd3e869f4df703ad93a68867a07b0c5a625820650b99106a3c8fc2ba8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "3b2323ce258fc8a14778a029a9e5e37808ad0739783d703ab39b65ab08246c25";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c598f3484a0345f00e08eda077ff7d873a817cc756689d0f6644b3ba0aa69c20";
   };
 
   buildType = "catkin";

--- a/distros/melodic/auv-msgs/default.nix
+++ b/distros/melodic/auv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-auv-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/oceansystemslab/auv_msgs-release/archive/release/melodic/auv_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "773b034a505af916981ca2116c387d65004a1cbe4a55296cf81ac9517a75f21d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides message types commonly used with Autonomous Underwater Vehicles'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/carla-msgs/default.nix
+++ b/distros/melodic/carla-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-carla-msgs";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/melodic/carla_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0b66cc070a8c1950429f5fa6975bdcfbe1b47508cfcf6b5fc18c8f5b6ac4f3ed";
+    url = "https://github.com/carla-simulator/ros-carla-msgs-release/archive/release/melodic/carla_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "389e435f51057fdca2134d0aee0d9ddae099d6f7acb90eab95f1e5d784138a5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "de5c85ab68b8bfdc4b97e6ed0353ed8c3ea4b076cd61d445d62f505f1dc5e78b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "4ba9da0e767569e4386af0b46fe8c5a83eeb47c7b13511e607a1f9b830173316";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-msg-filters/default.nix
+++ b/distros/melodic/dataspeed-can-msg-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-msg-filters";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "ac5059d8fc34cd27e9b5704f02766a36ed54e8ec48c4677fc85d1764fb7fb247";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_msg_filters/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "e3a3bac07cceb049cd83ab91bdc6a5d4052bc325cbe2a28920fb68017b1c1248";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-tools/default.nix
+++ b/distros/melodic/dataspeed-can-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-tools";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "60a79fceef9b5289c77cb08e01703866dca33f86e62bcf6deda2dc8b8b55571e";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_tools/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "ecbc5514862e8d5eaf6407cace95e369a6dd770cb2853f81e267635e1c3cef87";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can-usb/default.nix
+++ b/distros/melodic/dataspeed-can-usb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can-usb";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "84de61b0d7e1579d062b53a275b6a0082e991245208db0f5791e50cf59c0ae3c";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can_usb/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "0e43215ea8a06c3f802321632f33e104c659b521f91b4f18a8067e2085aa887c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-can/default.nix
+++ b/distros/melodic/dataspeed-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-can";
-  version = "1.0.15-r1";
+  version = "1.0.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.15-1.tar.gz";
-    name = "1.0.15-1.tar.gz";
-    sha256 = "2a5a118b55ac5200022941673a73e6e58bcaae063d379377fece35ebaa9b818f";
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/melodic/dataspeed_can/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "8015e12e78f9d3b328e1e9615ec32a986134c4ed429f6678e3fb82379feefbed";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-can/default.nix
+++ b/distros/melodic/dataspeed-pds-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-can";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "9ac85ae64a11d73e1049f6971720e1dddfe9af4548df5ed6cd083d855d60dbd4";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c8bcdd70d393ceb84e5f3c87580f1faf3ecbde3b5ef3bee1806582e1d2389e5b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-msgs/default.nix
+++ b/distros/melodic/dataspeed-pds-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-msgs";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "9b0543765ab6f1173f9e4dc3f8e38a3be0843b3a9a439bcfdffd505a1b436ba5";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7cb03c4bc2380159c20600d7553666509069d5a6154c12799482795c5f552b41";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-rqt/default.nix
+++ b/distros/melodic/dataspeed-pds-rqt/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, rospy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, pythonPackages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-rqt";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "e88f4d791492e0e2966a559a4af4e2b676ce72d2710220ee67c939da43e5d186";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7b3e6f7fcab659357456ae8c6c770878fe14ac8f59c9c8f04ee3412e33405ba4";
   };
 
   buildType = "catkin";
   propagatedBuildInputs = [ dataspeed-pds-msgs python-qt-binding rospy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''ROS rqt GUI for the Dataspeed Inc. Power Distribution System (PDS)'';

--- a/distros/melodic/dataspeed-pds-scripts/default.nix
+++ b/distros/melodic/dataspeed-pds-scripts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-scripts";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "9affa7c314ddfe3804829e680b0889aef2e5b9b17c0ca0334cdf0b647ab9f666";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d2c468585fbff4ecb19770cc8d57df66242afdc675d37a5916a42098821d1836";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds/default.nix
+++ b/distros/melodic/dataspeed-pds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-msgs, dataspeed-pds-scripts }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds";
-  version = "1.0.2";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.2-0.tar.gz";
-    name = "1.0.2-0.tar.gz";
-    sha256 = "d69d2b28ac8d0d207b3873acf559044a47c3b99d20fd20f01de6aa51cfe4feed";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d13c93b88a446da5990f052ca82a1aa28c3f106f0c110a9becc853e54496aa0b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-can/default.nix
+++ b/distros/melodic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-can";
-  version = "1.2.7-r1";
+  version = "1.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "b701e37fa696038ddb838dacbf36f419129256f315e743989d0aa38640030544";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "37024979c4ccdba68290b45710c484838cb314dbfabe4210b9e5d38db5c1a763";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-description/default.nix
+++ b/distros/melodic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-description";
-  version = "1.2.7-r1";
+  version = "1.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "f4192a596f917c67b5ee6b3114e3b10291e09eb373f185917a9cca546a965d71";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "e19016d5c35787424c02952969ea39ea66454924764afa888514e814af3c0100";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/melodic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-joystick-demo";
-  version = "1.2.7-r1";
+  version = "1.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "0c3270baaa8cdf5487c144cddc68547edc375229fd5419dd3de2b24b7798cf7d";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "4cc9f1d8308d7a8b0a53b1c9cdb5bf07820d88888ce8ec27ba0dabeb70bff911";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-msgs/default.nix
+++ b/distros/melodic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-msgs";
-  version = "1.2.7-r1";
+  version = "1.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "cc04b3d632a06e82df37106a80638f4ab6929c85eda101694a874c8b12a5975b";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "b383073390016e44f2a96a1a3e3798ed0e6d14852e868d1299dbea908890b0a5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz/default.nix
+++ b/distros/melodic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz";
-  version = "1.2.7-r1";
+  version = "1.2.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.2.7-1.tar.gz";
-    name = "1.2.7-1.tar.gz";
-    sha256 = "17df7b95f4ecf3354709c705ade105120af4775cbb2afa6fe9dce16ad67e6667";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "1d3b8ab5b4a80a9502ceaa15e150c3aa14046819aef84e828959d396998b1330";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dual-quaternions-ros/default.nix
+++ b/distros/melodic/dual-quaternions-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dual-quaternions-ros";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/melodic/dual_quaternions_ros/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "93084d18038c68680ace921c976e5ea15f86072c59c40e1a0f61fb978a69c1ee";
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/melodic/dual_quaternions_ros/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "66a4e3cebb3779e92bd153e90a2dc8b3bdc93e9276faebc39e46812390ffa21b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-graph/default.nix
+++ b/distros/melodic/dynamic-graph/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
+buildRosPackage {
+  pname = "ros-melodic-dynamic-graph";
+  version = "4.2.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.2.1-4.tar.gz";
+    name = "4.2.1-4.tar.gz";
+    sha256 = "e711b2f736b5a53a9e90099a9001de517ee316236fd09e4665905fcbed869770";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin eigen graphviz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Dynamic graph library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-driver";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "cbce3658bbde18eedfe14719b2ce4e8d4c4f52068f6405314d3c87d0e1c73e74";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "750fbb51252fba2e6705d6a180fde509cf1907cc9770898ba61172e7f9275614";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "5cfa74b0c1db4f23c997db11624e95b1956167d92bc9d2eca08e6a86564d0328";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "0a3d7a6220a9fcfecdf31ce7463934bc8515a1bc4fc307dc811369d9e76b3a84";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -132,6 +132,8 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ auv-msgs = self.callPackage ./auv-msgs {};
+
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
 
  aws-common = self.callPackage ./aws-common {};
@@ -647,6 +649,8 @@ self: super: {
  dwb-msgs = self.callPackage ./dwb-msgs {};
 
  dwb-plugins = self.callPackage ./dwb-plugins {};
+
+ dynamic-graph = self.callPackage ./dynamic-graph {};
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
@@ -2003,6 +2007,8 @@ self: super: {
  nextage-ros-bridge = self.callPackage ./nextage-ros-bridge {};
 
  nlopt = self.callPackage ./nlopt {};
+
+ nmc-nlp-lite = self.callPackage ./nmc-nlp-lite {};
 
  nmea-comms = self.callPackage ./nmea-comms {};
 

--- a/distros/melodic/joy/default.nix
+++ b/distros/melodic/joy/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, linuxConsoleTools, rosbag, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, linuxConsoleTools, rosbag, roscpp, roslint, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-joy";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/joy/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "369447b7b00655bd9ff8e267b40084009a5bafedaf748f5265b3fa7a8ac27fa6";
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/joy/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "05eef45382fb49c008a833290b4b842da049b2f3bcfeae505751edb40ac50e21";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   checkInputs = [ rosbag ];
   propagatedBuildInputs = [ diagnostic-updater linuxConsoleTools roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/joystick-drivers/default.nix
+++ b/distros/melodic/joystick-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, ps3joy, spacenav-node, wiimote }:
 buildRosPackage {
   pname = "ros-melodic-joystick-drivers";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/joystick_drivers/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "40f5d279303bcca1d36d8c540ebb8b57a67269d7bca43fe7db89c400f3edb9b8";
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/joystick_drivers/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f0454955c9262422916a88ff9e2751d21c26c631ccd08b6224a57c83c6909550";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "46cc7fd3cacf311aa0b09155c710772431e1e5af3f69c8d9f1aa17cc53b98978";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "ac8fe08e6167c3a9f86103b5d7251f880a446669112d8384ee0ff2cc1332b42a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "817c94d6bacd5789a8058ab41fdf36492336e35a6942aef138d02b0c4af38bab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "87525c19a34ed1e13d208dab1f5c925aee3ac35ff69a3a68d0bbe8ab7f59087c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2020.6.6-r1";
+  version = "2020.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.6.6-1.tar.gz";
-    name = "2020.6.6-1.tar.gz";
-    sha256 = "295c071126d132007c586ddc4b5eaced67ceded52def43ffa1458fc9ded14263";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.7.7-1.tar.gz";
+    name = "2020.7.7-1.tar.gz";
+    sha256 = "d3f7de5bbc4bf10e04d89842e43e0d9777df227c340a50c32d3638ef764c7c18";
   };
 
   buildType = "cmake";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "68a7515ee383320e174a4b95decbe5244a742604b618f247d9cf14fcb940e2d0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "4788c8ace5864e84457797494477808fb8bcd5070c9a2f84a5d68bdfae755ede";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "78b81d7ce119822aa9df6689502c60ae7c5a849d8eb00312f6aafc65f3fe82bc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a8f96614bcac226c9903ab496ac8fc7bf1a32806a2522eceeabc314e4f570525";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "6d4a4687206276ca134e986d7458942e033f5c0cb17fbff21d1f15e76a7ad009";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "3c6318b8d16feaf0db3b0efd3775f46ad36910fefabe237a5e97e8ad79cb2fdf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nmc-nlp-lite/default.nix
+++ b/distros/melodic/nmc-nlp-lite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-nmc-nlp-lite";
+  version = "0.0.7-r2";
+
+  src = fetchurl {
+    url = "https://github.com/nmcbins/nmc_nlp_lite-release/archive/release/melodic/nmc_nlp_lite/0.0.7-2.tar.gz";
+    name = "0.0.7-2.tar.gz";
+    sha256 = "70672d64024f0d40ee9dc069dee925711a44a7ecbadb93b989cd25bf3bf9e306";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The nmc_nlp_lite package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "66a6e81cae08b7e418f05d849728b480b88907dd9b98bd1a386a5a499a6bcb16";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "40601832795ea5313f0401d4e8b3fd609f76b35c3f9187022d7d14d1969a68da";
   };
 
   buildType = "catkin";

--- a/distros/melodic/oxford-gps-eth/default.nix
+++ b/distros/melodic/oxford-gps-eth/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gps-common, nav-msgs, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gps-common, nav-msgs, pythonPackages, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-oxford-gps-eth";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/oxford_gps_eth-release/archive/release/melodic/oxford_gps_eth/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bcd0dd5be46ee6f14125e36fb76cd6eb1e951d97fab3d1917243609fcf3b8eda";
+    url = "https://github.com/DataspeedInc-release/oxford_gps_eth-release/archive/release/melodic/oxford_gps_eth/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a547714565ca32151d3952e87eb39f6a0f5c6a241d926d4d053702c4c54de2ad";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
   propagatedBuildInputs = [ geometry-msgs gps-common nav-msgs roscpp roslaunch rospy sensor-msgs std-msgs tf ];
-  nativeBuildInputs = [ catkin ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
     description = ''Ethernet interface to OxTS GPS receivers (NCOM packet structure)'';

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "6b159dcc73d268a38490e42ce63101671198fca706dd9a3af25ec844b678ffd8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "0179466fe0692c8acb65d84a86b43ac8d970c3dd9ce8829d2f4792db7bc3255b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.8.1-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.8.1-1.tar.gz";
-    name = "2.8.1-1.tar.gz";
-    sha256 = "003bb27782933e3388307f646b040be5a8e8fe9b0db8d6ace08783901bcede5d";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "76f2337a863336bc00a4ad3aa222c683fdc612cdbc3c0dac7f21438ec26e8d53";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ps3joy/default.nix
+++ b/distros/melodic/ps3joy/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb, linuxConsoleTools, pythonPackages, rosgraph, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ps3joy";
-  version = "1.13.0-r1";
+  version = "1.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/ps3joy/1.13.0-1.tar.gz";
-    name = "1.13.0-1.tar.gz";
-    sha256 = "766b29d7a4fcc3aa123fdc796f10c6862b9028466bfed7290d51976d547750b2";
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/melodic/ps3joy/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "2bd4850de3aeef1b9696fe5fbacab24f716c454dc5abd648ad59fb29009349be";
   };
 
   buildType = "catkin";
+  buildInputs = [ roslint ];
   propagatedBuildInputs = [ bluez diagnostic-msgs libusb linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/psen-scan/default.nix
+++ b/distros/melodic/psen-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d71c7cff894a84aae9434e0e6ea40b201e6e036abdb76973ff1d7eeec81db118";
+    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c99d1c1f10ef086e790e4c4f5e617983a17875c2f21206fe81f501323a7e5c35";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-emacs-utils/default.nix
+++ b/distros/melodic/ros-emacs-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp-repl, slime-ros, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-ros-emacs-utils";
-  version = "0.4.14-r1";
+  version = "0.4.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/ros_emacs_utils/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "16c4f4392ebf6bdd5bbf145fe60fe6829255850fa1502dd1926572e44f9be447";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/ros_emacs_utils/0.4.16-1.tar.gz";
+    name = "0.4.16-1.tar.gz";
+    sha256 = "89c647ad2f3cd9c745050bd6740fdf726a4de063970e3f18c7de93ac38b788a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosemacs/default.nix
+++ b/distros/melodic/rosemacs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, emacs }:
 buildRosPackage {
   pname = "ros-melodic-rosemacs";
-  version = "0.4.14-r1";
+  version = "0.4.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/rosemacs/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "2a2cb471fbfaebdf764ed4472dbed5ce2de28e2b33e6ce35db052d86ecc0d345";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/rosemacs/0.4.16-1.tar.gz";
+    name = "0.4.16-1.tar.gz";
+    sha256 = "ceebd187f93e5787f70dc2b79f0afaffab866b752acbe7d8aacce36b5c2c0e30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslisp-repl/default.nix
+++ b/distros/melodic/roslisp-repl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-ros, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-roslisp-repl";
-  version = "0.4.14-r1";
+  version = "0.4.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/roslisp_repl/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "cefb6b7478f0354353b231bd85e2c31fa82dc803833acebb4038f4521e67507f";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/roslisp_repl/0.4.16-1.tar.gz";
+    name = "0.4.16-1.tar.gz";
+    sha256 = "e61ec7c039072709e4635378db091237d9d7eaa4d961557237497e006aa7152b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "b36a7d65ebfbcd2abfa303e366c45f9fb4cc6c2321aca1c6eac36fb7715464f9";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "dc6a18765585b49855389e85c166c3743332a9a37a4257f73e8a3f8fc0b3414b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "8c0c7e98d5060c900e369cf4f97b8a1002c70dc002010f71d79fd935bf36e692";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "adf300c07c0b409314ec2a3630a82620925c89526c5027bbda2b6bb61018bdde";
   };
 
   buildType = "catkin";
   checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
-  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/sick-scan/default.nix
+++ b/distros/melodic/sick-scan/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-scan";
-  version = "1.6.0-r1";
+  version = "1.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "184c3b79c1efff80ee30ed6fda4200dc975645b01f2e4fdb57d1cf29ad0e1bf1";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.6-1.tar.gz";
+    name = "1.7.6-1.tar.gz";
+    sha256 = "6ef933174a40989020b0af747bcc51d872e241fcc4fd2c79bc6b58e5640c58fb";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime pcl-conversions pcl-ros roscpp sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''A ROS driver for the SICK TiM and SICK MRS series of laser scanners.
+    description = ''A ROS driver for the SICK TiM and SICK MRS series of lidars.
     This package is based on the original sick_tim-repository of Martin Günther et al.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/melodic/slime-ros/default.nix
+++ b/distros/melodic/slime-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosemacs, roslisp, sbcl, slime-wrapper }:
 buildRosPackage {
   pname = "ros-melodic-slime-ros";
-  version = "0.4.14-r1";
+  version = "0.4.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_ros/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "043cf95acd112b9349ef2ba71360677a7dc501f1e42b17d647f497b647b2b293";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_ros/0.4.16-1.tar.gz";
+    name = "0.4.16-1.tar.gz";
+    sha256 = "626705c68ddf409fb0990f686038f71cef98a8742cc1118cb0cc186fc7949f43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slime-wrapper/default.nix
+++ b/distros/melodic/slime-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, emacs }:
 buildRosPackage {
   pname = "ros-melodic-slime-wrapper";
-  version = "0.4.14-r1";
+  version = "0.4.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_wrapper/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "246f8018e61b66b887d4f86b1c39f3b4fd50d7369896b3e93bb9fd850439008e";
+    url = "https://github.com/code-iai-release/ros_emacs_utils-release/archive/release/melodic/slime_wrapper/0.4.16-1.tar.gz";
+    name = "0.4.16-1.tar.gz";
+    sha256 = "e7e2a818ac01d6b941f20940051f9656a0be07afac18f76adf66ff761569575b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "498d3a4671cbfff4fe53165955156a5b9c9f24743eb915ef62e613232b539c8c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "9276569802c8571f3c231ee088f01e14ec70802e98722475e733c8b794b8309d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "479bca4bc6a28810039e5843206b93266ad930210d5793d6a825b8246de5f24f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "dae79f14ff47881c7e8f33631328c525ac8c5d87e6b2ece3f273a3ff65ef4724";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.5-r1";
+  version = "1.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.5-1.tar.gz";
-    name = "1.13.5-1.tar.gz";
-    sha256 = "e80b1d5e3c6fdd1581b7516081ee9d730391f499201789586914a5dc3ae321f0";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.6-1.tar.gz";
+    name = "1.13.6-1.tar.gz";
+    sha256 = "bd891b5fe7f3326b616f39b39b56cc961d2ddf8f088eecd836be19b068e55fdd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/auv-msgs/default.nix
+++ b/distros/noetic/auv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-auv-msgs";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/oceansystemslab/auv_msgs-release/archive/release/noetic/auv_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "190104bb958cf67a5ff4ca7cc1ee355c44ed127eb5e074441b0004bc40da61e2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides message types commonly used with Autonomous Underwater Vehicles'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "ad8f7a1dae2898dd94d59af08e33c89dbb8c2289efb062f1bb42921db87a3452";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "de5999e5390cc0c0d48c2febcad426f0dbd802b0c26c93505678bf4133b747e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-can-msg-filters/default.nix
+++ b/distros/noetic/dataspeed-can-msg-filters/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-can-msg-filters";
+  version = "1.0.16-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/noetic/dataspeed_can_msg_filters/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "39fc3a83ca608df4e078cc17f8e95a9993f60c4391f09e89a88235447e0f4001";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ can-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Time synchronize multiple CAN messages to get a single callback'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-can-tools/default.nix
+++ b/distros/noetic/dataspeed-can-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, rosbag, roscpp, roslib, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-can-tools";
+  version = "1.0.16-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/noetic/dataspeed_can_tools/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "8feafa2c97762920a39d19000342a5b43249ca61c87d80858fde32302dbeb83d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ can-msgs rosbag roscpp roslib std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''CAN bus introspection'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-can-usb/default.nix
+++ b/distros/noetic/dataspeed-can-usb/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, lusb, nodelet, roscpp, roslaunch, roslib, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-can-usb";
+  version = "1.0.16-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/noetic/dataspeed_can_usb/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "9bff56a17cd8dcad256c71383b56a1058a209e2ec090b234fb20f8f4fc838c75";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslib ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ can-msgs lusb nodelet roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver to interface with the Dataspeed Inc. USB CAN Tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-can/default.nix
+++ b/distros/noetic/dataspeed-can/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-can-msg-filters, dataspeed-can-tools, dataspeed-can-usb }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-can";
+  version = "1.0.16-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_can-release/archive/release/noetic/dataspeed_can/1.0.16-1.tar.gz";
+    name = "1.0.16-1.tar.gz";
+    sha256 = "38e1ac834ec961a5b75345f4cfd413a1279ca1d89d09adeb00794e270d771e54";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dataspeed-can-msg-filters dataspeed-can-tools dataspeed-can-usb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''CAN bus tools using Dataspeed hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dual-quaternions-ros/default.nix
+++ b/distros/noetic/dual-quaternions-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dual-quaternions, geometry-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-dual-quaternions-ros";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/noetic/dual_quaternions_ros/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "ecaf4f689fa6bde65227f924c43e933bd8e1cf836e407a79c66f5efb88bcc66c";
+    url = "https://github.com/Achllle/dual_quaternions_ros-release/archive/release/noetic/dual_quaternions_ros/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "9b05be8641a2435cb8e1756cef909151c8d7ef114ef1776f13b552a6e249779d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.1.1-r2";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "f02aa46caa568f14395046a873af254fd5af3403ff52099414091f908930ea48";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "109358fbe47d2113a169631ae42fad3f410d93c4a22f5e0143be153435d0ef0b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.1.1-r2";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.1-2.tar.gz";
-    name = "0.1.1-2.tar.gz";
-    sha256 = "98e9c1c9d95587620c9ef295a7a92417a8326fed1369dc873b57446b3f500590";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "d304fd952659e934321b489879180dda5755dfff7e64b68ba7999b8e13db21a3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -32,6 +32,8 @@ self: super: {
 
  audio-play = self.callPackage ./audio-play {};
 
+ auv-msgs = self.callPackage ./auv-msgs {};
+
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
 
  base-local-planner = self.callPackage ./base-local-planner {};
@@ -127,6 +129,14 @@ self: super: {
  cv-bridge = self.callPackage ./cv-bridge {};
 
  cv-camera = self.callPackage ./cv-camera {};
+
+ dataspeed-can = self.callPackage ./dataspeed-can {};
+
+ dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
+
+ dataspeed-can-tools = self.callPackage ./dataspeed-can-tools {};
+
+ dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
 
  dataspeed-ulc = self.callPackage ./dataspeed-ulc {};
 
@@ -360,7 +370,11 @@ self: super: {
 
  joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
 
+ joy = self.callPackage ./joy {};
+
  joy-teleop = self.callPackage ./joy-teleop {};
+
+ joystick-drivers = self.callPackage ./joystick-drivers {};
 
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
@@ -494,6 +508,8 @@ self: super: {
 
  mk = self.callPackage ./mk {};
 
+ mobile-robot-simulator = self.callPackage ./mobile-robot-simulator {};
+
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
@@ -574,6 +590,8 @@ self: super: {
 
  nodelet-tutorial-math = self.callPackage ./nodelet-tutorial-math {};
 
+ nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
+
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -601,6 +619,8 @@ self: super: {
  openni2-launch = self.callPackage ./openni2-launch {};
 
  openslam-gmapping = self.callPackage ./openslam-gmapping {};
+
+ oxford-gps-eth = self.callPackage ./oxford-gps-eth {};
 
  p2os-doc = self.callPackage ./p2os-doc {};
 
@@ -654,6 +674,8 @@ self: super: {
 
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
+ pid = self.callPackage ./pid {};
+
  pinocchio = self.callPackage ./pinocchio {};
 
  planner-cspace = self.callPackage ./planner-cspace {};
@@ -679,6 +701,10 @@ self: super: {
  posedetection-msgs = self.callPackage ./posedetection-msgs {};
 
  position-controllers = self.callPackage ./position-controllers {};
+
+ power-msgs = self.callPackage ./power-msgs {};
+
+ ps3joy = self.callPackage ./ps3joy {};
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
 
@@ -1156,6 +1182,20 @@ self: super: {
 
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
+ velodyne = self.callPackage ./velodyne {};
+
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pcl = self.callPackage ./velodyne-pcl {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ vision-msgs = self.callPackage ./vision-msgs {};
+
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-marker-tutorials = self.callPackage ./visualization-marker-tutorials {};
@@ -1170,9 +1210,13 @@ self: super: {
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
 
+ wiimote = self.callPackage ./wiimote {};
+
  xacro = self.callPackage ./xacro {};
 
  xmlrpcpp = self.callPackage ./xmlrpcpp {};
+
+ xv-11-laser-driver = self.callPackage ./xv-11-laser-driver {};
 
  ypspur = self.callPackage ./ypspur {};
 

--- a/distros/noetic/joy/default.nix
+++ b/distros/noetic/joy/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, linuxConsoleTools, rosbag, roscpp, roslint, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joy";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/joy/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "8a0d5118f416ecf37c66b55bf5618475e8ea6305190ac71271fd42a6b909b9ae";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosbag ];
+  propagatedBuildInputs = [ diagnostic-updater linuxConsoleTools roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver for a generic Linux joystick.
+    The joy package contains joy_node, a node that interfaces a
+    generic Linux joystick to ROS. This node publishes a &quot;Joy&quot;
+    message, which contains the current state of each one of the
+    joystick's buttons and axes.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joystick-drivers/default.nix
+++ b/distros/noetic/joystick-drivers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joy, ps3joy, spacenav-node, wiimote }:
+buildRosPackage {
+  pname = "ros-noetic-joystick-drivers";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/joystick_drivers/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "0a2a299c997f65767afa8b71b90a0414940c38ee4640f6d93e13d551cf72bd6e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joy ps3joy spacenav-node wiimote ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This metapackage depends on packages for interfacing common
+    joysticks and human input devices with ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "1693c64cbee3a278ebf9563fef912b8a99c0d771d766d2f2914b67d427fdf744";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "cad633f5be5448029315f0a4a218beba66b69dbca2550e48f61247d4e93e09e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "0eb8d8ecd60f966c28958219638fff077f3103404597997652edd63040d935ab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "cc80fe232883eff101853fc3abfaef7417c994bc5419593760569560a66d8c08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2020.6.6-r1";
+  version = "2020.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.6.6-1.tar.gz";
-    name = "2020.6.6-1.tar.gz";
-    sha256 = "42e149b8d0f0b1ee3b091f87e0e8d1932e493f3c0f56c1ff97d87d39fa2c6b70";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.7.7-1.tar.gz";
+    name = "2020.7.7-1.tar.gz";
+    sha256 = "ed90bf687e986be7ee331300cb08e154ad09b1e1597b818fc09275cdd3c00091";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mobile-robot-simulator/default.nix
+++ b/distros/noetic/mobile-robot-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mobile-robot-simulator";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/mobile_robot_simulator-release/archive/release/noetic/mobile_robot_simulator/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "264f763be9c1dac02cf090026034ceb2d94c89278b8ecab316c482b079d6a26d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mobile_robot_simulator package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "46ef7f29747b87082a7021ee3f03b7c4c796aa5eab8268624d6869876a93c08c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "fbf47bebeff6951da9e825fbebaf3e13c54824e369b99081a7fb18c6dd10297d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "26c032ba4c96b767afe187f2e387bcc05c4a3b17c269ad4d629fa5d57c56723b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "e1c50d7f75b60158898fd07e06d7d9b478c51662977d55ca8d1221717e37c729";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "232ecb889031db7c66af446699696fadbe821649a8e3072f852c0a579747a1d9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "ebfadd1c23d84c8e2ede2fa5f0c809ec890cd300759c2ee63e22e7c74bd071ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nonpersistent-voxel-layer/default.nix
+++ b/distros/noetic/nonpersistent-voxel-layer/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, message-filters, message-generation, message-runtime, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rosconsole, roscpp, sensor-msgs, std-msgs, tf, visualization-msgs, voxel-grid }:
+buildRosPackage {
+  pname = "ros-noetic-nonpersistent-voxel-layer";
+  version = "1.2.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/noetic/nonpersistent_voxel_layer/1.2.3-2.tar.gz";
+    name = "1.2.3-2.tar.gz";
+    sha256 = "1fb02c102340c981395ffb126313d7ebf1045b583153884c6d80991b30da82ad";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules message-generation ];
+  propagatedBuildInputs = [ costmap-2d dynamic-reconfigure geometry-msgs laser-geometry map-msgs message-filters message-runtime nav-msgs pcl-conversions pcl-ros pluginlib rosconsole roscpp sensor-msgs std-msgs tf visualization-msgs voxel-grid ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''include
+        This package provides an implementation of a 3D costmap that takes in sensor
+        data from the world, builds a 3D occupancy grid of the data for only one iteration.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "87bf224698821aaa124badd24e745fe1d95c004ed699d457fa57c3be7f153064";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "6065d43e3155dc6c33c936dfba4fdbb02ea869479c50ed90e4c3f245888a4ae3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/oxford-gps-eth/default.nix
+++ b/distros/noetic/oxford-gps-eth/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gps-common, nav-msgs, python3Packages, roscpp, roslaunch, rospy, rostest, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-oxford-gps-eth";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/oxford_gps_eth-release/archive/release/noetic/oxford_gps_eth/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5fe9b8de57e1db9acb31d159525360b63c417df60299228a5a765f20fc03f659";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ geometry-msgs gps-common nav-msgs roscpp roslaunch rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Ethernet interface to OxTS GPS receivers (NCOM packet structure)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pid/default.nix
+++ b/distros/noetic/pid/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pid";
+  version = "0.0.28-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AndyZe/pid-release/archive/release/noetic/pid/0.0.28-1.tar.gz";
+    name = "0.0.28-1.tar.gz";
+    sha256 = "153a7267a1990b210abb2deec0531548ef9e98390bac86e7daaa3b44eca062fc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch a PID control node.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "a6198e8a4f13b23f7d5219993d5c7cb2fe58e539f4e30ea3cf0e7c8ccfbf1583";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "99e214b6597c84285eaa01034841236c56e6d2666627deb6eb6d1c6725cee8c6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "2.8.0-r1";
+  version = "2.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/2.8.0-1.tar.gz";
-    name = "2.8.0-1.tar.gz";
-    sha256 = "f215819553015d48da273217039f844a0c2f206317d430d8df2f28622f9f0895";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/2.8.2-1.tar.gz";
+    name = "2.8.2-1.tar.gz";
+    sha256 = "2e9ba1a122bf56bbb3e772354bf49293cfb8ebb29b4e5b0158047c3b66c2ccb0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs ];
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs geometry-msgs nav-msgs plotjuggler-msgs qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg rosbag-storage roscpp roscpp-serialization sensor-msgs tf tf2-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/power-msgs/default.nix
+++ b/distros/noetic/power-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-power-msgs";
+  version = "0.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/power_msgs-release/archive/release/noetic/power_msgs/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "0ffc282953f4d9de6d8e6f86ab896d457b9b6d3a38448af09c35d63dd2507c71";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS messages for power measurement and breaker control.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ps3joy/default.nix
+++ b/distros/noetic/ps3joy/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ps3joy";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/ps3joy/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "bbbf4ebf7783fe4b00de19a2449903b5144c66497bc95800b931ddd6752837cc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ bluez diagnostic-msgs libusb linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Playstation 3 SIXAXIS or DUAL SHOCK 3 joystick driver.
+    Driver for the Sony PlayStation 3 SIXAXIS or DUAL SHOCK 3
+    joysticks. In its current state, this driver is not compatible
+    with the use of other Bluetooth HID devices. The driver listens
+    for a connection on the HID ports, starts the joystick
+    streaming data, and passes the data to the Linux uinput device
+    so that it shows up as a normal joystick.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a355bffe44bf9b82f9aad47ad704d0e11667df66daa9f81c8112458be18f5408";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "995e3cac9eab86f4bc87d302c58a12af6e4e11bc978790667ac587645a3a42d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "30452fb5d3b4e30f17e6ff64685cf1368d423f0414840e85d69d17179f29dd0f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b09ecb16d4f7d35eeb455d1755fd2a7fa40cf1fdf6a30957fa8f9346b8e10378";
   };
 
   buildType = "catkin";
   checkInputs = [ nav-msgs roslint rostest tf2-geometry-msgs ];
-  propagatedBuildInputs = [ diagnostic-updater eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure eigen geometry-msgs neonavigation-common pcl pcl-conversions pcl-ros roscpp safety-limiter-msgs sensor-msgs std-msgs tf2-ros tf2-sensor-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sick-scan/default.nix
+++ b/distros/noetic/sick-scan/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan";
-  version = "1.6.0-r1";
+  version = "1.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "dabe35907366de3a5a9f1445d24885c833d37f59beb2b4d742b6c5c6210f3f51";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.6-1.tar.gz";
+    name = "1.7.6-1.tar.gz";
+    sha256 = "9525f290f9b4f961f98d615228835cce267794833090f3c37f34192200336d1c";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime pcl-conversions pcl-ros roscpp sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''A ROS driver for the SICK TiM and SICK MRS series of laser scanners.
+    description = ''A ROS driver for the SICK TiM and SICK MRS series of lidars.
     This package is based on the original sick_tim-repository of Martin Günther et al.'';
     license = with lib.licenses; [ bsdOriginal ];
   };

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "bc6709cb9873c8d200f1401869183f43ed2bd2696012a98b35345bc7f6c4fab3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "48414b62aebfee26f3a2ce3b482d0b015f9139c31662a1a072467b6ffff61dc9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.8.8-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "f3b9b80de2fb851f85600453e1fc182dda26466cee997f929635a120bbfebe63";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "04b5120f4e75b69e0025b800fe28c2bb70a5d6d7699a9eeaef5f455be2fcf208";
   };
 
   buildType = "catkin";

--- a/distros/noetic/usb-cam-controllers/default.nix
+++ b/distros/noetic/usb-cam-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, controller-interface, controller-manager, cv-bridge, image-transport, pluginlib, roscpp, sensor-msgs, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-noetic-usb-cam-controllers";
-  version = "0.0.5-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_controllers/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "43433c266d8afe634fecb5efeb00e7808d503091075f2daf555227f5b51ece43";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_controllers/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d03a18132591acb321d86163fae2362d7477e9c6a7a33e6faad6f7cc385065af";
   };
 
   buildType = "catkin";

--- a/distros/noetic/usb-cam-hardware-interface/default.nix
+++ b/distros/noetic/usb-cam-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-usb-cam-hardware-interface";
-  version = "0.0.5-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_hardware_interface/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "cbc06c6cab14d3f075992784930cf1d21463788f5c0330e340603d6ea3e251d6";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_hardware_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "84813dd3d8819a31ffb19ccde2f66513203667ced7f254addb2cd9f75e4a9930";
   };
 
   buildType = "catkin";

--- a/distros/noetic/usb-cam-hardware/default.nix
+++ b/distros/noetic/usb-cam-hardware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, hardware-interface, nodelet, pluginlib, roscpp, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-noetic-usb-cam-hardware";
-  version = "0.0.5-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_hardware/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "7b95aab1c79774b281832dbbbd53e2adb2e25fabc203f24f4062a95a31d807e1";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/noetic/usb_cam_hardware/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "fe91fb847b79fe425a444a31d35f306c884e5cfbe20c2be3a661a6b6ce75d339";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-driver/default.nix
+++ b/distros/noetic/velodyne-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libpcap, nodelet, roscpp, roslaunch, roslint, rostest, tf, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne-driver";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "a81f0c6824c1ac06ee5d2f5abd7cf48d2d5661a93dc5e08381df8eff9c220c59";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libpcap nodelet roscpp tf velodyne-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/velodyne-laserscan/default.nix
+++ b/distros/noetic/velodyne-laserscan/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nodelet, roscpp, roslaunch, roslint, rostest, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne-laserscan";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "b41a82000caa5ffb71abef4e56447be313859394d948d68ce6d22691c5d7f521";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/velodyne-msgs/default.nix
+++ b/distros/noetic/velodyne-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne-msgs";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "563078f455430be8e3aad7225c51d74994d12c72b259d6f7c79b585378b269ea";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/velodyne-pcl/default.nix
+++ b/distros/noetic/velodyne-pcl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl-ros, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne-pcl";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "4e9f1613629cc23ce3c56ffda7b0cfeb1abe11ff1994cb505fc4b31ec7d07f23";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ pcl-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The velodyne_pcl package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne-pointcloud";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "39b31cb1d871a82d5a7a1c24ce6119588bbd310b3dec7a49e91f2e7827f5a9b4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ roslaunch rostest rosunit tf2-ros ];
+  propagatedBuildInputs = [ angles diagnostic-updater dynamic-reconfigure eigen libyamlcpp nodelet roscpp roslib sensor-msgs tf2-ros velodyne-driver velodyne-laserscan velodyne-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/velodyne/default.nix
+++ b/distros/noetic/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-noetic-velodyne";
+  version = "1.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "c8f5e8a30661b80796005171875f1db08536c6e6562680c419ea7b23a18920c0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/vision-msgs/default.nix
+++ b/distros/noetic/vision-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosunit, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-vision-msgs";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kukanani/vision_msgs-release/archive/release/noetic/vision_msgs/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "a2fe139f1c97bb56e6d891da6881080d5f8d5b31190d9f3db5fcf7f6bc462974";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for interfacing with various computer vision pipelines, such as
+    object detectors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/wiimote/default.nix
+++ b/distros/noetic/wiimote/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cwiid, geometry-msgs, message-generation, message-runtime, python3Packages, roscpp, roslib, roslint, rospy, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-wiimote";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/wiimote/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "bf6fdba87cacab7e95950de557af599926c155133f26871432782fab7898a072";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  propagatedBuildInputs = [ cwiid geometry-msgs message-runtime python3Packages.numpy roscpp roslib rospy sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The wiimote package allows ROS nodes to communicate with a Nintendo Wiimote
+    and its related peripherals, including the Nunchuk, Motion Plus, and
+    (experimentally) the Classic. The package implements a ROS node that uses
+    Bluetooth to communicate with the Wiimote device, obtaining accelerometer
+    and gyro data, the state of LEDs, the IR camera, rumble (vibrator),
+    buttons, joystick, and battery state. The node additionally enables ROS
+    nodes to control the Wiimote's LEDs and vibration for feedback to the human
+    Wiimote operator. LEDs and vibration may be switched on and off, or made to
+    operate according to a timed pattern.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.2-r1";
+  version = "1.14.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.2-1.tar.gz";
-    name = "1.14.2-1.tar.gz";
-    sha256 = "a574553928486c9ddca24d9c8c17778a63c742d0d47f750ecb7454e11dccf750";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.3-2.tar.gz";
+    name = "1.14.3-2.tar.gz";
+    sha256 = "67e6b271290c3da827fc8835fc678a19089e4c1afbaefceb1fc0bb8d43edae0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xv-11-laser-driver/default.nix
+++ b/distros/noetic/xv-11-laser-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-xv-11-laser-driver";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rohbotics/xv_11_laser_driver-release/archive/release/noetic/xv_11_laser_driver/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "50a7aa9f11a48f38be60f8fc05c4a8496de0f7df8488816cb89ca4712f829924";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roscpp sensor-msgs ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Neato XV-11 Laser Driver. This driver works with the laser when it is removed from the XV-11 Robot as opposed to reading scans from the Neato's USB port.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 3c28f55f91a45e6b1e078f89b2aa01e2a687850e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Eloquent Changes:
-----------------
* *mavlink 2020.6.6-r1 --> 2020.7.7-r1*
* *plansys2-bringup 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-domain-expert 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-executor 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-lifecycle-manager 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-msgs 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-pddl-parser 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-planner 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-problem-expert 0.0.8-r1 --> 0.0.9-r1*
* *plansys2-terminal 0.0.8-r1 --> 0.0.9-r1*

Foxy Changes:
-------------
* *control-msgs 2.3.0-r3 --> 2.4.0-r1*
* *costmap-queue 0.4.0-r1 --> 0.4.1-r1*
* *desktop 0.9.1-r1 --> 0.9.2-r1*
* *dwb-core 0.4.0-r1 --> 0.4.1-r1*
* *dwb-critics 0.4.0-r1 --> 0.4.1-r1*
* *dwb-msgs 0.4.0-r1 --> 0.4.1-r1*
* *dwb-plugins 0.4.0-r1 --> 0.4.1-r1*
* *nav-2d-msgs 0.4.0-r1 --> 0.4.1-r1*
* *nav-2d-utils 0.4.0-r1 --> 0.4.1-r1*
* *nav2-amcl 0.4.0-r1 --> 0.4.1-r1*
* *nav2-behavior-tree 0.4.0-r1 --> 0.4.1-r1*
* *nav2-bringup 0.4.0-r1 --> 0.4.1-r1*
* *nav2-bt-navigator 0.4.0-r1 --> 0.4.1-r1*
* *nav2-common 0.4.0-r1 --> 0.4.1-r1*
* *nav2-controller 0.4.0-r1 --> 0.4.1-r1*
* *nav2-core 0.4.0-r1 --> 0.4.1-r1*
* *nav2-costmap-2d 0.4.0-r1 --> 0.4.1-r1*
* *nav2-dwb-controller 0.4.0-r1 --> 0.4.1-r1*
* *nav2-gazebo-spawner 0.4.0-r1 --> 0.4.1-r1*
* *nav2-lifecycle-manager 0.4.0-r1 --> 0.4.1-r1*
* *nav2-map-server 0.4.0-r1 --> 0.4.1-r1*
* *nav2-msgs 0.4.0-r1 --> 0.4.1-r1*
* *nav2-navfn-planner 0.4.0-r1 --> 0.4.1-r1*
* *nav2-planner 0.4.0-r1 --> 0.4.1-r1*
* *nav2-recoveries 0.4.0-r1 --> 0.4.1-r1*
* *nav2-rviz-plugins 0.4.0-r1 --> 0.4.1-r1*
* *nav2-system-tests 0.4.0-r1 --> 0.4.1-r1*
* *nav2-util 0.4.0-r1 --> 0.4.1-r1*
* *nav2-voxel-grid 0.4.0-r1 --> 0.4.1-r1*
* *nav2-waypoint-follower 0.4.0-r1 --> 0.4.1-r1*
* *navigation2 0.4.0-r1 --> 0.4.1-r1*
* *rcl 1.1.5-r1 --> 1.1.6-r1*
* *rcl-action 1.1.5-r1 --> 1.1.6-r1*
* *rcl-lifecycle 1.1.5-r1 --> 1.1.6-r1*
* *rcl-yaml-param-parser 1.1.5-r1 --> 1.1.6-r1*
* *rclcpp 2.0.1-r1 --> 2.0.2-r1*
* *rclcpp-action 2.0.1-r1 --> 2.0.2-r1*
* *rclcpp-components 2.0.1-r1 --> 2.0.2-r1*
* *rclcpp-lifecycle 2.0.1-r1 --> 2.0.2-r1*
* *rclpy 1.0.3-r1 --> 1.0.4-r1*
* *realtime-tools 2.1.0-r1*
* *rmw-connext-cpp 1.0.0-r1 --> 1.0.1-r1*
* *rmw-connext-shared-cpp 1.0.0-r1 --> 1.0.1-r1*
* *rmw-cyclonedds-cpp 0.7.1-r1 --> 0.7.2-r1*
* *rmw-fastrtps-cpp 1.0.1-r1 --> 1.0.2-r1*
* *rmw-fastrtps-dynamic-cpp 1.0.1-r1 --> 1.0.2-r1*
* *rmw-fastrtps-shared-cpp 1.0.1-r1 --> 1.0.2-r1*
* *ros-base 0.9.1-r1 --> 0.9.2-r1*
* *ros-core 0.9.1-r1 --> 0.9.2-r1*
* *ros1-bridge 0.9.2-r1 --> 0.9.3-r1*
* *ros2action 0.9.6-r1 --> 0.9.7-r1*
* *ros2cli 0.9.6-r1 --> 0.9.7-r1*
* *ros2component 0.9.6-r1 --> 0.9.7-r1*
* *ros2interface 0.9.6-r1 --> 0.9.7-r1*
* *ros2lifecycle 0.9.6-r1 --> 0.9.7-r1*
* *ros2lifecycle-test-fixtures 0.9.6-r1 --> 0.9.7-r1*
* *ros2multicast 0.9.6-r1 --> 0.9.7-r1*
* *ros2node 0.9.6-r1 --> 0.9.7-r1*
* *ros2param 0.9.6-r1 --> 0.9.7-r1*
* *ros2pkg 0.9.6-r1 --> 0.9.7-r1*
* *ros2run 0.9.6-r1 --> 0.9.7-r1*
* *ros2service 0.9.6-r1 --> 0.9.7-r1*
* *ros2topic 0.9.6-r1 --> 0.9.7-r1*
* *tango-icons-vendor 0.0.1-r1*
* *webots-ros2 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-abb 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-core 0.0.4-r1*
* *webots-ros2-demos 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-desktop 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-epuck 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-examples 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-importer 0.0.4-r1*
* *webots-ros2-msgs 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-tiago 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-universal-robot 0.0.3-r1 --> 0.0.4-r1*
* *webots-ros2-ur-e-description 0.0.3-r1 --> 0.0.4-r1*

Kinetic Changes:
----------------
* *auv-msgs 0.1.0 --> 0.1.1-r1*
* *carla-msgs 1.0.1-r1 --> 1.1.0-r1*
* *costmap-cspace 0.8.8-r1 --> 0.9.0-r1*
* *dataspeed-can 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-msg-filters 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-tools 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-usb 1.0.15-r1 --> 1.0.16-r1*
* *dual-quaternions-ros 0.1.3-r3 --> 0.1.4-r1*
* *joystick-interrupt 0.8.8-r1 --> 0.9.0-r1*
* *map-organizer 0.8.8-r1 --> 0.9.0-r1*
* *mavlink 2020.6.6-r1 --> 2020.7.7-r1*
* *neonavigation 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-common 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-launch 0.8.8-r1 --> 0.9.0-r1*
* *obj-to-pointcloud 0.8.8-r1 --> 0.9.0-r1*
* *oxford-gps-eth 1.1.1-r1 --> 1.2.0-r1*
* *planner-cspace 0.8.8-r1 --> 0.9.0-r1*
* *plotjuggler 2.8.1-r2 --> 2.8.2-r1*
* *rospy-message-converter 0.5.1-r1 --> 0.5.2-r1*
* *safety-limiter 0.8.8-r1 --> 0.9.0-r1*
* *sick-scan 1.6.0-r1 --> 1.7.6-r1*
* *track-odometry 0.8.8-r1 --> 0.9.0-r1*
* *trajectory-tracker 0.8.8-r1 --> 0.9.0-r1*

Melodic Changes:
----------------
* *auv-msgs 0.1.1-r1*
* *carla-msgs 1.0.1-r1 --> 1.1.0-r1*
* *costmap-cspace 0.8.8-r1 --> 0.9.0-r1*
* *dataspeed-can 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-msg-filters 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-tools 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-can-usb 1.0.15-r1 --> 1.0.16-r1*
* *dataspeed-pds 1.0.2 --> 1.0.3-r1*
* *dataspeed-pds-can 1.0.2 --> 1.0.3-r1*
* *dataspeed-pds-msgs 1.0.2 --> 1.0.3-r1*
* *dataspeed-pds-rqt 1.0.2 --> 1.0.3-r1*
* *dataspeed-pds-scripts 1.0.2 --> 1.0.3-r1*
* *dbw-mkz 1.2.7-r1 --> 1.2.9-r1*
* *dbw-mkz-can 1.2.7-r1 --> 1.2.9-r1*
* *dbw-mkz-description 1.2.7-r1 --> 1.2.9-r1*
* *dbw-mkz-joystick-demo 1.2.7-r1 --> 1.2.9-r1*
* *dbw-mkz-msgs 1.2.7-r1 --> 1.2.9-r1*
* *dual-quaternions-ros 0.1.3-r1 --> 0.1.4-r1*
* *dynamic-graph 4.2.1-r4*
* *fadecandy-driver 0.1.0-r1 --> 0.1.2-r1*
* *fadecandy-msgs 0.1.0-r1 --> 0.1.2-r1*
* *joy 1.13.0-r1 --> 1.14.0-r1*
* *joystick-drivers 1.13.0-r1 --> 1.14.0-r1*
* *joystick-interrupt 0.8.8-r1 --> 0.9.0-r1*
* *map-organizer 0.8.8-r1 --> 0.9.0-r1*
* *mavlink 2020.6.6-r1 --> 2020.7.7-r1*
* *neonavigation 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-common 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-launch 0.8.8-r1 --> 0.9.0-r1*
* *nmc-nlp-lite 0.0.7-r2*
* *obj-to-pointcloud 0.8.8-r1 --> 0.9.0-r1*
* *oxford-gps-eth 1.1.1-r1 --> 1.2.0-r1*
* *planner-cspace 0.8.8-r1 --> 0.9.0-r1*
* *plotjuggler 2.8.1-r1 --> 2.8.2-r1*
* *ps3joy 1.13.0-r1 --> 1.14.0-r1*
* *psen-scan 1.0.4-r1 --> 1.0.6-r1*
* *ros-emacs-utils 0.4.14-r1 --> 0.4.16-r1*
* *rosemacs 0.4.14-r1 --> 0.4.16-r1*
* *roslisp-repl 0.4.14-r1 --> 0.4.16-r1*
* *rospy-message-converter 0.5.1-r1 --> 0.5.2-r1*
* *safety-limiter 0.8.8-r1 --> 0.9.0-r1*
* *sick-scan 1.6.0-r1 --> 1.7.6-r1*
* *slime-ros 0.4.14-r1 --> 0.4.16-r1*
* *slime-wrapper 0.4.14-r1 --> 0.4.16-r1*
* *track-odometry 0.8.8-r1 --> 0.9.0-r1*
* *trajectory-tracker 0.8.8-r1 --> 0.9.0-r1*
* *xacro 1.13.5-r1 --> 1.13.6-r1*

Noetic Changes:
---------------
* *auv-msgs 0.1.1-r1*
* *costmap-cspace 0.8.8-r1 --> 0.9.0-r1*
* *dataspeed-can 1.0.16-r1*
* *dataspeed-can-msg-filters 1.0.16-r1*
* *dataspeed-can-tools 1.0.16-r1*
* *dataspeed-can-usb 1.0.16-r1*
* *dual-quaternions-ros 0.1.3-r1 --> 0.1.4-r1*
* *fadecandy-driver 0.1.1-r2 --> 0.1.2-r1*
* *fadecandy-msgs 0.1.1-r2 --> 0.1.2-r1*
* *joy 1.14.0-r1*
* *joystick-drivers 1.14.0-r1*
* *joystick-interrupt 0.8.8-r1 --> 0.9.0-r1*
* *map-organizer 0.8.8-r1 --> 0.9.0-r1*
* *mavlink 2020.6.6-r1 --> 2020.7.7-r1*
* *mobile-robot-simulator 1.0.1-r1*
* *neonavigation 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-common 0.8.8-r1 --> 0.9.0-r1*
* *neonavigation-launch 0.8.8-r1 --> 0.9.0-r1*
* *nonpersistent-voxel-layer 1.2.3-r2*
* *obj-to-pointcloud 0.8.8-r1 --> 0.9.0-r1*
* *oxford-gps-eth 1.2.0-r1*
* *pid 0.0.28-r1*
* *planner-cspace 0.8.8-r1 --> 0.9.0-r1*
* *plotjuggler 2.8.0-r1 --> 2.8.2-r1*
* *power-msgs 0.4.1-r1*
* *ps3joy 1.14.0-r1*
* *rospy-message-converter 0.5.1-r1 --> 0.5.2-r1*
* *safety-limiter 0.8.8-r1 --> 0.9.0-r1*
* *sick-scan 1.6.0-r1 --> 1.7.6-r1*
* *track-odometry 0.8.8-r1 --> 0.9.0-r1*
* *trajectory-tracker 0.8.8-r1 --> 0.9.0-r1*
* *usb-cam-controllers 0.0.5-r1 --> 0.2.1-r1*
* *usb-cam-hardware 0.0.5-r1 --> 0.2.1-r1*
* *usb-cam-hardware-interface 0.0.5-r1 --> 0.2.1-r1*
* *velodyne 1.6.0-r1*
* *velodyne-driver 1.6.0-r1*
* *velodyne-laserscan 1.6.0-r1*
* *velodyne-msgs 1.6.0-r1*
* *velodyne-pcl 1.6.0-r1*
* *velodyne-pointcloud 1.6.0-r1*
* *vision-msgs 0.0.1-r1*
* *wiimote 1.14.0-r1*
* *xacro 1.14.2-r1 --> 1.14.3-r2*
* *xv-11-laser-driver 0.3.0-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] nextage_calibration
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

