### PR TITLE
rosdistro sync, Fri Jul 17 13:18:57 2020

### DIFF
--- a/distros/dashing/ament-clang-format/default.nix
+++ b/distros/dashing/ament-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-clang-format";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_clang_format/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "6d7a29da79ad1e1ac88a05de27963b0c2b9e302f8aa5d5c513e876f774d541dd";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_clang_format/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "6f4784d6b8f3faa027ca8e31a33b2876ad271ce2a3ce4d79388fe6d3543a7fe4";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-clang-tidy/default.nix
+++ b/distros/dashing/ament-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, clang, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-clang-tidy";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_clang_tidy/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "e7ff536a9009952a123951eff6e8ca3bafc935d736b995a91cdc26abb9eb3591";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_clang_tidy/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "46985a47d6a51dd5e7e701ab12c8fe0b9bf86d9e34c34e6b2755cdbfa22022cf";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-cmake-auto/default.nix
+++ b/distros/dashing/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-auto";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_auto/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "936deaa36b66a74c15c11f1c0abccbc42994c839213bdb334042cb2baa934379";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_auto/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "44b41a215ac8c8746fb3e033b1bba94701b0d9af54ffadc93b7c9ebc698c5dc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-clang-format/default.nix
+++ b/distros/dashing/ament-cmake-clang-format/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-format, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-clang-format";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_clang_format/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "d68d21c0556efbcffc6b65a1165419404ed73487cc12b247a9466418c4929c82";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_clang_format/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "4287b9544556d851dffd4c7dffda374842beb5b81733268874dad6507660b0d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-clang-tidy/default.nix
+++ b/distros/dashing/ament-cmake-clang-tidy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-clang-tidy, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-clang-tidy";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_clang_tidy/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "bf4fff69f984ef4feb667e83592e70c7d4bcd68443ef8b0411d44f4c61a0d73b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_clang_tidy/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "677a7709b0fdbbac7ef2d6cca458df9c5a03687747bc7720a5531c533a3af947";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-copyright/default.nix
+++ b/distros/dashing/ament-cmake-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-copyright }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-copyright";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_copyright/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "3a37e105be72e8e47d3f329cf96cb1e8b1fe95e9ddf8956b7acf5769acafd416";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_copyright/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "1c490c613c051de11f7a0af3d9c243ada128e72eb3c329851c91ee41ce9ca295";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-core/default.nix
+++ b/distros/dashing/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-core";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_core/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "d9e308452be90fb2dabc009319fdb70e7137307ea7e643d36b74f8b0221e45f6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_core/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "dfe80dce8735821a95f810d76923adedfd383b459a1b6289ddde6e83df0e6895";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-cppcheck/default.nix
+++ b/distros/dashing/ament-cmake-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cppcheck }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-cppcheck";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_cppcheck/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "155acc2508d50413648fb976cc73553acaa8f520d5272bc0694970fe2e247c9f";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_cppcheck/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "4132aa04790ccf12a29b7ca01ca33b40738414de8e2dc7f43f20981f83babef9";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-cpplint/default.nix
+++ b/distros/dashing/ament-cmake-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-cpplint }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-cpplint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_cpplint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "98e0c2ef204595971c016b477b0aad15cd2d94c13aba012ff6a59efa574e84db";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_cpplint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "9c094b71ac80dcca8028dd62f8a4d508c6438abd17cf5078e4429543522cb36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-definitions/default.nix
+++ b/distros/dashing/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-definitions";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_definitions/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "e6a308c0724927d8ab359310f5fa4e9dc0255f6f673c5a4628931c7baae08cf2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_definitions/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "22ed48236a403683bea19547c1ee7c5db6c60f6cac66d1c77ebd9ff61540e2c4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-dependencies/default.nix
+++ b/distros/dashing/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-dependencies";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_dependencies/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "da4f09e9412d291d4f59208e85b69d7942c0037abd31aafe93a69eaa0927aa4d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_dependencies/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "13bb21280d51700def5b8fcd700da8d0a722f716db41ba471cb3ed571c160670";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-include-directories/default.nix
+++ b/distros/dashing/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-include-directories";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_include_directories/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "0ab2e62198c50745e4657e57527d5c3bca1df440b82aef426c5d92205ddb7507";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_include_directories/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "46f16e95e564e0a50199e4d25f5f17dceabe69b047a58a1074bb5ad7dfc7fcf4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-interfaces/default.nix
+++ b/distros/dashing/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-interfaces";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_interfaces/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "83a244de9126822a35628df0bd9a12c22f19935193a216b34a3c425fcd6457fa";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_interfaces/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "e8ee87b1d9843f4a3b6ad20ba6db0c3d9b170b0358a916bff1676d1cd97a4777";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-libraries/default.nix
+++ b/distros/dashing/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-libraries";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_libraries/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "48adb4c4129235d2f2d693e6bdd5da88a52fe77c3c84f1995535e62d149cdd46";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_libraries/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "1c6275785e2a7e0672aa68675613141311c2675a9c88c9e003b5608e37f210cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-export-link-flags/default.nix
+++ b/distros/dashing/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-export-link-flags";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_link_flags/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "c9e6a26f1dd9a6c7977dea8666dc8f614a7f797b67957c36213b9e490e22ab59";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_export_link_flags/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "11ad2ba8adb8a1de1fa257a592b112cbae06fcebfdb48daaa59c86b7f276d90b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-flake8/default.nix
+++ b/distros/dashing/ament-cmake-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-flake8 }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-flake8";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_flake8/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "844c1e69cc00de0a3632000a09f393aa511970b75b000786f0353913436b12d3";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_flake8/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "7966fa608f8c43e5fe9c2e537dacd904ad6978fbe27b4f5d7c29118f22a372a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-gmock/default.nix
+++ b/distros/dashing/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock, gmock-vendor }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-gmock";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gmock/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "3c20dbe22a2991fb46f82c49a9587cad71c698c8e3503b90be0031e44e0630d8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gmock/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "cdbb5245f8d9462438de155e33036749e6519e9e984b5781064b9d9a140f7f87";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-gtest/default.nix
+++ b/distros/dashing/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-gtest";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gtest/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "d3134f4f8676af0eaadba25e6efdbf132a0033a5a25000373cc6d33fc044089d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_gtest/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "b69214549d2e8f3d89d8b5a9189a2367a671892a9d274a49eb7c0a2d633c49ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-include-directories/default.nix
+++ b/distros/dashing/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-include-directories";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_include_directories/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "0778af87455a25e073d93635146e3d45db28bf44771432cd3abe5e17e83892e1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_include_directories/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "164a6eeddf28c1fd5a091cc72c3b19bedc51a2bdf0ae187048958fff83f080c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-libraries/default.nix
+++ b/distros/dashing/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-libraries";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_libraries/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "a9e580ee98b547670baacfa5abe951d5a4a0c95524792c9d9e5d92bc7ffd618e";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_libraries/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "eae4998c57245ddaef9a7ef28fda752d543fda6cdf503cd01eba3dd026e417ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-lint-cmake/default.nix
+++ b/distros/dashing/ament-cmake-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, ament-lint-cmake }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-lint-cmake";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_lint_cmake/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "7ea859e3e7322208aecfea5e46b4fa86ccc21280b04e7663daf54437235662f2";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_lint_cmake/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "b592c891d7809b55378cf7adc2de7dbdb6e43c97c2fe825819b8c48d7fb6857e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-nose/default.nix
+++ b/distros/dashing/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-nose";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_nose/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "5c1dcaf23d0df2f37fd484d0b7a49b297d3d24f2175e4e327ef5fa9610f48d58";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_nose/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "476e7e71dfe6381172ff6df3df7097ce48ce6f44788ea4b2991f4a31d15855f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-pclint/default.nix
+++ b/distros/dashing/ament-cmake-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pclint }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pclint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pclint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "229f3da6992f9b1a2de38ec0d3c61d95921027146a1b459800e5321a65e0f976";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pclint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "b8245e44d849a94bf40c42891ca00cb00a47baae9a40d27c6e89521baf9ea380";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-pep257/default.nix
+++ b/distros/dashing/ament-cmake-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep257 }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pep257";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pep257/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "cf24606d5677b5370b8125d4568be13d4ae8e07b4af6ba2aa6724563124b046c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pep257/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "70ef9242c62467de288c9b035ff23394007223ce903bb50418e1e31e16e01e60";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-pep8/default.nix
+++ b/distros/dashing/ament-cmake-pep8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pep8 }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pep8";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pep8/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "bfececc6e0d6dd3f73d50ea9c6ee213f3f0fc24820a7f22408ecdbdbc8601f47";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pep8/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "70c0e65a0715652b8dfb1433423f9920d118af049e84a3f49f81898689a6ac89";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-pyflakes/default.nix
+++ b/distros/dashing/ament-cmake-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-pyflakes }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pyflakes";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pyflakes/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "ed98aeea9d559202b597bbcc40b3d4264b92fc3dae2dce0e9950dc371ca95a39";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_pyflakes/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "8a7af89b2e61eea14541ee4cd60e94f34d0b4c924ef6f4dd4d448f5994f781d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-pytest/default.nix
+++ b/distros/dashing/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-pytest";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_pytest/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "404c5c7909190f7c6ab90b44c009dd4e5bebb0ceada24caa019475852777948d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_pytest/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "8cb12f8cec16ec216146a3291495146b2fc5af90a9df35a4bcc51a6ff559b110";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-python/default.nix
+++ b/distros/dashing/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-python";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_python/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "5758e8d2bc0acbb8cbf7222bae792f3af0f8f748d2f238f0a819f961f8d592d1";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_python/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "3dace0b6b97732250c4f37ad2afa158bde00d1913050511d5be3969d480c96d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-target-dependencies/default.nix
+++ b/distros/dashing/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-target-dependencies";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_target_dependencies/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "f0b483d7d65306707eb1d93c2f68c91f2e5515dedccd233849f98451b00cb11d";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_target_dependencies/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "67fdfc23411046a431bb2c249acf4f086ed3f34a5055da991cdf6bfdfd0c418b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-test/default.nix
+++ b/distros/dashing/ament-cmake-test/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-test";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_test/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "96a5a939a05e680cfb5337cc288e4dec979890c481b40da102d463b0418b8643";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake_test/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "0550f96a347e5303d4461d3ae441c62bc4b64064dcb6dac5c1c515ce70aa339b";
   };
 
   buildType = "ament_cmake";
   propagatedBuildInputs = [ ament-cmake-core ];
-  nativeBuildInputs = [ ament-cmake-core ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-python ];
 
   meta = {
     description = ''The ability to add tests in the ament buildsystem in CMake.'';

--- a/distros/dashing/ament-cmake-uncrustify/default.nix
+++ b/distros/dashing/ament-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-uncrustify";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_uncrustify/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "f077685e8a981fb0e38887c781fdbd9aeb6850d0d657492be2e3b2e5233adcff";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_uncrustify/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "01e490dd6611b5982c780a7c7ca391bf9069b4d7c71a68db2f0316fd55420c3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake-xmllint/default.nix
+++ b/distros/dashing/ament-cmake-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-xmllint }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-xmllint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_xmllint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "24986c84ce92b0f05bb41bb477a69b9840eafcb5501ca2949056301ab2363c2b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cmake_xmllint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "b5412d96323c461e46a27e491d1373922185d19154e6daeb17b3c8e45cdf4eea";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-cmake/default.nix
+++ b/distros/dashing/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, cmake }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "fe1f62c644a688180848873dc9a8a865e3a440d406163b1bf3ad3e8b46dde818";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/dashing/ament_cmake/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "d6b8b14ceec4486a9fbd54e49114125e12241f6c22a6be12f9868fb02e909e8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-copyright/default.nix
+++ b/distros/dashing/ament-copyright/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-copyright";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_copyright/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "949c8d7270f14a6c9fb53b96dd99ade08c92fb9e1a57e20b8765fdea7ed2c506";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_copyright/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "f76dc03c16ad0fc489f4afc285dd4aaff16ae546829e1f9473b30af5e676dddf";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-cppcheck/default.nix
+++ b/distros/dashing/ament-cppcheck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cppcheck }:
 buildRosPackage {
   pname = "ros-dashing-ament-cppcheck";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cppcheck/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "69bd84eee65eca753895869aad6b538504c6a5506862eee57a41da48e583b448";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cppcheck/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "d8fb3b285627b9b38989c6ec2f77553730d6908d36ae10d8e159a170698d6206";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-cpplint/default.nix
+++ b/distros/dashing/ament-cpplint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-cpplint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cpplint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "857539f95ee16b8d2ebaa761b6427040ad2aa87e448302b85a64df7766c6f724";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_cpplint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "a6be3400cb528abae2a61f7da123bdd87d6342bc827423d7c8a682b3727b7820";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-flake8/default.nix
+++ b/distros/dashing/ament-flake8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-flake8";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_flake8/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "b243a5b91471227d8331771ccc39e920eb4c0808f6af30e8b9ae09779380029b";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_flake8/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "2d1897f382d2763d26b533a3c43c0587ed002c9b615afa4a0bfff788ce4018c6";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-lint-auto/default.nix
+++ b/distros/dashing/ament-lint-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
 buildRosPackage {
   pname = "ros-dashing-ament-lint-auto";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_auto/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "b831c3a559656deafe08c8585bc40727776fca73c26ba665e7c8b842b2cc88e8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_auto/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "46d84e3417027708ec87a2009e9aadfae4596daab91a06ed72cd1d7c7b27f1e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-lint-cmake/default.nix
+++ b/distros/dashing/ament-lint-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-lint-cmake";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_cmake/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "9cf18eae8839631a3211b16c15a4a947876e8778f817fc9f4299c53ef89d551c";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_cmake/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "35351a2ef922b6851352ee503a7e1543d3240b25839ad0c50c20a52c01f9ee19";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-lint-common/default.nix
+++ b/distros/dashing/ament-lint-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-export-dependencies, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint }:
 buildRosPackage {
   pname = "ros-dashing-ament-lint-common";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_common/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "28e7cadc7ef915f3306bb02e90460e72f1f7bc0a9f530c2afdef300d2949f328";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint_common/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "6bf330c193f502805417abc1963363889724f3d602c13dbaa93d25cc24719efa";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ament-lint/default.nix
+++ b/distros/dashing/ament-lint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-dashing-ament-lint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "cefed9626afc2ab9fe66e668ba900b812addddffbd321accf5340293b5c3d7ae";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_lint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "e2dc547f24c5373a37dfca3d01dba2f7fcc11dd2dff503b6c63ee32ff2cb148c";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-pclint/default.nix
+++ b/distros/dashing/ament-pclint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-pclint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pclint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "e381395a5e6f3651bb2f86590750637334464ff7a41b09a475bdfaf27f1ed944";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pclint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "5ede0b6a3cf0846e83b988dcad8699f8b5b35b5b5d16d1cd9f8b0eedd0c52d86";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-pep257/default.nix
+++ b/distros/dashing/ament-pep257/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-pep257";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pep257/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "8115567c2cdbb3443668c6d12835b4be6555d440251ab37254004ec71500cf64";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pep257/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "3c133732b4b1695e7d6d9727f4c161c1196c6abce930ca944e5b5f59829d0021";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-pep8/default.nix
+++ b/distros/dashing/ament-pep8/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-ament-pep8";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pep8/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "317aad2672e85f6683f5de62dd1f66d94b7b4228ca5fd5678d93a0ef61bd2a19";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pep8/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "bf2aabf5a838b9ad18d3e5c3bd146e0a3601dd3f276a6b314c4a11231d481671";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-pyflakes/default.nix
+++ b/distros/dashing/ament-pyflakes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-pep8, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-pyflakes";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pyflakes/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "7f8df5468f4437700ab4f78ac5c5aa1fa537551e365daf3c486678e3933463f7";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_pyflakes/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "a447f277bd5d412c3a09fab40e4bbe8930dbca547108375ed9d6f2a2c3a3a320";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-uncrustify/default.nix
+++ b/distros/dashing/ament-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, uncrustify-vendor }:
 buildRosPackage {
   pname = "ros-dashing-ament-uncrustify";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_uncrustify/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "db773d68f720572922d3df081ef5cd6bba04cd0d966bedaead414dec4f2e00c8";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_uncrustify/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "9c31baa0a34030d1d626a4f240061f576c62c0fb4eb162935b0b865be3bf2c7f";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ament-xmllint/default.nix
+++ b/distros/dashing/ament-xmllint/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint, ament-pep257, libxml2, pythonPackages }:
 buildRosPackage {
   pname = "ros-dashing-ament-xmllint";
-  version = "0.7.11-r1";
+  version = "0.7.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_xmllint/0.7.11-1.tar.gz";
-    name = "0.7.11-1.tar.gz";
-    sha256 = "9f037df0760a45510f7ef15ee486629bc7b0da8c1d07b37987b5496b77d95c56";
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/dashing/ament_xmllint/0.7.12-1.tar.gz";
+    name = "0.7.12-1.tar.gz";
+    sha256 = "d0b1e50611c1e92f6c6ce70f1ce2f40073d0ea1333422a8d0c18d622608955b6";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/behaviortree-cpp-v3/default.nix
+++ b/distros/dashing/behaviortree-cpp-v3/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, cppzmq, ncurses, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cppzmq }:
 buildRosPackage {
   pname = "ros-dashing-behaviortree-cpp-v3";
-  version = "3.5.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/dashing/behaviortree_cpp_v3/3.5.0-1.tar.gz";
-    name = "3.5.0-1.tar.gz";
-    sha256 = "05db4b874a44dcbdf1d5014edea6dcb648ffad20eb91a079cc319de4ce836833";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/dashing/behaviortree_cpp_v3/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "55902e5c1e718b02a0abcfa40dc5278485bc59a1a14da9d2f466767ae1c84a2f";
   };
 
-  buildType = "catkin";
-  propagatedBuildInputs = [ cppzmq ncurses rclcpp ];
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ cppzmq ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/desktop/default.nix
+++ b/distros/dashing/desktop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-tutorials, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor }:
+{ lib, buildRosPackage, fetchurl, action-tutorials, ament-cmake, angles, composition, demo-nodes-cpp, demo-nodes-cpp-native, demo-nodes-py, depthimage-to-laserscan, dummy-map-server, dummy-robot-bringup, dummy-sensors, examples-rclcpp-minimal-action-client, examples-rclcpp-minimal-action-server, examples-rclcpp-minimal-client, examples-rclcpp-minimal-composition, examples-rclcpp-minimal-publisher, examples-rclcpp-minimal-service, examples-rclcpp-minimal-subscriber, examples-rclcpp-minimal-timer, examples-rclpy-executors, examples-rclpy-minimal-action-client, examples-rclpy-minimal-action-server, examples-rclpy-minimal-client, examples-rclpy-minimal-publisher, examples-rclpy-minimal-service, examples-rclpy-minimal-subscriber, image-tools, intra-process-demo, joy, lifecycle, logging-demo, pcl-conversions, pendulum-control, pendulum-msgs, quality-of-service-demo-cpp, quality-of-service-demo-py, ros-base, rqt-common-plugins, rviz-default-plugins, rviz2, teleop-twist-joy, teleop-twist-keyboard, tlsf, tlsf-cpp, topic-monitor, turtlesim }:
 buildRosPackage {
   pname = "ros-dashing-desktop";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/desktop/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "c1be88a5ffb7d149cc73133c14dd2692cdb73850802d3df18059abbd4ebfe59c";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/desktop/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "8daeb34f0f6ef33656a4047681792cbb241ffbe8fdefdfa79cc2bfda3c070498";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ action-tutorials angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor ];
+  propagatedBuildInputs = [ action-tutorials angles composition demo-nodes-cpp demo-nodes-cpp-native demo-nodes-py depthimage-to-laserscan dummy-map-server dummy-robot-bringup dummy-sensors examples-rclcpp-minimal-action-client examples-rclcpp-minimal-action-server examples-rclcpp-minimal-client examples-rclcpp-minimal-composition examples-rclcpp-minimal-publisher examples-rclcpp-minimal-service examples-rclcpp-minimal-subscriber examples-rclcpp-minimal-timer examples-rclpy-executors examples-rclpy-minimal-action-client examples-rclpy-minimal-action-server examples-rclpy-minimal-client examples-rclpy-minimal-publisher examples-rclpy-minimal-service examples-rclpy-minimal-subscriber image-tools intra-process-demo joy lifecycle logging-demo pcl-conversions pendulum-control pendulum-msgs quality-of-service-demo-cpp quality-of-service-demo-py ros-base rqt-common-plugins rviz-default-plugins rviz2 teleop-twist-joy teleop-twist-keyboard tlsf tlsf-cpp topic-monitor turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -476,6 +476,8 @@ self: super: {
 
  lex-node = self.callPackage ./lex-node {};
 
+ lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
+
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
@@ -1107,6 +1109,16 @@ self: super: {
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
+
+ velodyne = self.callPackage ./velodyne {};
+
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/dashing/lgsvl-bridge/default.nix
+++ b/distros/dashing/lgsvl-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, rcl, rcutils }:
+buildRosPackage {
+  pname = "ros-dashing-lgsvl-bridge";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/ros2-lgsvl-bridge-release/archive/release/dashing/lgsvl_bridge/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6ce2171c25e0bb6f2cdbf8e5728e2c376f96c2d0bd0f38f4d05fd0cf15a45581";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rcl rcutils ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''LGSVL Simulator Bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/libcurl-vendor/default.nix
+++ b/distros/dashing/libcurl-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, curl, pkg-config }:
 buildRosPackage {
   pname = "ros-dashing-libcurl-vendor";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/libcurl_vendor/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "1986856afbec5cb344157e0b0459358e2a216202c3e73d809bc029a38bb5657b";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/libcurl_vendor/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "ea071d589ca9f418d7c58c2df176c7a549cb9f51b0452b249efbd82610835520";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/librealsense2/default.nix
+++ b/distros/dashing/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, gtk3, libGL, libGLU, libusb1, linuxHeaders, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-dashing-librealsense2";
-  version = "2.34.0-r1";
+  version = "2.16.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/dashing/librealsense2/2.34.0-1.tar.gz";
-    name = "2.34.0-1.tar.gz";
-    sha256 = "ed6fbe8bb80cceac8400fe9a9c074471681a5e72ee6feb6d1ea77a75416f498a";
+    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/dashing/librealsense2/2.16.5-1.tar.gz";
+    name = "2.16.5-1.tar.gz";
+    sha256 = "8200ccf50818a19a4dcd625f099e960c38285c2181cef249da10fae25206ee07";
   };
 
   buildType = "ament_cmake";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/dashing/orocos-kdl/default.nix
+++ b/distros/dashing/orocos-kdl/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, cppunit, eigen, pkg-config }:
+{ lib, buildRosPackage, fetchurl, cmake, cppunit, eigen, eigen3-cmake-module, pkg-config }:
 buildRosPackage {
   pname = "ros-dashing-orocos-kdl";
-  version = "3.2.1-r1";
+  version = "3.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/dashing/orocos_kdl/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d734e2a96069add0c6c5d1d865020de78821d63979ee3b815fdab5c2a004b091";
+    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/dashing/orocos_kdl/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "61072cbc866ffd721f77117cda066cb5a0b5840b0841b773373708f84ca71f59";
   };
 
   buildType = "cmake";
   checkInputs = [ cppunit ];
-  propagatedBuildInputs = [ eigen pkg-config ];
-  nativeBuildInputs = [ cmake ];
+  propagatedBuildInputs = [ eigen eigen3-cmake-module pkg-config ];
+  nativeBuildInputs = [ cmake eigen3-cmake-module ];
 
   meta = {
     description = ''This package contains a recent version of the Kinematics and Dynamics

--- a/distros/dashing/rcl-action/default.nix
+++ b/distros/dashing/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-generator-c, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rcl-action";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_action/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "c2aa2a6c51c98588202b0f7f7e71209501c64e8bae984ec56a405ff09bc6236e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_action/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "a6723ddb8ce51c9eaf724656316212b1b03b198a2341133034a2283f003c189a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rcl-lifecycle/default.nix
+++ b/distros/dashing/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw-implementation, rosidl-generator-c }:
 buildRosPackage {
   pname = "ros-dashing-rcl-lifecycle";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_lifecycle/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "59a79008952060bc9f9e15080d4aeb5c48d320ba22ce9c7cafaf23069abf0fd9";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_lifecycle/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "66e87267404df850d756287fe23c28624940f5778ebcf439b43750f40d357fcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rcl-yaml-param-parser/default.nix
+++ b/distros/dashing/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, rcl, rcutils }:
 buildRosPackage {
   pname = "ros-dashing-rcl-yaml-param-parser";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_yaml_param_parser/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "0c190303a560004d69964b50ef4725ee4168a12925524257e0ad8ebc48817125";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl_yaml_param_parser/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "8ce1cda3c699c6c40cd0a794b3a38792f35ad0cf75a0fbf89b5433a18cd12854";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rcl/default.nix
+++ b/distros/dashing/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-noop, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-default-runtime, rosidl-generator-c, test-msgs, tinydir-vendor }:
 buildRosPackage {
   pname = "ros-dashing-rcl";
-  version = "0.7.8-r1";
+  version = "0.7.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl/0.7.8-1.tar.gz";
-    name = "0.7.8-1.tar.gz";
-    sha256 = "a453c70b1aae81a4df3ac2888e472465dce6ae88af1ce71296d9ca963b28d5c2";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/dashing/rcl/0.7.9-1.tar.gz";
+    name = "0.7.9-1.tar.gz";
+    sha256 = "bd9ac33629ee0384c4ce992ee537e3094e37b52948594ba799d2a87ce7456710";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-action/default.nix
+++ b/distros/dashing/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcl-action, rclcpp, rosidl-generator-c, rosidl-generator-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-action";
-  version = "0.7.13-r1";
+  version = "0.7.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.13-1.tar.gz";
-    name = "0.7.13-1.tar.gz";
-    sha256 = "5ab26070f9a706bf9721ea272daba10d5282d689394b19f733d3c44fde4ba026";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_action/0.7.14-1.tar.gz";
+    name = "0.7.14-1.tar.gz";
+    sha256 = "f25e5fab12e02f62bb38782fbf395105201a8052b57cec37e763be730aa848a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-components/default.nix
+++ b/distros/dashing/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-components";
-  version = "0.7.13-r1";
+  version = "0.7.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.13-1.tar.gz";
-    name = "0.7.13-1.tar.gz";
-    sha256 = "f3dc76e4f8011c2a76baea0d7732f57cd53cf488f79ca34cccb932fdac96d70d";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_components/0.7.14-1.tar.gz";
+    name = "0.7.14-1.tar.gz";
+    sha256 = "8ddac365e4a66386658ac38f0dbd684b1deda368f6595ef1371980deebfc91f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp-lifecycle/default.nix
+++ b/distros/dashing/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, rcl-lifecycle, rclcpp, rmw-implementation, rosidl-typesupport-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp-lifecycle";
-  version = "0.7.13-r1";
+  version = "0.7.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.13-1.tar.gz";
-    name = "0.7.13-1.tar.gz";
-    sha256 = "db0e9ed504d776ca7d5af19f7446b247c41f61f924c36b3fabb564c892de93eb";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp_lifecycle/0.7.14-1.tar.gz";
+    name = "0.7.14-1.tar.gz";
+    sha256 = "33455793ab8beeac811bc50fe5cfea10064cb9198abacf109a493a23ddd24790";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclcpp/default.nix
+++ b/distros/dashing/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rcl-yaml-param-parser, rmw, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclcpp";
-  version = "0.7.13-r1";
+  version = "0.7.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.13-1.tar.gz";
-    name = "0.7.13-1.tar.gz";
-    sha256 = "50be58a8aca9bcfe3831e39f98c21da456be63b03e88578583e1cf6ad7473c12";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/dashing/rclcpp/0.7.14-1.tar.gz";
+    name = "0.7.14-1.tar.gz";
+    sha256 = "ae0aad3c279b677b374f687f56258dd07fbed22d3ee2456a6c052cb9ae409328";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclpy/default.nix
+++ b/distros/dashing/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclpy";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/dashing/rclpy/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "ec1cc65437379102035181934e7a1e68b72d33abfcd94ff08d2a51e6fe527bb7";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/dashing/rclpy/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "0690e2cb731c13e02ec9029924e91a3c170747383ab9fe47b7cceef69008eaa1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/resource-retriever/default.nix
+++ b/distros/dashing/resource-retriever/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-index-cpp, libcurl-vendor }:
 buildRosPackage {
   pname = "ros-dashing-resource-retriever";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/resource_retriever/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "53aec80c0e8de04c3a3665a96c4ad906b6f842a2408ec692851776121ddc5ba9";
+    url = "https://github.com/ros2-gbp/resource_retriever-release/archive/release/dashing/resource_retriever/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "f58cd5a5e1dba6b9394d12427202ad1d0b083b4d291f114b3ae434ab09bbd3cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rmw-connext-cpp/default.nix
+++ b/distros/dashing/rmw-connext-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rmw-connext-shared-cpp, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-generator-dds-idl, rosidl-typesupport-connext-c, rosidl-typesupport-connext-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-connext-cpp";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_cpp/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "e93e9082d98e287fb1e91d43aa7b018ea5db1399beaf32d039219b1ffd2b59d5";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_cpp/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "4e6722f1323c1f4ba044e99f38e6bd061278eb34513133eaceb084dece9e58aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rmw-connext-shared-cpp/default.nix
+++ b/distros/dashing/rmw-connext-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcpputils, rcutils, rmw, rosidl-cmake }:
 buildRosPackage {
   pname = "ros-dashing-rmw-connext-shared-cpp";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_shared_cpp/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "1ac2c7c9d13c2db20015463c8c9ba90bb1020028bf383a2fc6151520dc7f628b";
+    url = "https://github.com/ros2-gbp/rmw_connext-release/archive/release/dashing/rmw_connext_shared_cpp/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "fb0296c8663e8badedf9dc04d8cc925ccb25b85fa09ffa0e754e0f1fe4106f23";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros-base/default.nix
+++ b/distros/dashing/ros-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, kdl-parser, robot-state-publisher, ros-core, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-dashing-ros-base";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/ros_base/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "08bec82c0cf706a317f99f53f03616a8062661fbf41721d2eee89744b332f513";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/ros_base/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "e0ea6c438898c482b538c112cad250b541da9a66d8a98ef8d66d562103228324";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros-core/default.nix
+++ b/distros/dashing/ros-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-cpp, ament-index-python, ament-lint-auto, ament-lint-common, class-loader, common-interfaces, pluginlib, rcl-lifecycle, rclcpp, rclcpp-lifecycle, rclpy, ros-environment, ros2action, ros2component, ros2launch, ros2lifecycle, ros2msg, ros2multicast, ros2node, ros2param, ros2pkg, ros2run, ros2service, ros2srv, ros2topic, rosidl-default-generators, rosidl-default-runtime, sros2, sros2-cmake }:
 buildRosPackage {
   pname = "ros-dashing-ros-core";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/ros_core/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "efb7103e01a3628d49a4395b3f7ca20a3ffb58635d23685ab9c154f1210eee4c";
+    url = "https://github.com/ros2-gbp/variants-release/archive/release/dashing/ros_core/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "203f9e97cb8211eff2b2780f3b9c0d30134436b33b61bdf55d815f610f93bba2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros1-bridge/default.nix
+++ b/distros/dashing/ros1-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, actionlib-msgs, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, demo-nodes-cpp, diagnostic-msgs, example-interfaces, gazebo-msgs, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nav-msgs, pkg-config, python3Packages, rclcpp, rcutils, rmw-implementation-cmake, ros2run, rosidl-cmake, rosidl-parser, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, tf2-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ros1-bridge";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "8922a36968861339b30c56ac8a57d9f5105ddc9fedd027b8f4c19e3613c69f7c";
+    url = "https://github.com/ros2-gbp/ros1_bridge-release/archive/release/dashing/ros1_bridge/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "c034844f1b69c063022f64ade3c937aa43fe226ddfb5873fafda56f0f8ced023";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/ros2action/default.nix
+++ b/distros/dashing/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-ros2action";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "dea7b7a2578c5f9f0df501264f97d0f700a0e2ce8e2f9f17d2602978c771253a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2action/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "1a2cebd821fd5ac3743e4d2bb32139ef8a237f1418411ce93fd0bc35c853821b";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2cli/default.nix
+++ b/distros/dashing/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-ros2cli";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "2c93d9207eb1463bc80d3f8e3990077370f667c1589f99442be0fa5eb190d731";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2cli/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "ef1e6a926986d64b89764083c91b0b3ce7be6bbd2dc6e83e12c2dca66badb712";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2component/default.nix
+++ b/distros/dashing/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-dashing-ros2component";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "4ecd9c7c490d2f2684f5d54a421d6ecfe3270e2e67db2f6f20dcce75cc29400a";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2component/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "c94390e9523a0f4b2d84b93702b91cac26fed21206c04516990ac7ad12615fa3";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2lifecycle/default.nix
+++ b/distros/dashing/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-dashing-ros2lifecycle";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "7337e5aa79511e6fe056e61d63d3de41130cd2b85b0615e4d34426e3cbe4f4b9";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2lifecycle/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "596bd2571ce71470ad319e78bff80933fcdd6390bbcaffbc57259221f075259a";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2msg/default.nix
+++ b/distros/dashing/ros2msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-ros2msg";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "674ffd4c65a7ebe6b6f76d0b59b87eff7371b42b66a3a281f1fd5e811b5eff5e";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2msg/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "a4242f0308dbe7d4d2c272d97aba0246ed3b07dc825c3510a339013e44ccb11c";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2multicast/default.nix
+++ b/distros/dashing/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2multicast";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "ffdf72d272a19e9233dc26529d3d88b0edc994062c0dd6a928a65e13e9e973bd";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2multicast/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "c90783392f749a7069f69f93fda4afd3427fa521d879b9f762fe478123d6e68a";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2node/default.nix
+++ b/distros/dashing/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2node";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "86341fa400424abfbe4059211bc3369306b4e6ff7b4cc634df42ef1bfa01bb00";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2node/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "1cc40a5ca34dce264ecc38e9718bb0da3145da2c5ddac4a2f07ef20e9b2f7301";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2param/default.nix
+++ b/distros/dashing/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-dashing-ros2param";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1099bd3e66e97cd6cf7738165e93b00500730201013ed4e3cfb7f21b5f755d25";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2param/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "d9dd98d772eedbceec3d691f11ea7272a1d860a7ce13e73c70371efe7e42c408";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2pkg/default.nix
+++ b/distros/dashing/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-dashing-ros2pkg";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "80a9aa72cef1048b9825510b5b012b401352a60ecc20f36b2a8f0eeac093aa95";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2pkg/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "8bcf0aaa6e2b6291afcdf6560d4745cea3e831456383d869ed1d51ba9d379435";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2run/default.nix
+++ b/distros/dashing/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-dashing-ros2run";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "8867efcea5c4a0ce700d149601ebf18a5bf3e5e148bf2e4ace026f57a3c3fba6";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2run/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "9bfe417f66524817bdc178bbc10a52d0ddc8293d78105cbc00783dae555e82de";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2service/default.nix
+++ b/distros/dashing/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros2cli, ros2srv, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-dashing-ros2service";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1c01e9ad32981920f2931db93b9936e9d1a99679bb91f5a138f8560eef044053";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2service/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "3f120772229d88b8f205f9743730a7c403bc800eb615716ce4e1219d7276ac28";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2srv/default.nix
+++ b/distros/dashing/ros2srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros2cli, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-ros2srv";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "d8e660143245f78987a5981261b63bddb246aa9bd4f41ed0937f393bbbb5e260";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2srv/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "57efee1e7a4ee13ded00b4c7b6eb4805b732c4c05f46b300df58af8522b65433";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2topic/default.nix
+++ b/distros/dashing/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros2cli, ros2msg, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-dashing-ros2topic";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "65e6b8b3634b05646bd07e5aa9d28720f06876b7a5c394ebc3d9c7c6316d2d4b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/dashing/ros2topic/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "772d3d337b410e759ec6569906af9c1edb4969b1a1ffc0a96b7547730d14cc07";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/velodyne-driver/default.nix
+++ b/distros/dashing/velodyne-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-velodyne-driver";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/dashing/velodyne_driver/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb52c0840e87988f55b7cb0b4c4b4d067be911acb012717a0c461e9a1663064d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater libpcap rclcpp rclcpp-components tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/velodyne-laserscan/default.nix
+++ b/distros/dashing/velodyne-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-velodyne-laserscan";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/dashing/velodyne_laserscan/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "f37db01e5414a177959fdb0229c522483f6cf3731c23f51c4a6aa34decd03458";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/velodyne-msgs/default.nix
+++ b/distros/dashing/velodyne-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-velodyne-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/dashing/velodyne_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "f834b66f3be7458a6b7d3e282c5b04ae4e63beda03b7f64cb10f7c0cc5ed1159";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/velodyne-pointcloud/default.nix
+++ b/distros/dashing/velodyne-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-velodyne-pointcloud";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/dashing/velodyne_pointcloud/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "eb01118bdb950dc9aa181d8147d4a51fb3d845be6a7b0aa27568ff4f74e8bc80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/velodyne/default.nix
+++ b/distros/dashing/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-dashing-velodyne";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/dashing/velodyne/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a5a8593eba774b685f970c1bb49da30a5bfe419389e4ba03023337f3f1239937";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -444,6 +444,8 @@ self: super: {
 
  launch-yaml = self.callPackage ./launch-yaml {};
 
+ lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
+
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
@@ -1051,6 +1053,16 @@ self: super: {
  v4l2-camera = self.callPackage ./v4l2-camera {};
 
  velocity-smoother = self.callPackage ./velocity-smoother {};
+
+ velodyne = self.callPackage ./velodyne {};
+
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/eloquent/lgsvl-bridge/default.nix
+++ b/distros/eloquent/lgsvl-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, rcl, rcutils }:
+buildRosPackage {
+  pname = "ros-eloquent-lgsvl-bridge";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/ros2-lgsvl-bridge-release/archive/release/eloquent/lgsvl_bridge/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "87c55e403bc41a3168f5a24a33c52a6d5cd4a23f60448d13b996e04e29ac8b6c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rcl rcutils ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''LGSVL Simulator Bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/swri-console-util/default.nix
+++ b/distros/eloquent/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-console-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_console_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "fb300214d4e942ca600e802335223813dc92b075f9a3d0e880b73c7403ea87d9";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_console_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e5511f26b1da8afc02de460a8a6fc0c8bf0522a0b504837b0474d372d06f15f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-dbw-interface/default.nix
+++ b/distros/eloquent/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-eloquent-swri-dbw-interface";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_dbw_interface/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "dff91ca9aefb7d325f35ed4d9aedf0b5772eea8c7f4b6c4a33f47e53cf6b863b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_dbw_interface/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "f706897cf65196c0a3fdcb1f53900aeaa926813298f8e3707574f3ef8e1519b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-geometry-util/default.nix
+++ b/distros/eloquent/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-swri-geometry-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_geometry_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "30c2412d61475f1fb0107660e7ecc6d3ba0527bf938302e1f85d3c186263d8e9";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_geometry_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "d8e11476d041d33267613ace4909b730236bfd531dbf2e0471de4fc927c645e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-image-util/default.nix
+++ b/distros/eloquent/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-eloquent-swri-image-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_image_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "69159988fd1bf36f509cb66032f0c091be089a3d21782f4c904012ac5cc182df";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_image_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "a5c1d649c7e9cf8530ad943a1b73e63188b46ea514344639b15bf546baaa8996";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-math-util/default.nix
+++ b/distros/eloquent/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-math-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_math_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "9477d2bfa4e20b5526457202045ed2bd7af0ff15b4c9e7a58ba247d786bb14ba";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_math_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2669db90847befb3f419b73677434e51d908a2ee7e2f007b1f5c54637c9e0a5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-opencv-util/default.nix
+++ b/distros/eloquent/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-eloquent-swri-opencv-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_opencv_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c449e6bcb8b1a66e2cafc09a19613bc3862acffae05fdc94c30eefe2a674565c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_opencv_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "4eeef37e9e4dcf5edd0b3e016a716bb7de4dfc6cd4d2aec19b73e59215396a56";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-prefix-tools/default.nix
+++ b/distros/eloquent/swri-prefix-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-eloquent-swri-prefix-tools";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_prefix_tools/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "831a9f4fa4eb6c0d84c345f04d4b97e9dc5469d5f172ec4945d142a1feadf81c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_prefix_tools/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1e9cb68af9cec6c0b815342c3116bb73ebd995479c573a33cfb5e37153559e63";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ pythonPackages.psutil ];
+  propagatedBuildInputs = [ python3Packages.psutil ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/eloquent/swri-roscpp/default.nix
+++ b/distros/eloquent/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-eloquent-swri-roscpp";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_roscpp/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "180a48d78b51fe318ad93d6b5f2388419596fd35e9468507a70331020c898c77";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_roscpp/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "6fa7df93bb773dfc54facc30186f88599b4602af4b33fd6f72d1c8eba8f6893f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-route-util/default.nix
+++ b/distros/eloquent/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-swri-route-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_route_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "0147dab4ca9425afdb0ef2000430fcd5d485d8f7bfc987e31f13cb8517e19c6f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_route_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "d410172a67cdace2a62e9409766e183964b57ad5ca0dff92b5d692bbbddd1584";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-serial-util/default.nix
+++ b/distros/eloquent/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-eloquent-swri-serial-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_serial_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "23d3232ddca32997aae4e0f467c873bd66a45c4b96a637ce51cd150d049bc025";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_serial_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "466dcabfa483a3086f5bba78143262cde4e41070077a167e8338c0b15c20214b";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-system-util/default.nix
+++ b/distros/eloquent/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-swri-system-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_system_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "bb1ade3b9b060716ded6ea4be875a2dbfba7d6a3c46bd9fc30766de14a6c2a9d";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_system_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "3988bb10fb84db26c74e57e8f812d9dde6bff5daa9d22bf9ebdb93ea72fe78f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/swri-transform-util/default.nix
+++ b/distros/eloquent/swri-transform-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-eloquent-swri-transform-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_transform_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "9457b0999db00b89eac86ff31a2e002d6dbbaec9e66a8053863369a45bcfe6b9";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/eloquent/swri_transform_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "8187d44c8b4b51ab024e0044c140359deb65df4a7ba888c96531a11fd82af2f1";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/eloquent/velodyne-driver/default.nix
+++ b/distros/eloquent/velodyne-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-velodyne-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/eloquent/velodyne_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "26e3ea7f9446769e4ac426e2fe4279d8d7d39f3e4dcd5bfdbf0b0e523b32a6e3";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater libpcap rclcpp rclcpp-components tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/velodyne-laserscan/default.nix
+++ b/distros/eloquent/velodyne-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-velodyne-laserscan";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/eloquent/velodyne_laserscan/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "2d2bfead8cddbeba85ae7f83296869d5ae52aa5d6cc9ee89a56371b840a94a6e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/velodyne-msgs/default.nix
+++ b/distros/eloquent/velodyne-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-velodyne-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/eloquent/velodyne_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "540ac3869fd248117f5c922a38f806ffea7f8fdb7495bf08afe271dd7578ac35";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/velodyne-pointcloud/default.nix
+++ b/distros/eloquent/velodyne-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-velodyne-pointcloud";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/eloquent/velodyne_pointcloud/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b8f8bf816398a493c9539cf8e913036775cfb13d89604d6b9bc8ca96f3dcf0f6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/velodyne/default.nix
+++ b/distros/eloquent/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-eloquent-velodyne";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/eloquent/velodyne/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "8a4ece28a1cfd727b08a6c7a57a1b8c97fd91e9db5d98da2463912d9f112caaf";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/diagnostic-aggregator/default.nix
+++ b/distros/foxy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-aggregator";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "7a6d4824adea8a25f382cbaf1f18c3e8b4477d7bf52c5fc85c7045ccee710c7b";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d36750431f5d4686ad9c469dbfc44092919e970c3b49d1d9d4f58c84c2602a74";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-updater/default.nix
+++ b/distros/foxy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-updater";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "d5e7d155361f128af65498d6911f3d8dfb16b52b2f4bc7cc1606cd562879aa2e";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "7291d91746c3dcd9afe6c2c2c73feda8796aa1d6f97d9297b04150e3bb57e2a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -294,6 +294,8 @@ self: super: {
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
+ hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
+
  image-common = self.callPackage ./image-common {};
 
  image-geometry = self.callPackage ./image-geometry {};
@@ -345,6 +347,8 @@ self: super: {
  launch-xml = self.callPackage ./launch-xml {};
 
  launch-yaml = self.callPackage ./launch-yaml {};
+
+ lgsvl-bridge = self.callPackage ./lgsvl-bridge {};
 
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
@@ -440,6 +444,8 @@ self: super: {
 
  nodl-python = self.callPackage ./nodl-python {};
 
+ nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
+
  octomap = self.callPackage ./octomap {};
 
  octomap-msgs = self.callPackage ./octomap-msgs {};
@@ -496,6 +502,8 @@ self: super: {
 
  pluginlib = self.callPackage ./pluginlib {};
 
+ py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
+
  python-cmake-module = self.callPackage ./python-cmake-module {};
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
@@ -515,6 +523,8 @@ self: super: {
  quality-of-service-demo-cpp = self.callPackage ./quality-of-service-demo-cpp {};
 
  quality-of-service-demo-py = self.callPackage ./quality-of-service-demo-py {};
+
+ random-numbers = self.callPackage ./random-numbers {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -595,6 +605,8 @@ self: super: {
  ros2bag = self.callPackage ./ros2bag {};
 
  ros2cli = self.callPackage ./ros2cli {};
+
+ ros2cli-common-extensions = self.callPackage ./ros2cli-common-extensions {};
 
  ros2component = self.callPackage ./ros2component {};
 
@@ -766,6 +778,8 @@ self: super: {
 
  rviz-visual-testing-framework = self.callPackage ./rviz-visual-testing-framework {};
 
+ sbg-driver = self.callPackage ./sbg-driver {};
+
  sdl2-vendor = self.callPackage ./sdl2-vendor {};
 
  self-test = self.callPackage ./self-test {};
@@ -775,6 +789,10 @@ self: super: {
  shape-msgs = self.callPackage ./shape-msgs {};
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
+
+ slam-toolbox = self.callPackage ./slam-toolbox {};
+
+ sophus = self.callPackage ./sophus {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
 
@@ -897,6 +915,16 @@ self: super: {
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
+
+ velodyne = self.callPackage ./velodyne {};
+
+ velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
+
+ velodyne-msgs = self.callPackage ./velodyne-msgs {};
+
+ velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/foxy/hls-lfcd-lds-driver/default.nix
+++ b/distros/foxy/hls-lfcd-lds-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-hls-lfcd-lds-driver";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/foxy/hls_lfcd_lds_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "4f66e46c20c8c578dbe9ecb43d06662d422e3b2e262d400057fc5368839346e6";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS package for LDS(HLS-LFCD2).
+    The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/lgsvl-bridge/default.nix
+++ b/distros/foxy/lgsvl-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, rcl, rcutils }:
+buildRosPackage {
+  pname = "ros-foxy-lgsvl-bridge";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lgsvl/ros2-lgsvl-bridge-release/archive/release/foxy/lgsvl_bridge/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "d97554a54f026d417812ec4df464f850d9821c0e44f9d3cc14f586cd9579f20b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rcl rcutils ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''LGSVL Simulator Bridge'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/nonpersistent-voxel-layer/default.nix
+++ b/distros/foxy/nonpersistent-voxel-layer/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, geometry-msgs, laser-geometry, map-msgs, nav-msgs, nav2-costmap-2d, nav2-msgs, nav2-voxel-grid, pcl, pcl-conversions, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-nonpersistent-voxel-layer";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/foxy/nonpersistent_voxel_layer/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e189c07f0f785bd3324cd9d28f25acf8a9baec967e79225cdf1a69ed5cd70d93";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  propagatedBuildInputs = [ geometry-msgs laser-geometry map-msgs nav-msgs nav2-costmap-2d nav2-msgs nav2-voxel-grid pcl pcl-conversions pluginlib rclcpp sensor-msgs std-msgs tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''include
+        This package provides an implementation of a 3D costmap that takes in sensor
+        data from the world, builds a 3D occupancy grid of the data for only one iteration.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/py-trees-ros-interfaces/default.nix
+++ b/distros/foxy/py-trees-ros-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, diagnostic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-py-trees-ros-interfaces";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/py_trees_ros_interfaces-release/archive/release/foxy/py_trees_ros_interfaces/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b06839cd575506d3cfcde376f52f1211d2e11ad13f6f07b20a6446cf00f621fa";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs diagnostic-msgs geometry-msgs rosidl-default-runtime unique-identifier-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interfaces used by py_trees_ros and py_trees_ros_tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/random-numbers/default.nix
+++ b/distros/foxy/random-numbers/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost }:
+buildRosPackage {
+  pname = "ros-foxy-random-numbers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/random_numbers-release/archive/release/foxy/random_numbers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ec03b0c18f5a669cbba971e71cb9b652b4689a1beb2426c716c62ce959f34926";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This  library contains wrappers for generating floating point values, integers, quaternions using boost libraries.
+
+  The constructor of the wrapper is guaranteed to be thread safe and initialize its random number generator to a random seed.
+  Seeds are obtained using a separate and different random number generator.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ros2cli-common-extensions/default.nix
+++ b/distros/foxy/ros2cli-common-extensions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-xml, launch-yaml, ros2action, ros2cli, ros2component, ros2doctor, ros2interface, ros2launch, ros2lifecycle, ros2multicast, ros2node, ros2param, ros2pkg, ros2run, ros2service, ros2topic, sros2 }:
+buildRosPackage {
+  pname = "ros-foxy-ros2cli-common-extensions";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli_common_extensions-release/archive/release/foxy/ros2cli_common_extensions/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1a431b3ad5c3b44c607b8cd0420cacac18d22836f8feb98c59b40efd3d2e463d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-xml launch-yaml ros2action ros2cli ros2component ros2doctor ros2interface ros2launch ros2lifecycle ros2multicast ros2node ros2param ros2pkg ros2run ros2service ros2topic sros2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package for ros2cli common extensions'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/sbg-driver/default.nix
+++ b/distros/foxy/sbg-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geometry-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-foxy-sbg-driver";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SBG-Systems/sbg_ros2-release/archive/release/foxy/sbg_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ada708074bdf3f3972ea2e8db9e496cffbae3bf3a485ebc0418eb0a8b5926461";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost geometry-msgs rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS driver package for communication with the SBG navigation systems.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/self-test/default.nix
+++ b/distros/foxy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-self-test";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "06e928a4cbe2034fca555bd341052a2ed9253944b5f7ec937047a11726b02501";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "9a400908ef62c936ea1c5fcf685d5cf80481b631151906f6831dcf23d90624b6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/slam-toolbox/default.nix
+++ b/distros/foxy/slam-toolbox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-slam-toolbox";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/foxy/slam_toolbox/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2343c9c190b4a6f2bb32b0067b40b7db64b8287e56db52a62fb19ebe6a5aebb0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-uncrustify ament-lint-auto launch launch-testing ];
+  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides a sped up improved slam karto with updated SDK and visualization and modification toolsets'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/foxy/sophus/default.nix
+++ b/distros/foxy/sophus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen }:
+buildRosPackage {
+  pname = "ros-foxy-sophus";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/foxy/sophus/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a89b3dcf9f6149d18062537ecd7bbfa48573b73c7d912bc43c12e0beff173f28";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''C++ implementation of Lie Groups using Eigen.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/swri-console-util/default.nix
+++ b/distros/foxy/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-console-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "4fc60c781cc4197cb3a098c03e1b8bf5e4afcf1af9bc5e8c8b2ffa96baf6a187";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_console_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "67d3372ee1a549851fd5fbee20384070951937bb279aebe28c70ae66a8e7eed8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-dbw-interface/default.nix
+++ b/distros/foxy/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-swri-dbw-interface";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d5e99f0f36644514719b163ded3611a7e9c9d584ee63987d3c0a2064f32a36bc";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_dbw_interface/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "f5929d2dd76a7b34e78f9751d5f75b3d681ec976b4ae9986cf2b532a542a04a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-geometry-util/default.nix
+++ b/distros/foxy/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-geometry-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "bf7c50f1fa69e63b965b186150aeb094c199f93986858948d5f80d943f1b68cd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_geometry_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "76f630a4d6fa7000ff711fb52d2fd276f77b3791ce0154e851d026f551e018c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-image-util/default.nix
+++ b/distros/foxy/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-swri-image-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "0dd5f892d0bb296227be96e21157904988d84b1b9ad1f76f79d939bced5cb9eb";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_image_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "683fbac28253044cbb9cf606f432b554dce730d024b4f5a9536a97ef514b62df";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-math-util/default.nix
+++ b/distros/foxy/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-math-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f054a45351bdd10c2390e29d14b53a178f963740b5498b5fd5ff1203eade2b5e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_math_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e4f41aa420dce49200d93496df9275626a11b44a1fcd1f7ba64710d5cc542851";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-opencv-util/default.nix
+++ b/distros/foxy/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-foxy-swri-opencv-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d740fdd421c8ef02495eb14c44417c3f50c5b404124caed817a0c6a2679ef70a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_opencv_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "51aa80bc2a0fc988d3c0736d20e3a95c791a0d137a471cf60dfcfd7a0b5e9d2f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-prefix-tools/default.nix
+++ b/distros/foxy/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-swri-prefix-tools";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "af03955a242c54329d2664be0c6ea50a4a6e86bfd948d6cf0da9976e091675f3";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_prefix_tools/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2f71ab2f3471ce70a8e747748795f313ffc1dcd13f36c67a845926dbce367a22";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-roscpp/default.nix
+++ b/distros/foxy/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-swri-roscpp";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d450bfd1938877d0130c56b383f4a12cbe3ea7c993b57dd3314adcb4d5bcde7a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_roscpp/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "773cc152739cc9e6ad883c9823de46da17465556aea1cd9650f9fce372ad2e40";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-route-util/default.nix
+++ b/distros/foxy/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-swri-route-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "ad0a02243e9b372a49a1e2be61b0fdb8f9ece473373ceed728600258189259ec";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_route_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b70bd22080c2eca7c4dcd89e42c1c2fc204cee33db1dfd3dd3ade48c4266689d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-serial-util/default.nix
+++ b/distros/foxy/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-foxy-swri-serial-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "c2a9211b880edd78ec637796137a9551f45eb7f229411c64c8b9a0def3e2acc8";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_serial_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1759ecf87f26a6ac400768364b77d154b849be0cae79ec46ca750503917f00e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-system-util/default.nix
+++ b/distros/foxy/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-swri-system-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "bfac19e7760c2979ebdee1e22bd0c3e4ad232e17aaf83d6ba5752415c3a98202";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_system_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "8c5eac6c7a0e29b89c9bfe498e3bdbbc87d57aba1b4a428a2625031ba62ab9f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/swri-transform-util/default.nix
+++ b/distros/foxy/swri-transform-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, launch-xml, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-py, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-swri-transform-util";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "459d30e66e59bb7777304f15d37305c74a4034e1c8787f6b136d78a2288b444f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/foxy/swri_transform_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b8f752e875060001e150b14908ccf529ce2ff4486fef77ba36111110bb3e90d5";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs launch-xml libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-py tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.2.0-r4";
+  version = "0.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.2.0-4.tar.gz";
-    name = "0.2.0-4.tar.gz";
-    sha256 = "5419abbbf6ebfe02fc5cd41b2fd3afb79b031e1685aaf714b14ae867d0dd52a3";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "dcf3193e9aa441a03471fd578a30beb92fa3409ff92fd0c6487cdb9f5bfdc137";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.2.0-r4";
+  version = "0.2.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.2.0-4.tar.gz";
-    name = "0.2.0-4.tar.gz";
-    sha256 = "7ae15bca8134944fe25e649313f2f00b05ee8575c2259fc594dc702eea2870a4";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "3f4c848b7df17ac99743d412b7843311abdabc66d3b4120e99f85516a383c15f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velodyne-driver/default.nix
+++ b/distros/foxy/velodyne-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, libpcap, rclcpp, rclcpp-components, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_driver/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "dcd53879bfe59dab8a75aed0854e30897a8f5cc073a9e92332ff267a28c64117";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater libpcap rclcpp rclcpp-components tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''ROS device driver for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-laserscan/default.nix
+++ b/distros/foxy/velodyne-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-laserscan";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_laserscan/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "1384f7a87a0541b0300293ca5c8a46758f57451f96f5560adf04eaf483f9fd64";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extract a single ring of a Velodyne PointCloud2 and publish it as a LaserScan message'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-msgs/default.nix
+++ b/distros/foxy/velodyne-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "ca34811a64993988832d77a9dfed728a9d6c6785e10d90820edae0dd700eab41";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS message definitions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-pointcloud/default.nix
+++ b/distros/foxy/velodyne-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, diagnostic-updater, geometry-msgs, libyamlcpp, message-filters, pcl, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, velodyne-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-pointcloud";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne_pointcloud/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "cb9c8876d8f8f603c5cfcbc23c3370b044b6126285e5551c57c073fc1bb8a5d6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles diagnostic-updater geometry-msgs libyamlcpp message-filters pcl rclcpp rclcpp-components sensor-msgs tf2 tf2-ros velodyne-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Point cloud conversions for Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne/default.nix
+++ b/distros/foxy/velodyne/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/foxy/velodyne/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6af955d9a5f27ae867bd15ecdbe93f53a6ec881bba3b80c06e5f31e747641c15";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-driver velodyne-laserscan velodyne-msgs velodyne-pointcloud ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Basic ROS support for the Velodyne 3D LIDARs.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/agv-msgs/default.nix
+++ b/distros/kinetic/agv-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-agv-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/agv_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "01b0589f98ed858c688eda3fb07e81442d067b0ecbd587d3050ae2ad64cbce13";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The agv_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "d21e09117bd6ae019e39cfaa3a540b7e6c47c4360b5473dfa0d09a1a43603aca";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "01d9c8d5a83becc7d46582ecd97767b8ec047c407ed9532f20f6429ac7105584";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -54,6 +54,8 @@ self: super: {
 
  agni-tf-tools = self.callPackage ./agni-tf-tools {};
 
+ agv-msgs = self.callPackage ./agv-msgs {};
+
  agvs-common = self.callPackage ./agvs-common {};
 
  agvs-control = self.callPackage ./agvs-control {};
@@ -2979,6 +2981,18 @@ self: super: {
  phidgets-imu = self.callPackage ./phidgets-imu {};
 
  phidgets-msgs = self.callPackage ./phidgets-msgs {};
+
+ phm-hazard-rate-calculation = self.callPackage ./phm-hazard-rate-calculation {};
+
+ phm-msgs = self.callPackage ./phm-msgs {};
+
+ phm-reliability-calculation = self.callPackage ./phm-reliability-calculation {};
+
+ phm-robot-task-completion = self.callPackage ./phm-robot-task-completion {};
+
+ phm-start = self.callPackage ./phm-start {};
+
+ phm-tools = self.callPackage ./phm-tools {};
 
  pid = self.callPackage ./pid {};
 

--- a/distros/kinetic/hls-lfcd-lds-driver/default.nix
+++ b/distros/kinetic/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-hls-lfcd-lds-driver";
-  version = "1.1.0";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/kinetic/hls_lfcd_lds_driver/1.1.0-0.tar.gz";
-    name = "1.1.0-0.tar.gz";
-    sha256 = "f45977a88b9db1f469b9a6031a29a25d161d6c3ff9c0ff7415f960f07c050aa4";
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/kinetic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "3a61d95dd976fbfbd0f54cbe17fb9be35c6da6a3726b18cbdd8270598e56920e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "4cc21bf33da327cadc600521074976af71d12a4c0d3d5face321cb6a668b3535";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "5bb6f1103a158fb9fa756c78db6a2e819361435fae4b962081d1e0711055ea10";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.35.2-r2";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.35.2-2.tar.gz";
-    name = "2.35.2-2.tar.gz";
-    sha256 = "87a3e6ee46cada6c2122abc5ff71fa52811ea34c69b6f35c78453e45515d66c2";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "17227090c8b22b3ba3b6017a99b3d3b2d86d488229f7839ab9c2edf00fca63a9";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "2fab816333736e6d551817a1b6d15dfa4756e4e4ee68277c2f5c9187783b69cb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "f689ecb1cc66e5b9b7d29a3dcfe03624171d2f281e97659ae99b4f7ac98b48f2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-data-structures/default.nix
+++ b/distros/kinetic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-marti-data-structures";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/marti_data_structures/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "19052bb18832c62895d3896b05d99ad62bbbe1a819db31bd6fbcfd7323f0c04f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/marti_data_structures/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "dbdf1daf2b8b7d1886a069129ccda96ee3afb06c60f005a75b124cb1a797c121";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "f3feecd5f6023049ff48a56ae3a6f0a3e0831f64853cfa16a6396aa6f4364805";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "aa8765466d60b6c2e59fe60cbac796a62e84aad3f27ccc0d26202ee403009bb8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "483957df163d485cf9cc74c272b7dc6f43d2778e4bd4b32c010b9a7ee164bcec";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "ac05a81b87948aa2a7fa12e710957443d7a602063384674da3ace07a9b987235";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "7efb24f4caf7f580254d31f1eb07db5b2cab4b9e60a3aef01bc73045598aea8a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "ad29fd8ab726b6911071ee1f86c1c914a08d6d4262bff27d415dc70af1961279";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e59775d28cc1d2477dcc55695f370a2098c9f606d9319695fc24bb08bf465bb2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "8948c3b8d8c772854b64aecdee096db4b9eff8775810c24d2f1cc3f4fdcf9368";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phm-hazard-rate-calculation/default.nix
+++ b/distros/kinetic/phm-hazard-rate-calculation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rostest, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-hazard-rate-calculation";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_hazard_rate_calculation/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "029c5764d99bd633e0f576930d755c3b89f8f67cc1855647c295ca75e76837fd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ rospy rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_hazard_rate_calculation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/phm-msgs/default.nix
+++ b/distros/kinetic/phm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9f5fc3a04606cc14708e9d5101ef22ca748e2d29129e5c15adb19bc1c75f92ed";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/phm-reliability-calculation/default.nix
+++ b/distros/kinetic/phm-reliability-calculation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rostest, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-reliability-calculation";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_reliability_calculation/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8e2c48684f357b1d9596850da4bc629889a6bdec8de884ccd6ee923317924d4b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ rospy rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_reliability_calculation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/phm-robot-task-completion/default.nix
+++ b/distros/kinetic/phm-robot-task-completion/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rostest, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-robot-task-completion";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_robot_task_completion/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "96f1b0ffb41b99f5c2ed702fdba7f7f9f79f33a765ec83be60c4c972bf24d4bc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ rospy rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_robot_task_completion package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/phm-start/default.nix
+++ b/distros/kinetic/phm-start/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rostest, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-start";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_start/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d72de97585bbc5a4ee88b1fa3c4f4bfc29b87baf9861c1ef1d7e91217e717d62";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ rospy rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_start package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/phm-tools/default.nix
+++ b/distros/kinetic/phm-tools/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-kinetic-phm-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inomuh/phm_tools-release/archive/release/kinetic/phm_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "03a0c94123b549575edcb6e50a2b4b2e568afbdf0ce1dcb66a3bc73893946674";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The phm_tools package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "bbd288c97c22d03d2d04c18a016f4c1023ce34cb0fceaae979da7991b9968bdf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "4269505946b9656e1b4125c68583b0d31cf1d85cd017ce0d27624899ea859562";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/plotjuggler/default.nix
+++ b/distros/kinetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-plotjuggler";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "c5f377d38abb12e3dc0550e725d9f97f8fdbac6000e5a723fcdb9de8194b1a1f";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/kinetic/plotjuggler/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "dfed79aeff95330e6f20302880a591ead41f0b196687f0b2e00984268606fc08";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "19a9d9e6b6bec03b400abef04c150629fe3d750e34ae07030852130a304599c6";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "6668dd0063bf75bc1f3185d3b1f068093672c09f2d185724323c5964373ee6fe";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "0219bbedc5d2f55f653a87ac05c645bd9feccb66569603d9120fa0243f9d0564";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "2f45a4014448a2fd760a70bdbba34c961159f580242d3e78b7e6d94b8d943275";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rtabmap-ros/default.nix
+++ b/distros/kinetic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rtabmap-ros";
-  version = "0.19.3-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kinetic/rtabmap_ros/0.19.3-1.tar.gz";
-    name = "0.19.3-1.tar.gz";
-    sha256 = "5cbb5ccff9054f8e45ea1c2f25433f9381d6131612aa505aa1f15e6d326c4652";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/kinetic/rtabmap_ros/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "636819592f8ed627c1fc974c3824a9fb430e771b561fc3f3066eaaaf3048207f";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "2de20f780ed7b7d1d09383b5e08b1cf862bbaf2dd90a3b2cd212261e320f21e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "4c0108f9ec535e4f82f6d4d8e536411434a1e3d2bf860c9bceb14b99abb7d9cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-scan/default.nix
+++ b/distros/kinetic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-scan";
-  version = "1.7.6-r1";
+  version = "1.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.7.6-1.tar.gz";
-    name = "1.7.6-1.tar.gz";
-    sha256 = "e738ee00e2332a00bd7185d0c725e59c3515f038c70d38353396b25a9c21388e";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.7.6-2.tar.gz";
+    name = "1.7.6-2.tar.gz";
+    sha256 = "ba1e597058eb274c5d5a975b6a907d2b7c10b40132a794b40492ae6250fce699";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-console-util/default.nix
+++ b/distros/kinetic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-kinetic-swri-console-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_console_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "ec3ed1e2d793d8642cc43b0287434183a0c748336ebe6f19c0a652a74fa0e119";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_console_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "2e629dca4d70f47b8bbecef30fbc5cfe49d16404a0bd9c6c5bb206545ff71fe7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-dbw-interface/default.nix
+++ b/distros/kinetic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-swri-dbw-interface";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_dbw_interface/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "1c777765f2fe459aac3e6bc2570eb46519fdcc2e12d6efde8bfba1026f48bd62";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_dbw_interface/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "a8a54bbdcbb090f25706cfdcc26109d348e829935176f38121689339e6237a5c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-geometry-util/default.nix
+++ b/distros/kinetic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-swri-geometry-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_geometry_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "f54773ff93988ef1122ec139a290ad6205a2e940dea0fe3123eaa78e175ade8b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_geometry_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "cce7347f08b3adfa9a6edc2a2be4c528a63b71a0560ee34742f322785240f642";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-image-util/default.nix
+++ b/distros/kinetic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-kinetic-swri-image-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_image_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "01a4b131a0aca4b2f1bb9fc4b58c2efa5e257b27798d262ae7547ab82134984e";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_image_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "93520a6958d9bc6ee577472608f669e6dbdf162cf1ed9c837fe80e27cddda0e9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-math-util/default.nix
+++ b/distros/kinetic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-math-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_math_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "2d930d2089e91c9a5ded1b27aa676d5adbcdf5662c379d64c61a79362442246a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_math_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "07ee68ea71ce6e50415d7c1b3c44d8bf42a043904d2301dee7b3d3eb401e3da2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-nodelet/default.nix
+++ b/distros/kinetic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-nodelet";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_nodelet/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "5d69f5292ee12db22fb818ef29fb5575cc7a1cb99fe5f49558a71fc46594a370";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_nodelet/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1d9a0e27ac1ed3ef62bd0d2478e5351b3b807f89a2b72666471b16873876e735";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-opencv-util/default.nix
+++ b/distros/kinetic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-kinetic-swri-opencv-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_opencv_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "d1a2e6aa769d9a9511d259f28b8c61abfe31623b2e814477fcad64cfbaf83dff";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_opencv_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "be61c751aad85b69b57c04ccecfe9d9ef6589bb506a824f5482687f779344a3b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-prefix-tools/default.nix
+++ b/distros/kinetic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-swri-prefix-tools";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_prefix_tools/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "f129f5e692e8071aa5762ebaadca3ac3100f1f1fbf7b6a816777118333766ae5";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_prefix_tools/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f0c85d4294304fbcde18c30b1b60084702cb18eecca43ae4bd054921cb1e9b8f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-roscpp/default.nix
+++ b/distros/kinetic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-roscpp";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_roscpp/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "2d80c80f21b80d8f389353584accedbf645848fbfce9e2e29d671180e26b38c2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_roscpp/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "35fae20a4e3f74dd739c6a7f854cef52da2e1ec76cd7022d1f3a7e914c74e776";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-rospy/default.nix
+++ b/distros/kinetic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-rospy";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_rospy/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "0032c8d177bb58fa332e47ff205c2d2e51b66983bed36078e84c1c0a654e95ae";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_rospy/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1fafcfafd33e57f47195e6cad70ce58885e07a3c6d86f0874013d0df3c1d0e72";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-route-util/default.nix
+++ b/distros/kinetic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-swri-route-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_route_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "86b7da6549f13080d05ee4fc5f78371aa36b151ec3ddb61be02935fcb6639c61";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_route_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "81c56f954f14801a3d7c1a4c81ab34d8170f40f7d5a1fa859f6cdfcb033cb66d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-serial-util/default.nix
+++ b/distros/kinetic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-swri-serial-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_serial_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "dd9c463a6b1445b9b82b9a1809ed2f54a76ab1342447df5f1698767b73e32043";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_serial_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "30999353a1721acca665017c4f7a95ea3e56da8a3a18dc4abada30936f9bd42d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-string-util/default.nix
+++ b/distros/kinetic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-string-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_string_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "7e1d7d3c800babcad80741897f1e6c28cd765b5a478dbb62300248ac160e41a2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_string_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "480635854a4e23067728148d3840d30312cf812733fa6b1b6b23a897f27d6d33";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-system-util/default.nix
+++ b/distros/kinetic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-swri-system-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_system_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "5f5a8ba9cb1b45c6033c256520aa7bf323ff60d56c21e6f32fc56850eb238e4c";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_system_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "0f1f0e29e0d5eb2ca4489d20e369476b23441be8b92b9dee66fc9537a18a9385";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/swri-transform-util/default.nix
+++ b/distros/kinetic/swri-transform-util/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, pythonPackages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-swri-transform-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_transform_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "dcd4f16ba41e928781e4548474f328020376cf76b6c8f6871ed1a66909683a33";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_transform_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "8811c2466e29a848a221edf5b09a2c9e83da0741853b3f31c7a550a4e6a374a8";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj pythonPackages.numpy roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
   nativeBuildInputs = [ catkin pkg-config pythonPackages.setuptools ];
 
   meta = {

--- a/distros/kinetic/swri-yaml-util/default.nix
+++ b/distros/kinetic/swri-yaml-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
 buildRosPackage {
   pname = "ros-kinetic-swri-yaml-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_yaml_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "6459b016826cfecea3c7dbb3d5901011afb2c31349f3d3ec673d9653e5b7cf0a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/kinetic/swri_yaml_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "90490378132b3ac952461a2ea1e4c3f0e37240ee8a5270380ccb4f03375989b8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "979ae27cd3e869f4df703ad93a68867a07b0c5a625820650b99106a3c8fc2ba8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "cae5d5bba90d4a6c86754be22e826c73f1a58e92fb1607e90e9a695079108065";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "c598f3484a0345f00e08eda077ff7d873a817cc756689d0f6644b3ba0aa69c20";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "a129cf2f56040aa080619cb54b4e5d5dba820daa33b15a4bbc5bc9676b306d21";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/turtlebot3-msgs/default.nix
+++ b/distros/kinetic/turtlebot3-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-turtlebot3-msgs";
-  version = "1.0.0";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release/archive/release/kinetic/turtlebot3_msgs/1.0.0-0.tar.gz";
-    name = "1.0.0-0.tar.gz";
-    sha256 = "d1784363fbd5e87c349d45d09b25f7c59f02d603d8fab5739d06dfd94197c589";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release/archive/release/kinetic/turtlebot3_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "9e80a7bfe69f5993a678510bb1b3a151ec521b0165923fc6279b9bdc1c35f5d6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/usb-cam-controllers/default.nix
+++ b/distros/kinetic/usb-cam-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, controller-interface, controller-manager, cv-bridge, image-transport, pluginlib, roscpp, sensor-msgs, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-kinetic-usb-cam-controllers";
-  version = "0.0.3";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_controllers/0.0.3-0.tar.gz";
-    name = "0.0.3-0.tar.gz";
-    sha256 = "a3f88938c7ba79e961dcec2ed5921cebfa88e94c857ac4855a8900bc650b1d75";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_controllers/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "a80034132c917cd10fa2ac8e47b7901e60917341982d7d4b5dad37fc1008fd71";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_controllers package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/kinetic/usb-cam-hardware-interface/default.nix
+++ b/distros/kinetic/usb-cam-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-usb-cam-hardware-interface";
-  version = "0.0.3";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_hardware_interface/0.0.3-0.tar.gz";
-    name = "0.0.3-0.tar.gz";
-    sha256 = "354d24284eee974c217e6c800c13dce30a348688e35558ca6aad9e857acd8d2e";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_hardware_interface/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "e11f4c6f0c30937eeede02a02cfc7677e46746f2baf89283ac949abb2fbf79a3";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_hardware_interface package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/kinetic/usb-cam-hardware/default.nix
+++ b/distros/kinetic/usb-cam-hardware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, hardware-interface, nodelet, pluginlib, roscpp, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-kinetic-usb-cam-hardware";
-  version = "0.0.3";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_hardware/0.0.3-0.tar.gz";
-    name = "0.0.3-0.tar.gz";
-    sha256 = "e7cdc34a962eb471e116d8cda31ab920b9422588d0b5b971090c3003a1cef35f";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/kinetic/usb_cam_hardware/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "9b76ad745241a7374a784fd041630e5661a55b0fcd6d0bc3ee64cabac7289c55";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_hardware package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/apriltag-ros/default.nix
+++ b/distros/melodic/apriltag-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-apriltag-ros";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "a703b93d69b4451a75acd90076aed64ca7eabe84e88eda2dc798b532de39fb52";
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/melodic/apriltag_ros/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "e30c59625ea64099fb38dab357f142b0182926b860615128e7e0a5f0d0948c39";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chomp-motion-planner/default.nix
+++ b/distros/melodic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-chomp-motion-planner";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "2224b38f8413b5a765d7c3cd3e213d7ab168ee25291124be2a543ac318ed9afa";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/chomp_motion_planner/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "15f7ca6d20b7ed483f60864e011e59002efbc288d9021b01ce5abd2dc29ca899";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "4ba9da0e767569e4386af0b46fe8c5a83eeb47c7b13511e607a1f9b830173316";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "705f6da30497ce7ba32427b89cffe84653a755a0f6f9fcb90327a7c044623169";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-can/default.nix
+++ b/distros/melodic/dbw-fca-can/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-can";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "96509722dd038c74b0905b89b8e5ee940190446cf61b9d4f63bd6c191a9d5b3d";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "2abd13f0fc3ae8bbd9ca5f346c1b9d61f36a56fe51a1b33e8343f43b07012933";
   };
 
   buildType = "catkin";
+  buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
   propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/dbw-fca-description/default.nix
+++ b/distros/melodic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-description";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "6ba589ca001f5f73c2479525cbadb50c8a17d045e526d4d4481c104028c6b87f";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "af79b2915a2f7157fda28f56c9fd3e917afbf55504015d0ab0797add1be04636";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-joystick-demo/default.nix
+++ b/distros/melodic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-joystick-demo";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "5be5b5800bcae7a6667789cd54e34f95bdccbf0f118932369e74d0912a7a3e78";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "34b2c455eea10d73bc443105314109cd9837792a5e836fb9148cd79314eb544e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-msgs/default.nix
+++ b/distros/melodic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "2307d4b9754ca3be66c3df4dd763cc49e715260ddaf78c90d07594b963d98737";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "56caa5fb543db897ecc2e2dd614488120375fafbf8711c9ce12d9bf3e8b76afb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca/default.nix
+++ b/distros/melodic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "bd90d2ef8a5cd91d8021389e8114203d531f400b2d1df44ccd34066c8d61f09a";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "758a1c41ad0b146d0c5a8a8d74e6a108f3b823ef3b93dcdb157a18a670d033c8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1782,8 +1782,6 @@ self: super: {
 
  moveit-controller-manager-example = self.callPackage ./moveit-controller-manager-example {};
 
- moveit-experimental = self.callPackage ./moveit-experimental {};
-
  moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
@@ -1830,6 +1828,8 @@ self: super: {
 
  moveit-runtime = self.callPackage ./moveit-runtime {};
 
+ moveit-servo = self.callPackage ./moveit-servo {};
+
  moveit-setup-assistant = self.callPackage ./moveit-setup-assistant {};
 
  moveit-sim-controller = self.callPackage ./moveit-sim-controller {};
@@ -1845,6 +1845,8 @@ self: super: {
  mpc-local-planner-examples = self.callPackage ./mpc-local-planner-examples {};
 
  mpc-local-planner-msgs = self.callPackage ./mpc-local-planner-msgs {};
+
+ mqtt-bridge = self.callPackage ./mqtt-bridge {};
 
  mrpt1 = self.callPackage ./mrpt1 {};
 
@@ -2235,6 +2237,8 @@ self: super: {
  pilz-robots = self.callPackage ./pilz-robots {};
 
  pilz-status-indicator-rqt = self.callPackage ./pilz-status-indicator-rqt {};
+
+ pilz-store-positions = self.callPackage ./pilz-store-positions {};
 
  pilz-testutils = self.callPackage ./pilz-testutils {};
 
@@ -3087,6 +3091,8 @@ self: super: {
  rtmros-common = self.callPackage ./rtmros-common {};
 
  rtmros-hironx = self.callPackage ./rtmros-hironx {};
+
+ rtmros-nextage = self.callPackage ./rtmros-nextage {};
 
  rviz = self.callPackage ./rviz {};
 

--- a/distros/melodic/hls-lfcd-lds-driver/default.nix
+++ b/distros/melodic/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hls-lfcd-lds-driver";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/melodic/hls_lfcd_lds_driver/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "d748e0b392248e2d2c64695d95a7ac37fe884a0f0c999e2e0c8e69931efeda89";
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/melodic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d178dcdb4efd0c7550eaa85e02e59e874221e0fb3a34e2c1c21b136fbcfc16d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "ac8fe08e6167c3a9f86103b5d7251f880a446669112d8384ee0ff2cc1332b42a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "85f353fd431c984a2776d0d4ab6fe50ea438164ddbb17995cfcc4fd4b6f6cdc6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-scan-publisher-tutorial/default.nix
+++ b/distros/melodic/laser-scan-publisher-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-laser-scan-publisher-tutorial";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/laser_scan_publisher_tutorial/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "a2ae17a2a286701f18239ceb8e8ce3723a45bf349ecfd3df1f4d085f25174fbd";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/laser_scan_publisher_tutorial/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "c0b0218c7cd794f7c3a06cb85c2d8d3df2fce24a5a8ebea919021ec6084d98c5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.35.2-r2";
+  version = "2.36.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.35.2-2.tar.gz";
-    name = "2.35.2-2.tar.gz";
-    sha256 = "7e72c4cc5911111e6c2c37ba2b433f98f139386fc78a066db25f7255c82a86fc";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.36.0-1.tar.gz";
+    name = "2.36.0-1.tar.gz";
+    sha256 = "de57b6a0c7e42345c17fc4a999925c3a93b3651a06b1af7485f78ebce4d40fcd";
   };
 
   buildType = "cmake";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "87525c19a34ed1e13d208dab1f5c925aee3ac35ff69a3a68d0bbe8ab7f59087c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "be7b5b3e3a3d7ea00a198104fd4c3e3a7608aaec3693998d48b109e14bc1b5ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-data-structures/default.nix
+++ b/distros/melodic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-marti-data-structures";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/marti_data_structures/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "e27860dddee53b9e385be3b5a67b64bfc18f5b154cdfc4bd73b98a32436db3a5";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/marti_data_structures/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "aab13c8429ea5b71ba1588da0b7b94b7079b768bc71eb77eb27e2a1f42cc780f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/melodic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-melodic-moveit-chomp-optimizer-adapter";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "000acaeaf53f74d81b565dc2e42a88f3e8eb3234cde04fded31114b6da56bb7b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_chomp_optimizer_adapter/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "936e6e15d721ea052ea25ae7b72c4718883c30d750b4e6b64b8b4943f49b6227";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-controller-manager-example/default.nix
+++ b/distros/melodic/moveit-controller-manager-example/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-controller-manager-example";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "0d62051fc967e5bb92c523bb86cf904f7eccca7fe88d77633871eef36cdbae06";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_controller_manager_example/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "cea8d3d7a351ff61db38a6b4054150fedb12707ad7a82b24f87d02f575b1ea00";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-fake-controller-manager/default.nix
+++ b/distros/melodic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-fake-controller-manager";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1f7feefa5884b7f2a4299bb4df48164f130a09073eb103bab9abdc6dcf90c048";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_fake_controller_manager/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bc614a21feaa5631fb341d38688a07525911da16a7bb2e60844352f79983bb0f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-kinematics/default.nix
+++ b/distros/melodic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-kinematics";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "f198d6a837c63f94ad7bb0ee0d490bd8fc2abce1e70d044ae8ee1cf2f4b21a68";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_kinematics/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ef091efe076e61dc40cd7cc66b2fb2bbe9f9797cc7b66a578a386ec823d94d5e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-chomp/default.nix
+++ b/distros/melodic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-chomp";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ba4b086bde240d7bb134715761d8079f4ab533ff3eb641e10a3191c24d7de389";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_chomp/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "93e1fad681a0a8c4d23f0e7a81b9eefa7da776d3a07fd5d839373b3ef2377aab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners-ompl/default.nix
+++ b/distros/melodic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners-ompl";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "eac77ce7ecece47dc3b9c3c301830ab281533b3ec578a4d55038fe26c528c110";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners_ompl/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7d621971b4d0423a01e58ab980ae0b0abfbdbda2f30c27e52281f5fef627d54e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-planners/default.nix
+++ b/distros/melodic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-planners";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "547543d86aafe00698991a8c93e6f1d48fdb5ca3c30471bf0641efead444d92c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_planners/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ab1abb8dd169527320ba4f4ccb669cc32c0402bff02f5293619e15f790a38576";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-plugins/default.nix
+++ b/distros/melodic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-melodic-moveit-plugins";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "9b302f534ff8980927d0f02e1e7846168438e7045250b9205ead7c6986f870bb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_plugins/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "2334af9820618973c3d20bfbe0b38bcb59114733c094b2288c11a21b46ac9a9b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-benchmarks/default.nix
+++ b/distros/melodic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-benchmarks";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "68eccb4d52c73395d0a0b1fd14632757a61e7bc58e31c57bfea776682614b465";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_benchmarks/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "7cce9106d2c426929caad8d136e8ea5737426b3b392cb4641365a5d1a910c85f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-control-interface/default.nix
+++ b/distros/melodic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-control-interface";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "86f51712fef6308ec700345b468be3ca094320362cd07cab72adf9c89217170c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_control_interface/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "097de586589ad4ed6f74b56578e990b79261b47daddc080a6427d8fcf2b1fc02";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-manipulation/default.nix
+++ b/distros/melodic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-manipulation";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "60ebd2266a1fd32df6b935f8a3d9e9fef350f15faa6d8a7975921c81d25c49d7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_manipulation/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "49199bee5e1d653f69e6f00cbeaa427459ea748a5e869bac685eb06acefceb8b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-move-group/default.nix
+++ b/distros/melodic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-move-group";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "dc44ae4e8f512f3d32e4bc83f4cac096b414a2d1d142edb3c51998bd9d26357e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_move_group/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ad99cd0211741773b9576f1bb236883c07b6ecdc9b8e905be3d754f98dac3ae0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/melodic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-occupancy-map-monitor";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "88e331c73ae8481aa96aea9e193efa888d2114ec5354f29662061c04bfd947be";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_occupancy_map_monitor/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "b42c9d25d6f6cbce9ea9c1974f429ccf4dee7a9cb1aa82f397f4a6d9b0803b69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-perception/default.nix
+++ b/distros/melodic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-perception";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c4f4928ac27a6a69aeda2f0e4539e92e299d8579aebc0d3291c9d373dc5d5e3b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_perception/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "818c53b4e47bdf19711b6c5d7637ffe9633fb3b6fba30a335db79d0b1cceed83";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-planning-interface/default.nix
+++ b/distros/melodic/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python, pythonPackages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning-interface";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "f652004ec1003945b933ec3efe53dff095136817a3674eb525c7968f573409d1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning_interface/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e97d65d48503f156cfd24e4c74f26e0f0125299a6ae5edad6ede3e24a987e33c";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen ];
-  checkInputs = [ moveit-resources rostest ];
+  checkInputs = [ eigen-conversions moveit-resources rostest ];
   propagatedBuildInputs = [ actionlib eigenpy geometry-msgs moveit-msgs moveit-ros-manipulation moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python rosconsole roscpp rospy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin pythonPackages.catkin-pkg ];
 

--- a/distros/melodic/moveit-ros-planning/default.nix
+++ b/distros/melodic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-planning";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "de1389300435535c314721f75a9201b6cd8ce9e594ce811fa8f4ef55c62f679e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_planning/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "2d8596f779dee13cc517584c09083c0cbbf68aff9bc43a5924fe9f2f695e9175";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-robot-interaction/default.nix
+++ b/distros/melodic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-robot-interaction";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "c19096e9aa75f78adfe5dc32ba5de6359ba3f4e92b397ef59cf6bc2c95a4787f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_robot_interaction/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "5368e97e86d48adca87f5fe04a0e5547faaf705625a96dd333fa54ce0462439d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-visualization/default.nix
+++ b/distros/melodic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-visualization";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "dfa6bf99363798a3be585f35be0f98ce43e7ef1bad93dd3df504dbc213895b3c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_visualization/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "8e38d05a56b957d38b87b00c2af268ac7b0bf5f8c270ac750867ebeb987d4874";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros-warehouse/default.nix
+++ b/distros/melodic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros-warehouse";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "7af8a9eb7715671578a06554c6c02ae3ad5a9c315fd12d354257a0c6873774c6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros_warehouse/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "b0c96c7cbac60eaffbbb65d3458db4fe722ec84a316ab8334c9d6b32f8393d5a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-ros/default.nix
+++ b/distros/melodic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-ros";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "3b5648d93088fab229febc1d0e74cc9da57c4cb5b6aa0084bc083ac0dad59878";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_ros/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f65732f7ac3c0694ff15b9897994a964e403c282952f4ed9891c6e9abacca1a1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-runtime/default.nix
+++ b/distros/melodic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-melodic-moveit-runtime";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "85c5f93107c37e8a97659bd43e92a7e2587801168fce0e99c16d4ddab74abb6f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_runtime/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "3340248ffc0695fe80a93d7ec9d5b2fdaee6cb96d279205a51bc07e7c7edfcfb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-servo/default.nix
+++ b/distros/melodic/moveit-servo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-moveit-servo";
+  version = "1.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_servo/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "33869a8bc86e46a6cde13464e608d62782b2a3683463848005776affde5514fd";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ moveit-resources rostest ];
+  propagatedBuildInputs = [ control-msgs geometry-msgs joy-teleop moveit-msgs moveit-ros-planning-interface rosparam-shortcuts sensor-msgs spacenav-node std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides real-time manipulator Cartesian and joint servoing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/moveit-setup-assistant/default.nix
+++ b/distros/melodic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources, moveit-ros-planning, moveit-ros-visualization, ogre1_9, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-setup-assistant";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1e23726919235ba613a9a764245094d633e4f26d15e86a3359ea85fc2644cac5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_setup_assistant/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "18c2b60015a48210fa38677db8c713872cb76a3f9148cbcf74cedf643b341c73";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-simple-controller-manager/default.nix
+++ b/distros/melodic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-moveit-simple-controller-manager";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "ad2ec0bfb1a46c154f023ffc6076c7013f4ce0a8b61e101b66fcbec05d079db7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_simple_controller_manager/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bdb0551b6bde54d1903ea438be6efa48d9eeef767e419d190109027a2c864319";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit/default.nix
+++ b/distros/melodic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-melodic-moveit";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "e36c58bf4f0ddaea4772108cacd3c3f8d77ff237d9117da763c27b73e851f6d3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "e57ceeb7039229412801f4d8ea5863e30ccb878f27e3570f242ca82b5bb09fd2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mqtt-bridge/default.nix
+++ b/distros/melodic/mqtt-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosbridge-library, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mqtt-bridge";
+  version = "0.1.7-r7";
+
+  src = fetchurl {
+    url = "https://github.com/groove-x/mqtt_bridge-release/archive/release/melodic/mqtt_bridge/0.1.7-7.tar.gz";
+    name = "0.1.7-7.tar.gz";
+    sha256 = "9634feb4b2d21c826199396342529bccf22aaa9c7c262446f9a03e6165c920b8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rosbridge-library rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mqtt_bridge package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/navigation-stage/default.nix
+++ b/distros/melodic/navigation-stage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, fake-localization, gmapping, map-server, move-base, stage-ros }:
 buildRosPackage {
   pname = "ros-melodic-navigation-stage";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/navigation_stage/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "369bdc91f45d18128113301f533112e08708c83e02b16ae38f1bd765114d6310";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/navigation_stage/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "7b69a708535f1a2a6fb5afa0c6cb62c8ca229a04e0d9a979b2cd3f5e65ca35a9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/navigation-tutorials/default.nix
+++ b/distros/melodic/navigation-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-scan-publisher-tutorial, navigation-stage, odometry-publisher-tutorial, point-cloud-publisher-tutorial, robot-setup-tf-tutorial, roomba-stage, simple-navigation-goals-tutorial }:
 buildRosPackage {
   pname = "ros-melodic-navigation-tutorials";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/navigation_tutorials/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "0dc79f75fcfaff0dd5de61b32502b6e657d2e5d2994252bd974989e8a1848793";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/navigation_tutorials/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "c6c2d22bc24f5e224dbb15758e735708f490409a2318427b00d7ac673a4bf32d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "4788c8ace5864e84457797494477808fb8bcd5070c9a2f84a5d68bdfae755ede";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "9bc31f94900050a97b02388e70f60bd0a94662558e8411f4af9f062337b65d7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "a8f96614bcac226c9903ab496ac8fc7bf1a32806a2522eceeabc314e4f570525";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "bd1af0cefd7ac7685b87cb120a5edfa7c40d7633d528dfd834d0dbcb3b0679c4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "3c6318b8d16feaf0db3b0efd3775f46ad36910fefabe237a5e97e8ad79cb2fdf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "834b0c33cceda04f42578ddd8815a36fad4248589765c5513accb1d83c638822";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-description/default.nix
+++ b/distros/melodic/nextage-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf }:
 buildRosPackage {
   pname = "ros-melodic-nextage-description";
-  version = "0.8.6-r2";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_description/0.8.6-2.tar.gz";
-    name = "0.8.6-2.tar.gz";
-    sha256 = "c06c664de39850b480423fb108db95240ffc80ee76ce0e359e0f1258350961d8";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_description/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "fc5de78839960234d82b28541e497fba5ed8f85d81e6edaaeb6da0a4acb6db43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-gazebo/default.nix
+++ b/distros/melodic/nextage-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, nextage-description, nextage-moveit-config, ros-controllers, rostest }:
 buildRosPackage {
   pname = "ros-melodic-nextage-gazebo";
-  version = "0.8.6-r2";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_gazebo/0.8.6-2.tar.gz";
-    name = "0.8.6-2.tar.gz";
-    sha256 = "4dacb42e09770b860820cebba3aec0d2b3015de683d62b373179b43cf177ba44";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_gazebo/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "bafdf9503709b361786350ec586dfc827e3d65b05f5c2ce69be727d093050be1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-ik-plugin/default.nix
+++ b/distros/melodic/nextage-ik-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-nextage-ik-plugin";
-  version = "0.8.6-r2";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_ik_plugin/0.8.6-2.tar.gz";
-    name = "0.8.6-2.tar.gz";
-    sha256 = "3b0cc08f63314cf443553181e6482f742c30fb74b18750c213a8d62ea0fce0a3";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_ik_plugin/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "fc2949716c46013dfd7fd58720b47bfda645c0854145e72126d0366e201a0be6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-moveit-config/default.nix
+++ b/distros/melodic/nextage-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hironx-moveit-config, joint-state-publisher, moveit-planners, moveit-ros, moveit-ros-move-group, moveit-ros-planning-interface, moveit-ros-visualization, moveit-simple-controller-manager, nextage-ros-bridge, robot-state-publisher, rostest, trac-ik-kinematics-plugin }:
 buildRosPackage {
   pname = "ros-melodic-nextage-moveit-config";
-  version = "0.8.6-r2";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_moveit_config/0.8.6-2.tar.gz";
-    name = "0.8.6-2.tar.gz";
-    sha256 = "5a07e0b4721870aeff7a976dc04db078aad81a5faa0d69dad7959ebf59bf621b";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_moveit_config/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "f788c840073dd3e24b8bd1fe72976ff35ae5885b88439ece7c649af799f4ee80";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nextage-ros-bridge/default.nix
+++ b/distros/melodic/nextage-ros-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ar-track-alvar, catkin, hironx-ros-bridge, nextage-description, roslint, rostest, stereo-image-proc }:
 buildRosPackage {
   pname = "ros-melodic-nextage-ros-bridge";
-  version = "0.8.6-r2";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_ros_bridge/0.8.6-2.tar.gz";
-    name = "0.8.6-2.tar.gz";
-    sha256 = "5014d98f0b9d5cf399ba28e4d5e6ad295fa53a27f0c33513fe8db544e9661d3c";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/nextage_ros_bridge/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "f727161636ea80db90488a1fd7d46ace9735585285f3af2cd6a8dd4fdf846f2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "40601832795ea5313f0401d4e8b3fd609f76b35c3f9187022d7d14d1969a68da";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "57a346f0fe7242787f4eaa036fc4ccc9bc4d5f6a51d47bdc808743799b277254";
   };
 
   buildType = "catkin";

--- a/distros/melodic/odometry-publisher-tutorial/default.nix
+++ b/distros/melodic/odometry-publisher-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-odometry-publisher-tutorial";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/odometry_publisher_tutorial/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "2f5bd429f29f3d9c424db0f617558d73af9c851f1087f24742ebdda967f4e664";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/odometry_publisher_tutorial/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "527ce0ada618e0e9a3109b743ceb896dd43f53e32acbe8bd948bf5cd82b23748";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-extensions/default.nix
+++ b/distros/melodic/pilz-extensions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, joint-limits-interface, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-pilz-extensions";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_extensions/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "73843793e0904c3c122e5c83c23e1f2b00a4661d0a9aff6ed630faeadd67af1f";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_extensions/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "8706781c11acadf051e68e804aedf2198e855f873198a9d4117c9a415f30d8bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion-testutils/default.nix
+++ b/distros/melodic/pilz-industrial-motion-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-commander, moveit-core, moveit-msgs, pilz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion-testutils";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion_testutils/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "fd839ad672afda28b7730b366bbd35df8866b034d39e0de791a0573c168087f8";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion_testutils/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "9b3a7d28215e7e282d4e9d5b93c36ee832b664a8d5d847c44ad149bdac6c990e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion/default.nix
+++ b/distros/melodic/pilz-industrial-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-extensions, pilz-msgs, pilz-robot-programming, pilz-trajectory-generation }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "d3c47872d7be84ebddf35bb90ef3ca2ad2f690a663f70672f9b8f7338050859d";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "efbd579fd09475b7933f7a154c43198f6b8df1295aefccf946e29654df1c0e36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-msgs/default.nix
+++ b/distros/melodic/pilz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-msgs";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_msgs/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "937bb1f1603f5e16e9508ac7f4413011590f25cf452695da17e6687588d7a1c1";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_msgs/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "fac7d90d19ca56776af8459809406baac313f24335ff7902ac0f05f9e8fdac27";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-robot-programming/default.nix
+++ b/distros/melodic/pilz-robot-programming/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, moveit-commander, pilz-industrial-motion-testutils, pilz-msgs, pilz-trajectory-generation, prbt-moveit-config, prbt-pg70-support, pythonPackages, roslint, rospy, rostest, rosunit, tf, tf-conversions }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, moveit-commander, pilz-industrial-motion-testutils, pilz-msgs, pilz-trajectory-generation, prbt-moveit-config, prbt-pg70-support, pythonPackages, roslint, rospy, rostest, rosunit, tf-conversions, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robot-programming";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_robot_programming/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "8e62a064d692627092b97d2d2c6ccb735468197d97a881df6542b6a2e75ce8a5";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_robot_programming/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "2080175dbc3fc4f9504e055296af871ce5367ac1fbc869d16ee57bfc1492f4d1";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  checkInputs = [ pilz-industrial-motion-testutils prbt-moveit-config prbt-pg70-support pythonPackages.coverage pythonPackages.docopt pythonPackages.mock rostest rosunit ];
-  propagatedBuildInputs = [ moveit-commander pilz-msgs pilz-trajectory-generation pythonPackages.psutil rospy tf tf-conversions ];
+  checkInputs = [ code-coverage pilz-industrial-motion-testutils prbt-moveit-config prbt-pg70-support pythonPackages.coverage pythonPackages.docopt pythonPackages.mock rostest rosunit ];
+  propagatedBuildInputs = [ moveit-commander pilz-msgs pilz-trajectory-generation pythonPackages.psutil rospy tf-conversions tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pilz-store-positions/default.nix
+++ b/distros/melodic/pilz-store-positions/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, geometry-msgs, libyaml, pythonPackages, ros-pytest, roslint, rospy, rostest, std-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pilz-store-positions";
+  version = "0.4.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_store_positions/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "eeb1b6477af7e08da098c06a18a1bac417ba64dcbcb07956331030961ab38ff9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint std-msgs ];
+  checkInputs = [ code-coverage pythonPackages.mock pythonPackages.pytestcov ros-pytest rostest visualization-msgs ];
+  propagatedBuildInputs = [ geometry-msgs libyaml rospy tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Allows to store poses during teach-in.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/melodic/pilz-trajectory-generation/default.nix
+++ b/distros/melodic/pilz-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, eigen-conversions, kdl-conversions, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-extensions, pilz-industrial-motion-testutils, pilz-msgs, pilz-testutils, pluginlib, prbt-moveit-config, prbt-pg70-support, prbt-support, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-trajectory-generation";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_trajectory_generation/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "2ed5cdd473ec158b703757562794c8981cdf6a44c290f776d6307a6b807dc42c";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_trajectory_generation/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "dd9eb39d48554378c2a80e3e15a00106fcdb3356dfed82b85b2e364189276711";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "0179466fe0692c8acb65d84a86b43ac8d970c3dd9ce8829d2f4792db7bc3255b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "2390c418449db49280bfbed744627ed07ba3e1b53a4cce83b4e3c4d2bc24387a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "76f2337a863336bc00a4ad3aa222c683fdc612cdbc3c0dac7f21438ec26e8d53";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "868283fbe19b1d554d49a588c8d9e8fd01a16e696a43a474de29a1b595f81c8b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/point-cloud-publisher-tutorial/default.nix
+++ b/distros/melodic/point-cloud-publisher-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-point-cloud-publisher-tutorial";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/point_cloud_publisher_tutorial/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "0d214a51702c19e1fdfc493801baed7c5a4c23c3b543bd66f1b84500f300d96e";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/point_cloud_publisher_tutorial/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "f7cacd1a860ecf30ebb011da43d04f9992cf1cfed04b8ff1e5b6d1ccb55f0680";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "6851e08defc6323e042eb92fe6411c3005ac6b46435674230d9689d0afe8e86c";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "6509ab44fd948de5873dd22296d2fab0093f35911614363cb7cdadd908a881b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.14-r1";
+  version = "2.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.14-1.tar.gz";
-    name = "2.2.14-1.tar.gz";
-    sha256 = "01d818f0390c8ac2de1280702466c247e9c928986498e02f4cf7b6ebb9724ea2";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.15-1.tar.gz";
+    name = "2.2.15-1.tar.gz";
+    sha256 = "44cc5edbf2b4acd92224f0965102209fc6726a95706fc38542384923866b7961";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-setup-tf-tutorial/default.nix
+++ b/distros/melodic/robot-setup-tf-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-robot-setup-tf-tutorial";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/robot_setup_tf_tutorial/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "56636941f8a10861807e4cd860cf5c123247372f2f079f250aa2e26d0990000d";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/robot_setup_tf_tutorial/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "fed0dd85c06de7584585f1940e91a5f591c8c2d33375aae4d83beaee5725ad65";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roomba-stage/default.nix
+++ b/distros/melodic/roomba-stage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fake-localization, map-server, move-base, stage-ros }:
 buildRosPackage {
   pname = "ros-melodic-roomba-stage";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/roomba_stage/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "3eb6f70b0f7abdfe001d4ca9ce4c387b8604bbd788a4c11ccd2d8a4c3a79e433";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/roomba_stage/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "36ce4d4177e886417214af1136d05abf9c665f404b3ae0037020b0b2675693ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.19.3-r1";
+  version = "0.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.19.3-1.tar.gz";
-    name = "0.19.3-1.tar.gz";
-    sha256 = "5d5099589b46f8aec805e0f7b194b7d6a87960778034d3893347e0ec3b078ef8";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.0-1.tar.gz";
+    name = "0.20.0-1.tar.gz";
+    sha256 = "b8d4832ba5b71f7e36d4be3c907e77955d80e78d8e1de0b5d1385dcfd8b104a3";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/melodic/rtmros-nextage/default.nix
+++ b/distros/melodic/rtmros-nextage/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, nextage-calibration, nextage-description, nextage-gazebo, nextage-ik-plugin, nextage-moveit-config, nextage-ros-bridge }:
+{ lib, buildRosPackage, fetchurl, catkin, nextage-description, nextage-gazebo, nextage-ik-plugin, nextage-moveit-config, nextage-ros-bridge }:
 buildRosPackage {
   pname = "ros-melodic-rtmros-nextage";
-  version = "0.8.6-r1";
+  version = "0.8.6-r3";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/rtmros_nextage/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "1782ef9b7f29f11fcd1fd6f8c66dc6f65044e3f5b4343868678e6b6fd6ce4704";
+    url = "https://github.com/tork-a/rtmros_nextage-release/archive/release/melodic/rtmros_nextage/0.8.6-3.tar.gz";
+    name = "0.8.6-3.tar.gz";
+    sha256 = "f2c142f406e576dcf8820ec267d0dfb4c3dec98e32d87dc15e9901bd17451660";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ nextage-calibration nextage-description nextage-gazebo nextage-ik-plugin nextage-moveit-config nextage-ros-bridge ];
+  propagatedBuildInputs = [ nextage-description nextage-gazebo nextage-ik-plugin nextage-moveit-config nextage-ros-bridge ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "adf300c07c0b409314ec2a3630a82620925c89526c5027bbda2b6bb61018bdde";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "6d054a85c9fdf7aad259b6908d7bb378b7fb638e3f12cbc3b9bf8878d8f19787";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sick-scan/default.nix
+++ b/distros/melodic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-scan";
-  version = "1.7.6-r1";
+  version = "1.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.6-1.tar.gz";
-    name = "1.7.6-1.tar.gz";
-    sha256 = "6ef933174a40989020b0af747bcc51d872e241fcc4fd2c79bc6b58e5640c58fb";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.6-2.tar.gz";
+    name = "1.7.6-2.tar.gz";
+    sha256 = "3d8ce4d0caf8c7ffc51b43f6e9312412a38c48048551fd935f2365e3f1ce04c4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/simple-navigation-goals-tutorial/default.nix
+++ b/distros/melodic/simple-navigation-goals-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, move-base-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-simple-navigation-goals-tutorial";
-  version = "0.2.3-r1";
+  version = "0.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/simple_navigation_goals_tutorial/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "822743ee6df1764688c0cd3898150d95fa634fc85224ee6e2024d2f45f9d1799";
+    url = "https://github.com/ros-gbp/navigation_tutorials-release/archive/release/melodic/simple_navigation_goals_tutorial/0.2.4-1.tar.gz";
+    name = "0.2.4-1.tar.gz";
+    sha256 = "463089eeedbdf2ae763fd9459fc309d5fa85bae49f8f6d7129587b36b067a622";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-console-util/default.nix
+++ b/distros/melodic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-melodic-swri-console-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_console_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "81162c0a6f7bd8994fe453745895324c45d6389046ba7b28c303cfbd845b2697";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_console_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "45c76f17a3623f373075a1dc83be915e59693bdd5b4f61243854054e705b9c1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-dbw-interface/default.nix
+++ b/distros/melodic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-swri-dbw-interface";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_dbw_interface/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "d74d1c82dc1f74f235f34ec66aee08101ccf404fa7f4131f6e497788d9e8a27f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_dbw_interface/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "43571481fa612847d568386ec277bf78fc1c6a1deee2e5fd139d96d03801507b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-geometry-util/default.nix
+++ b/distros/melodic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-melodic-swri-geometry-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_geometry_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "9b42120111aa3dd5c48efe01113e4f5298650c3abc125f3c34a480d1e6e00892";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_geometry_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "b70981370edbefe2dcae962223447cb0daea17b531b1d29f2fe48331c15f6fee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-image-util/default.nix
+++ b/distros/melodic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-melodic-swri-image-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_image_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "e9e78f2604416a4c7a59af0a5c19072d83edd5a88980b365c0980d71af6029be";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_image_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "adc8daa043f7973e5006b49481e021d8c092ad5a092282835fde8b4483d03278";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-math-util/default.nix
+++ b/distros/melodic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-math-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_math_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "81ddbc5ce7286cac7066957f2bd59037132ba3f75b974bad5368da0a60264749";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_math_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1c24eb47c6fad489e011e6f3eae111e015c168780e7177c68416a6bb774b6c41";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-nodelet/default.nix
+++ b/distros/melodic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-swri-nodelet";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_nodelet/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "8a966aa7b1b49f85372cf958189a81a6cddfb44ef54208dbd42d95f7a5bec508";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_nodelet/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "8b519aa6336cc2d02e9fec51959b9aa6837562f345e183cdbeab2ded9ceec2e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-opencv-util/default.nix
+++ b/distros/melodic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-melodic-swri-opencv-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_opencv_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "bd85456c9599156025dcf5fa9bd4e82cb2f9cf9bc6ca74e4aa9c507c7fcb96c7";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_opencv_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "0e4c26aa47124e1e55ce6aea6658a4f83fa169bdaea2bd55c948154df802e129";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-prefix-tools/default.nix
+++ b/distros/melodic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-swri-prefix-tools";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_prefix_tools/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "2c16aa6654d707868a2e25e6f013244ae0b4c9efe6e589f77abec2744da146ea";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_prefix_tools/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "07cce45972c437e73700eb3a53cddacf380fb9bc33891340191fe4f13b304804";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-roscpp/default.nix
+++ b/distros/melodic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-swri-roscpp";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_roscpp/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "14d07b20c176e0b01b0267ce509cea1da54d8b4496a2b89de2f740b239cff653";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_roscpp/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f9b00c90fa95dce459d21b7447c77e328e7fafdbcddc9db00aa02c490c7cdfe7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-rospy/default.nix
+++ b/distros/melodic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-swri-rospy";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_rospy/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "3747ca0c3dc30aa14e24acad37fd191728230cf7fe353a74ec5621707752778b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_rospy/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e319c33b4b05ca2a9bd8d142c54603bbf7cb2b6308f6571ec6f77e5f347bb496";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-route-util/default.nix
+++ b/distros/melodic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-swri-route-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_route_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "041ad9e1fa3e5a4039f8cb36d9d8897df7ea2649031cae9e09fad0e194f3860f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_route_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "8b29cfb021f40ecca0ba98f83d209d5e6693c39f44507bf6f21b149ce33d58ca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-serial-util/default.nix
+++ b/distros/melodic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-melodic-swri-serial-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_serial_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "d8f88e9a98bc825193bb7b7b57ae1e8704ae411a2fb884ad5b2edee8d7191726";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_serial_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "17f60bba6b5da790c9a9def4ebf53dd116c252868db3e4d08493be4b5c67bb97";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-string-util/default.nix
+++ b/distros/melodic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-string-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_string_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "71195166737246eededb0d793f606c728f5df5b1ace8df2543871478e984b80b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_string_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "561a17dee7a71ebba0151ab2a90d7bf3cd75a4a4fdfd05564a86ac89d34b3bce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-system-util/default.nix
+++ b/distros/melodic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-swri-system-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_system_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "9c7199344d3f653d1dfa72ba96ed6345a4f4f6a6cd56476a3107f70f34b46900";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_system_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7ef1848e804f5fbd316930ba3ffecfb0a0d4121b5a64b7bb1f2268d49537284b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/swri-transform-util/default.nix
+++ b/distros/melodic/swri-transform-util/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, pythonPackages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-swri-transform-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_transform_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "56015990a895a067705e62289be7010c0ea17f2b8723592d57722eee35b60429";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_transform_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "df210c6721b8727eecf474e09e03656ed82e484d78bd3d942e7c4b983b653283";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj pythonPackages.numpy roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
   nativeBuildInputs = [ catkin pkg-config pythonPackages.setuptools ];
 
   meta = {

--- a/distros/melodic/swri-yaml-util/default.nix
+++ b/distros/melodic/swri-yaml-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-swri-yaml-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_yaml_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "dbbcfe6df04855f34053e80278d69d57b3bc58c0744a1e986dd5ea2c900f2a82";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/melodic/swri_yaml_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "31694538caf69f051d66b9189890e6a0ca0bf57bead3b3fef78d3c39f03e36d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "9276569802c8571f3c231ee088f01e14ec70802e98722475e733c8b794b8309d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "8c8a237f3528ea7092f566685d75ec9d309bba15afae5eedd5696c2e444e46bd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "dae79f14ff47881c7e8f33631328c525ac8c5d87e6b2ece3f273a3ff65ef4724";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "a62778910f603f12e0ddb46c8d8543731b87bffd413d30af55508c3494025aaf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/turtlebot3-msgs/default.nix
+++ b/distros/melodic/turtlebot3-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-turtlebot3-msgs";
-  version = "1.0.0";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release/archive/release/melodic/turtlebot3_msgs/1.0.0-0.tar.gz";
-    name = "1.0.0-0.tar.gz";
-    sha256 = "45317e8776023604286708e4f7f9b206d3d64e59601af91849a5f80b94cbd0db";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release/archive/release/melodic/turtlebot3_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c5c91c55fd028b5e07dde17b1e0c380618ce4dcffddb0a315c267106181c5697";
   };
 
   buildType = "catkin";

--- a/distros/melodic/usb-cam-controllers/default.nix
+++ b/distros/melodic/usb-cam-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, controller-interface, controller-manager, cv-bridge, image-transport, pluginlib, roscpp, sensor-msgs, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-melodic-usb-cam-controllers";
-  version = "0.0.4";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_controllers/0.0.4-0.tar.gz";
-    name = "0.0.4-0.tar.gz";
-    sha256 = "e4c15169d9f29ff1ed5ac782395a6f6251130a54c23b42be7a81ed26c0ef7ce6";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_controllers/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "1f3b3500161706be6f2420612ecfff387942aa71cd1cc755da4c40267c707891";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_controllers package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/usb-cam-hardware-interface/default.nix
+++ b/distros/melodic/usb-cam-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-usb-cam-hardware-interface";
-  version = "0.0.4";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_hardware_interface/0.0.4-0.tar.gz";
-    name = "0.0.4-0.tar.gz";
-    sha256 = "27863a2c68f5c59653e0625b1aafd1edb8f12f90c4439176db8a325a26f79b61";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_hardware_interface/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "96288caef7a5aed8832e30d5a874e820179435133deacf8159186cd2d7ab2c33";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_hardware_interface package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/usb-cam-hardware/default.nix
+++ b/distros/melodic/usb-cam-hardware/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, hardware-interface, nodelet, pluginlib, roscpp, usb-cam-hardware-interface }:
 buildRosPackage {
   pname = "ros-melodic-usb-cam-hardware";
-  version = "0.0.4";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_hardware/0.0.4-0.tar.gz";
-    name = "0.0.4-0.tar.gz";
-    sha256 = "29d9274d9b3cf8787c3f80c5354eb605608205118e6ccf56a2aabd26011f7b43";
+    url = "https://github.com/yoshito-n-students/usb_cam_hardware-release/archive/release/melodic/usb_cam_hardware/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "d2548637f0638d86eb84a650f0db22fe13cefda2a17ee16acd913061df7440fb";
   };
 
   buildType = "catkin";
@@ -19,6 +19,6 @@ buildRosPackage {
 
   meta = {
     description = ''The usb_cam_hardware package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/noetic/apriltag-ros/default.nix
+++ b/distros/noetic/apriltag-ros/default.nix
@@ -1,0 +1,32 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, apriltag, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-generation, message-runtime, nodelet, opencv3, pluginlib, roscpp, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-apriltag-ros";
+  version = "3.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/AprilRobotics/apriltag_ros-release/archive/release/noetic/apriltag_ros/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "303875c5224713f03cba55605b0d5110fbce4325ecce284505aa825ea8224537";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules message-generation ];
+  propagatedBuildInputs = [ apriltag cv-bridge eigen geometry-msgs image-geometry image-transport message-runtime nodelet opencv3 pluginlib roscpp sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS wrapper of the AprilTag 3 visual fiducial detection
+    algorithm. Provides full access to the core AprilTag 3 algorithm's
+    customizations and makes the tag detection image and detected tags' poses
+    available over ROS topics (including tf). The core AprilTag 3 algorithm is
+    extended to allow the detection of tag bundles and a bundle calibration
+    script is provided (bundle detection is more accurate than single tag
+    detection). Continuous (camera image stream) and single image detector nodes
+    are available.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-pds-can/default.nix
+++ b/distros/noetic/dataspeed-pds-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds-can";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_can/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "a3897af0aa43d63cc75702e9fdb5bd2277b9ee6ed911f585b488fbb4414bdaa6";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ dataspeed-can-msg-filters ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-pds-msgs message-filters nodelet roscpp roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS) via CAN'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-pds-msgs/default.nix
+++ b/distros/noetic/dataspeed-pds-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds-msgs";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "b5ad7936655ebdb154427b76fb804db98eb0fe1ee55a59f02942b1f8a020c44b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for the Dataspeed Inc. Power Distribution System (PDS)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-pds-rqt/default.nix
+++ b/distros/noetic/dataspeed-pds-rqt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds-rqt";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_rqt/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "ae6f0ce9ca65ad851a6536101d44c739c94d07f9454acaa5915b35a093ef49db";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dataspeed-pds-msgs python-qt-binding rospy rqt-gui rqt-gui-py ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''ROS rqt GUI for the Dataspeed Inc. Power Distribution System (PDS)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-pds-scripts/default.nix
+++ b/distros/noetic/dataspeed-pds-scripts/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds-scripts";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_scripts/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "fd1fbfd1288fc1ed5c629f21bbbdb0c160e68f2d4235da349c22f8616af1667e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dataspeed-pds-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Test scripts to interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dataspeed-pds/default.nix
+++ b/distros/noetic/dataspeed-pds/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-msgs, dataspeed-pds-scripts }:
+buildRosPackage {
+  pname = "ros-noetic-dataspeed-pds";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2c3c2765a77742cbacba3fadbe13753c96de4e25eeacc932d85bbcaaccb05293";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dataspeed-pds-can dataspeed-pds-msgs dataspeed-pds-scripts ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-fca-can";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "afc3a3ba831ed4f5f5a440d7838a94466ea51e9c91e343e800837695b45f5a5c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ dataspeed-can-msg-filters ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire interface to the Dataspeed Inc. Chrysler Pacifica DBW kit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-fca-description";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "7d9e052777ebb63e94efdaa3dca498b79327a85400bb75b7b7e1b7143ce8d4d7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslib rviz ];
+  propagatedBuildInputs = [ robot-state-publisher roslaunch urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF and meshes describing the Chrysler Pacifica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-fca-joystick-demo";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "d19fdd0973443483739b5f585a0b79a29218f1fe67e7dbc623ed50844aae6050";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslib ];
+  propagatedBuildInputs = [ dbw-fca-can dbw-fca-msgs joy roscpp roslaunch sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Demonstration of drive-by-wire with joystick'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-fca-msgs";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "8f98ba7772e145a119dc4cf53b6fafa066cc970f5781082edae4793c60aa6fd9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire messages for the Chrysler Pacifica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-fca";
+  version = "1.0.10-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "64c1fcc3be602d70b046fa88fd7a08330236e66ca3e70a3d22beffbdaf315974";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dbw-fca-can dbw-fca-description dbw-fca-joystick-demo dbw-fca-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire interface to the Dataspeed Inc. Chrysler Pacifica DBW kit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-mkz-can";
+  version = "1.2.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "946b620d59ee76ef68ff1ff07e839ee8f167146a7c00e96d043f1e64d559161f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ dataspeed-can-msg-filters ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire interface to the Dataspeed Inc. Lincoln MKZ DBW kit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-mkz-description";
+  version = "1.2.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "4811f7951a55569dbe480ed2b3dd54b6ad0bf17414f914fc4ea63d2f407a1563";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslib rviz ];
+  propagatedBuildInputs = [ robot-state-publisher roslaunch urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF and meshes describing the Lincoln MKZ.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-mkz-joystick-demo";
+  version = "1.2.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "842a370679cdfbed6d8296726e46fbf12a848f58e20d462c79f6771f551d2872";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslib ];
+  propagatedBuildInputs = [ dbw-mkz-can dbw-mkz-msgs joy roscpp roslaunch sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Demonstration of drive-by-wire with joystick'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-mkz-msgs";
+  version = "1.2.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "88b83dec55f5a9bf3255423a7be6310f47b9b967b4cabf7a48885c258faa064c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire messages for the Lincoln MKZ'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dbw-mkz";
+  version = "1.2.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.2.9-1.tar.gz";
+    name = "1.2.9-1.tar.gz";
+    sha256 = "3dac6cba2f74c36d7604718ee011a8f13b369ef1505d3b903987d24d7bfb7b53";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dbw-mkz-can dbw-mkz-description dbw-mkz-joystick-demo dbw-mkz-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Drive-by-wire interface to the Dataspeed Inc. Lincoln MKZ DBW kit'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dynamic-tf-publisher/default.nix
+++ b/distros/noetic/dynamic-tf-publisher/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rospy, tf }:
+buildRosPackage {
+  pname = "ros-noetic-dynamic-tf-publisher";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/dynamic_tf_publisher/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "641d4138a4c105415c5199235e6b783357adbf11831e9ab0e60ec3a368bcefc5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ dynamic-reconfigure message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rospy tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''dynamically set the tf trensformation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -20,6 +20,8 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ apriltag-ros = self.callPackage ./apriltag-ros {};
+
  assisted-teleop = self.callPackage ./assisted-teleop {};
 
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
@@ -138,11 +140,41 @@ self: super: {
 
  dataspeed-can-usb = self.callPackage ./dataspeed-can-usb {};
 
+ dataspeed-pds = self.callPackage ./dataspeed-pds {};
+
+ dataspeed-pds-can = self.callPackage ./dataspeed-pds-can {};
+
+ dataspeed-pds-msgs = self.callPackage ./dataspeed-pds-msgs {};
+
+ dataspeed-pds-rqt = self.callPackage ./dataspeed-pds-rqt {};
+
+ dataspeed-pds-scripts = self.callPackage ./dataspeed-pds-scripts {};
+
  dataspeed-ulc = self.callPackage ./dataspeed-ulc {};
 
  dataspeed-ulc-can = self.callPackage ./dataspeed-ulc-can {};
 
  dataspeed-ulc-msgs = self.callPackage ./dataspeed-ulc-msgs {};
+
+ dbw-fca = self.callPackage ./dbw-fca {};
+
+ dbw-fca-can = self.callPackage ./dbw-fca-can {};
+
+ dbw-fca-description = self.callPackage ./dbw-fca-description {};
+
+ dbw-fca-joystick-demo = self.callPackage ./dbw-fca-joystick-demo {};
+
+ dbw-fca-msgs = self.callPackage ./dbw-fca-msgs {};
+
+ dbw-mkz = self.callPackage ./dbw-mkz {};
+
+ dbw-mkz-can = self.callPackage ./dbw-mkz-can {};
+
+ dbw-mkz-description = self.callPackage ./dbw-mkz-description {};
+
+ dbw-mkz-joystick-demo = self.callPackage ./dbw-mkz-joystick-demo {};
+
+ dbw-mkz-msgs = self.callPackage ./dbw-mkz-msgs {};
 
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
@@ -195,6 +227,8 @@ self: super: {
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
+
+ dynamic-tf-publisher = self.callPackage ./dynamic-tf-publisher {};
 
  ecl-build = self.callPackage ./ecl-build {};
 
@@ -314,6 +348,8 @@ self: super: {
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
 
+ hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
+
  hokuyo3d = self.callPackage ./hokuyo3d {};
 
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
@@ -337,6 +373,8 @@ self: super: {
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
 
  image-view = self.callPackage ./image-view {};
+
+ image-view2 = self.callPackage ./image-view2 {};
 
  imu-complementary-filter = self.callPackage ./imu-complementary-filter {};
 
@@ -378,6 +416,8 @@ self: super: {
 
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
+ jsk-common = self.callPackage ./jsk-common {};
+
  jsk-common-msgs = self.callPackage ./jsk-common-msgs {};
 
  jsk-footstep-msgs = self.callPackage ./jsk-footstep-msgs {};
@@ -385,6 +425,12 @@ self: super: {
  jsk-gui-msgs = self.callPackage ./jsk-gui-msgs {};
 
  jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
+
+ jsk-network-tools = self.callPackage ./jsk-network-tools {};
+
+ jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
+
+ jsk-topic-tools = self.callPackage ./jsk-topic-tools {};
 
  kartech-linear-actuator-msgs = self.callPackage ./kartech-linear-actuator-msgs {};
 
@@ -405,6 +451,8 @@ self: super: {
  lgsvl-msgs = self.callPackage ./lgsvl-msgs {};
 
  libdlib = self.callPackage ./libdlib {};
+
+ libfranka = self.callPackage ./libfranka {};
 
  libg2o = self.callPackage ./libg2o {};
 
@@ -529,6 +577,8 @@ self: super: {
  mpc-local-planner-msgs = self.callPackage ./mpc-local-planner-msgs {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
+ multi-map-server = self.callPackage ./multi-map-server {};
 
  multi-object-tracking-lidar = self.callPackage ./multi-object-tracking-lidar {};
 
@@ -982,6 +1032,8 @@ self: super: {
 
  safety-limiter-msgs = self.callPackage ./safety-limiter-msgs {};
 
+ sainsmart-relay-usb = self.callPackage ./sainsmart-relay-usb {};
+
  sbpl = self.callPackage ./sbpl {};
 
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};
@@ -1132,6 +1184,8 @@ self: super: {
 
  turtle-tf2 = self.callPackage ./turtle-tf2 {};
 
+ turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
+
  turtlesim = self.callPackage ./turtlesim {};
 
  twist-mux = self.callPackage ./twist-mux {};
@@ -1193,6 +1247,8 @@ self: super: {
  velodyne-pcl = self.callPackage ./velodyne-pcl {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ virtual-force-publisher = self.callPackage ./virtual-force-publisher {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 

--- a/distros/noetic/hls-lfcd-lds-driver/default.nix
+++ b/distros/noetic/hls-lfcd-lds-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-hls-lfcd-lds-driver";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/noetic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "5ec411d7393221815e2c31f2a850fafea7fd2defb6874cfa660ba913fa39bd8c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS package for LDS(HLS-LFCD2).
+    The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-view2/default.nix
+++ b/distros/noetic/image-view2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, image-geometry, image-transport, image-view, message-filters, message-generation, message-runtime, pcl-ros, python3Packages, roscpp, rostest, sensor-msgs, std-msgs, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-image-view2";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/image_view2/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "07e18eb3ce6a3761e5d3a2a6ded61460d1e41b08001bc442bd8a1c3c5e0b4dc2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation rostest ];
+  checkInputs = [ python3Packages.numpy python3Packages.scipy ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs image-geometry image-transport image-view message-filters message-runtime pcl-ros roscpp sensor-msgs std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A simple viewer for ROS image topics with draw-on features'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-common/default.nix
+++ b/distros/noetic/jsk-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-tf-publisher, image-view2, jsk-network-tools, jsk-tilt-laser, jsk-tools, jsk-topic-tools, multi-map-server, virtual-force-publisher }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-common";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_common/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "9ee5054f39d5142c74fa731f7d481591fd93a3bd0b95efe1302ed6c8d63d9653";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-tf-publisher image-view2 jsk-network-tools jsk-tilt-laser jsk-tools jsk-topic-tools multi-map-server virtual-force-publisher ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains commonly used toolset for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-network-tools/default.nix
+++ b/distros/noetic/jsk-network-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, rospy, rostest, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-network-tools";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_network_tools/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "f3976c28ca7989552adb68edacaf2a1e8817ea05341eecc772acf10d45c4a4fc";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation rostest ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure message-runtime roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''jsk_network_tools'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-tilt-laser/default.nix
+++ b/distros/noetic/jsk-tilt-laser/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, laser-assembler, laser-filters, robot-state-publisher, sensor-msgs, tf, tf-conversions, urg-node }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-tilt-laser";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_tilt_laser/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "32b4a5b174f2864b9b7279990b19fe86b7b5f623c00042bddef623618ffab997";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ dynamic-reconfigure laser-assembler laser-filters robot-state-publisher sensor-msgs tf tf-conversions urg-node ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jsk_tilt_laser package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-topic-tools/default.nix
+++ b/distros/noetic/jsk-topic-tools/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, python3Packages, roscpp, roscpp-tutorials, roslaunch, roslint, rosnode, rostest, rostime, rostopic, sensor-msgs, sound-play, std-msgs, std-srvs, tf, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-topic-tools";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/jsk_topic_tools/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "a58c0a7e52161b09eb76b6eb9a0b52b12fa7f91ec4dcd5e5c32391bf16c94263";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation rostest ];
+  checkInputs = [ roscpp-tutorials roslint ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs image-transport message-runtime nodelet python3Packages.numpy python3Packages.opencv3 python3Packages.scipy roscpp roslaunch rosnode rostime rostopic sensor-msgs sound-play std-msgs std-srvs tf topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''jsk_topic_tools'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libfranka/default.nix
+++ b/distros/noetic/libfranka/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, eigen, poco }:
+buildRosPackage {
+  pname = "ros-noetic-libfranka";
+  version = "0.8.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/frankaemika/libfranka-release/archive/release/noetic/libfranka/0.8.0-4.tar.gz";
+    name = "0.8.0-4.tar.gz";
+    sha256 = "57aa6bf7475f06a2446e18d34f59b3137037c376ec6c2d9fc08ecfdd914368cb";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ eigen ];
+  propagatedBuildInputs = [ catkin poco ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''libfranka is a C++ library for Franka Emika research robots'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/marti-data-structures/default.nix
+++ b/distros/noetic/marti-data-structures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-marti-data-structures";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "3d1ea9778de561ed68491cc012622134e0d46b596085bd3928d7d66b4ec9006a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/marti_data_structures/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "7df4a654973349be08170cbad4697d36331798964877b3642a384ca8389d174f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/multi-map-server/default.nix
+++ b/distros/noetic/multi-map-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, SDL_image, catkin, jsk-tools, libyamlcpp, map-server, nav-msgs, python3Packages, pythonPackages, rosconsole, roscpp, rosmake, rospy, tf }:
+buildRosPackage {
+  pname = "ros-noetic-multi-map-server";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/multi_map_server/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "e29c65c0ecd6a1199c1f247b056d171b575c49225866c48f504a2c06b6735d1c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ jsk-tools python3Packages.pyyaml pythonPackages.pillow rosmake ];
+  propagatedBuildInputs = [ SDL_image libyamlcpp map-server nav-msgs rosconsole roscpp rospy tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''multi_map_server provides the'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "2.8.2-r1";
+  version = "2.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/2.8.2-1.tar.gz";
-    name = "2.8.2-1.tar.gz";
-    sha256 = "2e9ba1a122bf56bbb3e772354bf49293cfb8ebb29b4e5b0158047c3b66c2ccb0";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/2.8.3-1.tar.gz";
+    name = "2.8.3-1.tar.gz";
+    sha256 = "bd098c7581a749330f5f086a8ffc146194b3c655e39d67b6aa67dbd97822aa1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sainsmart-relay-usb/default.nix
+++ b/distros/noetic/sainsmart-relay-usb/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libftdi, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sainsmart-relay-usb";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/sainsmart_relay_usb-release/archive/release/noetic/sainsmart_relay_usb/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "f13e0ed3e0dfd8522c79674412557adb424f9009dd6e6471606988ede73c0136";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libftdi roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''SainSmart USB relay driver controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sick-scan/default.nix
+++ b/distros/noetic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan";
-  version = "1.7.6-r1";
+  version = "1.7.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.6-1.tar.gz";
-    name = "1.7.6-1.tar.gz";
-    sha256 = "9525f290f9b4f961f98d615228835cce267794833090f3c37f34192200336d1c";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.6-2.tar.gz";
+    name = "1.7.6-2.tar.gz";
+    sha256 = "610d4724ae7a4845dfac87caa908219d5a30d00085b483d15efcaed90a009ffc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-console-util/default.nix
+++ b/distros/noetic/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-console-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "8ea8842d16b091fbbc0c6956a78435f099a8f15da47b444412fa4864a27ea2e3";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_console_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e5fdaddf5630d453855d3fb410302465e2f8f11dc4519b16f1573bd9e9447c26";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-dbw-interface/default.nix
+++ b/distros/noetic/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-dbw-interface";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "2fdcaaceebdc1bc419fc206d6cc812507e4f29e8c210001cbe8d612be9b270e2";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_dbw_interface/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "6e2eddadd12aa5dc13eaa6a5fe371c9daeed7f4751843d7f739ea6e2504dc9e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-geometry-util/default.nix
+++ b/distros/noetic/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geos, pkg-config, roscpp, rostest, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-geometry-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "04fe5f3a7adf58a5779f2a7ce54c55af4aaa1235fd6f82550f25693acf1c2f1b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_geometry_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "772b3e26ce4cfdd59dc64bd416381cfb026a8549f61d22f6f0afdc17ba893e7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-image-util/default.nix
+++ b/distros/noetic/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, camera-calibration-parsers, catkin, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, nodelet, pkg-config, roscpp, rospy, rostest, std-msgs, swri-geometry-util, swri-math-util, swri-nodelet, swri-opencv-util, swri-roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-swri-image-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "8be884f0504ad3c0921951c7e174e565e66850748a2e7a482e4192cd2faede1b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_image_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "e2c31e95a26a8479b70e822395b473aa6826b951135ad9c5c8de8d8b083e2a60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-math-util/default.nix
+++ b/distros/noetic/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-math-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "6b8777a02c30e004dce5320e018ca3820315c96876707d83c3eb51ebbd672f5f";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_math_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "2f7ede9023a6970e5f7a1a2a9365d0008ccac4d2d6fca3ef707aaf1b064f5418";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-nodelet/default.nix
+++ b/distros/noetic/swri-nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, nodelet, rosbash, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-nodelet";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "e399f8e3f45b1f10a8b5211bcdcb36a2bb36a18828bc22173ca51370691e5f04";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_nodelet/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "f2313fe9e60c8829d3ed06dcc54cffcf9df9aef84b600e8db08155231bbf4e3c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-opencv-util/default.nix
+++ b/distros/noetic/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-noetic-swri-opencv-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "9935a5dc8ddf01210b5440db41a88930babcdd7576cc3676639e705ba92d8b6b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_opencv_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "d358f7766086ac67f4611ca0f9f4fc2083d467c9afd64a707e804c8b57c7c23c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-prefix-tools/default.nix
+++ b/distros/noetic/swri-prefix-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-swri-prefix-tools";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "ce9e9b764d4c1177e9f6da484f289eeb7fb7cc25da943461ada9a595f8d2ccaf";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_prefix_tools/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "28022e478c8cbce5ff3f27fa88928608e66d21d2431d2ec1a1a42e748c7e9af7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-roscpp/default.nix
+++ b/distros/noetic/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-updater, dynamic-reconfigure, gtest, libyamlcpp, marti-common-msgs, message-generation, message-runtime, nav-msgs, pkg-config, roscpp, rostest, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-swri-roscpp";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "b6437e57d20ac6693ceb0dd684de98a1fab097784ad58e2e36e987259bf54e9a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_roscpp/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "b3c40eebcefb29b939935b44ceeea02eb3e53845194ab71d42d31e7491d2d7ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-rospy/default.nix
+++ b/distros/noetic/swri-rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-swri-rospy";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "0478f898c89727781bb10633602e830b237d1c19dbb70f2a7451a661dd60add1";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_rospy/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "c8eb7399bdf0e39d6f06708baec0c8a3330d2c85ac8ceb1190d19db587ab3dbd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-route-util/default.nix
+++ b/distros/noetic/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, marti-common-msgs, marti-nav-msgs, roscpp, swri-geometry-util, swri-math-util, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-swri-route-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "fe5270269f463ff201d7af02e394423d739c721ce02ded1455633b39800de7cd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_route_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "5247b46e1a9d06919eab46e514dba25cd690cf28dcb0eb8ea7924e940c5e8e90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-serial-util/default.nix
+++ b/distros/noetic/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-noetic-swri-serial-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "29ce4696c8153224d6e1d9abdf2e758c82712b676b520cddcace0ed2a4da35f6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_serial_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "021ca7c3a1ac6f3c3633f0cabd0081d511eb6f095bac3f7a685b9adb64bc2085";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-string-util/default.nix
+++ b/distros/noetic/swri-string-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-string-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "b2204cbb033260ea9860074f040af28b8db3d76141ad5e6aaec715c71656b9ba";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_string_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "454f1b6743bc070797474af693f6fa6f64a184496daeedd82c922d6a427fd854";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-system-util/default.nix
+++ b/distros/noetic/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-swri-system-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "a17513b1864453a6ef6e8d55efc056ccb9f55b0b172e9d9196e101a75a55fb7b";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_system_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "13e21ee77cce4a00eec6c268d7cd727d19b9bceaa8b5e2511d89ddc882a43d50";
   };
 
   buildType = "catkin";

--- a/distros/noetic/swri-transform-util/default.nix
+++ b/distros/noetic/swri-transform-util/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-common, libyamlcpp, marti-nav-msgs, nodelet, pkg-config, proj, python3Packages, roscpp, rospy, rostest, sensor-msgs, swri-math-util, swri-nodelet, swri-roscpp, swri-yaml-util, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-swri-transform-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "065a831045abca9271bb9de4aa84a4c75f0233bc039494102d180dd632d53fc9";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_transform_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "33cb70737f3006e57aaf522fb644791c913b2ee3a7195c297f31aec41b9d1f23";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-common libyamlcpp marti-nav-msgs nodelet proj python3Packages.numpy roscpp rospy sensor-msgs swri-math-util swri-nodelet swri-roscpp swri-yaml-util tf topic-tools ];
   nativeBuildInputs = [ catkin pkg-config python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/swri-yaml-util/default.nix
+++ b/distros/noetic/swri-yaml-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libyamlcpp, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-swri-yaml-util";
-  version = "2.13.7-r1";
+  version = "2.14.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.13.7-1.tar.gz";
-    name = "2.13.7-1.tar.gz";
-    sha256 = "73ecf179004efc191a4bacf87254fd2fc498a287a4bd8d6a9bf7e3e88b0af626";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/noetic/swri_yaml_util/2.14.0-1.tar.gz";
+    name = "2.14.0-1.tar.gz";
+    sha256 = "1cf13ca8d724939265561748e877c95e2320e1f5dee14d2334bc20edc2d47ee3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-msgs/default.nix
+++ b/distros/noetic/turtlebot3-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_msgs-release/archive/release/noetic/turtlebot3_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "768e46ad69aff6599a5a5527993d47906a574a825b499a3a6fa8fabacf6763b0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Message and service types: custom messages and services for TurtleBot3 packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/virtual-force-publisher/default.nix
+++ b/distros/noetic/virtual-force-publisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, kdl-parser, sensor-msgs, tf-conversions, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-virtual-force-publisher";
+  version = "2.2.11-r2";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_common-release/archive/release/noetic/virtual_force_publisher/2.2.11-2.tar.gz";
+    name = "2.2.11-2.tar.gz";
+    sha256 = "2525226fd6c507c40f78ca2fcb145b28fd8f83c0090e4afea891408d3d3aa396";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs kdl-parser sensor-msgs tf-conversions urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''publish end effector's force, which is estmated from joint torque value'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit c0ebfc2faa28d8b80e8617dddc41c2a41db9ab16.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *ament-clang-format 0.7.11-r1 --> 0.7.12-r1*
* *ament-clang-tidy 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-auto 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-clang-format 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-clang-tidy 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-copyright 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-core 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-cppcheck 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-cpplint 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-export-definitions 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-export-dependencies 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-export-include-directories 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-export-interfaces 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-export-libraries 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-export-link-flags 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-flake8 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-gmock 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-gtest 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-include-directories 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-libraries 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-lint-cmake 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-nose 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-pclint 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-pep257 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-pep8 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-pyflakes 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-pytest 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-python 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-target-dependencies 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-test 0.7.4-r1 --> 0.7.5-r1*
* *ament-cmake-uncrustify 0.7.11-r1 --> 0.7.12-r1*
* *ament-cmake-xmllint 0.7.11-r1 --> 0.7.12-r1*
* *ament-copyright 0.7.11-r1 --> 0.7.12-r1*
* *ament-cppcheck 0.7.11-r1 --> 0.7.12-r1*
* *ament-cpplint 0.7.11-r1 --> 0.7.12-r1*
* *ament-flake8 0.7.11-r1 --> 0.7.12-r1*
* *ament-lint 0.7.11-r1 --> 0.7.12-r1*
* *ament-lint-auto 0.7.11-r1 --> 0.7.12-r1*
* *ament-lint-cmake 0.7.11-r1 --> 0.7.12-r1*
* *ament-lint-common 0.7.11-r1 --> 0.7.12-r1*
* *ament-pclint 0.7.11-r1 --> 0.7.12-r1*
* *ament-pep257 0.7.11-r1 --> 0.7.12-r1*
* *ament-pep8 0.7.11-r1 --> 0.7.12-r1*
* *ament-pyflakes 0.7.11-r1 --> 0.7.12-r1*
* *ament-uncrustify 0.7.11-r1 --> 0.7.12-r1*
* *ament-xmllint 0.7.11-r1 --> 0.7.12-r1*
* *behaviortree-cpp-v3 3.5.0-r1 --> 3.1.1-r1*
* *desktop 0.7.3-r1 --> 0.7.4-r1*
* *lgsvl-bridge 0.1.0-r1*
* *libcurl-vendor 2.1.2-r1 --> 2.1.3-r1*
* *librealsense2 2.34.0-r1 --> 2.16.5-r1*
* *orocos-kdl 3.2.1-r1 --> 3.2.2-r1*
* *rcl 0.7.8-r1 --> 0.7.9-r1*
* *rcl-action 0.7.8-r1 --> 0.7.9-r1*
* *rcl-lifecycle 0.7.8-r1 --> 0.7.9-r1*
* *rcl-yaml-param-parser 0.7.8-r1 --> 0.7.9-r1*
* *rclcpp 0.7.13-r1 --> 0.7.14-r1*
* *rclcpp-action 0.7.13-r1 --> 0.7.14-r1*
* *rclcpp-components 0.7.13-r1 --> 0.7.14-r1*
* *rclcpp-lifecycle 0.7.13-r1 --> 0.7.14-r1*
* *rclpy 0.7.10-r1 --> 0.7.11-r1*
* *resource-retriever 2.1.2-r1 --> 2.1.3-r1*
* *rmw-connext-cpp 0.7.4-r1 --> 0.7.5-r1*
* *rmw-connext-shared-cpp 0.7.4-r1 --> 0.7.5-r1*
* *ros-base 0.7.3-r1 --> 0.7.4-r1*
* *ros-core 0.7.3-r1 --> 0.7.4-r1*
* *ros1-bridge 0.7.5-r1 --> 0.7.6-r1*
* *ros2action 0.7.10-r1 --> 0.7.11-r1*
* *ros2cli 0.7.10-r1 --> 0.7.11-r1*
* *ros2component 0.7.10-r1 --> 0.7.11-r1*
* *ros2lifecycle 0.7.10-r1 --> 0.7.11-r1*
* *ros2msg 0.7.10-r1 --> 0.7.11-r1*
* *ros2multicast 0.7.10-r1 --> 0.7.11-r1*
* *ros2node 0.7.10-r1 --> 0.7.11-r1*
* *ros2param 0.7.10-r1 --> 0.7.11-r1*
* *ros2pkg 0.7.10-r1 --> 0.7.11-r1*
* *ros2run 0.7.10-r1 --> 0.7.11-r1*
* *ros2service 0.7.10-r1 --> 0.7.11-r1*
* *ros2srv 0.7.10-r1 --> 0.7.11-r1*
* *ros2topic 0.7.10-r1 --> 0.7.11-r1*
* *velodyne 2.0.0-r1*
* *velodyne-driver 2.0.0-r1*
* *velodyne-laserscan 2.0.0-r1*
* *velodyne-msgs 2.0.0-r1*
* *velodyne-pointcloud 2.0.0-r1*

Eloquent Changes:
-----------------
* *lgsvl-bridge 0.1.0-r1*
* *swri-console-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-dbw-interface 3.2.0-r1 --> 3.3.0-r1*
* *swri-geometry-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-image-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-math-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-opencv-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-prefix-tools 3.2.0-r1 --> 3.3.0-r1*
* *swri-roscpp 3.2.0-r1 --> 3.3.0-r1*
* *swri-route-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-serial-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-system-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-transform-util 3.2.0-r1 --> 3.3.0-r1*
* *velodyne 2.1.0-r1*
* *velodyne-driver 2.1.0-r1*
* *velodyne-laserscan 2.1.0-r1*
* *velodyne-msgs 2.1.0-r1*
* *velodyne-pointcloud 2.1.0-r1*

Foxy Changes:
-------------
* *diagnostic-aggregator 2.0.2-r1 --> 2.0.3-r1*
* *diagnostic-updater 2.0.2-r1 --> 2.0.3-r1*
* *hls-lfcd-lds-driver 2.0.1-r1*
* *lgsvl-bridge 0.1.0-r1*
* *nonpersistent-voxel-layer 2.2.1-r1*
* *py-trees-ros-interfaces 2.0.3-r1*
* *random-numbers 1.0.0-r1*
* *ros2cli-common-extensions 0.1.0-r1*
* *sbg-driver 1.0.1-r1*
* *self-test 2.0.2-r1 --> 2.0.3-r1*
* *slam-toolbox 2.3.0-r1*
* *sophus 1.2.0-r1*
* *swri-console-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-dbw-interface 3.2.1-r1 --> 3.3.0-r1*
* *swri-geometry-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-image-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-math-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-opencv-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-prefix-tools 3.2.1-r1 --> 3.3.0-r1*
* *swri-roscpp 3.2.1-r1 --> 3.3.0-r1*
* *swri-route-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-serial-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-system-util 3.2.1-r1 --> 3.3.0-r1*
* *swri-transform-util 3.2.1-r1 --> 3.3.0-r1*
* *system-modes 0.2.0-r4 --> 0.2.1-r2*
* *system-modes-examples 0.2.0-r4 --> 0.2.1-r2*
* *velodyne 2.1.0-r1*
* *velodyne-driver 2.1.0-r1*
* *velodyne-laserscan 2.1.0-r1*
* *velodyne-msgs 2.1.0-r1*
* *velodyne-pointcloud 2.1.0-r1*

Kinetic Changes:
----------------
* *agv-msgs 1.0.1-r1*
* *costmap-cspace 0.9.0-r1 --> 0.9.1-r1*
* *hls-lfcd-lds-driver 1.1.0 --> 1.1.1-r1*
* *joystick-interrupt 0.9.0-r1 --> 0.9.1-r1*
* *librealsense2 2.35.2-r2 --> 2.36.0-r1*
* *map-organizer 0.9.0-r1 --> 0.9.1-r1*
* *marti-data-structures 2.13.7-r1 --> 2.14.0-r1*
* *neonavigation 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-common 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-launch 0.9.0-r1 --> 0.9.1-r1*
* *obj-to-pointcloud 0.9.0-r1 --> 0.9.1-r1*
* *phm-hazard-rate-calculation 1.0.1-r1*
* *phm-msgs 1.0.1-r1*
* *phm-reliability-calculation 1.0.1-r1*
* *phm-robot-task-completion 1.0.1-r1*
* *phm-start 1.0.1-r1*
* *phm-tools 1.0.1-r1*
* *planner-cspace 0.9.0-r1 --> 0.9.1-r1*
* *plotjuggler 2.8.2-r1 --> 2.8.3-r1*
* *realsense2-camera 2.2.14-r1 --> 2.2.15-r1*
* *realsense2-description 2.2.14-r1 --> 2.2.15-r1*
* *rtabmap-ros 0.19.3-r1 --> 0.20.0-r1*
* *safety-limiter 0.9.0-r1 --> 0.9.1-r1*
* *sick-scan 1.7.6-r1 --> 1.7.6-r2*
* *swri-console-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-dbw-interface 2.13.7-r1 --> 2.14.0-r1*
* *swri-geometry-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-image-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-math-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-nodelet 2.13.7-r1 --> 2.14.0-r1*
* *swri-opencv-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-prefix-tools 2.13.7-r1 --> 2.14.0-r1*
* *swri-roscpp 2.13.7-r1 --> 2.14.0-r1*
* *swri-rospy 2.13.7-r1 --> 2.14.0-r1*
* *swri-route-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-serial-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-string-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-system-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-transform-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-yaml-util 2.13.7-r1 --> 2.14.0-r1*
* *track-odometry 0.9.0-r1 --> 0.9.1-r1*
* *trajectory-tracker 0.9.0-r1 --> 0.9.1-r1*
* *turtlebot3-msgs 1.0.0 --> 1.0.1-r1*
* *usb-cam-controllers 0.0.3 --> 0.0.6-r1*
* *usb-cam-hardware 0.0.3 --> 0.0.6-r1*
* *usb-cam-hardware-interface 0.0.3 --> 0.0.6-r1*

Melodic Changes:
----------------
* *apriltag-ros 3.1.1-r1 --> 3.1.2-r1*
* *chomp-motion-planner 1.0.4-r1 --> 1.0.5-r1*
* *costmap-cspace 0.9.0-r1 --> 0.9.1-r1*
* *dbw-fca 1.0.9-r1 --> 1.0.10-r1*
* *dbw-fca-can 1.0.9-r1 --> 1.0.10-r1*
* *dbw-fca-description 1.0.9-r1 --> 1.0.10-r1*
* *dbw-fca-joystick-demo 1.0.9-r1 --> 1.0.10-r1*
* *dbw-fca-msgs 1.0.9-r1 --> 1.0.10-r1*
* *hls-lfcd-lds-driver 1.1.0-r1 --> 1.1.1-r1*
* *joystick-interrupt 0.9.0-r1 --> 0.9.1-r1*
* *laser-scan-publisher-tutorial 0.2.3-r1 --> 0.2.4-r1*
* *librealsense2 2.35.2-r2 --> 2.36.0-r1*
* *map-organizer 0.9.0-r1 --> 0.9.1-r1*
* *marti-data-structures 2.13.7-r1 --> 2.14.0-r1*
* *moveit 1.0.4-r1 --> 1.0.5-r1*
* *moveit-chomp-optimizer-adapter 1.0.4-r1 --> 1.0.5-r1*
* *moveit-controller-manager-example 1.0.4-r1 --> 1.0.5-r1*
* *moveit-fake-controller-manager 1.0.4-r1 --> 1.0.5-r1*
* *moveit-kinematics 1.0.4-r1 --> 1.0.5-r1*
* *moveit-planners 1.0.4-r1 --> 1.0.5-r1*
* *moveit-planners-chomp 1.0.4-r1 --> 1.0.5-r1*
* *moveit-planners-ompl 1.0.4-r1 --> 1.0.5-r1*
* *moveit-plugins 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-benchmarks 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-control-interface 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-manipulation 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-move-group 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-occupancy-map-monitor 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-perception 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-planning 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-planning-interface 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-robot-interaction 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-visualization 1.0.4-r1 --> 1.0.5-r1*
* *moveit-ros-warehouse 1.0.4-r1 --> 1.0.5-r1*
* *moveit-runtime 1.0.4-r1 --> 1.0.5-r1*
* *moveit-servo 1.0.5-r1*
* *moveit-setup-assistant 1.0.4-r1 --> 1.0.5-r1*
* *moveit-simple-controller-manager 1.0.4-r1 --> 1.0.5-r1*
* *mqtt-bridge 0.1.7-r7*
* *navigation-stage 0.2.3-r1 --> 0.2.4-r1*
* *navigation-tutorials 0.2.3-r1 --> 0.2.4-r1*
* *neonavigation 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-common 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-launch 0.9.0-r1 --> 0.9.1-r1*
* *nextage-description 0.8.6-r2 --> 0.8.6-r3*
* *nextage-gazebo 0.8.6-r2 --> 0.8.6-r3*
* *nextage-ik-plugin 0.8.6-r2 --> 0.8.6-r3*
* *nextage-moveit-config 0.8.6-r2 --> 0.8.6-r3*
* *nextage-ros-bridge 0.8.6-r2 --> 0.8.6-r3*
* *obj-to-pointcloud 0.9.0-r1 --> 0.9.1-r1*
* *odometry-publisher-tutorial 0.2.3-r1 --> 0.2.4-r1*
* *pilz-extensions 0.4.10-r1 --> 0.4.11-r1*
* *pilz-industrial-motion 0.4.10-r1 --> 0.4.11-r1*
* *pilz-industrial-motion-testutils 0.4.10-r1 --> 0.4.11-r1*
* *pilz-msgs 0.4.10-r1 --> 0.4.11-r1*
* *pilz-robot-programming 0.4.10-r1 --> 0.4.11-r1*
* *pilz-store-positions 0.4.11-r1*
* *pilz-trajectory-generation 0.4.10-r1 --> 0.4.11-r1*
* *planner-cspace 0.9.0-r1 --> 0.9.1-r1*
* *plotjuggler 2.8.2-r1 --> 2.8.3-r1*
* *point-cloud-publisher-tutorial 0.2.3-r1 --> 0.2.4-r1*
* *realsense2-camera 2.2.14-r1 --> 2.2.15-r1*
* *realsense2-description 2.2.14-r1 --> 2.2.15-r1*
* *robot-setup-tf-tutorial 0.2.3-r1 --> 0.2.4-r1*
* *roomba-stage 0.2.3-r1 --> 0.2.4-r1*
* *rtabmap-ros 0.19.3-r1 --> 0.20.0-r1*
* *rtmros-nextage 0.8.6-r1 --> 0.8.6-r3*
* *safety-limiter 0.9.0-r1 --> 0.9.1-r1*
* *sick-scan 1.7.6-r1 --> 1.7.6-r2*
* *simple-navigation-goals-tutorial 0.2.3-r1 --> 0.2.4-r1*
* *swri-console-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-dbw-interface 2.13.7-r1 --> 2.14.0-r1*
* *swri-geometry-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-image-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-math-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-nodelet 2.13.7-r1 --> 2.14.0-r1*
* *swri-opencv-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-prefix-tools 2.13.7-r1 --> 2.14.0-r1*
* *swri-roscpp 2.13.7-r1 --> 2.14.0-r1*
* *swri-rospy 2.13.7-r1 --> 2.14.0-r1*
* *swri-route-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-serial-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-string-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-system-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-transform-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-yaml-util 2.13.7-r1 --> 2.14.0-r1*
* *track-odometry 0.9.0-r1 --> 0.9.1-r1*
* *trajectory-tracker 0.9.0-r1 --> 0.9.1-r1*
* *turtlebot3-msgs 1.0.0 --> 1.0.1-r1*
* *usb-cam-controllers 0.0.4 --> 0.1.1-r1*
* *usb-cam-hardware 0.0.4 --> 0.1.1-r1*
* *usb-cam-hardware-interface 0.0.4 --> 0.1.1-r1*

Noetic Changes:
---------------
* *apriltag-ros 3.1.2-r1*
* *dataspeed-pds 1.0.3-r1*
* *dataspeed-pds-can 1.0.3-r1*
* *dataspeed-pds-msgs 1.0.3-r1*
* *dataspeed-pds-rqt 1.0.3-r1*
* *dataspeed-pds-scripts 1.0.3-r1*
* *dbw-fca 1.0.10-r1*
* *dbw-fca-can 1.0.10-r1*
* *dbw-fca-description 1.0.10-r1*
* *dbw-fca-joystick-demo 1.0.10-r1*
* *dbw-fca-msgs 1.0.10-r1*
* *dbw-mkz 1.2.9-r1*
* *dbw-mkz-can 1.2.9-r1*
* *dbw-mkz-description 1.2.9-r1*
* *dbw-mkz-joystick-demo 1.2.9-r1*
* *dbw-mkz-msgs 1.2.9-r1*
* *dynamic-tf-publisher 2.2.11-r2*
* *hls-lfcd-lds-driver 1.1.1-r1*
* *image-view2 2.2.11-r2*
* *jsk-common 2.2.11-r2*
* *jsk-network-tools 2.2.11-r2*
* *jsk-tilt-laser 2.2.11-r2*
* *jsk-topic-tools 2.2.11-r2*
* *libfranka 0.8.0-r4*
* *marti-data-structures 2.13.7-r1 --> 2.14.0-r1*
* *multi-map-server 2.2.11-r2*
* *plotjuggler 2.8.2-r1 --> 2.8.3-r1*
* *sainsmart-relay-usb 0.0.3-r1*
* *sick-scan 1.7.6-r1 --> 1.7.6-r2*
* *swri-console-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-dbw-interface 2.13.7-r1 --> 2.14.0-r1*
* *swri-geometry-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-image-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-math-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-nodelet 2.13.7-r1 --> 2.14.0-r1*
* *swri-opencv-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-prefix-tools 2.13.7-r1 --> 2.14.0-r1*
* *swri-roscpp 2.13.7-r1 --> 2.14.0-r1*
* *swri-rospy 2.13.7-r1 --> 2.14.0-r1*
* *swri-route-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-serial-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-string-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-system-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-transform-util 2.13.7-r1 --> 2.14.0-r1*
* *swri-yaml-util 2.13.7-r1 --> 2.14.0-r1*
* *turtlebot3-msgs 1.0.1-r1*
* *virtual-force-publisher 2.2.11-r2*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] autoware_auto_cmake
 * [ ] autoware_auto_helper_functions
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-5-arm-linux-gnueabihf
 * [ ] g++-5-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] multistrap
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-colorama
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-imageio
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-texttable
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

