### PR TITLE
rosdistro sync, Fri Jul 24 13:00:10 2020

### DIFF
--- a/distros/dashing/dynamixel-sdk/default.nix
+++ b/distros/dashing/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-dynamixel-sdk";
-  version = "3.7.20-r1";
+  version = "3.7.30-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk/3.7.20-1.tar.gz";
-    name = "3.7.20-1.tar.gz";
-    sha256 = "3414e7a3a2f70fdd8b1e2d64a1befd58c9cc9df73834579b41024c80536bb078";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk/3.7.30-1.tar.gz";
+    name = "3.7.30-1.tar.gz";
+    sha256 = "66cbfa21ac459da1c83a344434d1b6d5791298c80bbee2fe320f91b5aee5bb9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -950,6 +950,8 @@ self: super: {
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
+ serial-driver = self.callPackage ./serial-driver {};
+
  shape-msgs = self.callPackage ./shape-msgs {};
 
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};

--- a/distros/dashing/hls-lfcd-lds-driver/default.nix
+++ b/distros/dashing/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-hls-lfcd-lds-driver";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "e61706dcdf5eba4b6979572f5eca489af4d17d06123dba49f4075f103f00372c";
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a70559ce1e1a78ad3e8578781acdd151065e0067faa2292127cd811d1d7ba1f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/kdl-parser/default.nix
+++ b/distros/dashing/kdl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, orocos-kdl, tinyxml, tinyxml-vendor, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-dashing-kdl-parser";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/kdl_parser-release/archive/release/dashing/kdl_parser/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d232172cd462fe64bd4ce7fd2a63782f25914f50f4fcb73dbe597e0bf7fbc758";
+    url = "https://github.com/ros2-gbp/kdl_parser-release/archive/release/dashing/kdl_parser/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e72ec0c0999c1a7ea6cca23d256eff1b960d929aad2b4b197ee82d18c4730cc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/serial-driver/default.nix
+++ b/distros/dashing/serial-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-serial-driver";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/serial_driver/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "dc08840cd29cc804a545fbe4e407ab0a6c89c041b22e8290d637a7758e84ae8f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''A template class and associated utilities which encapsulate basic reading from serial ports'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/swri-console-util/default.nix
+++ b/distros/dashing/swri-console-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-console-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "860369f8b0df2a9a8e36f71c76048437e5ff6893dc365377735b0f1517973c7a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_console_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "8a6489c3cd7d4f1fce32d1f0dd5c93a2ea278ab4f1b6a239fcaf299873f26be4";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-dbw-interface/default.nix
+++ b/distros/dashing/swri-dbw-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-swri-dbw-interface";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "6dd35433f51a7ab2a4bf056e69b190b8a44740c68cc4ba6f4b3af5f20ff9e777";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_dbw_interface/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "623f4038d4b87877d8e8cb1f7ce60cb17980cdbcaca9d0aaa7639d663e1fbf7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-geometry-util/default.nix
+++ b/distros/dashing/swri-geometry-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cv-bridge, eigen, geos, pkg-config, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-geometry-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "d9fc2acd58536679cab47bdb7e1d8338749103141791cc85689ef61cbb59b7bb";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_geometry_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "bd8cbeece343bd9ebb61ca94bb09d7f66e3a0fa561e365044034c4f749d2be8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-image-util/default.nix
+++ b/distros/dashing/swri-image-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, camera-calibration-parsers, cv-bridge, eigen, geometry-msgs, image-geometry, image-transport, message-filters, nav-msgs, pkg-config, rclcpp, rclcpp-components, rclpy, std-msgs, swri-geometry-util, swri-math-util, swri-opencv-util, swri-roscpp, tf2 }:
 buildRosPackage {
   pname = "ros-dashing-swri-image-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "35ce269c542881773129b82b2c1549f599e91424377570ee16de22889e7bfa21";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_image_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "4688ff96d2886082cdefd27a36bd926cfe3b445c6079b0405d060cbc9a139137";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-math-util/default.nix
+++ b/distros/dashing/swri-math-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-math-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "9a41ef2777bb50e1112c64d6a129e6e7f24ed1eb4112b8832ac2482e61768230";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_math_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "2fb618bffec80d91b458ec85e4603ca4f9be28366f81e62bd6452ec7ecba30dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-opencv-util/default.nix
+++ b/distros/dashing/swri-opencv-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cv-bridge, swri-math-util }:
 buildRosPackage {
   pname = "ros-dashing-swri-opencv-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "7ea592055f254376d5ff62720bb2d38372e71e8d155095e33cc8c6073b5236a0";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_opencv_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "28b0f8f9ea7f251210f0402ae9551ff8665af87abae260b15757816c89fc0e62";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-prefix-tools/default.nix
+++ b/distros/dashing/swri-prefix-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-swri-prefix-tools";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "26a477246baa8b4c9795cbfe5e417f82caec79dc1fcc6afebcfe29bed04faf2a";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_prefix_tools/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "be977e65baa077cc5fd6cb6be4e07c62eceb3744228a503846f9a3a5ea34e360";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ pythonPackages.psutil ];
+  propagatedBuildInputs = [ python3Packages.psutil ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/swri-roscpp/default.nix
+++ b/distros/dashing/swri-roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, diagnostic-updater, gtest, marti-common-msgs, nav-msgs, rclcpp, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-dashing-swri-roscpp";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "896655e4463e21399e53f139427d2379a561ad49c283938c134bc841b3924748";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_roscpp/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "96e96b7a3653f4da4a24ab6ba93aef6683801f9404b1dac8955b0df6968dbd4b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-route-util/default.nix
+++ b/distros/dashing/swri-route-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, marti-common-msgs, marti-nav-msgs, rclcpp, swri-geometry-util, swri-math-util, swri-roscpp, swri-transform-util, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-swri-route-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "d161673327133d6e32d2ba0fd0c71a9beb905481531a83a40d2673220cd3bcf6";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_route_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "cd55b624e864fa3f71a39aa5562125c9bef0c1a3d6cd6b66afbc1acedf2af364";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-serial-util/default.nix
+++ b/distros/dashing/swri-serial-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost }:
 buildRosPackage {
   pname = "ros-dashing-swri-serial-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "6ce76ea1e2a44e5353f2511a7e623d5e2c14a32ef815914f30173de4768dfd01";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_serial_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "c3c1707ce5a4fcfe9da877d8f0afd3056e4489943105efc7f38d69c05f7ce4e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-system-util/default.nix
+++ b/distros/dashing/swri-system-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, boost, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-swri-system-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "041f3b0319fdf56ed501c297044e064a52b04441b5be220aa77294ee5721dae4";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_system_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "ff441368d3f4a3e4ef506d6b717627f533241b4504929393836a380756d5520f";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/swri-transform-util/default.nix
+++ b/distros/dashing/swri-transform-util/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, boost, cv-bridge, diagnostic-msgs, geographic-msgs, geometry-msgs, geos, gps-msgs, libyamlcpp, marti-nav-msgs, pkg-config, proj, python3Packages, rcl-interfaces, rclcpp, rclcpp-components, rclpy, sensor-msgs, swri-math-util, swri-roscpp, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-dashing-swri-transform-util";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c8373ce436adf26a79f7b2099a172c9a337306588aff240724ae4a4a25a7f5fd";
+    url = "https://github.com/swri-robotics-gbp/marti_common-release/archive/release/dashing/swri_transform_util/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "7bc53b66e9b96d724429504fd9e57c8cb491afe934dc05373a3fa1ead4684db4";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs libyamlcpp marti-nav-msgs proj rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ boost cv-bridge diagnostic-msgs geographic-msgs geometry-msgs geos gps-msgs libyamlcpp marti-nav-msgs proj python3Packages.numpy rcl-interfaces rclcpp rclcpp-components rclpy sensor-msgs swri-math-util swri-roscpp tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python pkg-config ];
 
   meta = {

--- a/distros/dashing/system-modes-examples/default.nix
+++ b/distros/dashing/system-modes-examples/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, boost, rclcpp, rclcpp-lifecycle, system-modes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-dashing-system-modes-examples";
-  version = "0.2.0-r3";
+  version = "0.2.1-r7";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.2.0-3.tar.gz";
-    name = "0.2.0-3.tar.gz";
-    sha256 = "893e4b0099bb12a4a07528199f7f1d4f29892a2faf1e0a2ca1769963786ab074";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.2.1-7.tar.gz";
+    name = "0.2.1-7.tar.gz";
+    sha256 = "b90d7cf3c6c1a52e25c3d5b4acb6d0f1e8d3e794c0531885b2a928afb8fd2b72";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake ];
   propagatedBuildInputs = [ boost rclcpp rclcpp-lifecycle system-modes ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Simple example system for system_modes package.'';

--- a/distros/dashing/system-modes/default.nix
+++ b/distros/dashing/system-modes/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-ros, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-system-modes";
-  version = "0.2.0-r3";
+  version = "0.2.1-r7";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.2.0-3.tar.gz";
-    name = "0.2.0-3.tar.gz";
-    sha256 = "5474cb959ac3bf8df018dc5bd6a9ab73d3ef73e28e7eae58275755bfdb61496d";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.2.1-7.tar.gz";
+    name = "0.2.1-7.tar.gz";
+    sha256 = "bde3b4e6e9a2dbe37c51ff40d13568786f410b7dc9e681c3ed9650a76c18b197";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
   propagatedBuildInputs = [ boost builtin-interfaces rclcpp rclcpp-lifecycle rosidl-default-generators std-msgs ];
-  nativeBuildInputs = [ ament-cmake-ros ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Model-based distributed configuration handling.'';

--- a/distros/dashing/udp-driver/default.nix
+++ b/distros/dashing/udp-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-udp-driver";
-  version = "0.0.4-r3";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/udp_driver/0.0.4-3.tar.gz";
-    name = "0.0.4-3.tar.gz";
-    sha256 = "150a7a7a507281fe163b5a2b4fa01bb1fc3da7719b75fabbf1036d78e3b9e76b";
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/dashing/udp_driver/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "3088da3d61a32e08496698a38c082a3f6c217f2a31db1cdc753f2cdb5601e4f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/dynamixel-sdk/default.nix
+++ b/distros/eloquent/dynamixel-sdk/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-eloquent-dynamixel-sdk";
+  version = "3.7.30-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/eloquent/dynamixel_sdk/3.7.30-1.tar.gz";
+    name = "3.7.30-1.tar.gz";
+    sha256 = "9fa335dc65ec470650e5a4f1e667fa8627ec8a4b1158f72aa1d1538de98659be";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -226,6 +226,8 @@ self: super: {
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
+ dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-command-line = self.callPackage ./ecl-command-line {};
@@ -385,6 +387,8 @@ self: super: {
  gpsd-client = self.callPackage ./gpsd-client {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
+
+ hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
  image-common = self.callPackage ./image-common {};
 

--- a/distros/eloquent/hls-lfcd-lds-driver/default.nix
+++ b/distros/eloquent/hls-lfcd-lds-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-eloquent-hls-lfcd-lds-driver";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/eloquent/hls_lfcd_lds_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "b608830853c063542a5fb542624fdfc303a60b64a9bebd48aeb4f9de5f3e5974";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS package for LDS(HLS-LFCD2).
+    The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/plansys2-bringup/default.nix
+++ b/distros/eloquent/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-bringup";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "7e566d92231d8cb62dad358ef231a7ff046b72a3ffd07c8d985051887a055d3a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_bringup/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "c452b353840a280196f7d7040151e97ebf703504c9c1ba395e2e54293e103178";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-domain-expert/default.nix
+++ b/distros/eloquent/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-domain-expert";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "e6986f6631bd7c7ed891b545cffd90988acf4dac2695f07a5d1e1346f248eb03";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_domain_expert/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "f8557ba4b20dff25ea4c34c9bb14874480c14081a8bd6a21a24b9053d7acb727";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-executor/default.nix
+++ b/distros/eloquent/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, boost, geometry-msgs, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-executor";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "99b542f9454cf8229cc63ef2901e4d508b606c71854f5ed2b10a862828960653";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_executor/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "928143ee6cfbb14b0513157d0d184c6e57e1ff5e2479e6629ca034989a375959";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-lifecycle-manager/default.nix
+++ b/distros/eloquent/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-lifecycle-manager";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "c476594144516b5758f7e82545522e765a79690dbc8e567970367df42b9cb803";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_lifecycle_manager/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "7d01a2968b3f0d9a826d75413f0413ccac3d34584fe3c9aba860a8f29ac47985";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-msgs/default.nix
+++ b/distros/eloquent/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-msgs";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "0a9e90eb31f013c8c8a46b41061024b6377b24460b9b8c01524d372c76873640";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_msgs/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "6954a2aedf57ec80c3af1cb1ac856ffc031c0d40a33abdbb8d4fee8a2b17f950";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-pddl-parser/default.nix
+++ b/distros/eloquent/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-pddl-parser";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "425ac3f46c65940ff68934fd3baa12889002f0d99b213112859044b4093ebbe5";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_pddl_parser/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "8ccb1ce9d6cc4df4c97bae5971e20357e713a113692c5d67d07c8c0f08fb6df9";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-planner/default.nix
+++ b/distros/eloquent/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-planner";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "f023c0467cd297b2653be4e50f745cb33b7b41114de7bf46fce61a7467095f48";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_planner/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "efaceeffc918d5dd35d03b9b334466597978e2d97edf547eb436da8d8be6b47f";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-problem-expert/default.nix
+++ b/distros/eloquent/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-problem-expert";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "eeac6dfed607a757fb01165e4a9b5a05f3245132f960b820ab6448ef47bce0e5";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_problem_expert/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "e88c7524b32bbbedf94db34a10d263dec6cef5a07fb50c8f3565045a21498f88";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/plansys2-terminal/default.nix
+++ b/distros/eloquent/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, boost, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-eloquent-plansys2-terminal";
-  version = "0.0.9-r1";
+  version = "0.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.9-1.tar.gz";
-    name = "0.0.9-1.tar.gz";
-    sha256 = "ad6d7d3c39bd6a984c8d8f723daa6443b211d79ea82715e6133d900644829879";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/eloquent/plansys2_terminal/0.0.10-1.tar.gz";
+    name = "0.0.10-1.tar.gz";
+    sha256 = "527ac8fb6c9f3adbade32f75096417a71253c12d9570486fc4f54bcb9a297dc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/actionlib-msgs/default.nix
+++ b/distros/foxy/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-actionlib-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "440f4f079f187f08a364bae49c43d587588516e641fed8f31acd1c69488c76ee";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "f4f3e0b24772bbdde05690d3541d2f90669a3e6099db046a7ec1f6dda201c51f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cascade-lifecycle-msgs/default.nix
+++ b/distros/foxy/cascade-lifecycle-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
+buildRosPackage {
+  pname = "ros-foxy-cascade-lifecycle-msgs";
+  version = "0.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/cascade_lifecycle_msgs/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "d1c5fc2fce98d13e55663a70e763c687542d444c5ece61434a2310db4dca332e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rclcpp rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for rclcpp_cascade_lifecycle package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/common-interfaces/default.nix
+++ b/distros/foxy/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-common-interfaces";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "9636533dc375e6d6b8a2489c731d1914b9f4de04003f879d681cec24d8d859de";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "7b98e9226c90afe4013f99df7fb403b93714cb92ac008926563cfa292c8a89a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cv-bridge/default.nix
+++ b/distros/foxy/cv-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-index-python, ament-lint-auto, ament-lint-common, boost, opencv3, python-cmake-module, python3Packages, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cv-bridge";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/cv_bridge/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7455ffed849afe7238d4968dc4982c984e8f78fa3123743dbb063c6a7f86ed13";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/cv_bridge/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e9d4556dbf71b80b05c724dd6aeab3a6c5f471d9445ac19d84cfd34e951da8b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-msgs/default.nix
+++ b/distros/foxy/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "d4d72bda8e658ba4403ac2cede6087178281d509fc5f0d27e5e3ef087288959f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "98f41a5c64c85082936161088aa03021099d5937411f570e73dd31fefba81d5a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-sdk/default.nix
+++ b/distros/foxy/dynamixel-sdk/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-foxy-dynamixel-sdk";
+  version = "3.7.30-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk/3.7.30-1.tar.gz";
+    name = "3.7.30-1.tar.gz";
+    sha256 = "935d40973ca7c2e940db3deaa27921a1810a9d47ca356269b2eb8b0fd9fe0556";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ecl-build/default.nix
+++ b/distros/foxy/ecl-build/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-build";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/foxy/ecl_build/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "214ae9d32b18abc87968e4d75e9dc444bfffd139b4524ea3ed072544ddcfe5e8";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Collection of cmake/make build tools primarily for ecl development itself, but also
+     contains a few cmake modules useful outside of the ecl.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-config/default.nix
+++ b/distros/foxy/ecl-config/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-config";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_config/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "54560f5ee96d75ddde9415ccc9f740ac8fa7ef5b6ca7287525aebd3f7adbfeea";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''These tools inspect and describe your system with macros, types
+     and functions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-console/default.nix
+++ b/distros/foxy/ecl-console/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-console";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_console/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "43db25e0d2276b630c4cefbdfc0add8716d495faac1a913c4ebbdb84816ecfad";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Color codes for ansii consoles.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-converters-lite/default.nix
+++ b/distros/foxy/ecl-converters-lite/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-converters-lite";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_converters_lite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "8b15f002cb74ac11083660ef294160b0419875d0bbdc3d96ef5460b942fcaa19";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''These are a very simple version of some of the functions in ecl_converters
+     suitable for firmware development. That is, there is no use of new,
+     templates or exceptions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-errors/default.nix
+++ b/distros/foxy/ecl-errors/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-errors";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_errors/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "92f939390679eb59a1e2a3d5829742847d03487081a7cc53b1e6c5399d8413c2";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  propagatedBuildInputs = [ ecl-config ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This library provides lean and mean error mechanisms.
+    It includes c style error functions as well as a few
+    useful macros. For higher level mechanisms,
+    refer to ecl_exceptions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-io/default.nix
+++ b/distros/foxy/ecl-io/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-io";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_io/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "521ad2b9d3a64c4ea9cd8c7c689db9d07ad16b4acddb10a8f1e6b85ca3a16ccb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Most implementations (windows, posix, ...) have slightly different api for
+     low level input-output functions. These are gathered here and re-represented
+     with a cross platform set of functions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-license/default.nix
+++ b/distros/foxy/ecl-license/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-license";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/foxy/ecl_license/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "9f8d4239be3316975aa152be73ece578f71ea0588d92c5ec77e4174c79b84779";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Maintains the ecl licenses and also provides an install
+     target for deploying licenses with the ecl libraries.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-lite/default.nix
+++ b/distros/foxy/ecl-lite/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-config, ecl-converters-lite, ecl-errors, ecl-io, ecl-sigslots-lite, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-lite";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_lite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e2c49af84d52bbd6e4aa87565cbbc3970921b4ba2a4400c43b3ba693093379a6";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-config ecl-converters-lite ecl-errors ecl-io ecl-sigslots-lite ecl-time-lite ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Libraries and utilities for embedded and low-level linux development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-sigslots-lite/default.nix
+++ b/distros/foxy/ecl-sigslots-lite/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-sigslots-lite";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_sigslots_lite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "02e614dabfd2f52815044f0c33bb8cf93151adf4dc4d83d89acb9846aa41eca9";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This avoids use of dynamic storage (malloc/new) and thread safety (mutexes) to
+     provide a very simple sigslots implementation that can be used for *very*
+     embedded development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-time-lite/default.nix
+++ b/distros/foxy/ecl-time-lite/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-time-lite";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_lite-release/archive/release/foxy/ecl_time_lite/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f6e53e5fdcb6ae15de797a288c812aa5dc9dbca043696488ed2f992256a1819b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Provides a portable set of time functions that are especially useful for
+     porting other code or being wrapped by higher level c++ classes.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-tools/default.nix
+++ b/distros/foxy/ecl-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-tools";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_tools-release/archive/release/foxy/ecl_tools/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "4a9651ff2fe597408b5c8507f16d58547ce3afa1c59a2927ab35a84577e20df4";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-build ecl-license ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Tools and utilities for ecl development.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -146,6 +146,8 @@ self: super: {
 
  cartographer-ros-msgs = self.callPackage ./cartographer-ros-msgs {};
 
+ cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
+
  class-loader = self.callPackage ./class-loader {};
 
  common-interfaces = self.callPackage ./common-interfaces {};
@@ -205,6 +207,30 @@ self: super: {
  dwb-plugins = self.callPackage ./dwb-plugins {};
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
+
+ dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
+
+ ecl-build = self.callPackage ./ecl-build {};
+
+ ecl-config = self.callPackage ./ecl-config {};
+
+ ecl-console = self.callPackage ./ecl-console {};
+
+ ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-errors = self.callPackage ./ecl-errors {};
+
+ ecl-io = self.callPackage ./ecl-io {};
+
+ ecl-license = self.callPackage ./ecl-license {};
+
+ ecl-lite = self.callPackage ./ecl-lite {};
+
+ ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-time-lite = self.callPackage ./ecl-time-lite {};
+
+ ecl-tools = self.callPackage ./ecl-tools {};
 
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
@@ -358,8 +384,6 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
- librealsense2 = self.callPackage ./librealsense2 {};
-
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -502,6 +526,10 @@ self: super: {
 
  pluginlib = self.callPackage ./pluginlib {};
 
+ pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
+
+ py-trees-ros = self.callPackage ./py-trees-ros {};
+
  py-trees-ros-interfaces = self.callPackage ./py-trees-ros-interfaces {};
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
@@ -550,6 +578,8 @@ self: super: {
 
  rclcpp-action = self.callPackage ./rclcpp-action {};
 
+ rclcpp-cascade-lifecycle = self.callPackage ./rclcpp-cascade-lifecycle {};
+
  rclcpp-components = self.callPackage ./rclcpp-components {};
 
  rclcpp-lifecycle = self.callPackage ./rclcpp-lifecycle {};
@@ -559,14 +589,6 @@ self: super: {
  rcpputils = self.callPackage ./rcpputils {};
 
  rcutils = self.callPackage ./rcutils {};
-
- realsense-examples = self.callPackage ./realsense-examples {};
-
- realsense-msgs = self.callPackage ./realsense-msgs {};
-
- realsense-node = self.callPackage ./realsense-node {};
-
- realsense-ros = self.callPackage ./realsense-ros {};
 
  realtime-tools = self.callPackage ./realtime-tools {};
 
@@ -591,6 +613,8 @@ self: super: {
  rmw-implementation = self.callPackage ./rmw-implementation {};
 
  rmw-implementation-cmake = self.callPackage ./rmw-implementation-cmake {};
+
+ robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
@@ -645,6 +669,8 @@ self: super: {
  ros-core = self.callPackage ./ros-core {};
 
  ros-environment = self.callPackage ./ros-environment {};
+
+ ros-ign = self.callPackage ./ros-ign {};
 
  ros-testing = self.callPackage ./ros-testing {};
 
@@ -713,6 +739,8 @@ self: super: {
  rosidl-typesupport-introspection-c = self.callPackage ./rosidl-typesupport-introspection-c {};
 
  rosidl-typesupport-introspection-cpp = self.callPackage ./rosidl-typesupport-introspection-cpp {};
+
+ rplidar-ros = self.callPackage ./rplidar-ros {};
 
  rpyutils = self.callPackage ./rpyutils {};
 

--- a/distros/foxy/geometry-msgs/default.nix
+++ b/distros/foxy/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometry-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "4a7be413df0ca8f928c0a360c64ea1b9232017460bd5a6b04041abbc51c54d25";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "676cee383b07509d255a046fdb3abaffe2313d4eb71633bfc14605d58d54e4ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-geometry/default.nix
+++ b/distros/foxy/image-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-cmake-ros, opencv3, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-geometry";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/image_geometry/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "c11672af3abc4911d5ccf24cbee2ed5501163946b54bc89ceadc26fc7ec9dba6";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/image_geometry/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d0937df243548f57c6c68f3f753a0f4e72c9371d1ad6b772ad43664dd4a04156";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav-msgs/default.nix
+++ b/distros/foxy/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "2d459fafe11b0eed1c5325493a6c73c95181d3e70aa6ab666c5f889ab9e23950";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "39cbba7119d3968c187cf0e87fcab96d44d49a7c37ecbe043d80b25b6ec9a5f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pointcloud-to-laserscan/default.nix
+++ b/distros/foxy/pointcloud-to-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, laser-geometry, launch, launch-ros, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-pointcloud-to-laserscan";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/foxy/pointcloud_to_laserscan/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "32c421f51b02bb3b4b0b082b1b382c5e70764bf7cec67e790c6e19f9f0325277";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ laser-geometry launch launch-ros message-filters rclcpp rclcpp-components sensor-msgs tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts a 3D Point Cloud into a 2D laser scan. This is useful for making devices like the Kinect appear like a laser scanner for 2D-based algorithms (e.g. laser-based SLAM).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/py-trees-ros/default.nix
+++ b/distros/foxy/py-trees-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-py-trees-ros";
+  version = "2.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/foxy/py_trees_ros/2.0.11-1.tar.gz";
+    name = "2.0.11-1.tar.gz";
+    sha256 = "b59bbf7efb689db67853a793fe3ea3aab76be32aa5033e1146ab16bb38f2e371";
+  };
+
+  buildType = "ament_python";
+  buildInputs = [ python3Packages.setuptools ];
+  checkInputs = [ pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-ros-interfaces rcl-interfaces rclpy ros2topic sensor-msgs std-msgs tf2-ros unique-identifier-msgs ];
+
+  meta = {
+    description = ''ROS2 extensions and behaviours for py_trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rcl-logging-log4cxx/default.nix
+++ b/distros/foxy/rcl-logging-log4cxx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, log4cxx, python3Packages, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-log4cxx";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_log4cxx/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "952291254328237f225b9a1f5c0b512303c7fce5f7069d0f2a2cc38bd7fd1923";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_log4cxx/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d38f5cbaefeb0c3649ee51ceacbf9a87096adfb8f14657668bf9e46c5a8602b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-logging-noop/default.nix
+++ b/distros/foxy/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-noop";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_noop/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "884f625e22e262b35be502415d84e0392c5a1bb372aec7bbb435a891493bfa08";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_noop/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4648dd4e8d556c603d1b32b7f06f035ab25ab9773c7e08012772a2ad8432d155";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-logging-spdlog/default.nix
+++ b/distros/foxy/rcl-logging-spdlog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-spdlog";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_spdlog/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "6f9f88d2899c67074e37f1369da74e92da20d88c6ac6316a522dad62887ebb96";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_spdlog/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7399d2d8559620f9b27942a23d2bf7b005c67250bb7c443ed0cfecbba65c0c4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-cascade-lifecycle/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-foxy-rclcpp-cascade-lifecycle";
+  version = "0.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/rclcpp_cascade_lifecycle/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "e8a85a1fc0c67567eb150bc0ce2f3f89ba7551273c5112cbba4703478c84d371";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cascade-lifecycle-msgs lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides a mechanism to make trees of lifecycle nodes to propagate state changes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rcpputils/default.nix
+++ b/distros/foxy/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcpputils";
-  version = "1.1.0-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/foxy/rcpputils/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6ba6b5beacc1778a3381d391f5c36100f93477e9897159dd774c81e06247e1c0";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/foxy/rcpputils/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "35d1f87ccc910299f08243f4bdc75daebeb8c8101a983a05d421d4f58643a00e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "9e2e01744e4d0b45c61ff7eefac15e8469f4aa3c675f270b895b4c4e9a2df760";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "885610777256755d02de45e6b7f54076eef9f4bb66e9c933eaa8a285ce7ed880";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.0.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "712fcd630599b9fe7508896b241a300e99ea7a8c70963072ef86c4121cc5785c";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "563cb52c67c42ce7e7d67dafe5e26c87115fb6af2d9693934a89713c4dc55ccf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.0.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "38a0c3016ceab92ba4258ebc38639986f2b512b4c30a13259d3f55b23d46d2a9";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "acaa4bd8b0f44de7a7e5cd6d36fd80fa4ad5dcf44e2914c57dc4d59e8c0469b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.0.2-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "2ebfef3dd6b3a1fb25c11778fd2b650d67c3fcd6dfd31e8568e1dcfff37b6bda";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b7f2c1491048fc74a05d4be7dbf7b6a36e8cd487107696252f09f386d36565a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/robot-localization/default.nix
+++ b/distros/foxy/robot-localization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, builtin-interfaces, diagnostic-msgs, diagnostic-updater, eigen, geographic-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, libyamlcpp, nav-msgs, rclcpp, rmw-implementation, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-robot-localization";
+  version = "3.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/foxy/robot_localization/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "5d4ee836e941dd006a6d799d64ef4fc6edb48fe09dfc769daf6b63a027ef73b5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common builtin-interfaces launch-ros launch-testing-ament-cmake ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater eigen geographic-msgs geometry-msgs libyamlcpp nav-msgs rclcpp rmw-implementation rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake builtin-interfaces rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides nonlinear state estimation through sensor fusion of an abritrary number of sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ros-ign/default.nix
+++ b/distros/foxy/ros-ign/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
+buildRosPackage {
+  pname = "ros-foxy-ros-ign";
+  version = "0.221.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign/0.221.0-1.tar.gz";
+    name = "0.221.0-1.tar.gz";
+    sha256 = "172b71011a05d9df803c732528a704aaed089152e288d79dcd582aa456c053a0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ros-ign-bridge ros-ign-gazebo ros-ign-gazebo-demos ros-ign-image ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta-package containing interfaces for using ROS 2 with <a href="https://ignitionrobotics.org">Ignition</a> simulation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rplidar-ros/default.nix
+++ b/distros/foxy/rplidar-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, rclcpp, rclcpp-components, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-foxy-rplidar-ros";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/allenh1/rplidar_ros-release/archive/release/foxy/rplidar_ros/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "416d8802542ddfe6fb35e1416cf117a04098fac0c1ca8ff4205815ca765d0d48";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp rclcpp-components sensor-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-ros ];
+
+  meta = {
+    description = ''The rplidar ros package, support rplidar A2/A1 and A3/S1'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/sensor-msgs/default.nix
+++ b/distros/foxy/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-sensor-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a5ce25ff8b638bd4b680d4ba775d348acb6df184a237e63014def6aec718e0e3";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "085d2a034281e03cb734361535a40c207275a52670598ce49b60f26c1fd6f3a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shape-msgs/default.nix
+++ b/distros/foxy/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-shape-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "e53438ef731b8cb9f7d0284b0abfdeac483d9b1ebc50792859d540b0261250f2";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "3f347fe010c14636023e45890aa10be3653d5bc477feb663d70a555b4b379695";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/std-msgs/default.nix
+++ b/distros/foxy/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "8df3db4920ddb9f684e21ae84bdf7e6938fcfa9675a28cdfb059857481d9eaaf";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ede1a545c01d4cd0538ef34594688f082d7b77695e7f76ae2052a95ff6f1aa3d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/std-srvs/default.nix
+++ b/distros/foxy/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-srvs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "eeed7d8f023db743d168d78e98e43bbaff1480c3f26b7796deb7ac4330855e7d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "3f9f8cc2e1882b0a4bb008dbee489d73b1bf6c63436f6a53b210d888906c49de";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/stereo-msgs/default.nix
+++ b/distros/foxy/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-stereo-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "14d31659408d824bcfeef726a161f271a2a8c45908dda66934c6c5594404eb0d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "a46baa7a4675c795665f1312cdc9ebc2172aa76df7da2209e294a4931d427ab8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, rclcpp-lifecycle, system-modes }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "dcf3193e9aa441a03471fd578a30beb92fa3409ff92fd0c6487cdb9f5bfdc137";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "2d6a22e7700346923b22021d6295bbeb5be28e9400c98d9e417e48de9023514d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.2.1-r2";
+  version = "0.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.2.1-2.tar.gz";
-    name = "0.2.1-2.tar.gz";
-    sha256 = "3f4c848b7df17ac99743d412b7843311abdabc66d3b4120e99f85516a383c15f";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.2.3-1.tar.gz";
+    name = "0.2.3-1.tar.gz";
+    sha256 = "dcda1582f8c3b69c1421aa2e4c5e199fd40a9a8a522847c50f723697fbc64688";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/trajectory-msgs/default.nix
+++ b/distros/foxy/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-trajectory-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a0b12161fb9fc687cbc8ad709bc0876c94cc07a782930b6e1e9b9c5742f334b5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "ba09a09927ca906c2efce8234306601bf90197fe7033877cd62e05940b68649b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/vision-opencv/default.nix
+++ b/distros/foxy/vision-opencv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-geometry }:
 buildRosPackage {
   pname = "ros-foxy-vision-opencv";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/vision_opencv/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a8b7cc4af3252afa0a38c60fead3176d5e12667be582ded8a1212760b38e5947";
+    url = "https://github.com/ros2-gbp/vision_opencv-release/archive/release/foxy/vision_opencv/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f378194df1cacbbdecd116bf4e0eccc2d84aee0d0e66a039de2bbe72342f8472";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/visualization-msgs/default.nix
+++ b/distros/foxy/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-visualization-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "76e98c25102305945cdeb30f3965feab2a19d818b61212ba2cb3e9d2062a2b75";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "39a5ff0d5643414e842a16a7d9f0abf97e60f84d27db6e532080b4789d3ca397";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/dynamixel-sdk/default.nix
+++ b/distros/kinetic/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-sdk";
-  version = "3.7.21-r1";
+  version = "3.7.31-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/kinetic/dynamixel_sdk/3.7.21-1.tar.gz";
-    name = "3.7.21-1.tar.gz";
-    sha256 = "aac70fdfbf914d7d74ac03b05d27cddd234666f0b763338bb2595d6b40c7c131";
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/kinetic/dynamixel_sdk/3.7.31-1.tar.gz";
+    name = "3.7.31-1.tar.gz";
+    sha256 = "b999544df975f9e0e0df3719c6fd0f6b7cbb6d91347461f725055f5bb0a0f289";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -3746,8 +3746,6 @@ self: super: {
 
  ros-core = self.callPackage ./ros-core {};
 
- ros-cvb-camera-driver = self.callPackage ./ros-cvb-camera-driver {};
-
  ros-emacs-utils = self.callPackage ./ros-emacs-utils {};
 
  ros-environment = self.callPackage ./ros-environment {};
@@ -3795,8 +3793,6 @@ self: super: {
  rosbag-migration-rule = self.callPackage ./rosbag-migration-rule {};
 
  rosbag-pandas = self.callPackage ./rosbag-pandas {};
-
- rosbag-snapshot = self.callPackage ./rosbag-snapshot {};
 
  rosbag-snapshot-msgs = self.callPackage ./rosbag-snapshot-msgs {};
 
@@ -4329,8 +4325,6 @@ self: super: {
  sick-visionary-t-driver = self.callPackage ./sick-visionary-t-driver {};
 
  sicktoolbox = self.callPackage ./sicktoolbox {};
-
- sicktoolbox-wrapper = self.callPackage ./sicktoolbox-wrapper {};
 
  simple-arm = self.callPackage ./simple-arm {};
 

--- a/distros/melodic/dynamixel-sdk/default.nix
+++ b/distros/melodic/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-sdk";
-  version = "3.7.21-r1";
+  version = "3.7.31-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/melodic/dynamixel_sdk/3.7.21-1.tar.gz";
-    name = "3.7.21-1.tar.gz";
-    sha256 = "6298842f665570ec035fbe27e02900b4018a4ff25185b73645c7143a87dee50a";
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/melodic/dynamixel_sdk/3.7.31-1.tar.gz";
+    name = "3.7.31-1.tar.gz";
+    sha256 = "949d7eca39b060ec04eb87a2d52e892b4eee48a6e90bcbb204cb2fd935f7771d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3532,6 +3532,8 @@ self: super: {
 
  ubnt-airos-tools = self.callPackage ./ubnt-airos-tools {};
 
+ udp-com = self.callPackage ./udp-com {};
+
  um6 = self.callPackage ./um6 {};
 
  um7 = self.callPackage ./um7 {};

--- a/distros/melodic/sick-scan/default.nix
+++ b/distros/melodic/sick-scan/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, rospy, sensor-msgs, tf, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-scan";
-  version = "1.7.6-r2";
+  version = "1.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.6-2.tar.gz";
-    name = "1.7.6-2.tar.gz";
-    sha256 = "3d8ce4d0caf8c7ffc51b43f6e9312412a38c48048551fd935f2365e3f1ce04c4";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.7-1.tar.gz";
+    name = "1.7.7-1.tar.gz";
+    sha256 = "5231942525dc4921aff7e18775b90a74a9b944139fab15e487009ef5ebdf01a1";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp rospy sensor-msgs tf tf2 visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/udp-com/default.nix
+++ b/distros/melodic/udp-com/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nodelet, roscpp, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-udp-com";
+  version = "0.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/flynneva/udp_com-release/archive/release/melodic/udp_com/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "80acc627cff5396a71aa01948fd791f94e1dde528db1e10d945ad6c45126beea";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ message-generation message-runtime nodelet roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The udp_com package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/catkin-virtualenv/default.nix
+++ b/distros/noetic/catkin-virtualenv/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3, python3Packages, pythonPackages, rosbash, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-catkin-virtualenv";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/catkin_virtualenv-release/archive/release/noetic/catkin_virtualenv/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "625ce599f1b78253e9a31fec7b9257bede986d4e713993fe8a331805e3f78a1f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ python3 python3Packages.nose python3Packages.rospkg python3Packages.virtualenv pythonPackages.virtualenv rosbash ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Bundle python requirements in a catkin package via virtualenv.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "de5999e5390cc0c0d48c2febcad426f0dbd802b0c26c93505678bf4133b747e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "5db84865b067d2d7e5ca7411d1136ac1043f383c53df00c3f48719f97c75f78d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamixel-sdk/default.nix
+++ b/distros/noetic/dynamixel-sdk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-sdk";
+  version = "3.7.31-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/noetic/dynamixel_sdk/3.7.31-1.tar.gz";
+    name = "3.7.31-1.tar.gz";
+    sha256 = "258090ab7b333982492ec6361b98b49850837cab53d11a7860918078e4f075c0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is wrapping version of ROBOTIS Dynamixel SDK for ROS. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -76,6 +76,8 @@ self: super: {
 
  catkin = self.callPackage ./catkin {};
 
+ catkin-virtualenv = self.callPackage ./catkin-virtualenv {};
+
  class-loader = self.callPackage ./class-loader {};
 
  clear-costmap-recovery = self.callPackage ./clear-costmap-recovery {};
@@ -229,6 +231,8 @@ self: super: {
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
 
  dynamic-tf-publisher = self.callPackage ./dynamic-tf-publisher {};
+
+ dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
  ecl-build = self.callPackage ./ecl-build {};
 
@@ -755,6 +759,8 @@ self: super: {
  power-msgs = self.callPackage ./power-msgs {};
 
  ps3joy = self.callPackage ./ps3joy {};
+
+ py-trees-msgs = self.callPackage ./py-trees-msgs {};
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
 

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "cad633f5be5448029315f0a4a218beba66b69dbca2550e48f61247d4e93e09e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "ce884aba36d2d6a11174227d9b6b9009b535605fc0dfc6ded8a97ceb66bbe304";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "cc80fe232883eff101853fc3abfaef7417c994bc5419593760569560a66d8c08";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "a68376f1b54ca901791fd873494789e5a80dfda5671038bd09de6f4f15292c37";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "fbf47bebeff6951da9e825fbebaf3e13c54824e369b99081a7fb18c6dd10297d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "aa058e7af2c25cc9c7b5ba34c8581674f949b4b4affc641bbca7ed4595b4ee61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e1c50d7f75b60158898fd07e06d7d9b478c51662977d55ca8d1221717e37c729";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "9f0fc0e3c3f8e613697c47e5a7566351ef344b48d388eda30ee5093b05824ba6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "ebfadd1c23d84c8e2ede2fa5f0c809ec890cd300759c2ee63e22e7c74bd071ac";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "20e40c2f0b36aed81fdc058697adeb13bb0139c6718381c29f29efc3a9cc8954";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "6065d43e3155dc6c33c936dfba4fdbb02ea869479c50ed90e4c3f245888a4ae3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "399e3cddc8068d420143d3c47eb7ee339a665720cb45f48e9ab3835a7470bd33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "99e214b6597c84285eaa01034841236c56e6d2666627deb6eb6d1c6725cee8c6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "877a79d5346ba2c24843e337ea1b3818e62c3762a6befc1ca03e46d0d6e1c416";
   };
 
   buildType = "catkin";

--- a/distros/noetic/py-trees-msgs/default.nix
+++ b/distros/noetic/py-trees-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, dynamic-reconfigure, message-generation, message-runtime, std-msgs, uuid-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-py-trees-msgs";
+  version = "0.3.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/py_trees_msgs-release/archive/release/noetic/py_trees_msgs/0.3.6-1.tar.gz";
+    name = "0.3.6-1.tar.gz";
+    sha256 = "a472c703fa0c24a837a7a12176663d4a76cda25e174c58c6b8b700cc430b723c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs dynamic-reconfigure message-runtime std-msgs uuid-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages used by py_trees_ros and some extras for the mock demos/tests.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "b09ecb16d4f7d35eeb455d1755fd2a7fa40cf1fdf6a30957fa8f9346b8e10378";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "7e6aca76b4d4ea32bdfc2f6465be267d0b16337777c9e3d7709fa3b4eb6fc153";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan/default.nix
+++ b/distros/noetic/sick-scan/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, perception-pcl, roscpp, rospy, sensor-msgs, tf, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan";
-  version = "1.7.6-r2";
+  version = "1.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.6-2.tar.gz";
-    name = "1.7.6-2.tar.gz";
-    sha256 = "610d4724ae7a4845dfac87caa908219d5a30d00085b483d15efcaed90a009ffc";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.7-1.tar.gz";
+    name = "1.7.7-1.tar.gz";
+    sha256 = "c679c3607b67c004774483b593570f77161051360c8c48d12613432df5e80e04";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure message-runtime perception-pcl roscpp rospy sensor-msgs tf tf2 visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sophus/default.nix
+++ b/distros/noetic/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-noetic-sophus";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/noetic/sophus/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c30680143378020b2b52ef83dfb48855b47ca7c894166649c34f01c00ee6dc04";
+    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/noetic/sophus/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "91e49d8613c81936a3ffcc4121e6b02b8101bcdf23c59afcd063c24c0b078770";
   };
 
   buildType = "cmake";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "48414b62aebfee26f3a2ce3b482d0b015f9139c31662a1a072467b6ffff61dc9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "1460e735705344f8bbab9c23ba0db2f3bcc20dc87814aea5fe64aab7eda6f4c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "04b5120f4e75b69e0025b800fe28c2bb70a5d6d7699a9eeaef5f455be2fcf208";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "606e8ce0a9ef0192959f9c4f5b0270a318a0ddade0e5d020dd7267b1ede43470";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 49af921d1ed2e4a6f2dd991fb19195f45096fab6.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *dynamixel-sdk 3.7.20-r1 --> 3.7.30-r1*
* *hls-lfcd-lds-driver 2.0.0-r1 --> 2.0.1-r1*
* *kdl-parser 2.2.0-r1 --> 2.2.1-r1*
* *serial-driver 0.0.5-r1*
* *swri-console-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-dbw-interface 3.2.0-r1 --> 3.3.0-r1*
* *swri-geometry-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-image-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-math-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-opencv-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-prefix-tools 3.2.0-r1 --> 3.3.0-r1*
* *swri-roscpp 3.2.0-r1 --> 3.3.0-r1*
* *swri-route-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-serial-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-system-util 3.2.0-r1 --> 3.3.0-r1*
* *swri-transform-util 3.2.0-r1 --> 3.3.0-r1*
* *system-modes 0.2.0-r3 --> 0.2.1-r7*
* *system-modes-examples 0.2.0-r3 --> 0.2.1-r7*
* *udp-driver 0.0.4-r3 --> 0.0.5-r1*

Eloquent Changes:
-----------------
* *dynamixel-sdk 3.7.30-r1*
* *hls-lfcd-lds-driver 2.0.1-r1*
* *plansys2-bringup 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-domain-expert 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-executor 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-lifecycle-manager 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-msgs 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-pddl-parser 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-planner 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-problem-expert 0.0.9-r1 --> 0.0.10-r1*
* *plansys2-terminal 0.0.9-r1 --> 0.0.10-r1*

Foxy Changes:
-------------
* *actionlib-msgs 2.0.1-r1 --> 2.0.3-r1*
* *cascade-lifecycle-msgs 0.0.6-r1*
* *common-interfaces 2.0.1-r1 --> 2.0.3-r1*
* *cv-bridge 2.2.0-r1 --> 2.2.1-r1*
* *diagnostic-msgs 2.0.1-r1 --> 2.0.3-r1*
* *dynamixel-sdk 3.7.30-r1*
* *ecl-build 1.0.2-r2*
* *ecl-config 1.1.0-r1*
* *ecl-console 1.1.0-r1*
* *ecl-converters-lite 1.1.0-r1*
* *ecl-errors 1.1.0-r1*
* *ecl-io 1.1.0-r1*
* *ecl-license 1.0.2-r2*
* *ecl-lite 1.1.0-r1*
* *ecl-sigslots-lite 1.1.0-r1*
* *ecl-time-lite 1.1.0-r1*
* *ecl-tools 1.0.2-r2*
* *geometry-msgs 2.0.1-r1 --> 2.0.3-r1*
* *image-geometry 2.2.0-r1 --> 2.2.1-r1*
* *nav-msgs 2.0.1-r1 --> 2.0.3-r1*
* *pointcloud-to-laserscan 2.0.0-r1*
* *py-trees-ros 2.0.11-r1*
* *rcl-logging-log4cxx 1.0.0-r1 --> 1.0.1-r1*
* *rcl-logging-noop 1.0.0-r1 --> 1.0.1-r1*
* *rcl-logging-spdlog 1.0.0-r1 --> 1.0.1-r1*
* *rclcpp-cascade-lifecycle 0.0.6-r1*
* *rcpputils 1.1.0-r1 --> 1.3.0-r1*
* *rmw-cyclonedds-cpp 0.7.2-r1 --> 0.7.3-r1*
* *rmw-fastrtps-cpp 1.0.2-r1 --> 1.2.0-r1*
* *rmw-fastrtps-dynamic-cpp 1.0.2-r1 --> 1.2.0-r1*
* *rmw-fastrtps-shared-cpp 1.0.2-r1 --> 1.2.0-r1*
* *robot-localization 3.1.1-r1*
* *ros-ign 0.221.0-r1*
* *rplidar-ros 2.0.0-r1*
* *sensor-msgs 2.0.1-r1 --> 2.0.3-r1*
* *shape-msgs 2.0.1-r1 --> 2.0.3-r1*
* *std-msgs 2.0.1-r1 --> 2.0.3-r1*
* *std-srvs 2.0.1-r1 --> 2.0.3-r1*
* *stereo-msgs 2.0.1-r1 --> 2.0.3-r1*
* *system-modes 0.2.1-r2 --> 0.2.3-r1*
* *system-modes-examples 0.2.1-r2 --> 0.2.3-r1*
* *trajectory-msgs 2.0.1-r1 --> 2.0.3-r1*
* *vision-opencv 2.2.0-r1 --> 2.2.1-r1*
* *visualization-msgs 2.0.1-r1 --> 2.0.3-r1*

Kinetic Changes:
----------------
* *dynamixel-sdk 3.7.21-r1 --> 3.7.31-r1*

Melodic Changes:
----------------
* *dynamixel-sdk 3.7.21-r1 --> 3.7.31-r1*
* *sick-scan 1.7.6-r2 --> 1.7.7-r1*
* *udp-com 0.0.6-r1*

Noetic Changes:
---------------
* *catkin-virtualenv 0.6.0-r1*
* *costmap-cspace 0.9.0-r1 --> 0.9.1-r1*
* *dynamixel-sdk 3.7.31-r1*
* *joystick-interrupt 0.9.0-r1 --> 0.9.1-r1*
* *map-organizer 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-common 0.9.0-r1 --> 0.9.1-r1*
* *neonavigation-launch 0.9.0-r1 --> 0.9.1-r1*
* *obj-to-pointcloud 0.9.0-r1 --> 0.9.1-r1*
* *planner-cspace 0.9.0-r1 --> 0.9.1-r1*
* *py-trees-msgs 0.3.6-r1*
* *safety-limiter 0.9.0-r1 --> 0.9.1-r1*
* *sick-scan 1.7.6-r2 --> 1.7.7-r1*
* *sophus 1.1.0-r1 --> 1.2.0-r1*
* *track-odometry 0.9.0-r1 --> 0.9.1-r1*
* *trajectory-tracker 0.9.0-r1 --> 0.9.1-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] ignition-gazebo3
 * [ ] ignition-math6
 * [ ] ignition-msgs5
 * [ ] ignition-transport8
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dev
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-colorama
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-imageio
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-texttable
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

