### PR TITLE
rosdistro sync, Fri Jul 31 13:40:46 2020

### DIFF
--- a/distros/dashing/camera-calibration/default.nix
+++ b/distros/dashing/camera-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-dashing-camera-calibration";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/camera_calibration/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "ca755e0c2c63fd3c14dbbdd41b27e8a32ddc0def5399f63c7053d73f6ad8732d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.requests pythonPackages.pytest ];
+  propagatedBuildInputs = [ cv-bridge image-geometry message-filters rclpy sensor-msgs std-srvs ];
+
+  meta = {
+    description = ''camera_calibration allows easy calibration of monocular or stereo
+     cameras using a checkerboard calibration target.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/depth-image-proc/default.nix
+++ b/distros/dashing/depth-image-proc/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-depth-image-proc";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/depth_image_proc/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "3e481a585a001d636fbbfa165c88b3cccf13e3434a735e43214c05266bc59794";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ class-loader message-filters sensor-msgs stereo-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-transport tf2 tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Contains components for processing depth images such as those
+     produced by OpenNI camera. Functions include creating disparity
+     images and point clouds, as well as registering (reprojecting)
+     a depth image into another camera frame.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -150,6 +150,8 @@ self: super: {
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
+ camera-calibration = self.callPackage ./camera-calibration {};
+
  camera-calibration-parsers = self.callPackage ./camera-calibration-parsers {};
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
@@ -221,6 +223,8 @@ self: super: {
  demo-nodes-cpp-native = self.callPackage ./demo-nodes-cpp-native {};
 
  demo-nodes-py = self.callPackage ./demo-nodes-py {};
+
+ depth-image-proc = self.callPackage ./depth-image-proc {};
 
  depthimage-to-laserscan = self.callPackage ./depthimage-to-laserscan {};
 
@@ -426,11 +430,21 @@ self: super: {
 
  image-geometry = self.callPackage ./image-geometry {};
 
+ image-pipeline = self.callPackage ./image-pipeline {};
+
+ image-proc = self.callPackage ./image-proc {};
+
+ image-publisher = self.callPackage ./image-publisher {};
+
+ image-rotate = self.callPackage ./image-rotate {};
+
  image-tools = self.callPackage ./image-tools {};
 
  image-transport = self.callPackage ./image-transport {};
 
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
+
+ image-view = self.callPackage ./image-view {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
@@ -975,6 +989,8 @@ self: super: {
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
+
+ stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 

--- a/distros/dashing/image-pipeline/default.nix
+++ b/distros/dashing/image-pipeline/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate }:
+buildRosPackage {
+  pname = "ros-dashing-image-pipeline";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/image_pipeline/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "b1a91ea077d4f535330dc9edb56f099913a589fea780f41a482976e2c34649c7";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ camera-calibration depth-image-proc image-proc image-publisher image-rotate ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''image_pipeline fills the gap between getting raw images from a camera driver and higher-level vision processing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/image-proc/default.nix
+++ b/distros/dashing/image-proc/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, rclcpp, rclcpp-components, rcutils, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-image-proc";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/image_proc/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "4d61ba6095fbdec650de41f71279f8b6133b6ffb8ff9068a14f63da4c2908f28";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-transport rclcpp rclcpp-components rcutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Single image rectification and color processing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/image-publisher/default.nix
+++ b/distros/dashing/image-publisher/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, class-loader, cv-bridge, image-geometry, image-transport, rclcpp, rclcpp-components }:
+buildRosPackage {
+  pname = "ros-dashing-image-publisher";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/image_publisher/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "e3daa2c8fa53a2e85fd848f52de08b20b329e0902c940c75c9df470757a7fc8d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-info-manager class-loader cv-bridge image-geometry image-transport rclcpp rclcpp-components ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      Contains a node publish an image stream from single image file
+      or avi motion file.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/image-rotate/default.nix
+++ b/distros/dashing/image-rotate/default.nix
@@ -1,0 +1,43 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-transport, rclcpp, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-image-rotate";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/image_rotate/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "ecd999676f180a6ae811759355585a62697138916b6976384754a1781eb79491";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ class-loader ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge image-transport rclcpp rclcpp-components tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      Contains a node that rotates an image stream in a way that minimizes
+      the angle between a vector in some arbitrary frame and a vector in the
+      camera frame. The frame of the outgoing image is published by the node.
+    </p>
+    <p>
+      This node is intended to allow camera images to be visualized in an
+      orientation that is more intuitive than the hardware-constrained
+      orientation of the physical camera. This is particularly helpful, for
+      example, to show images from the PR2's forearm cameras with a
+      consistent up direction, despite the fact that the forearms need to
+      rotate in arbitrary ways during manipulation.
+    </p>
+    <p>
+      It is not recommended to use the output from this node for further
+      computation, as it interpolates the source image, introduces black
+      borders, and does not output a camera_info.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/image-view/default.nix
+++ b/distros/dashing/image-view/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-image-view";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/image_view/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "bca42b6b0457d368d01a27550512f2a7a1b251f73a39d876e585b3b2be35b8ce";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ camera-calibration-parsers cv-bridge image-transport message-filters rclcpp rclcpp-components sensor-msgs std-srvs stereo-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A simple viewer for ROS image topics. Includes a specialized viewer
+  for stereo + disparity images.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/stereo-image-proc/default.nix
+++ b/distros/dashing/stereo-image-proc/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, sensor-msgs, stereo-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-stereo-image-proc";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/dashing/stereo_image_proc/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "97faaa2a39b47f4067f2932e0ec1dc271b66bed1c7a3fe4af5145480786b76ab";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-ros launch-testing launch-testing-ament-cmake python-cmake-module python3Packages.opencv3 rclpy ];
+  propagatedBuildInputs = [ cv-bridge image-geometry image-proc image-transport message-filters rclcpp rclcpp-components sensor-msgs stereo-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Stereo and single image rectification and disparity processing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/camera-calibration/default.nix
+++ b/distros/foxy/camera-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, cv-bridge, image-geometry, message-filters, python3Packages, pythonPackages, rclpy, sensor-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-foxy-camera-calibration";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/camera_calibration/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "9d6cd1f240821c8e135e6eeb9c171d1507fe43c3c481225e17e28c1cba477f99";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/camera_calibration/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "026126168e71465ea03c2c8234f9d3791f510c949ebb0b42b262e62f0650ebf1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/control-toolbox/default.nix
+++ b/distros/foxy/control-toolbox/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, rclcpp, rclcpp-lifecycle, realtime-tools }:
+buildRosPackage {
+  pname = "ros-foxy-control-toolbox";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/control_toolbox-release/archive/release/foxy/control_toolbox/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2023bb22a3f9d0c4a8c6761922b62f456a323b89ab88c49bf1a81dc6ee22da28";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common rclcpp-lifecycle ];
+  propagatedBuildInputs = [ control-msgs rclcpp realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The control toolbox contains modules that are useful across all controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/depth-image-proc/default.nix
+++ b/distros/foxy/depth-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-geometry, image-transport, message-filters, sensor-msgs, stereo-msgs, tf2, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-depth-image-proc";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/depth_image_proc/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "f6b62ea5348803c3f5efba86db67d838270ff95eaada78fd3f287375d183b38e";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/depth_image_proc/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "ade4efec13b8f61f38fc3510e027d05dff173eb029246f52d7f2c5b4383a80ed";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamic-graph/default.nix
+++ b/distros/foxy/dynamic-graph/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, doxygen, eigen, git, graphviz }:
+buildRosPackage {
+  pname = "ros-foxy-dynamic-graph";
+  version = "4.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "9044a56f1b493709619b6ce9bf8db8156fa5687d681dfa08b847c271ee8d0559";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ ament-cmake boost eigen graphviz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Dynamic graph library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-command-line/default.nix
+++ b/distros/foxy/ecl-command-line/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-command-line";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_command_line/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3cc6c26c55f9a6d7a9d88b5855e3eaffa852d853d981c9935e80918a5594d08a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Embeds the TCLAP library inside the ecl. This is a very convenient
+     command line parser in templatised c++.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-concepts/default.nix
+++ b/distros/foxy/ecl-concepts/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-concepts";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_concepts/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "954030a702dba5b548284ed4f7d08336fc347b9540550d08763562fc880ce935";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Introduces a compile time concept checking mechanism that can be used
+     most commonly to check for required functionality when passing
+     template arguments.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-containers/default.nix
+++ b/distros/foxy/ecl-containers/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-converters, ecl-errors, ecl-exceptions, ecl-formatters, ecl-license, ecl-mpl, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-containers";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_containers/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "195b591d53f731d0bc6202791dd1b1b83ebb12a56907aa52b962b1fb1884b613";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-converters ecl-errors ecl-exceptions ecl-formatters ecl-license ecl-mpl ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''The containers included here are intended to extend the stl containers.
+    In all cases, these implementations are designed to implement
+    c++ conveniences and safety where speed is not sacrificed.
+
+    Also includes techniques for memory debugging of common problems such
+    as buffer overruns.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-converters/default.nix
+++ b/distros/foxy/ecl-converters/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-converters";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_converters/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a55af2aa8f4a5f9a66971942bf58bf46f042912d63277eb0ca7c1f2166c9f009";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-concepts ecl-config ecl-errors ecl-exceptions ecl-license ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Some fast/convenient type converters, mostly for char strings or strings.
+     These are not really fully fleshed out, alot of them could use the addition for
+     the whole range of fundamental types (e.g. all integers, not just int, unsigned int).
+
+     They will come as the need arises.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-core-apps/default.nix
+++ b/distros/foxy/ecl-core-apps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, ecl-config, ecl-containers, ecl-converters, ecl-devices, ecl-errors, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-license, ecl-linear-algebra, ecl-sigslots, ecl-streams, ecl-threads, ecl-time-lite, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-core-apps";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_core_apps/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "65591dce5fcd9edf103823a70948e0846f85aef8ecac5034716efae5afaffa89";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-build ecl-command-line ecl-config ecl-containers ecl-converters ecl-devices ecl-errors ecl-exceptions ecl-formatters ecl-geometry ecl-ipc ecl-license ecl-linear-algebra ecl-sigslots ecl-streams ecl-threads ecl-time-lite ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This includes a suite of programs demo'ing various aspects of the
+     ecl_core. It also includes various benchmarking and utility programs for
+     use primarily with embedded systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-core/default.nix
+++ b/distros/foxy/ecl-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-command-line, ecl-concepts, ecl-containers, ecl-converters, ecl-core-apps, ecl-devices, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-sigslots, ecl-statistics, ecl-streams, ecl-threads, ecl-time, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-core";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c3876a089cf6c8f093e0f2ba2647c3dc24f9cc5fed07b08b845565c6b9b9e715";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ecl-command-line ecl-concepts ecl-containers ecl-converters ecl-core-apps ecl-devices ecl-eigen ecl-exceptions ecl-formatters ecl-geometry ecl-ipc ecl-linear-algebra ecl-math ecl-mpl ecl-sigslots ecl-statistics ecl-streams ecl-threads ecl-time ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''A set of tools and interfaces extending the capabilities of c++ to
+    provide a lightweight, consistent interface with a focus for control
+    programming.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-devices/default.nix
+++ b/distros/foxy/ecl-devices/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-containers, ecl-errors, ecl-license, ecl-mpl, ecl-threads, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-devices";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_devices/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b89d68fef5d3f0358db7e8ed79da06b43fdfc1815f711153484d6fd84be908c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-containers ecl-errors ecl-license ecl-mpl ecl-threads ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Provides an extensible and standardised framework for input-output devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-eigen/default.nix
+++ b/distros/foxy/ecl-eigen/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, eigen }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-eigen";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_eigen/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c6fb8c638ad609f84ad0951c5095c36d016a058afce8dbdbb544d450b6ae96cb";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This provides an Eigen implementation for ecl's linear algebra.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-exceptions/default.nix
+++ b/distros/foxy/ecl-exceptions/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-exceptions";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_exceptions/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "15bc56b9fd7cdb4e448142d22019559261ba3c32a3c4091d8d4f1af26eccfaee";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Template based exceptions - these are simple and practical
+     and avoid the proliferation of exception types. Although not
+     syntatactically ideal, it is convenient and eminently practical.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-filesystem/default.nix
+++ b/distros/foxy/ecl-filesystem/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-filesystem";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_filesystem/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ab2243d16f1f918ac02cc7c3faeb58686891d9642081339d5d207d3d01de83fe";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Cross platform filesystem utilities (until c++11 makes its way in).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-formatters/default.nix
+++ b/distros/foxy/ecl-formatters/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-config, ecl-converters, ecl-exceptions, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-formatters";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_formatters/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "a9a94c2784a3d5bbf7640cd2d4db0d17b1e649d1e94d464162af4fea356d06d3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  propagatedBuildInputs = [ ecl-config ecl-converters ecl-exceptions ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''The formatters here simply format various input types to a specified
+   text format. They can be used with most streaming types (including both
+   ecl and stl streams).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-geometry/default.nix
+++ b/distros/foxy/ecl-geometry/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-containers, ecl-exceptions, ecl-formatters, ecl-license, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-geometry";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_geometry/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "fea4cdd8472c804d6484ebb4e47a2a688da84fccb61c514005b917dcda2e4537";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-containers ecl-exceptions ecl-formatters ecl-license ecl-linear-algebra ecl-math ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Any tools relating to mathematical geometry.
+     Primarily featuring polynomials and interpolations.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-ipc/default.nix
+++ b/distros/foxy/ecl-ipc/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-threads, ecl-time, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-ipc";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_ipc/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "e2a4508afd8204017843feee03f5abc2ec5e3ac8770f09eb6565b5169a27d2e5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-exceptions ecl-license ecl-threads ecl-time ecl-time-lite ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Interprocess mechanisms vary greatly across platforms - sysv, posix, win32, there
+  are more than a few. This package provides an infrastructure to allow for developing
+  cross platform c++ wrappers around the lower level c api's that handle these
+  mechanisms. These make it not only easier to utilise such mechanisms, but allow it
+  to be done consistently across platforms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-linear-algebra/default.nix
+++ b/distros/foxy/ecl-linear-algebra/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-converters, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-license, ecl-math, sophus }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-linear-algebra";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_linear_algebra/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "02424cddb8b9dccf13e1439ee7c71bcd0e1d892147ec2a3e29d4c73e5a15031b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-converters ecl-eigen ecl-exceptions ecl-formatters ecl-license ecl-math sophus ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Ecl frontend to a linear matrix package (currently eigen).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-manipulators/default.nix
+++ b/distros/foxy/ecl-manipulators/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-manipulators";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_manipulators/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c071062c30178ade1722f44cf24fbd02762316f54e83497d9d7480e3fa689ca1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-exceptions ecl-formatters ecl-geometry ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Deploys various manipulation algorithms, currently just
+    feedforward filters (interpolations).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-math/default.nix
+++ b/distros/foxy/ecl-math/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-math";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_math/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b06274f45917e8c1042ccebdc38ba3c96018d5eda2e8cd250bfbf0ee049b957a";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-license ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This package provides simple support to cmath, filling in holes
+    or redefining in a c++ formulation where desirable.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-mobile-robot/default.nix
+++ b/distros/foxy/ecl-mobile-robot/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-errors, ecl-formatters, ecl-geometry, ecl-license, ecl-linear-algebra, ecl-math }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-mobile-robot";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_mobile_robot/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0853eb4442e8c5f0dde6a7816d070492647041f7443160f29036e15e873e1dd0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-errors ecl-formatters ecl-geometry ecl-license ecl-linear-algebra ecl-math ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Contains transforms (e.g. differential drive inverse kinematics)
+    for the various types of mobile robot platforms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-mpl/default.nix
+++ b/distros/foxy/ecl-mpl/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-license }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-mpl";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_mpl/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "f6098672bebf9b5b8fc3e9dea68f1d72faa5bb7212fd79310f2e3f843da394fd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Metaprogramming tools move alot of runtime calculations to be shifted to
+    compile time. This has only very elementary structures at this stage.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-sigslots/default.nix
+++ b/distros/foxy/ecl-sigslots/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-threads }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-sigslots";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_sigslots/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8707009ab6a7db085d70f7e48ebce52a67b0bd462722e7a18c77b079a3b66025";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-threads ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Provides a signal/slot mechanism (in the same vein as qt sigslots,
+     boost::signals etc for intra-process communication. These include
+     some improvements - they do not need a preprocessor, are fully type safe,
+     allow for simple connections via a posix style string identifier
+     and are multithread-safe.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-statistics/default.nix
+++ b/distros/foxy/ecl-statistics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-linear-algebra, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-statistics";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_statistics/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "98f0cbea4b1a136aad6e07c224e2c735a9087ce182e6ac1d8257fd82aa696af6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-license ecl-linear-algebra ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Common statistical structures and algorithms for control systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-streams/default.nix
+++ b/distros/foxy/ecl-streams/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-converters, ecl-devices, ecl-errors, ecl-license, ecl-time, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-streams";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_streams/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "4b2a693cc2ebdc143e5d16bdf40f03bafe64172957f0b18f639a90a04726239e";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-concepts ecl-converters ecl-devices ecl-errors ecl-license ecl-time ecl-type-traits ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''These are lightweight text streaming classes that connect to standardised
+     ecl type devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-threads/default.nix
+++ b/distros/foxy/ecl-threads/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-threads";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_threads/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "797d185cdb354c82a65123e40eb48aaa9b9ee937326e42f6c339688c27d11a3c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-concepts ecl-config ecl-errors ecl-exceptions ecl-license ecl-time ecl-utilities ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''This package provides the c++ extensions for a variety of threaded
+     programming tools. These are usually different on different
+     platforms, so the architecture for a cross-platform framework
+     is also implemented.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-time/default.nix
+++ b/distros/foxy/ecl-time/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-time";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_time/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "c5e04a486d634a7a629e0ae1f9369f84b54315d3c4f1033be08acb39efc16055";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-exceptions ecl-license ecl-time-lite ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Timing utilities are very dependent on the system api provided for their use.
+	This package provides a means for handling different timing models. Current support
+
+	- posix rt : complete.
+	- macosx : posix timers only, missing absolute timers.
+	- win : none.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-type-traits/default.nix
+++ b/distros/foxy/ecl-type-traits/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-config, ecl-license, ecl-mpl }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-type-traits";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_type_traits/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "8aa0f63958dfd527fde48c667f537f2caebaf49da59c6702f58ca387c3e7447f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-mpl ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Extends c++ type traits and implements a few more to boot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ecl-utilities/default.nix
+++ b/distros/foxy/ecl-utilities/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, ecl-build, ecl-concepts, ecl-license, ecl-mpl }:
+buildRosPackage {
+  pname = "ros-foxy-ecl-utilities";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/foxy/ecl_utilities/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "468ab6afcdeacbd001fe87c11bed1f3d5212f4e085864807727d89c9a198f6dc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ecl-build ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ecl-concepts ecl-license ecl-mpl ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Includes various supporting tools and utilities for c++ programming.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.0-r3";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "bd1251c65311656f1b5e0447c67cc396352abb09fd39b9080a392f3e1f2cbeca";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "811e81b7858d73cffed9984d6075451a1e92a5a8cf881e3ec0f05947c77ddd30";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -166,6 +166,8 @@ self: super: {
 
  control-msgs = self.callPackage ./control-msgs {};
 
+ control-toolbox = self.callPackage ./control-toolbox {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cv-bridge = self.callPackage ./cv-bridge {};
@@ -206,31 +208,83 @@ self: super: {
 
  dwb-plugins = self.callPackage ./dwb-plugins {};
 
+ dynamic-graph = self.callPackage ./dynamic-graph {};
+
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
  ecl-build = self.callPackage ./ecl-build {};
 
+ ecl-command-line = self.callPackage ./ecl-command-line {};
+
+ ecl-concepts = self.callPackage ./ecl-concepts {};
+
  ecl-config = self.callPackage ./ecl-config {};
 
  ecl-console = self.callPackage ./ecl-console {};
 
+ ecl-containers = self.callPackage ./ecl-containers {};
+
+ ecl-converters = self.callPackage ./ecl-converters {};
+
  ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-core = self.callPackage ./ecl-core {};
+
+ ecl-core-apps = self.callPackage ./ecl-core-apps {};
+
+ ecl-devices = self.callPackage ./ecl-devices {};
+
+ ecl-eigen = self.callPackage ./ecl-eigen {};
 
  ecl-errors = self.callPackage ./ecl-errors {};
 
+ ecl-exceptions = self.callPackage ./ecl-exceptions {};
+
+ ecl-filesystem = self.callPackage ./ecl-filesystem {};
+
+ ecl-formatters = self.callPackage ./ecl-formatters {};
+
+ ecl-geometry = self.callPackage ./ecl-geometry {};
+
  ecl-io = self.callPackage ./ecl-io {};
+
+ ecl-ipc = self.callPackage ./ecl-ipc {};
 
  ecl-license = self.callPackage ./ecl-license {};
 
+ ecl-linear-algebra = self.callPackage ./ecl-linear-algebra {};
+
  ecl-lite = self.callPackage ./ecl-lite {};
 
+ ecl-manipulators = self.callPackage ./ecl-manipulators {};
+
+ ecl-math = self.callPackage ./ecl-math {};
+
+ ecl-mobile-robot = self.callPackage ./ecl-mobile-robot {};
+
+ ecl-mpl = self.callPackage ./ecl-mpl {};
+
+ ecl-sigslots = self.callPackage ./ecl-sigslots {};
+
  ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-statistics = self.callPackage ./ecl-statistics {};
+
+ ecl-streams = self.callPackage ./ecl-streams {};
+
+ ecl-threads = self.callPackage ./ecl-threads {};
+
+ ecl-time = self.callPackage ./ecl-time {};
 
  ecl-time-lite = self.callPackage ./ecl-time-lite {};
 
  ecl-tools = self.callPackage ./ecl-tools {};
+
+ ecl-type-traits = self.callPackage ./ecl-type-traits {};
+
+ ecl-utilities = self.callPackage ./ecl-utilities {};
 
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
@@ -384,6 +438,8 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
+ librealsense2 = self.callPackage ./librealsense2 {};
+
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -469,6 +525,8 @@ self: super: {
  nodl-python = self.callPackage ./nodl-python {};
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
+
+ object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
  octomap = self.callPackage ./octomap {};
 
@@ -589,6 +647,14 @@ self: super: {
  rcpputils = self.callPackage ./rcpputils {};
 
  rcutils = self.callPackage ./rcutils {};
+
+ realsense-examples = self.callPackage ./realsense-examples {};
+
+ realsense-msgs = self.callPackage ./realsense-msgs {};
+
+ realsense-node = self.callPackage ./realsense-node {};
+
+ realsense-ros = self.callPackage ./realsense-ros {};
 
  realtime-tools = self.callPackage ./realtime-tools {};
 

--- a/distros/foxy/image-pipeline/default.nix
+++ b/distros/foxy/image-pipeline/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, camera-calibration, depth-image-proc, image-proc, image-publisher, image-rotate }:
 buildRosPackage {
   pname = "ros-foxy-image-pipeline";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_pipeline/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "835885e3dae6c078595ba261449e6e1570235c0ba1da70be3bbdb1ab559d5401";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_pipeline/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "7353eb75b68c576b7057d1362c94f072f0100eaa2755f932ac84a5f99dd1f210";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-proc/default.nix
+++ b/distros/foxy/image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-transport, rclcpp, rclcpp-components, rcutils, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-proc";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_proc/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "fa31dd55b17e61c761bfac0e74d7a620fcef85926b66234e8983d9b14f215b2d";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_proc/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "82aebf942f8d4ee76a101c497713debd60fb0efc59059e9f50cbd2eb71b3da71";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-publisher/default.nix
+++ b/distros/foxy/image-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, class-loader, cv-bridge, image-geometry, image-transport, rclcpp, rclcpp-components }:
 buildRosPackage {
   pname = "ros-foxy-image-publisher";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_publisher/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "abc6501557928178c747f15a1b17174083b3be52eb7d6fb9203c90f2b0bc1bfa";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_publisher/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "db46da23ed6e55bd07f76e7ef87e77d35eef14a78cc0a07601e8ada1afde468a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-rotate/default.nix
+++ b/distros/foxy/image-rotate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, cv-bridge, image-transport, rclcpp, rclcpp-components, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-image-rotate";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_rotate/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a2bae4765e9411977341a2dc41ab0c4c34edacb9a76e438be1ebac5b62d792da";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_rotate/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "3c792340b6a2b35517904daddb2db95919039b32b2c00816c6c5ff3bd72c7512";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/image-view/default.nix
+++ b/distros/foxy/image-view/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, gtk3, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, camera-calibration-parsers, cv-bridge, image-transport, message-filters, rclcpp, rclcpp-components, sensor-msgs, std-srvs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-foxy-image-view";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_view/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "591b0dc05f891de20578c9fd32f671cebb81a0c14605d3d5dfa2709fb2688196";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/image_view/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "c2455892cbe17fa32188069159788e468a06152b5b295b5867c1cb73394df2ba";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost camera-calibration-parsers cv-bridge gtk3 image-transport message-filters rclcpp rclcpp-components sensor-msgs std-srvs stereo-msgs ];
+  propagatedBuildInputs = [ boost camera-calibration-parsers cv-bridge image-transport message-filters rclcpp rclcpp-components sensor-msgs std-srvs stereo-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, glfw3, gtk3, libGL, libGLU, libusb1, linuxHeaders, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.34.0-r1";
+  version = "2.34.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/foxy/librealsense2/2.34.0-1.tar.gz";
-    name = "2.34.0-1.tar.gz";
-    sha256 = "503027762eade3b295496ed35c3fd9c2076f06fa4ed3d763a40bc71c83a1cab9";
+    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/foxy/librealsense2/2.34.0-3.tar.gz";
+    name = "2.34.0-3.tar.gz";
+    sha256 = "3fb5217dd0bdbecce6dfd3db2bbcce25b843280cf7fc3b6ef2479d9222591d07";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/object-recognition-msgs/default.nix
+++ b/distros/foxy/object-recognition-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-object-recognition-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/object_recognition_msgs-release/archive/release/foxy/object_recognition_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "16ab384e99d3e6f75d017588c69f6d944cc0942c9f37efcf703db45d1f38a639";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Object_recognition_msgs contains the ROS message and the actionlib definition used in object_recognition_core'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ros2trace/default.nix
+++ b/distros/foxy/ros2trace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, pythonPackages, ros2cli, tracetools-trace }:
 buildRosPackage {
   pname = "ros-foxy-ros2trace";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/ros2trace/1.0.1-2";
+    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/ros2trace/1.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "3063e5e107fe56d10ad354dfa5a7635b622ea92bf3f60b7eb974c417e7fbf5a8";
+    sha256 = "fc758ad19f04dd7da5b8ee548a79b692b6699b2f5d4e9079332a7a755719cb46";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/sophus/default.nix
+++ b/distros/foxy/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-foxy-sophus";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/foxy/sophus/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a89b3dcf9f6149d18062537ecd7bbfa48573b73c7d912bc43c12e0beff173f28";
+    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/foxy/sophus/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "99781189c8556ca3e7e369b588103964bc1866e55a875b26aac9efb311f1b880";
   };
 
   buildType = "cmake";

--- a/distros/foxy/stereo-image-proc/default.nix
+++ b/distros/foxy/stereo-image-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-geometry, image-proc, image-transport, launch, launch-ros, launch-testing, launch-testing-ament-cmake, message-filters, python-cmake-module, python3Packages, rclcpp, rclcpp-components, rclpy, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-foxy-stereo-image-proc";
-  version = "2.1.1-r1";
+  version = "2.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/stereo_image_proc/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "4817db61784be6d53e0bb62d50b4aaa61bda3f14abb2e4648178a598db444254";
+    url = "https://github.com/ros2-gbp/image_pipeline-release/archive/release/foxy/stereo_image_proc/2.2.0-2.tar.gz";
+    name = "2.2.0-2.tar.gz";
+    sha256 = "1c763c98757f432632e1be9291e8b0dcba42e9913772314b2a7d60940f41a38a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tracetools-launch/default.nix
+++ b/distros/foxy/tracetools-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, ament-xmllint, launch, launch-ros, pythonPackages, tracetools-trace }:
 buildRosPackage {
   pname = "ros-foxy-tracetools-launch";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools_launch/1.0.1-2";
+    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools_launch/1.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "bb1b1a719b0e16d9eaeaf3be94211b4ade00aec8911bd0782c8ca182fccb8f93";
+    sha256 = "d710c7b678b90a781a6118b5001e40456093c9be511ba0ed13ed514b546ac8c5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/tracetools-test/default.nix
+++ b/distros/foxy/tracetools-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-mypy, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch-ros, pkg-config, python3Packages, pythonPackages, rclcpp, std-msgs, std-srvs, tracetools, tracetools-launch, tracetools-read }:
 buildRosPackage {
   pname = "ros-foxy-tracetools-test";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools_test/1.0.1-2";
+    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools_test/1.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "2e620584b6d334fa66ced47aec31e880d68cce6523eadbc0640d906c5ba1df0d";
+    sha256 = "36bb1722a4c11bb6fedc3dab647524cdd4751e1fb28df176a57b319d988aaf16";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tracetools/default.nix
+++ b/distros/foxy/tracetools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, pkg-config }:
 buildRosPackage {
   pname = "ros-foxy-tracetools";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools/1.0.1-2";
+    url = "https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing-release/repository/archive.tar.gz?ref=release/foxy/tracetools/1.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "96a4b8490bcdcec3948994d06500a203ec8ad6bc2fd9628a13ef5cc47e2a7ae9";
+    sha256 = "73a8b19cca5d14cabbc8a1f72f2c1a245867e99042821ca1943d2af87d639540";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/dataspeed-pds-can/default.nix
+++ b/distros/melodic/dataspeed-pds-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-can";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "c8bcdd70d393ceb84e5f3c87580f1faf3ecbde3b5ef3bee1806582e1d2389e5b";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d4030fa958f78ced46d62ca11f471a888c4c30cb4415cfa1470110c3b270891c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-msgs/default.nix
+++ b/distros/melodic/dataspeed-pds-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "7cb03c4bc2380159c20600d7553666509069d5a6154c12799482795c5f552b41";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "038214dc8e9b629180d6e4bb1de75bb5ea4def4b0447378b54d11bcdd869b86c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-rqt/default.nix
+++ b/distros/melodic/dataspeed-pds-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, pythonPackages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-rqt";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "7b3e6f7fcab659357456ae8c6c770878fe14ac8f59c9c8f04ee3412e33405ba4";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "e394903d48266d38ebd7138abef80ef19ba689f379c1651eb46482963b4d2f5e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-scripts/default.nix
+++ b/distros/melodic/dataspeed-pds-scripts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-scripts";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d2c468585fbff4ecb19770cc8d57df66242afdc675d37a5916a42098821d1836";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "586e2fdece998d4cb65e503d85e9deca0e7109f10552fbd4e905aeed411e56eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds/default.nix
+++ b/distros/melodic/dataspeed-pds/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-msgs, dataspeed-pds-scripts }:
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-lcm, dataspeed-pds-msgs, dataspeed-pds-scripts }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d13c93b88a446da5990f052ca82a1aa28c3f106f0c110a9becc853e54496aa0b";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9ecd284e28b242f31169b0f08fbe166ef061106c77440b474f7a448062b3fb6c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dataspeed-pds-can dataspeed-pds-msgs dataspeed-pds-scripts ];
+  propagatedBuildInputs = [ dataspeed-pds-can dataspeed-pds-lcm dataspeed-pds-msgs dataspeed-pds-scripts ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dynamic-graph-python/default.nix
+++ b/distros/melodic/dynamic-graph-python/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, git, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-dynamic-graph-python";
+  version = "3.5.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/3.5.3-2.tar.gz";
+    name = "3.5.3-2.tar.gz";
+    sha256 = "13545602485a4127a069c383f39e937df533f9253c408465fde9cfc3ed89f73f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin dynamic-graph roscpp ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Dynamic graph library Python bindings'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/dynamic-graph/default.nix
+++ b/distros/melodic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph";
-  version = "4.2.1-r4";
+  version = "4.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.2.1-4.tar.gz";
-    name = "4.2.1-4.tar.gz";
-    sha256 = "e711b2f736b5a53a9e90099a9001de517ee316236fd09e4665905fcbed869770";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "07bccde8806aa97248cec22b34d777d3bf072a1f6ca8a3954a150baf275bdf96";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -652,6 +652,8 @@ self: super: {
 
  dynamic-graph = self.callPackage ./dynamic-graph {};
 
+ dynamic-graph-python = self.callPackage ./dynamic-graph-python {};
+
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
@@ -2069,6 +2071,12 @@ self: super: {
  odometry-publisher-tutorial = self.callPackage ./odometry-publisher-tutorial {};
 
  odva-ethernetip = self.callPackage ./odva-ethernetip {};
+
+ omnibase-control = self.callPackage ./omnibase-control {};
+
+ omnibase-description = self.callPackage ./omnibase-description {};
+
+ omnibase-gazebo = self.callPackage ./omnibase-gazebo {};
 
  ompl = self.callPackage ./ompl {};
 

--- a/distros/melodic/omnibase-control/default.nix
+++ b/distros/melodic/omnibase-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-omnibase-control";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_control/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "475170d7c08ca3d1aed5babae0c0a9f3e9d16b3c9d977c89cd5bbb9c947e8a1d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The omnibase_control package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/omnibase-description/default.nix
+++ b/distros/melodic/omnibase-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-omnibase-description";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_description/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3bc6477a84b61dbbb75d7bbd386fc5d468ea4ee220c572e6a02521e3987622d4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package constains the model files of the omnibase(omniwheeled robot)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/omnibase-gazebo/default.nix
+++ b/distros/melodic/omnibase-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, geometry-msgs, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-omnibase-gazebo";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_gazebo/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3d24516f5a8b6940a1579a5435139f6812813d5550e8b665663d5118ad5c2eed";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-msgs geometry-msgs roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The omnibase_gazebo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/audibot-description/default.nix
+++ b/distros/noetic/audibot-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-audibot-description";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robustify/audibot-release/archive/release/noetic/audibot_description/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "21dabbcc305e4cf3baf8294ed177bab0eca6f205cbe74321e51459d646b3a9a8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meshes and URDF descriptions for audibot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/audibot-gazebo/default.nix
+++ b/distros/noetic/audibot-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, audibot-description, catkin, gazebo-ros, gazebo-ros-pkgs, robot-state-publisher, roscpp, rospy, rostest, rviz, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-audibot-gazebo";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robustify/audibot-release/archive/release/noetic/audibot_gazebo/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "a585f6842f3f584e737997b3f9cd682e766d2ab83cb99f3d13dc91bc81f30693";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rospy rostest ];
+  propagatedBuildInputs = [ audibot-description gazebo-ros gazebo-ros-pkgs robot-state-publisher roscpp rviz tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo model plugin to simulate Audibot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/audibot/default.nix
+++ b/distros/noetic/audibot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, audibot-description, audibot-gazebo, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-audibot";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robustify/audibot-release/archive/release/noetic/audibot/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "75f51485661586fa9905a63aa4231dd3f56eb468580543fd795636301878d596";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ audibot-description audibot-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for audibot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
-  version = "0.8.6-r1";
+  version = "0.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.6-1.tar.gz";
-    name = "0.8.6-1.tar.gz";
-    sha256 = "2f1a36f2666c735509055696b4cf81b4b7256270b445008a91d6ff6c0caff572";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.8-1.tar.gz";
+    name = "0.8.8-1.tar.gz";
+    sha256 = "4379b18382c6d1576d31c7ed1e9f373d746a148b1d95fa7daf1a710fb1bfe3b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds-can/default.nix
+++ b/distros/noetic/dataspeed-pds-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-can";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_can/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "a3897af0aa43d63cc75702e9fdb5bd2277b9ee6ed911f585b488fbb4414bdaa6";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_can/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "f22fd5414cd0fbb26bc91a39a4e2a593e2a5ae2b12a93447f5a4466b3ad823e1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds-msgs/default.nix
+++ b/distros/noetic/dataspeed-pds-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "b5ad7936655ebdb154427b76fb804db98eb0fe1ee55a59f02942b1f8a020c44b";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_msgs/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "9b9b7b3eac15fa9bf444c45a829c7f417613124661b17e346485c5606412ee6d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds-rqt/default.nix
+++ b/distros/noetic/dataspeed-pds-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-rqt";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_rqt/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "ae6f0ce9ca65ad851a6536101d44c739c94d07f9454acaa5915b35a093ef49db";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_rqt/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "bc67fb5fe19b991e962442a5b325ad78985a126d938a292cd099cc8d69380d87";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds-scripts/default.nix
+++ b/distros/noetic/dataspeed-pds-scripts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-scripts";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_scripts/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "fd1fbfd1288fc1ed5c629f21bbbdb0c160e68f2d4235da349c22f8616af1667e";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_scripts/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "6cc2ce71d6e5d433c53c5bef9b841f43f125b135a468972a4daeda8d9929a596";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds/default.nix
+++ b/distros/noetic/dataspeed-pds/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-msgs, dataspeed-pds-scripts }:
+{ lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-lcm, dataspeed-pds-msgs, dataspeed-pds-scripts }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds";
-  version = "1.0.3-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2c3c2765a77742cbacba3fadbe13753c96de4e25eeacc932d85bbcaaccb05293";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "44c8a7c766f762858594df8de00e49d1a701c93c4899f3ecfdde3dcee05687a6";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dataspeed-pds-can dataspeed-pds-msgs dataspeed-pds-scripts ];
+  propagatedBuildInputs = [ dataspeed-pds-can dataspeed-pds-lcm dataspeed-pds-msgs dataspeed-pds-scripts ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, git, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-dynamic-graph-python";
+  version = "3.5.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/3.5.3-2.tar.gz";
+    name = "3.5.3-2.tar.gz";
+    sha256 = "8b6a74f4078a0314d0b2ecba099e6e078400eea037cc7cdc4ba9d5704ae205d4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin dynamic-graph roscpp ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Dynamic graph library Python bindings'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
+buildRosPackage {
+  pname = "ros-noetic-dynamic-graph";
+  version = "4.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.2.2-1.tar.gz";
+    name = "4.2.2-1.tar.gz";
+    sha256 = "9044a56f1b493709619b6ce9bf8db8156fa5687d681dfa08b847c271ee8d0559";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin eigen graphviz ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Dynamic graph library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-command-line/default.nix
+++ b/distros/noetic/ecl-command-line/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-command-line";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_command_line/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "b335dcdc6566bd392aa52b2e4a88fd8b9b7973227d0232cac74d25b6dd38239a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Embeds the TCLAP library inside the ecl. This is a very convenient
+     command line parser in templatised c++.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-concepts/default.nix
+++ b/distros/noetic/ecl-concepts/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-license, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-concepts";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_concepts/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "ca986e4e7735e5afa7eb147248b82a7bb9f8aa5481da11ed0978f1cac537f417";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Introduces a compile time concept checking mechanism that can be used
+     most commonly to check for required functionality when passing
+     template arguments.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-containers/default.nix
+++ b/distros/noetic/ecl-containers/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-converters, ecl-errors, ecl-exceptions, ecl-formatters, ecl-license, ecl-mpl, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-containers";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_containers/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "35524cfb59473cbf2e63c1899780fe96014925ddc96b8f6c02d390b91c4a4d26";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-converters ecl-errors ecl-exceptions ecl-formatters ecl-license ecl-mpl ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The containers included here are intended to extend the stl containers.
+    In all cases, these implementations are designed to implement
+    c++ conveniences and safety where speed is not sacrificed. 
+
+    Also includes techniques for memory debugging of common problems such
+    as buffer overruns.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-converters/default.nix
+++ b/distros/noetic/ecl-converters/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-converters";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_converters/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "9f2ed714c59a749e966239423ecda1f7e35c84bf9a74ddb99650c8dc6705873e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-concepts ecl-config ecl-errors ecl-exceptions ecl-license ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Some fast/convenient type converters, mostly for char strings or strings.
+     These are not really fully fleshed out, alot of them could use the addition for
+     the whole range of fundamental types (e.g. all integers, not just int, unsigned int).
+     
+     They will come as the need arises.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-core-apps/default.nix
+++ b/distros/noetic/ecl-core-apps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-command-line, ecl-config, ecl-containers, ecl-converters, ecl-devices, ecl-errors, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-license, ecl-linear-algebra, ecl-sigslots, ecl-streams, ecl-threads, ecl-time-lite, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-core-apps";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_core_apps/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "56f1d22a224461a12e76c84341d6c917f39705e4d15525f93ed9dfb250f0ebc8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-command-line ecl-config ecl-containers ecl-converters ecl-devices ecl-errors ecl-exceptions ecl-formatters ecl-geometry ecl-ipc ecl-license ecl-linear-algebra ecl-sigslots ecl-streams ecl-threads ecl-time-lite ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This includes a suite of programs demo'ing various aspects of the
+     ecl_core. It also includes various benchmarking and utility programs for
+     use primarily with embedded systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-core/default.nix
+++ b/distros/noetic/ecl-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-command-line, ecl-concepts, ecl-containers, ecl-converters, ecl-core-apps, ecl-devices, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-geometry, ecl-ipc, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-sigslots, ecl-statistics, ecl-streams, ecl-threads, ecl-time, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-core";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_core/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "8370d36c81a97f43a32b2c7019d6675acf6cfc4765dd707397e3f73a0b8ed8a1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-command-line ecl-concepts ecl-containers ecl-converters ecl-core-apps ecl-devices ecl-eigen ecl-exceptions ecl-formatters ecl-geometry ecl-ipc ecl-linear-algebra ecl-math ecl-mpl ecl-sigslots ecl-statistics ecl-streams ecl-threads ecl-time ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A set of tools and interfaces extending the capabilities of c++ to 
+    provide a lightweight, consistent interface with a focus for control
+    programming.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-devices/default.nix
+++ b/distros/noetic/ecl-devices/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-containers, ecl-errors, ecl-license, ecl-mpl, ecl-threads, ecl-type-traits, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-devices";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_devices/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "d25c30f708faaf5f62b827ba45033950a8cd4c87a39cab5cbe6900774c03264e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-containers ecl-errors ecl-license ecl-mpl ecl-threads ecl-type-traits ecl-utilities ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides an extensible and standardised framework for input-output devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-eigen/default.nix
+++ b/distros/noetic/ecl-eigen/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, ecl-license, eigen }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-eigen";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_eigen/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "9704ee0c76f3fbce656f22cf38f0af3d28a57405cfedcb805ec12c3e6408abff";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ ecl-license eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This provides an Eigen implementation for ecl's linear algebra.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-exceptions/default.nix
+++ b/distros/noetic/ecl-exceptions/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-errors, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-exceptions";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_exceptions/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "628711cbc195b9e839014887790d1ac2f793025c99e8f1bf1d84ed9cb8391d17";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-errors ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Template based exceptions - these are simple and practical
+     and avoid the proliferation of exception types. Although not
+     syntatactically ideal, it is convenient and eminently practical.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-filesystem/default.nix
+++ b/distros/noetic/ecl-filesystem/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-filesystem";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_filesystem/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "00aa5f749c876148911be2f179efc2f46bb0c8cd5c3f8c9e6417a927dc086861";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-exceptions ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cross platform filesystem utilities (until c++11 makes its way in).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-formatters/default.nix
+++ b/distros/noetic/ecl-formatters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-converters, ecl-exceptions, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-formatters";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_formatters/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "ba5fde09f5c98585e99e3d20dce7f757fa7c37260b500108b7069b5a40ee32d3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-converters ecl-exceptions ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The formatters here simply format various input types to a specified
+   text format. They can be used with most streaming types (including both
+   ecl and stl streams).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-geometry/default.nix
+++ b/distros/noetic/ecl-geometry/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-containers, ecl-exceptions, ecl-formatters, ecl-license, ecl-linear-algebra, ecl-math, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-geometry";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_geometry/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "3e788ecb243ac6521fd266f8178b9207d0b7ce13dfc9fe7bc2311a1f6e17e63b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-containers ecl-exceptions ecl-formatters ecl-license ecl-linear-algebra ecl-math ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Any tools relating to mathematical geometry. 
+     Primarily featuring polynomials and interpolations.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-ipc/default.nix
+++ b/distros/noetic/ecl-ipc/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-ipc";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_ipc/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "34c58eb9fea5505ed920f8a88e10c5c3d97a18928999a34334689b69de9fad80";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-exceptions ecl-license ecl-time ecl-time-lite ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Interprocess mechanisms vary greatly across platforms - sysv, posix, win32, there
+  are more than a few. This package provides an infrastructure to allow for developing 
+  cross platform c++ wrappers around the lower level c api's that handle these 
+  mechanisms. These make it not only easier to utilise such mechanisms, but allow it 
+  to be done consistently across platforms.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-linear-algebra/default.nix
+++ b/distros/noetic/ecl-linear-algebra/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-converters, ecl-eigen, ecl-exceptions, ecl-formatters, ecl-license, ecl-math, sophus }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-linear-algebra";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_linear_algebra/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "6654eee4925d4979632e46ab357a7756ded61edb1a488e63ecb49b2b0ce290c5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-converters ecl-eigen ecl-exceptions ecl-formatters ecl-license ecl-math sophus ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Ecl frontend to a linear matrix package (currently eigen).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-math/default.nix
+++ b/distros/noetic/ecl-math/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-license, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-math";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_math/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "da5a2d63538ebc983af647fef48ff0173b1119eb7d9b4de89a5849012adc7c4d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-license ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides simple support to cmath, filling in holes
+    or redefining in a c++ formulation where desirable.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-mpl/default.nix
+++ b/distros/noetic/ecl-mpl/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-license }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-mpl";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_mpl/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "9d52b486b17768f60ea316403f1aa545153fae2331d7c7b09b5063b7e6d91f84";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-license ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metaprogramming tools move alot of runtime calculations to be shifted to
+    compile time. This has only very elementary structures at this stage.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-sigslots/default.nix
+++ b/distros/noetic/ecl-sigslots/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-license, ecl-threads }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-sigslots";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_sigslots/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "38a1cccb17b81e055ae00a2e4c4fa1a4dfb990143209077d67553ceb5bf69873";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-threads ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a signal/slot mechanism (in the same vein as qt sigslots, 
+     boost::signals etc for intra-process communication. These include 
+     some improvements - they do not need a preprocessor, are fully type safe,
+     allow for simple connections via a posix style string identifier 
+     and are multithread-safe.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-statistics/default.nix
+++ b/distros/noetic/ecl-statistics/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-license, ecl-linear-algebra, ecl-mpl, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-statistics";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_statistics/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "e067ac97b7e596d086fdbbeb6b31ef268bb7fe7fe63c76ffb40e5be3ff350af5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-license ecl-linear-algebra ecl-mpl ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Common statistical structures and algorithms for control systems.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-streams/default.nix
+++ b/distros/noetic/ecl-streams/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-concepts, ecl-converters, ecl-devices, ecl-errors, ecl-license, ecl-time, ecl-type-traits }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-streams";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_streams/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "6978f56fd03e6f3d7ca205c50af68634fa04a7f02d4a81b28053bf6551fe08d6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-concepts ecl-converters ecl-devices ecl-errors ecl-license ecl-time ecl-type-traits ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These are lightweight text streaming classes that connect to standardised
+     ecl type devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-threads/default.nix
+++ b/distros/noetic/ecl-threads/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-concepts, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time, ecl-utilities }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-threads";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_threads/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "14e5043e44dc02ad4b3750e34f6ec4918d71eb31d2375c3d1e24fb8740442027";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-concepts ecl-config ecl-errors ecl-exceptions ecl-license ecl-time ecl-utilities ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides the c++ extensions for a variety of threaded 
+     programming tools. These are usually different on different 
+     platforms, so the architecture for a cross-platform framework
+     is also implemented.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-time/default.nix
+++ b/distros/noetic/ecl-time/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-build, ecl-config, ecl-errors, ecl-exceptions, ecl-license, ecl-time-lite }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-time";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_time/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "e0d43cb6938c7d34f61cfc74f608509a9c95de0c6715f5e718cf90ea544a4b26";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-build ecl-config ecl-errors ecl-exceptions ecl-license ecl-time-lite ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Timing utilities are very dependent on the system api provided for their use.
+	This package provides a means for handling different timing models. Current support
+	
+	- posix rt : complete.
+	- macosx : posix timers only, missing absolute timers.
+	- win : none.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-type-traits/default.nix
+++ b/distros/noetic/ecl-type-traits/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-config, ecl-license, ecl-mpl }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-type-traits";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_type_traits/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "3c344d595c1070b7aa7a44e669e201dbb9683f945cb668fe50b378fc25d199b7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-config ecl-license ecl-mpl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extends c++ type traits and implements a few more to boot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ecl-utilities/default.nix
+++ b/distros/noetic/ecl-utilities/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ecl-concepts, ecl-license, ecl-mpl }:
+buildRosPackage {
+  pname = "ros-noetic-ecl-utilities";
+  version = "0.62.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yujinrobot-release/ecl_core-release/archive/release/noetic/ecl_utilities/0.62.3-1.tar.gz";
+    name = "0.62.3-1.tar.gz";
+    sha256 = "aa61adc8fb24b902f8bd38b59fa1982b4335197ebf2a4c776fbe26a13a20f72e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ecl-concepts ecl-license ecl-mpl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Includes various supporting tools and utilities for c++ programming.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fkie-master-discovery/default.nix
+++ b/distros/noetic/fkie-master-discovery/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, avahi, catkin, fkie-multimaster-msgs, rosgraph, roslib, rospy, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-fkie-master-discovery";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "1769501c9eaa339a55f9f516a0f4d977c9a613c0ca49232d1432f226576d83f1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ avahi fkie-multimaster-msgs rosgraph roslib rospy std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Discover the running ROS Masters in local network. The 
+     discovering is done by sending an echo heartbeat messages to a defined 
+     multicast group.
+     The alternative is to use a zeroconf/avahi daemon to register the ROS 
+     master as service and discover other ROS masters.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fkie-master-sync/default.nix
+++ b/distros/noetic/fkie-master-sync/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-multimaster-msgs, rosgraph, roslib, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-fkie-master-sync";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "92e178eb1dfa046103d509a48afbb455176f016a1a90e7e8af5c039faf6de9e6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fkie-master-discovery fkie-multimaster-msgs rosgraph roslib rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Synchronize the local ROS master to the remote masters 
+     discovered by fkie_master_discovery node. The registration
+     of topics and services is only perform by local ROS master.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fkie-multimaster/default.nix
+++ b/distros/noetic/fkie-multimaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager, fkie-node-manager-daemon }:
+buildRosPackage {
+  pname = "ros-noetic-fkie-multimaster";
+  version = "1.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "066690e2f0cacd9e5674d6651e91cbf3766814c6fc25ecb8a92b6902b8711962";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fkie-master-discovery fkie-master-sync fkie-multimaster-msgs fkie-node-manager fkie-node-manager-daemon ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The metapackage to combine the nodes required to establish and manage a multimaster network.
+    This requires no or minimal configuration. The changes are automatically detected and synchronized.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -26,6 +26,12 @@ self: super: {
 
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
 
+ audibot = self.callPackage ./audibot {};
+
+ audibot-description = self.callPackage ./audibot-description {};
+
+ audibot-gazebo = self.callPackage ./audibot-gazebo {};
+
  audio-capture = self.callPackage ./audio-capture {};
 
  audio-common = self.callPackage ./audio-common {};
@@ -226,6 +232,10 @@ self: super: {
 
  dwb-plugins = self.callPackage ./dwb-plugins {};
 
+ dynamic-graph = self.callPackage ./dynamic-graph {};
+
+ dynamic-graph-python = self.callPackage ./dynamic-graph-python {};
+
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
  dynamic-reconfigure = self.callPackage ./dynamic-reconfigure {};
@@ -236,25 +246,71 @@ self: super: {
 
  ecl-build = self.callPackage ./ecl-build {};
 
+ ecl-command-line = self.callPackage ./ecl-command-line {};
+
+ ecl-concepts = self.callPackage ./ecl-concepts {};
+
  ecl-config = self.callPackage ./ecl-config {};
 
  ecl-console = self.callPackage ./ecl-console {};
 
+ ecl-containers = self.callPackage ./ecl-containers {};
+
+ ecl-converters = self.callPackage ./ecl-converters {};
+
  ecl-converters-lite = self.callPackage ./ecl-converters-lite {};
+
+ ecl-core = self.callPackage ./ecl-core {};
+
+ ecl-core-apps = self.callPackage ./ecl-core-apps {};
+
+ ecl-devices = self.callPackage ./ecl-devices {};
+
+ ecl-eigen = self.callPackage ./ecl-eigen {};
 
  ecl-errors = self.callPackage ./ecl-errors {};
 
+ ecl-exceptions = self.callPackage ./ecl-exceptions {};
+
+ ecl-filesystem = self.callPackage ./ecl-filesystem {};
+
+ ecl-formatters = self.callPackage ./ecl-formatters {};
+
+ ecl-geometry = self.callPackage ./ecl-geometry {};
+
  ecl-io = self.callPackage ./ecl-io {};
+
+ ecl-ipc = self.callPackage ./ecl-ipc {};
 
  ecl-license = self.callPackage ./ecl-license {};
 
+ ecl-linear-algebra = self.callPackage ./ecl-linear-algebra {};
+
  ecl-lite = self.callPackage ./ecl-lite {};
 
+ ecl-math = self.callPackage ./ecl-math {};
+
+ ecl-mpl = self.callPackage ./ecl-mpl {};
+
+ ecl-sigslots = self.callPackage ./ecl-sigslots {};
+
  ecl-sigslots-lite = self.callPackage ./ecl-sigslots-lite {};
+
+ ecl-statistics = self.callPackage ./ecl-statistics {};
+
+ ecl-streams = self.callPackage ./ecl-streams {};
+
+ ecl-threads = self.callPackage ./ecl-threads {};
+
+ ecl-time = self.callPackage ./ecl-time {};
 
  ecl-time-lite = self.callPackage ./ecl-time-lite {};
 
  ecl-tools = self.callPackage ./ecl-tools {};
+
+ ecl-type-traits = self.callPackage ./ecl-type-traits {};
+
+ ecl-utilities = self.callPackage ./ecl-utilities {};
 
  effort-controllers = self.callPackage ./effort-controllers {};
 
@@ -276,7 +332,13 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ fkie-master-discovery = self.callPackage ./fkie-master-discovery {};
+
+ fkie-master-sync = self.callPackage ./fkie-master-sync {};
+
  fkie-message-filters = self.callPackage ./fkie-message-filters {};
+
+ fkie-multimaster = self.callPackage ./fkie-multimaster {};
 
  fmi-adapter = self.callPackage ./fmi-adapter {};
 
@@ -490,6 +552,10 @@ self: super: {
 
  map-server = self.callPackage ./map-server {};
 
+ mapviz = self.callPackage ./mapviz {};
+
+ mapviz-plugins = self.callPackage ./mapviz-plugins {};
+
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
@@ -586,6 +652,8 @@ self: super: {
 
  multi-object-tracking-lidar = self.callPackage ./multi-object-tracking-lidar {};
 
+ multires-image = self.callPackage ./multires-image {};
+
  multisense = self.callPackage ./multisense {};
 
  multisense-bringup = self.callPackage ./multisense-bringup {};
@@ -634,6 +702,8 @@ self: super: {
 
  neonavigation-rviz-plugins = self.callPackage ./neonavigation-rviz-plugins {};
 
+ nerian-stereo = self.callPackage ./nerian-stereo {};
+
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nodelet = self.callPackage ./nodelet {};
@@ -663,6 +733,8 @@ self: super: {
  octovis = self.callPackage ./octovis {};
 
  ompl = self.callPackage ./ompl {};
+
+ open3d-conversions = self.callPackage ./open3d-conversions {};
 
  open-karto = self.callPackage ./open-karto {};
 
@@ -760,6 +832,8 @@ self: super: {
 
  ps3joy = self.callPackage ./ps3joy {};
 
+ py-trees = self.callPackage ./py-trees {};
+
  py-trees-msgs = self.callPackage ./py-trees-msgs {};
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
@@ -825,6 +899,8 @@ self: super: {
  ros-emacs-utils = self.callPackage ./ros-emacs-utils {};
 
  ros-environment = self.callPackage ./ros-environment {};
+
+ ros-ign = self.callPackage ./ros-ign {};
 
  ros-tutorials = self.callPackage ./ros-tutorials {};
 
@@ -1169,6 +1245,8 @@ self: super: {
  tf2-tools = self.callPackage ./tf2-tools {};
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
+
+ tile-map = self.callPackage ./tile-map {};
 
  topic-tools = self.callPackage ./topic-tools {};
 

--- a/distros/noetic/genpy/default.nix
+++ b/distros/noetic/genpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genpy";
-  version = "0.6.12-r1";
+  version = "0.6.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.12-1.tar.gz";
-    name = "0.6.12-1.tar.gz";
-    sha256 = "a7b6d5508b33b37a27e6e6ffa770b6835f3a51cb964dddba11b6da487c3df7d7";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.13-1.tar.gz";
+    name = "0.6.13-1.tar.gz";
+    sha256 = "5bfe2412c33cd5318acfd6a0f01ff51eae52034a96111761abba5b2e967fd309";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mapviz-plugins/default.nix
+++ b/distros/noetic/mapviz-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cv-bridge, gps-common, image-transport, map-msgs, mapviz, marti-common-msgs, marti-nav-msgs, marti-sensor-msgs, marti-visualization-msgs, move-base-msgs, nav-msgs, pluginlib, qt5, roscpp, sensor-msgs, std-msgs, stereo-msgs, swri-image-util, swri-math-util, swri-route-util, swri-transform-util, swri-yaml-util, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mapviz-plugins";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz_plugins/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "e3f3b3ad604b20468811f1c4ea20dd2c2bfe43b1a3752c73c11e148e8dad288b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib cv-bridge gps-common image-transport map-msgs mapviz marti-common-msgs marti-nav-msgs marti-sensor-msgs marti-visualization-msgs move-base-msgs nav-msgs pluginlib qt5.qtbase roscpp sensor-msgs std-msgs stereo-msgs swri-image-util swri-math-util swri-route-util swri-transform-util swri-yaml-util tf visualization-msgs ];
+  nativeBuildInputs = [ catkin qt5.qtbase ];
+
+  meta = {
+    description = ''Common plugins for the Mapviz visualization tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mapviz/default.nix
+++ b/distros/noetic/mapviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, freeglut, glew, image-transport, marti-common-msgs, message-generation, message-runtime, pkg-config, pluginlib, qt5, rosapi, roscpp, rqt-gui, rqt-gui-cpp, std-srvs, swri-transform-util, swri-yaml-util, tf, xorg }:
+buildRosPackage {
+  pname = "ros-noetic-mapviz";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/mapviz/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "4807272a020e920f896ef57e2d0822287fa78d2a44149fec98646e206d41437f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport marti-common-msgs message-runtime pluginlib qt5.qtbase rosapi roscpp rqt-gui rqt-gui-cpp std-srvs swri-transform-util swri-yaml-util tf xorg.libXi xorg.libXmu ];
+  nativeBuildInputs = [ catkin pkg-config qt5.qtbase ];
+
+  meta = {
+    description = ''mapviz'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/message-filters/default.nix
+++ b/distros/noetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-message-filters";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "1e38321ed1341969c525c8452aea10676b0657efd63cd7a85e1949842c009b06";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "855bb044da41c3540275e8c6d272b4dd34ac5d3fa224e30d3c1986bd82904239";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "f54382a10e1c8d84f8ba0011493f6954c395c678a793f0df78ef62a1c182778b";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "729772651c8251ac0b47f356f681240f7457f9e438f53e4e62b5d6134648e0de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/multires-image/default.nix
+++ b/distros/noetic/multires-image/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, gps-common, mapviz, pluginlib, qt5, roscpp, rospy, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
+buildRosPackage {
+  pname = "ros-noetic-multires-image";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/multires_image/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "5b6565618d831d5c13c745e6cff2c8b3049965c73a895564fbf02738df32be4c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs gps-common mapviz pluginlib qt5.qtbase roscpp rospy swri-math-util swri-transform-util swri-yaml-util tf ];
+  nativeBuildInputs = [ catkin qt5.qtbase ];
+
+  meta = {
+    description = ''multires_image'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nerian-stereo/default.nix
+++ b/distros/noetic/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-nerian-stereo";
+  version = "3.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.8.1-1.tar.gz";
+    name = "3.8.1-1.tar.gz";
+    sha256 = "8f11a621aa83524b23965991bd4937589a91c0c07ff44db1e281136c1b4a23a7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver node for SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/open3d-conversions/default.nix
+++ b/distros/noetic/open3d-conversions/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-open3d-conversions";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/perception_open3d-release/archive/release/noetic/open3d_conversions/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "67d58ef04e6ec6ee1788888cddaf5403bb9b0e3ca016e04748f7df966795ab34";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides conversion functions to and from Open3D datatypes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/py-trees/default.nix
+++ b/distros/noetic/py-trees/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-py-trees";
+  version = "0.7.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/py_trees-release/archive/release/noetic/py_trees/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "38bb008c75532924f7fad5a2f6662b413727dcca8a1ea9087baee4746fcf46ad";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.setuptools ];
+  propagatedBuildInputs = [ python3Packages.pydot ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Pythonic implementation of behaviour trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qt-dotgraph/default.nix
+++ b/distros/noetic/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-qt-dotgraph";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "e3093cafe6cbdbdc0f4a2dfa9605337ceac4282522ef07aabd8c31228c43a091";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_dotgraph/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "a879051a9279d88ee26a6468b3ce27816868bb3c56c1b80a6eadaa8e2745630a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-app/default.nix
+++ b/distros/noetic/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, qt-gui }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-app";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "0f1e6ba6eca18e5e5084ca6d34756af91baf3cfacb4247d7861abb87479f2303";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_app/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "ac27afd75d8effd07b6654b7b6e6d71eba0c4b8d171f01516db07cbccee5f5a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-core/default.nix
+++ b/distros/noetic/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-core";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "021c8ec1f3f4641abae8da00e9735a7464f8e0617cae45d2f08a7e0e34f93d2a";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_core/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "7a166499737a330456941515965c0357b715c1d145c9cc331e6ce6d338b543d9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-cpp/default.nix
+++ b/distros/noetic/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, python3Packages, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-cpp";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "806e9096994b81cc881e0a8bfded1d829573dfdc56c0a2cb8cd6e30fb43948f5";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_cpp/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "4673918813e1660f1c5b05e49e7ad869fd9c91507972f38262efa79665d10fbe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui-py-common/default.nix
+++ b/distros/noetic/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui-py-common";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "974b4ad8ac44f6666f9f23880479f5912839bef52d158f7cbbbefb8022da3e4c";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui_py_common/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "fa7d2b35a2513e6a10353cde91a8cbb1ad8e9eafee2f25d59b69c2f2187edd61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qt-gui/default.nix
+++ b/distros/noetic/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-noetic-qt-gui";
-  version = "0.4.1-r1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "a9d64ebc5adde5d914b9019cac696a7e337246f5e275e139a501d91d9e90a4c7";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/noetic/qt_gui/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "b565d65a2049bb96f1ce7cd81aa9e95f510e36ab8fede8a8ca4e959bfe84d10a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-comm/default.nix
+++ b/distros/noetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-ros-comm";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "e554fe5cbbe36ecefd7c8c3744cae74d6680822a2dd5117f12dc73fd456e6f9e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "72d42cd4c3ae9979909166d67bfdd53c05f8dd79d51ba922394629b1eca00252";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-ign/default.nix
+++ b/distros/noetic/ros-ign/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ros-ign-bridge, ros-ign-gazebo-demos, ros-ign-image }:
+buildRosPackage {
+  pname = "ros-noetic-ros-ign";
+  version = "0.111.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign/0.111.0-1.tar.gz";
+    name = "0.111.0-1.tar.gz";
+    sha256 = "21beeed679e05614595d381e55753bb6de4596921da96d621f53fb3c018e64ff";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ros-ign-bridge ros-ign-gazebo-demos ros-ign-image ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta-package containing interfaces for using ROS with <a href="https://ignitionrobotics.org">Ignition</a> simulation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "20b0bd750d975fbf728b0270691dae4f83d16aa2debce70eca6c10f46356f004";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "2c0cc911ea51054e78793030c2b15061a156e7619048bee51414c938cb16bd11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-storage/default.nix
+++ b/distros/noetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-storage";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "f6893769241c0595c8305adc19efcc34bed4ab895b3389be067337e7ed7d654e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "47c5663fa7739342da9127d19ffa00a0672bdfdd7f4b3e293d2234ce72226812";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag/default.nix
+++ b/distros/noetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, python3Packages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-rosbag";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "2c4650300776d33f616f122645638a44e0c1e98f4405fe22e28e0fdd7d5cb6e8";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "183a354fcaa5d2390744983c16335ad54707ac9ca15b6002603fe1fdbc56e216";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "5746cf5cc86ee06aa065e5507475690734fb0e8af661d15d5b15e17992d5f1bc";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "91350dc9d0d0ea75cd5b0217ddd55d95e68da44df1092dbd8e374c2e5ec16aa3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "944de8426dd933dd91962b85d3563840b4f014008582eb8b26ea427ca5385c3b";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "cf3676b2451f69b2846f166df9d5e0dcbda416f2a25a5e29163c8f8673a518c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "9b62ec7307ba7981898db9bc639dccdafd53db8ba3a1127d1824939168b5d161";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "bc2edd04f4f3a101fbc72d3f91bc9793964f1076c93ce348c0ee5665717265eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "d020d768c46a33a3892a3fd64a11a8a6a5ab9207888e6a74d1f5f491729dfb1e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "a8a84cc9c35608ce7385328bee77eae8b1d8d0b67d3cc68f6f5ff327522d0ba1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosconsole/default.nix
+++ b/distros/noetic/rosconsole/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apr, boost, catkin, cpp-common, log4cxx, rosbuild, rostime, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rosconsole";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosconsole-release/archive/release/noetic/rosconsole/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "6ccd2b982844a8e8ae6f32f1bfc261879e4495af6752c157dea441830a94c971";
+    url = "https://github.com/ros-gbp/rosconsole-release/archive/release/noetic/rosconsole/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "18c193f21df62bac1d3eae551f4735a4c17481054dff8fa1ff4ef0ef65d89470";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp/default.nix
+++ b/distros/noetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-roscpp";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "085de823d239af05dfe37a15c84be52e3f4c115fa405d86f69e798070c23e3b7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "aafbe9e65dfbbc07471cc368084f04f744b60fb6b122c7f12ec18ad35eb58432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "ed7dd2564d4f249bec2a811c028774ce4cd6c96e8d88ab5dcc5236fe79b1ac8c";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "309506fb7cfba551d9a85cfd9836356a13b37bd665988a34cf49defec69cdd4e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosgraph/default.nix
+++ b/distros/noetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "4ad4a471be1afacc01c4507e394a4ea23ff61dc10a2f3ef9afd2f9b14180124a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "ca1f0a038053af6825efb32ca6eec879b6d180a3f13d844ec9d9a66052450a57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "057f6f50542b02361a0158f482d2f490ce5943a65c9086c13a36b44a0d512cf1";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "4caa8df35ad733e457255f443f6087a8c376b8ed3581941fb92852fd64942aba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslaunch/default.nix
+++ b/distros/noetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslaunch";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "9191adb1cf8ec5d93c6b00a11cee802a2352cd035d0c30e237d743c3027bc8cd";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "2ba1e8765186ea4f2795b989291f968d333d2df67909fbe184b41169ed672071";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "a823579f6a06906bf1be3fe2b41697c75854178448b23e237eb83eb179449236";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "50f6144a8387442fc2d01d99df3b89b8834e7993bc296b1eec3c162f2c7f32b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslz4/default.nix
+++ b/distros/noetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslz4";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "1826944df6726d437c62a53bfeee216e21b98cbc078e43d0fcde65f2f7d17879";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "f931404bab54ed58000e473ad37a84009a45d5b51e6ed2ba77388f1816625a9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "8887dedc14b16a0e9c9a2f5d01712344cebc667ebf29b298c6b0d9172648dde4";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "9514440419b8559d52e985f991009c96227b1e7148f07af5c502cea93663fbf0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmaster/default.nix
+++ b/distros/noetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosmaster";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "b1291c70b6c0ea64e0f8112355cbd6ce315140c6038556c2e4c3dabc5fa7ad6d";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "37f21839c6caec0bf73b810278c911d2260a90594c247c57e100e50871043898";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmsg/default.nix
+++ b/distros/noetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosmsg";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "a7e94bdbddd95e04e779dbe98d521aeef16b34e2dc7822d60561cf0771749a7b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "d9dd9827e08ed2d50f514c110df6bd1569bf881ba0559dac7b486563bc90338b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosnode/default.nix
+++ b/distros/noetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-rosnode";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "d3c650c4b61dff991b97394fc3594363675d715c18bee27f96db97cbd836b81e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "05229d66611773a058858f9c1411f65424797ea7c41244cd25b929e0f4b1866a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosout/default.nix
+++ b/distros/noetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosout";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "35295be808290750efa22a08b9dea63e2db155eb787e32c217fb5bfd570b6601";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "d7613a2b77e241b454c12e3e649c3f515780b962343e8cf083295c41d2579209";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosparam/default.nix
+++ b/distros/noetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosparam";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "a485aeb5aa3d291212987f0807c80c31d2b14a9582a87157a98f28233b679fab";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "1e62aacfa6172cab0ff5d97d43da442fe276024269bdc5532528255793bff20d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy/default.nix
+++ b/distros/noetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "821ab132e25d18ceb7ee90f2a65a3570ce945cb96d8d1f19e59c30dafcb73285";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "0efbc52a916705493641ed196709f27a42db83f0886454728403896cfa942826";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosservice/default.nix
+++ b/distros/noetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosservice";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "667123f16a6a2c13640d94281a795a8fdf5b9643e863065499aa5d9203642f48";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "abac17649d479ec0baaf1d5082f0d54cff1dc9f07c1922d4636fe4aef3e94f97";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostest/default.nix
+++ b/distros/noetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rostest";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "060d801dbaabaca8ec8c27222796cd5be6924a7f1d77e6f7e0f68a84397a802e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "d09427ba996d77c3345dfb88a49d9d947625b1a5ada1175216da945b42e9696a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostopic/default.nix
+++ b/distros/noetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rostopic";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "f4bb6e4caf58ea8a7e0fdf7d6519ca3255b78200ef1a1bb62a7b28c1832c3825";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "1093c0293d3ea720a135ab5173c3389518a1bb0d6fddafb2fe48c63ddba81c48";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.4-r1";
+  version = "1.15.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.4-1.tar.gz";
-    name = "1.15.4-1.tar.gz";
-    sha256 = "8f94af7481f9c1ab894de78e65a72a75b6a8282ead882365935b9ca037cc347f";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.6-1.tar.gz";
+    name = "1.15.6-1.tar.gz";
+    sha256 = "940ea2a6f157c659762f4a06cbbbbf55b8cc1a1fc81d8bbdbbfbd93220e19176";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roswtf/default.nix
+++ b/distros/noetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, python3Packages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-roswtf";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "f5177fdbda944e73e015f20f4385c8f1b478d3638b2bc85f6cc4b9cf7605c983";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "5ab00879f4b5165088742b83b759ba73bfcc655ecb6d1fc839be954f66c3e893";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sophus/default.nix
+++ b/distros/noetic/sophus/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen }:
 buildRosPackage {
   pname = "ros-noetic-sophus";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/noetic/sophus/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "91e49d8613c81936a3ffcc4121e6b02b8101bcdf23c59afcd063c24c0b078770";
+    url = "https://github.com/yujinrobot-release/sophus-release/archive/release/noetic/sophus/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ef6951ab8dbffc56d6898d916e5421f44195bc7dce4fe4982f26796d790c72c0";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tile-map/default.nix
+++ b/distros/noetic/tile-map/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, glew, jsoncpp, mapviz, pluginlib, qt5, roscpp, swri-math-util, swri-transform-util, swri-yaml-util, tf }:
+buildRosPackage {
+  pname = "ros-noetic-tile-map";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/swri-robotics-gbp/mapviz-release/archive/release/noetic/tile_map/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "33a0cbbfea6d846191bd6904d11430a0a6cb988772b3a001390e686a88e7cf58";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ glew jsoncpp mapviz pluginlib qt5.qtbase roscpp swri-math-util swri-transform-util swri-yaml-util tf ];
+  nativeBuildInputs = [ catkin qt5.qtbase ];
+
+  meta = {
+    description = ''Tile map provides a slippy map style interface for visualizing 
+     OpenStreetMap and GooleMap tiles.  A mapviz visualization plug-in is also
+     implemented'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/topic-tools/default.nix
+++ b/distros/noetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-topic-tools";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "667ae42f21d555b5b08dde6b39d1ffd8c574695b97fb7ac734728049e51a1757";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "a41a17779a0ebee3da9a00f9199916d0d66c97e838bb375c742401f5cd5024be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xmlrpcpp/default.nix
+++ b/distros/noetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-xmlrpcpp";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "193951b33b8b4e77c03c8d96bb1e223372505251b99ff76512ba0b076f3f7c77";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "836067aee0b83fc283596badc4dba11145f9a77a25a6837d4665ef8bb6113f64";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 5c1bc7b755025f11c0c26866d1049046e458b732.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --all
```

Changes:
========
Dashing Changes:
----------------
* *camera-calibration 2.1.0-r1*
* *depth-image-proc 2.1.0-r1*
* *image-pipeline 2.1.0-r1*
* *image-proc 2.1.0-r1*
* *image-publisher 2.1.0-r1*
* *image-rotate 2.1.0-r1*
* *image-view 2.1.0-r1*
* *stereo-image-proc 2.1.0-r1*

Foxy Changes:
-------------
* *camera-calibration 2.1.1-r1 --> 2.2.0-r2*
* *control-toolbox 2.0.0-r1*
* *depth-image-proc 2.1.1-r1 --> 2.2.0-r2*
* *dynamic-graph 4.2.2-r1*
* *ecl-command-line 1.0.8-r1*
* *ecl-concepts 1.0.8-r1*
* *ecl-containers 1.0.8-r1*
* *ecl-converters 1.0.8-r1*
* *ecl-core 1.0.8-r1*
* *ecl-core-apps 1.0.8-r1*
* *ecl-devices 1.0.8-r1*
* *ecl-eigen 1.0.8-r1*
* *ecl-exceptions 1.0.8-r1*
* *ecl-filesystem 1.0.8-r1*
* *ecl-formatters 1.0.8-r1*
* *ecl-geometry 1.0.8-r1*
* *ecl-ipc 1.0.8-r1*
* *ecl-linear-algebra 1.0.8-r1*
* *ecl-manipulators 1.0.8-r1*
* *ecl-math 1.0.8-r1*
* *ecl-mobile-robot 1.0.8-r1*
* *ecl-mpl 1.0.8-r1*
* *ecl-sigslots 1.0.8-r1*
* *ecl-statistics 1.0.8-r1*
* *ecl-streams 1.0.8-r1*
* *ecl-threads 1.0.8-r1*
* *ecl-time 1.0.8-r1*
* *ecl-type-traits 1.0.8-r1*
* *ecl-utilities 1.0.8-r1*
* *fastrtps 2.0.0-r3 --> 2.0.1-r1*
* *image-pipeline 2.1.1-r1 --> 2.2.0-r2*
* *image-proc 2.1.1-r1 --> 2.2.0-r2*
* *image-publisher 2.1.1-r1 --> 2.2.0-r2*
* *image-rotate 2.1.1-r1 --> 2.2.0-r2*
* *image-view 2.1.1-r1 --> 2.2.0-r2*
* *librealsense2 2.34.0-r1 --> 2.34.0-r3*
* *object-recognition-msgs 2.0.0-r1*
* *ros2trace 1.0.1-r2 --> 1.0.2-r1*
* *sophus 1.2.0-r1 --> 1.2.1-r1*
* *stereo-image-proc 2.1.1-r1 --> 2.2.0-r2*
* *tracetools 1.0.1-r2 --> 1.0.2-r1*
* *tracetools-launch 1.0.1-r2 --> 1.0.2-r1*
* *tracetools-test 1.0.1-r2 --> 1.0.2-r1*

Melodic Changes:
----------------
* *dataspeed-pds 1.0.3-r1 --> 1.0.4-r1*
* *dataspeed-pds-can 1.0.3-r1 --> 1.0.4-r1*
* *dataspeed-pds-msgs 1.0.3-r1 --> 1.0.4-r1*
* *dataspeed-pds-rqt 1.0.3-r1 --> 1.0.4-r1*
* *dataspeed-pds-scripts 1.0.3-r1 --> 1.0.4-r1*
* *dynamic-graph 4.2.1-r4 --> 4.2.2-r1*
* *dynamic-graph-python 3.5.3-r2*
* *omnibase-control 0.0.2-r1*
* *omnibase-description 0.0.2-r1*
* *omnibase-gazebo 0.0.2-r1*

Noetic Changes:
---------------
* *audibot 0.2.1-r1*
* *audibot-description 0.2.1-r1*
* *audibot-gazebo 0.2.1-r1*
* *catkin 0.8.6-r1 --> 0.8.8-r1*
* *dataspeed-pds 1.0.3-r1 --> 1.0.5-r1*
* *dataspeed-pds-can 1.0.3-r1 --> 1.0.5-r1*
* *dataspeed-pds-msgs 1.0.3-r1 --> 1.0.5-r1*
* *dataspeed-pds-rqt 1.0.3-r1 --> 1.0.5-r1*
* *dataspeed-pds-scripts 1.0.3-r1 --> 1.0.5-r1*
* *dynamic-graph 4.2.2-r1*
* *dynamic-graph-python 3.5.3-r2*
* *ecl-command-line 0.62.3-r1*
* *ecl-concepts 0.62.3-r1*
* *ecl-containers 0.62.3-r1*
* *ecl-converters 0.62.3-r1*
* *ecl-core 0.62.3-r1*
* *ecl-core-apps 0.62.3-r1*
* *ecl-devices 0.62.3-r1*
* *ecl-eigen 0.62.3-r1*
* *ecl-exceptions 0.62.3-r1*
* *ecl-filesystem 0.62.3-r1*
* *ecl-formatters 0.62.3-r1*
* *ecl-geometry 0.62.3-r1*
* *ecl-ipc 0.62.3-r1*
* *ecl-linear-algebra 0.62.3-r1*
* *ecl-math 0.62.3-r1*
* *ecl-mpl 0.62.3-r1*
* *ecl-sigslots 0.62.3-r1*
* *ecl-statistics 0.62.3-r1*
* *ecl-streams 0.62.3-r1*
* *ecl-threads 0.62.3-r1*
* *ecl-time 0.62.3-r1*
* *ecl-type-traits 0.62.3-r1*
* *ecl-utilities 0.62.3-r1*
* *fkie-master-discovery 1.2.2-r1*
* *fkie-master-sync 1.2.2-r1*
* *fkie-multimaster 1.2.2-r1*
* *genpy 0.6.12-r1 --> 0.6.13-r1*
* *mapviz 1.4.0-r1*
* *mapviz-plugins 1.4.0-r1*
* *message-filters 1.15.7-r1 --> 1.15.8-r1*
* *mk 1.15.4-r1 --> 1.15.6-r1*
* *multires-image 1.4.0-r1*
* *nerian-stereo 3.8.1-r1*
* *open3d-conversions 0.0.2-r1*
* *py-trees 0.7.1-r1*
* *qt-dotgraph 0.4.1-r1 --> 0.4.2-r1*
* *qt-gui 0.4.1-r1 --> 0.4.2-r1*
* *qt-gui-app 0.4.1-r1 --> 0.4.2-r1*
* *qt-gui-core 0.4.1-r1 --> 0.4.2-r1*
* *qt-gui-cpp 0.4.1-r1 --> 0.4.2-r1*
* *qt-gui-py-common 0.4.1-r1 --> 0.4.2-r1*
* *ros 1.15.4-r1 --> 1.15.6-r1*
* *ros-comm 1.15.7-r1 --> 1.15.8-r1*
* *ros-ign 0.111.0-r1*
* *rosbag 1.15.7-r1 --> 1.15.8-r1*
* *rosbag-storage 1.15.7-r1 --> 1.15.8-r1*
* *rosbash 1.15.4-r1 --> 1.15.6-r1*
* *rosboost-cfg 1.15.4-r1 --> 1.15.6-r1*
* *rosbuild 1.15.4-r1 --> 1.15.6-r1*
* *rosclean 1.15.4-r1 --> 1.15.6-r1*
* *rosconsole 1.14.0-r1 --> 1.14.1-r1*
* *roscpp 1.15.7-r1 --> 1.15.8-r1*
* *roscreate 1.15.4-r1 --> 1.15.6-r1*
* *rosgraph 1.15.7-r1 --> 1.15.8-r1*
* *roslang 1.15.4-r1 --> 1.15.6-r1*
* *roslaunch 1.15.7-r1 --> 1.15.8-r1*
* *roslib 1.15.4-r1 --> 1.15.6-r1*
* *roslz4 1.15.7-r1 --> 1.15.8-r1*
* *rosmake 1.15.4-r1 --> 1.15.6-r1*
* *rosmaster 1.15.7-r1 --> 1.15.8-r1*
* *rosmsg 1.15.7-r1 --> 1.15.8-r1*
* *rosnode 1.15.7-r1 --> 1.15.8-r1*
* *rosout 1.15.7-r1 --> 1.15.8-r1*
* *rosparam 1.15.7-r1 --> 1.15.8-r1*
* *rospy 1.15.7-r1 --> 1.15.8-r1*
* *rosservice 1.15.7-r1 --> 1.15.8-r1*
* *rostest 1.15.7-r1 --> 1.15.8-r1*
* *rostopic 1.15.7-r1 --> 1.15.8-r1*
* *rosunit 1.15.4-r1 --> 1.15.6-r1*
* *roswtf 1.15.7-r1 --> 1.15.8-r1*
* *sophus 1.2.0-r1 --> 1.2.1-r1*
* *tile-map 1.4.0-r1*
* *topic-tools 1.15.7-r1 --> 1.15.8-r1*
* *xmlrpcpp 1.15.7-r1 --> 1.15.8-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] ignition-gazebo3
 * [ ] ignition-math6
 * [ ] ignition-msgs5
 * [ ] ignition-transport8
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-kdl
 * [ ] liborocos-kdl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dev
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-geographiclib
 * [ ] python-gst-1.0
 * [ ] python-impacket
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-sexpdata
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-colorama
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-grpcio
 * [ ] python3-ifcfg
 * [ ] python3-imageio
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pykdl
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-ruamel.yaml
 * [ ] python3-texttable
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

