### PR TITLE
fix build for libfranka

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -111,6 +111,14 @@ let
 
     laser-cb-detector = patchBoostSignals rosSuper.laser-cb-detector;
 
+    libfranka = rosSuper.libfranka.overrideAttrs({
+      buildInputs ? []
+      , cmakeFlags ? []
+      , ... }: {
+        buildInputs = buildInputs ++ [ self.zlib self.pcre ];
+        cmakeFlags = ["-DBUILD_TESTS=OFF"];
+    });
+
     libpcan = patchVendorUrl rosSuper.libpcan {
       url = "http://www.peak-system.com/fileadmin/media/linux/files/peak-linux-driver-8.3.tar.gz";
       sha256 = "0f6v3vjszyg1xp99jx48hyv8p32iyq4j18a4ir4x5p6f3b0z3r34";


### PR DESCRIPTION
`libfranka` requires `zlib` and `pcre` to build.

In addition, I set `-DBUILD-TESTS=OFF` for libfranka, because it attempts to download `googletest`, and for some reason it fails to resolve the fetch from GitHub.