### PR TITLE
rosdistro sync, Fri Oct  2 13:20:44 2020

### DIFF
--- a/distros/dashing/cloudwatch-logs-common/default.nix
+++ b/distros/dashing/cloudwatch-logs-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite, file-management }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-logs-common";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a04fc18cc569b86a49b377cddd10a040adae45a5c87bd2da35abde099d5fdf49";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_logs_common/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "774e21f3b7e04156c08596e67f0c04696d8f91f95e16618ff5c5cdf353431450";
   };
 
   buildType = "cmake";

--- a/distros/dashing/cloudwatch-metrics-common/default.nix
+++ b/distros/dashing/cloudwatch-metrics-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite, file-management }:
 buildRosPackage {
   pname = "ros-dashing-cloudwatch-metrics-common";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "6f99b5a7abac254acb71a5857b3d7233bce11c1417f2bdaeb17651c34122ba23";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/cloudwatch_metrics_common/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5a8c2c3ac0a8c61e37f37504920b17760336955404caa7d19e0d67a7cb04550b";
   };
 
   buildType = "cmake";

--- a/distros/dashing/dataflow-lite/default.nix
+++ b/distros/dashing/dataflow-lite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake }:
 buildRosPackage {
   pname = "ros-dashing-dataflow-lite";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "5a8ac08083f7b11b4f1d3623f9a3f1b60e131e6420fe4ac55b5c478be345aae8";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/dataflow_lite/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5142cfbd53d9c6254b37e584589aa9f0f99a475091d390a96f70822c255b32c0";
   };
 
   buildType = "cmake";

--- a/distros/dashing/file-management/default.nix
+++ b/distros/dashing/file-management/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, aws-common, cmake, dataflow-lite }:
 buildRosPackage {
   pname = "ros-dashing-file-management";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "592aea742ec6c451eac6c91ba77c0c46de3b6f0bfc9637c7110281a705e9c766";
+    url = "https://github.com/aws-gbp/cloudwatch_common-release/archive/release/dashing/file_management/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "ec609930010579466648cbceefd45512567a310738e3981a72dba33fcd41b9a4";
   };
 
   buildType = "cmake";

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -542,6 +542,8 @@ self: super: {
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
+ mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
  multires-image = self.callPackage ./multires-image {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};

--- a/distros/dashing/mrt-cmake-modules/default.nix
+++ b/distros/dashing/mrt-cmake-modules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
+buildRosPackage {
+  pname = "ros-dashing-mrt-cmake-modules";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/dashing/mrt_cmake_modules/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "0bc480fa4c29f84dd88080787200bc37c262fba5655263302c9309b66bd2a208";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gtest-vendor lcov python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+  nativeBuildInputs = [ ament-cmake-core python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+
+  meta = {
+    description = ''CMake Functions and Modules for automating CMake'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/generated.nix
+++ b/distros/eloquent/generated.nix
@@ -450,6 +450,24 @@ self: super: {
 
  kobuki-ros-interfaces = self.callPackage ./kobuki-ros-interfaces {};
 
+ lanelet2 = self.callPackage ./lanelet2 {};
+
+ lanelet2-core = self.callPackage ./lanelet2-core {};
+
+ lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-maps = self.callPackage ./lanelet2-maps {};
+
+ lanelet2-projection = self.callPackage ./lanelet2-projection {};
+
+ lanelet2-python = self.callPackage ./lanelet2-python {};
+
+ lanelet2-routing = self.callPackage ./lanelet2-routing {};
+
+ lanelet2-traffic-rules = self.callPackage ./lanelet2-traffic-rules {};
+
+ lanelet2-validation = self.callPackage ./lanelet2-validation {};
+
  laser-geometry = self.callPackage ./laser-geometry {};
 
  laser-proc = self.callPackage ./laser-proc {};

--- a/distros/eloquent/lanelet2-core/default.nix
+++ b/distros/eloquent/lanelet2-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, eigen, gtest, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-core";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_core/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "5a6a7dcbc841e7907620d1104ba4b929cc5ada6c0b6a3ea34aafa1666fe48b4b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost eigen mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Lanelet2 core module'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-examples/default.nix
+++ b/distros/eloquent/lanelet2-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, ros2cli }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-examples";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_examples/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "13d66e1bb35169e52632ed8dd7c86588138da18b06b643554456d6894f3cc67d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ros2cli ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Examples for working with Lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-maps/default.nix
+++ b/distros/eloquent/lanelet2-maps/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-maps";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_maps/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c3d1751dd0fb14d0f1697bab9cabecbcb4fadbb0deb51749bebaf33616011654";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lanelet2-core mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Example maps in the lanelet2-format'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-projection/default.nix
+++ b/distros/eloquent/lanelet2-projection/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, geographiclib, gtest, lanelet2-io, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-projection";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_projection/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a8a77b94d5fdb9a7e9e0c7f097c182953e9c97d59a58949cb9330fddf84e1df3";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ geographiclib lanelet2-io mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Lanelet2 projection library for lat/lon to local x/y conversion'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-python/default.nix
+++ b/distros/eloquent/lanelet2-python/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-python";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_python/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "9aaef05bb20bc7005875951bc7a91299c8efbe54a623ff178540dc070589fe75";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core lanelet2-io lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Python bindings for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-routing/default.nix
+++ b/distros/eloquent/lanelet2-routing/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-routing";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_routing/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "649caf75c9ab152917e15c237e6ba60edca4a80c0aa4e1e51e43ab10d83e5312";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Routing module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-traffic-rules/default.nix
+++ b/distros/eloquent/lanelet2-traffic-rules/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-traffic-rules";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_traffic_rules/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "f0ba8b467f9969781a64deada0d27eed302b38745ce9242f6df311029b7bc323";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ lanelet2-core mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Package for interpreting traffic rules in a lanelet map'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2-validation/default.nix
+++ b/distros/eloquent/lanelet2-validation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2-validation";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2_validation/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "0ca2eede514078794b314fa04632f879bad290b7fd5f3784667313dcc67a60aa";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest lanelet2-maps ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Package for sanitizing lanelet maps'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/lanelet2/default.nix
+++ b/distros/eloquent/lanelet2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
+buildRosPackage {
+  pname = "ros-eloquent-lanelet2";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/eloquent/lanelet2/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "7b495458913e2b33a9e7399b09254a67dfe4bb42a72500497e3b1d023c235456";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lanelet2-core lanelet2-examples lanelet2-io lanelet2-maps lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules lanelet2-validation ];
+  nativeBuildInputs = [ ament-cmake-core ros-environment ];
+
+  meta = {
+    description = ''Meta-package for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/mrt-cmake-modules/default.nix
+++ b/distros/eloquent/mrt-cmake-modules/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, lcov, python3Packages, ros-environment }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-eloquent-mrt-cmake-modules";
-  version = "1.0.4-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/eloquent/mrt_cmake_modules/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "d62142d2abee5a0006f8a5fbb8d01dd38876a572f445e82a272e493a702c9f3c";
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/eloquent/mrt_cmake_modules/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "23adb602c0e319cabcb4e5a862a5916bccd8f0e1b5d841ed6c3684e4ebc455ed";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ lcov python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+  propagatedBuildInputs = [ gtest-vendor lcov python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
   nativeBuildInputs = [ ament-cmake-core python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
 
   meta = {

--- a/distros/foxy/apex-test-tools/default.nix
+++ b/distros/foxy/apex-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-cmake-pclint, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp }:
 buildRosPackage {
   pname = "ros-foxy-apex-test-tools";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/foxy/apex_test_tools/0.0.1-1";
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/foxy/apex_test_tools/0.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "ef94c25a685938cb24b4164ceff77f876ae3247d281a8b0e8348d611601fcbc0";
+    sha256 = "892bad4ede47e5e159b2d8ced4a6381f116176ecc5469783003c5cdf350ed661";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -524,6 +524,8 @@ self: super: {
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
+ mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
  nav2-behavior-tree = self.callPackage ./nav2-behavior-tree {};

--- a/distros/foxy/lgsvl-bridge/default.nix
+++ b/distros/foxy/lgsvl-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-ros, boost, rcl, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-lgsvl-bridge";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/lgsvl/ros2-lgsvl-bridge-release/archive/release/foxy/lgsvl_bridge/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "eae3bee5eca6b86a46d892976c80561fbc47bd62e0012f722822a4b1e4928768";
+    url = "https://github.com/lgsvl/ros2-lgsvl-bridge-release/archive/release/foxy/lgsvl_bridge/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "291baea07b5e9f149ea70ee4d8393b9b6b9ec720b4cf43c582c170fda5525661";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mrt-cmake-modules/default.nix
+++ b/distros/foxy/mrt-cmake-modules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
+buildRosPackage {
+  pname = "ros-foxy-mrt-cmake-modules";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/foxy/mrt_cmake_modules/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b7bf3dcf5f190f8287847a109f5fca060184db2fdd4fd29c63cdbafb195b43ef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gtest-vendor lcov python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+  nativeBuildInputs = [ ament-cmake-core python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+
+  meta = {
+    description = ''CMake Functions and Modules for automating CMake'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/robot-state-publisher/default.nix
+++ b/distros/foxy/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-foxy-robot-state-publisher";
-  version = "2.4.0-r1";
+  version = "2.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.0-1.tar.gz";
-    name = "2.4.0-1.tar.gz";
-    sha256 = "2c88049844b9cc529f81f808228c4d0d701ffb69ca02b0ad98805a3e8b982a31";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.1-1.tar.gz";
+    name = "2.4.1-1.tar.gz";
+    sha256 = "9ddc81f216689e36e8b5cb0814fdd05b9e6fa5f67e4422a02dd8ef64f065f544";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-apex-test-tools/default.nix
+++ b/distros/foxy/test-apex-test-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, apex-test-tools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, apex-test-tools }:
 buildRosPackage {
   pname = "ros-foxy-test-apex-test-tools";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/foxy/test_apex_test_tools/0.0.1-1";
+    url = "https://gitlab.com/ApexAI/apex_test_tools-release/repository/archive.tar.gz?ref=release/foxy/test_apex_test_tools/0.0.2-1";
     name = "archive.tar.gz";
-    sha256 = "b7fae88aa4a1d2e3e1c92397759ecfe73001fad1db92f258a5afe27182316f11";
+    sha256 = "8f2a8281836a6ef61d778b7196cd77998aa4557285574064931e62e925832e5e";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ apex-test-tools ];
-  nativeBuildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto apex-test-tools ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
     description = ''Test package, which uses things exported by apex_test_tools'';

--- a/distros/foxy/v4l2-camera/default.nix
+++ b/distros/foxy/v4l2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-v4l2-camera";
-  version = "0.2.1-r3";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.2.1-3";
+    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.3.0-1";
     name = "archive.tar.gz";
-    sha256 = "7d25cc8e23e60d2a59de9a5d651256d20cd61d26bae55538152a9fddcd148f95";
+    sha256 = "538e02de489d0117527eddfd7ff342fde67599fdef31386e3d415bb4c69a22a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/cob-actions/default.nix
+++ b/distros/kinetic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-cob-actions";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_actions/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "71196b570d2e5790c8a9d065c608d552573bf2fbd0379bf58831d5232d2ba718";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_actions/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "52350a5b00706f937db15beeb657dd48e84a8dc2957171f79582e209a52a8ddd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-common/default.nix
+++ b/distros/kinetic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-kinetic-cob-common";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_common/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "cc740253d93b48a7b7187216787e2e03cde842fa5dbb76dbdc45fc684585698f";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_common/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "356d0a638963ffb6bc751bbace1a2a89b0ad164d01a378c326a885301f673929";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-default-env-config/default.nix
+++ b/distros/kinetic/cob-default-env-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-kinetic-cob-default-env-config";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/kinetic/cob_default_env_config/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "29db66450b6527af6462b9ae788891ebbf50882545d8e97800b44b359b1803f9";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/kinetic/cob_default_env_config/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "98482cb9415f11ca3c65030fe3281585615bc82571e92d479add0236bdae2e35";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-description/default.nix
+++ b/distros/kinetic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-cob-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "ee86dae56111b5eb9080a287fb3d99e34b270db02b0a412b9fe0d3b255eaf658";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "820410388c6c06b79b90a0b31b9c1665af3de62d4c96c79312855dd1f7a7d696";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-environments/default.nix
+++ b/distros/kinetic/cob-environments/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
 buildRosPackage {
   pname = "ros-kinetic-cob-environments";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/kinetic/cob_environments/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "121fa163fa1350094972975aeb05b47bc4d182c213be16efe1feacddeab8e457";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/kinetic/cob_environments/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "c86ea91a4e07191e229ad1d09d5a121cb21a2f093b2e1764e51840ac96522ff6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-gazebo-plugins/default.nix
+++ b/distros/kinetic/cob-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-gazebo-ros-control }:
 buildRosPackage {
   pname = "ros-kinetic-cob-gazebo-plugins";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/kinetic/cob_gazebo_plugins/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "910378ec3e804b6baa52574fc944f60332215e66e46c1fd1c3b3b777aa4849cc";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/kinetic/cob_gazebo_plugins/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "d9130f522461d01fef133b59f192732da7427a2adbe4d9dd33f5db7e39e99673";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-gazebo-ros-control/default.nix
+++ b/distros/kinetic/cob-gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-cob-gazebo-ros-control";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/kinetic/cob_gazebo_ros_control/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "67e027a6837ed713080ad0d357a8faa3bd481901be7cd336a2212e6c8921c0fd";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/kinetic/cob_gazebo_ros_control/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "5c433a61714731008812f1f02374bf250abc8792baf35e3f7a4fbffaecc76c48";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-msgs/default.nix
+++ b/distros/kinetic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-cob-msgs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_msgs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d44f662449291b2452e1d8b0f61c3233d217cce6c1a81ad6c56417c1a1900ea7";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "d26dea6b28ea6040a030585e865b4e8eda2622b9486e7f613bf72d880afc46e8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-srvs/default.nix
+++ b/distros/kinetic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-cob-srvs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_srvs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "866cc7f23ff49ddba08264ebe56eaf447f2b29dbb76a9dae8ad6da8381ed18a7";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/cob_srvs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "6ad68114f9130ad06e308926301114606254a0d16470cba59e5b81fbd18f8ab9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-supported-robots/default.nix
+++ b/distros/kinetic/cob-supported-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-cob-supported-robots";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/kinetic/cob_supported_robots/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "c51fe493a1bcfcc90ccf79b1faa0a34325aa53b4f11f228e564eb88a0ce99848";
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/kinetic/cob_supported_robots/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "541243cd72e87a3e3a56ceaf84692c98814e6fdd38b8a25bfade184536fb8a71";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-workbench-controllers/default.nix
+++ b/distros/kinetic/dynamixel-workbench-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamixel-workbench-msgs, dynamixel-workbench-toolbox, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-workbench-controllers";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_controllers/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "ef893c3483c8ca773e64a6e83b27b670a5adbe0d1f27a61d295b328202ce2807";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_controllers/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "c8ddcc9585858459f9b0846c0d312c6c7b4309f5a8d098bd60d0bd5a24a17ed2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-workbench-msgs/default.nix
+++ b/distros/kinetic/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-workbench-msgs";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release/archive/release/kinetic/dynamixel_workbench_msgs/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "5ce36f961e5d18eed39b03c502750eeb7df6fdf6f309d5c281a568a6edd55aa0";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release/archive/release/kinetic/dynamixel_workbench_msgs/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "b3712edb51cd26089473a32d1967a8a3692976939c8eab956e98127dfe4607ec";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-workbench-operators/default.nix
+++ b/distros/kinetic/dynamixel-workbench-operators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-workbench-operators";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_operators/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "d08cd161b668136a193c39b98ffe79c4042827f5a93d79808ce1e160b8fab9e7";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_operators/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "5154d3997cb68d4547afb36a137dba26f4bb62a8a7ee2d7467224fee7ab84f19";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-workbench-toolbox/default.nix
+++ b/distros/kinetic/dynamixel-workbench-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-workbench-toolbox";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_toolbox/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "b240a1ac8fcd1684a9e78513c0a44e45360c772157b5d16d7219153b1136463b";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench_toolbox/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "931d62c64241bb770da7e8e49de93499572d7700604ede24af52ec40b69f8dcd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-workbench/default.nix
+++ b/distros/kinetic/dynamixel-workbench/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamixel-workbench-controllers, dynamixel-workbench-operators, dynamixel-workbench-single-manager, dynamixel-workbench-single-manager-gui, dynamixel-workbench-toolbox }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-workbench-controllers, dynamixel-workbench-operators, dynamixel-workbench-toolbox }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-workbench";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "3b3076c4de54c9e8088751819d0af9ab14d772b3c5531c611182a7e7cad3d6bf";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/kinetic/dynamixel_workbench/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "b80403332a315c7b63240cec167e1c2781ce127c5f16fa1fcd39fd38ed5f889a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamixel-workbench-controllers dynamixel-workbench-operators dynamixel-workbench-single-manager dynamixel-workbench-single-manager-gui dynamixel-workbench-toolbox ];
+  propagatedBuildInputs = [ dynamixel-workbench-controllers dynamixel-workbench-operators dynamixel-workbench-toolbox ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -856,10 +856,6 @@ self: super: {
 
  dynamixel-workbench-operators = self.callPackage ./dynamixel-workbench-operators {};
 
- dynamixel-workbench-single-manager = self.callPackage ./dynamixel-workbench-single-manager {};
-
- dynamixel-workbench-single-manager-gui = self.callPackage ./dynamixel-workbench-single-manager-gui {};
-
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
  dynpick-driver = self.callPackage ./dynpick-driver {};

--- a/distros/kinetic/jackal-control/default.nix
+++ b/distros/kinetic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-control";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "eb64020ec44da9f4308e71320ee64675316e8cd1fcad653d7c4c21d0d5c0c5f1";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_control/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "8b8a2c8c1f02a51468569a1f608545f0ab42f299d6fe329270585ba59e2c1901";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-description/default.nix
+++ b/distros/kinetic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-description";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "5aaf31264641ec491dcc786cf5242234ba87ac84e4a59973a13f4b7366a5c75f";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_description/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "70ea9ed2b4dce651dd8e5b97c3dc711274977df14278df09bf1bc762ba6249c9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-msgs/default.nix
+++ b/distros/kinetic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-msgs";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "5b5117526dc08cda7e7431c243a113d03957cd838c0802609a7e32151a018f4d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_msgs/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "c51143c8b594ee9ef58e26564533ce0ba603516177a0193d942d9e81ec5fc040";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-navigation/default.nix
+++ b/distros/kinetic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-navigation";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "c40869b410e997c34e055cadff49002c2bd273ee7fe782f0557c50e66384d2bf";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_navigation/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "cab90e97b663bafac7acb6135a233eb573eea1541aa1be18f28ceab1a076dc62";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jackal-tutorials/default.nix
+++ b/distros/kinetic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-kinetic-jackal-tutorials";
-  version = "0.6.6-r1";
+  version = "0.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.6-1.tar.gz";
-    name = "0.6.6-1.tar.gz";
-    sha256 = "8e474dfad07b00ac80419482c3f071c1ef31f595089348efd1d935a0ca129595";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/kinetic/jackal_tutorials/0.6.7-1.tar.gz";
+    name = "0.6.7-1.tar.gz";
+    sha256 = "7d6363c5f2df6b59996a5e9bb6679ae5cb801b45c1cd077122c0c67231078037";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/raw-description/default.nix
+++ b/distros/kinetic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-raw-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/raw_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "b7d759b44c389f555a87449e3c9e6e5e2757f88519cecd6746acd3684315ed65";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/kinetic/raw_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "cded661002bf9ec92dfe2581ec06b38b0edaed304210b27abe9722e1d1aeb557";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/remote-rosbag-record/default.nix
+++ b/distros/kinetic/remote-rosbag-record/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-remote-rosbag-record";
-  version = "0.0.2-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/kinetic/remote_rosbag_record/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "e698fc6d26845d7cd2cdf5653eab92cba5853271260eaad95d3c8ef9a6195e33";
+    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/kinetic/remote_rosbag_record/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "3444e36ea651cd331b5b149e5161377c42a26a7f9c18ea8ceb413453f8a8c933";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robotis-manipulator/default.nix
+++ b/distros/kinetic/robotis-manipulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-robotis-manipulator";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release/archive/release/kinetic/robotis_manipulator/1.0.0-0.tar.gz";
-    name = "1.0.0-0.tar.gz";
-    sha256 = "473e954835e1ff720a6e7e95d402039ac435ea13d121a8df7bf1061b1bb9ffcb";
+    url = "https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release/archive/release/kinetic/robotis_manipulator/1.1.0-0.tar.gz";
+    name = "1.1.0-0.tar.gz";
+    sha256 = "ac35dcb7b7d8bcb1d11aba5f1edd0e131727409fd335b3a7f32fc5bdd24a470c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-actions/default.nix
+++ b/distros/melodic/cob-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-cob-actions";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_actions/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "c8f2442b4430c3a1289c871bf3671c22c1fd44f525e10c568d43844ba595eee5";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_actions/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "2013c1a7e3d3b98c3bbb34eaa553d847a258363b9a2b6bc5c8b8415a6f92e8f4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-common/default.nix
+++ b/distros/melodic/cob-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
 buildRosPackage {
   pname = "ros-melodic-cob-common";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_common/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "aa7aa82a608755458abb6e66d2460048f79f3931abc9199eacc39b5cd4be3480";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_common/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "27ce121ba80cf766e099dd54238e7e727fa34f902683e8c77c7b06702b949a9d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-default-env-config/default.nix
+++ b/distros/melodic/cob-default-env-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-cob-default-env-config";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_default_env_config/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "d1e459919f059b334c6a24685c711fb4b007d06123c376ea9463c6b08f9ad646";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_default_env_config/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "3de9a24f6d3fdcc549cafcebd7695f8fee6f43bff9db64de341c8f147e31e401";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-description/default.nix
+++ b/distros/melodic/cob-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cob-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d049d97db04bec0aa75d97c08ae7fc65b08be183dc21a75140212b0694e7fb47";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "215e0119533f54d087576a71617bcc009fe6b6776b0da8d6a96356868b9289c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-environments/default.nix
+++ b/distros/melodic/cob-environments/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
 buildRosPackage {
   pname = "ros-melodic-cob-environments";
-  version = "0.6.11-r1";
+  version = "0.6.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_environments/0.6.11-1.tar.gz";
-    name = "0.6.11-1.tar.gz";
-    sha256 = "b02a6060eb21ff68a0c881971f71fe8e99b6b1ba34964792947a8e4ffa5a2021";
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/melodic/cob_environments/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "ba9245a590fe7f3804ca97a203c4c23ab1ad46064c6f382f1f0d0cee72766e2a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-gazebo-plugins/default.nix
+++ b/distros/melodic/cob-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-gazebo-ros-control }:
 buildRosPackage {
   pname = "ros-melodic-cob-gazebo-plugins";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_plugins/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "d1b7bd521adfd41fd0232ba9ec0b63107f979236c7d933c3545da5e80c11455d";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_plugins/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "3fd936371180f27deb11d052aac705b5173f85c13d30599e70c0e1a6533f20ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-gazebo-ros-control/default.nix
+++ b/distros/melodic/cob-gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-cob-gazebo-ros-control";
-  version = "0.7.4-r1";
+  version = "0.7.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_ros_control/0.7.4-1.tar.gz";
-    name = "0.7.4-1.tar.gz";
-    sha256 = "2dff0323105ded5f8c582052e7e80f2377675c67e0777a54697ccd3341d2a9ab";
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/melodic/cob_gazebo_ros_control/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "5687adf479333067e28462c6d0de6df49a1542e58cb2fbc18cf5d094b20a3747";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-msgs/default.nix
+++ b/distros/melodic/cob-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cob-msgs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_msgs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "99d31afe431ee18434d8febaa177e820594ea4348455cd59a6ce1f568f764e25";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "fd2c39b071420db58fa3e818cda734db600553b50fc6d867d633d6c87d83153a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-srvs/default.nix
+++ b/distros/melodic/cob-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-cob-srvs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_srvs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "602cfa83943a258e384ac3d9a2e02628ee57ed80c5e614c11c9943bea66f6896";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/cob_srvs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "8a6d049b4cc176341883ca70f3ffc564029f548c9013778f6cfd7cf60d1ea3db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cob-supported-robots/default.nix
+++ b/distros/melodic/cob-supported-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-cob-supported-robots";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/melodic/cob_supported_robots/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "c5fcee979f72ca6a7399db095ed527f9c90745cb670b78130e3d8ec06e2f084e";
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/melodic/cob_supported_robots/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "ed78423a62385277880ea1d93f3adde5e1652422ebfefbd6352af188e12b2322";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.1-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f591fae9a43278d17b2746ba522c7175543444a78b85d79e895133766a51edd7";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "cce63de3184c10892d63e6ef3ba42638398fd9fdeb108ed78e26b360f2e36977";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.1-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "2c92ca00a591274bad3f384ce5c78f4de02d30a4611d4a0935cc820cee85b8e9";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "278046bca75cf452ce5c161c5588fa8138e6ea6a7f847ae9b6c69ea1c79140d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.1-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "8cc05ec1506f36dc77ac6fdcc98d10a00726b8302611e961706b383b0ed038ec";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "5d9283d4e8eecc722c26c726e4d0a522afdf021671d99dd006774f4a446d7da1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.1-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "a7024cd1924d148da454b9eebe138328d37e111ebdf79ceb2ae58f722ca69b9b";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "f55825fa1106223a4c27f8f7958749ea1d3cdcbed9241728be1dee64989c9a01";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamixel-workbench-controllers/default.nix
+++ b/distros/melodic/dynamixel-workbench-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamixel-workbench-msgs, dynamixel-workbench-toolbox, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-workbench-controllers";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_controllers/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "6a689760da538561f5481b327ee0f0c43fc49f3bc152b3fcfa51b406819ff40f";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_controllers/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "ee8de0278f4e337efe849f3bbf7347151e0f53d1b1e386d9bdb36811337ac062";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamixel-workbench-msgs/default.nix
+++ b/distros/melodic/dynamixel-workbench-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-workbench-msgs";
-  version = "2.0.0";
+  version = "2.0.1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release/archive/release/melodic/dynamixel_workbench_msgs/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "f4d7567a8deb08fa914feb0d768f67ad855f1c9baf060734bbe593b6961e070f";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release/archive/release/melodic/dynamixel_workbench_msgs/2.0.1-0.tar.gz";
+    name = "2.0.1-0.tar.gz";
+    sha256 = "28cc9426aa876bb8a64ed009d5683a61c547ff9b4926c68556e1a434065a8b18";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamixel-workbench-operators/default.nix
+++ b/distros/melodic/dynamixel-workbench-operators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-workbench-operators";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_operators/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "3b6f638d34a57d08365ca8029049067af23b0c8cbd185762ff4c2a65e07207f6";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_operators/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "7ee54432acff98b57a6111d496c3eb74fb34d0e324f2087c6c2d4cce29a3c47e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamixel-workbench-toolbox/default.nix
+++ b/distros/melodic/dynamixel-workbench-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-workbench-toolbox";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_toolbox/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "98a009c214814fb2ed6fe1b09590dab9503cd3e9fc6b5a9c5942ea7da8efcefb";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench_toolbox/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "53f4f6fd40d99a4559a67bacfc26e637d546ad455128380596ef8464ba639c70";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamixel-workbench/default.nix
+++ b/distros/melodic/dynamixel-workbench/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamixel-workbench-controllers, dynamixel-workbench-operators, dynamixel-workbench-single-manager, dynamixel-workbench-single-manager-gui, dynamixel-workbench-toolbox }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-workbench-controllers, dynamixel-workbench-operators, dynamixel-workbench-toolbox }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-workbench";
-  version = "2.0.0";
+  version = "2.2.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "00841253629ace29288f09f2eaeedc1d86eee69657d4b0ac32824b4561f5d574";
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/melodic/dynamixel_workbench/2.2.0-0.tar.gz";
+    name = "2.2.0-0.tar.gz";
+    sha256 = "4b6b839b6a403bb7d8e8a8a3f7943d05c71c624b08d2089f53b91ca782fba7d9";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ dynamixel-workbench-controllers dynamixel-workbench-operators dynamixel-workbench-single-manager dynamixel-workbench-single-manager-gui dynamixel-workbench-toolbox ];
+  propagatedBuildInputs = [ dynamixel-workbench-controllers dynamixel-workbench-operators dynamixel-workbench-toolbox ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/euslime/default.nix
+++ b/distros/melodic/euslime/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roseus, slime-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, roseus, slime-ros }:
 buildRosPackage {
   pname = "ros-melodic-euslime";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/melodic/euslime/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "2bda4669714d8380e33d1449eddb0a36247100d6b6288c207c42bec8233d1850";
+    url = "https://github.com/jsk-ros-pkg/euslime-release/archive/release/melodic/euslime/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "39ee14b35eccdb4b3024938289d3c5c4b9b23a356314f584500324aaf2f0a0cd";
   };
 
   buildType = "catkin";
+  buildInputs = [ catkin-virtualenv ];
   propagatedBuildInputs = [ roseus slime-ros ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/gazebo-video-monitor-plugins/default.nix
+++ b/distros/melodic/gazebo-video-monitor-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, libyamlcpp, message-generation, message-runtime, opencv3, roscpp, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-gazebo-video-monitor-plugins";
-  version = "0.4.2-r1";
+  version = "0.5.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitor_plugins-release/archive/release/melodic/gazebo_video_monitor_plugins/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "a776e5f3a7a45e1a2796d124057e86e722d305826f5d225729ceb15570e72eee";
+    url = "https://github.com/nlamprian/gazebo_video_monitor_plugins-release/archive/release/melodic/gazebo_video_monitor_plugins/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "181d2df71aab8de8603e287de380d92d38ae97dfd55aa6ce1e69da37cbfd74bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -716,10 +716,6 @@ self: super: {
 
  dynamixel-workbench-operators = self.callPackage ./dynamixel-workbench-operators {};
 
- dynamixel-workbench-single-manager = self.callPackage ./dynamixel-workbench-single-manager {};
-
- dynamixel-workbench-single-manager-gui = self.callPackage ./dynamixel-workbench-single-manager-gui {};
-
  dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
  easy-markers = self.callPackage ./easy-markers {};
@@ -829,6 +825,8 @@ self: super: {
  ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
 
  eus-assimp = self.callPackage ./eus-assimp {};
+
+ euslime = self.callPackage ./euslime {};
 
  euslisp = self.callPackage ./euslisp {};
 
@@ -3416,6 +3414,8 @@ self: super: {
 
  speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
 
+ sr-hand-detector = self.callPackage ./sr-hand-detector {};
+
  srdfdom = self.callPackage ./srdfdom {};
 
  stage = self.callPackage ./stage {};
@@ -3595,6 +3595,8 @@ self: super: {
  trajectory-tracker-rviz-plugins = self.callPackage ./trajectory-tracker-rviz-plugins {};
 
  transmission-interface = self.callPackage ./transmission-interface {};
+
+ tsid = self.callPackage ./tsid {};
 
  tts = self.callPackage ./tts {};
 

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "b2d19ea6eec2622f141f378e05b5526edd8e90a00c0cbd16fe3f5bc998fdaf5d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "6dd2cc6ccd638584dcdf7c35b28e1e151b6cde2be8d2f8890cd967086def42e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e96718bc63df357a5dec663251f4582034cfa1422e62899826f4687f78be1688";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "7afd26fd109053baa9ef1e0b4f2daef5ab66b5b690b7d4e3e1c8ec1bb9b211d9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "f198bdaddf8417af8228ba420018c319c900c538f3c9ae5c9440c22a80325e16";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "33548602caf997ac54844b8308f8284cf5cd60e758125b7ad8f3b44efe8741e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "484301b41b6f00768a0c0e186c2237f00239875698610979a8e075c16560758f";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "6f553f799ac5c79faea1e04c35ea3e2de88633611789e65e8f5eced6147c05df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "64d8c8203c20fdbbba99ef0740e38e1050c14706ab467bf538482a8a2b93b189";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "0d6f7be0ae8ef69cc1233bfdfbde0ab45599e859cb473a9a459d6cf191bb76cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/raw-description/default.nix
+++ b/distros/melodic/raw-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-raw-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/raw_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "5d2a5d6f22934576c575d09942d4e96c51c0948fce7693c1d694da89d476d497";
+    url = "https://github.com/ipa320/cob_common-release/archive/release/melodic/raw_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "15eaa3a8efd0d98a7bd89a2e63c196a2214bdd8f59e6c0ae74d7fef82960421f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/remote-rosbag-record/default.nix
+++ b/distros/melodic/remote-rosbag-record/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-remote-rosbag-record";
-  version = "0.0.2-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/melodic/remote_rosbag_record/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "cd628e9f0ab862a341e6c3b466b384cb2a7ed83a52fd5c8beddfb98c9d96f8c5";
+    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/melodic/remote_rosbag_record/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "a94f1d10d7a46c46afb268a1c2de5eb8c0d0bf15abe6f72678c959da87ef3447";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robotis-manipulator/default.nix
+++ b/distros/melodic/robotis-manipulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-robotis-manipulator";
-  version = "1.0.0";
+  version = "1.1.0";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release/archive/release/melodic/robotis_manipulator/1.0.0-0.tar.gz";
-    name = "1.0.0-0.tar.gz";
-    sha256 = "3e32af08b49c5a8b698e9e98b01c1fee182559c0b5e96025fc1be922ff306478";
+    url = "https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release/archive/release/melodic/robotis_manipulator/1.1.0-0.tar.gz";
+    name = "1.1.0-0.tar.gz";
+    sha256 = "1319f6251991f69621cc96ddef7769430fae53fc8686db0fe10e92d6524e504f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-environment/default.nix
+++ b/distros/melodic/ros-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-ros-environment";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_environment-release/archive/release/melodic/ros_environment/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "928aa91623553711b5e51dafc1271717e7d69ad0bd202a42309100c25721d53a";
+    url = "https://github.com/ros-gbp/ros_environment-release/archive/release/melodic/ros_environment/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "73dcd7530b240a850ef81f26d87a1bb38b34a4c59d31ac7ecefc64c90b3d88dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sr-hand-detector/default.nix
+++ b/distros/melodic/sr-hand-detector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, libyamlcpp, roscpp, roslib, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-sr-hand-detector";
+  version = "0.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/melodic/sr_hand_detector/0.0.1-3.tar.gz";
+    name = "0.0.1-3.tar.gz";
+    sha256 = "24352105d425a716f290d456599a839261b5e13c99ebf7f738ee685edf747241";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ ethercat-grant libyamlcpp roscpp roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The sr_hand_detector package'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/melodic/tsid/default.nix
+++ b/distros/melodic/tsid/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigenpy, eiquadprog, git, graphviz, pinocchio }:
+buildRosPackage {
+  pname = "ros-melodic-tsid";
+  version = "1.4.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/melodic/tsid/1.4.1-3.tar.gz";
+    name = "1.4.1-3.tar.gz";
+    sha256 = "04d008ab13e848c7d9c40ffb86d8b58d08c8bda30158bd3d505c1d08958f187e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin eigenpy eiquadprog graphviz pinocchio ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Efficient Task Space Inverse Dynamics (TSID) based on Pinocchio'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cob-actions/default.nix
+++ b/distros/noetic/cob-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-cob-actions";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_actions/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "5d44be233f950b6f5fda7c44cf5aaa34f49e7482203854979f6e23ca5015a38b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This Package contains Care-O-bot specific action definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-common/default.nix
+++ b/distros/noetic/cob-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-actions, cob-description, cob-msgs, cob-srvs, raw-description }:
+buildRosPackage {
+  pname = "ros-noetic-cob-common";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_common/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "dd599c647ef1e28ec622ea723131aba9c81bfcd1c500b5f2fb0470a2976e195f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-actions cob-description cob-msgs cob-srvs raw-description ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_common stack hosts common packages that are used within the Care-O-bot repository. E.g. utility packages or common message and service definitions etc. Also the urdf desciption of the robot is located in this stack.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-default-env-config/default.nix
+++ b/distros/noetic/cob-default-env-config/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-cob-default-env-config";
+  version = "0.6.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_default_env_config/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "25bf7d51166ad5d395862797d4ea5ecfbfa8a075d542af97b88b734150d1a390";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains configuration files for the default environments for Care-O-bot supported by IPA.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-description/default.nix
+++ b/distros/noetic/cob-description/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, rosbash, rospy, rosunit, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-cob-description";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "03382166f5c2c2872fd0ec7846299517f3453b24cd2ebd84f4458c86fe932bf6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros rosbash rospy rosunit xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the description (mechanical, kinematic, visual,
+  etc.) of the Care-O-bot robot. The files in this package are parsed and used by
+  a variety of other components. Most users will not interact directly
+  with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-environments/default.nix
+++ b/distros/noetic/cob-environments/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-default-env-config }:
+buildRosPackage {
+  pname = "ros-noetic-cob-environments";
+  version = "0.6.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_environments-release/archive/release/noetic/cob_environments/0.6.12-1.tar.gz";
+    name = "0.6.12-1.tar.gz";
+    sha256 = "67db40949f37cbee3164eb4cb75dff2010d196651aceddb91edc5ab0efe2905e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-default-env-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack holds packages for IPA default environment configuration.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-gazebo-plugins/default.nix
+++ b/distros/noetic/cob-gazebo-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-gazebo-ros-control }:
+buildRosPackage {
+  pname = "ros-noetic-cob-gazebo-plugins";
+  version = "0.7.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_plugins/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "84ef489330cd7d586a506e789852683a67d20215c5417d86eb91f3a8d6441463";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-gazebo-ros-control ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''cob_gazebo_plugins meta-package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-gazebo-ros-control/default.nix
+++ b/distros/noetic/cob-gazebo-ros-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-ros, gazebo-ros-control, hardware-interface, joint-limits-interface, pluginlib, roscpp, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-cob-gazebo-ros-control";
+  version = "0.7.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_gazebo_plugins-release/archive/release/noetic/cob_gazebo_ros_control/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "15f367fd65d13c9f016755782ed0af8ef9c78a3a34c5ce28e0b5710de9d626c7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface pluginlib roscpp transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a specialization of the gazebo_ros_control plugin.
+    The cob_gazebo_ros_control plugin allows Multi-HardwareInterface-Support.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-msgs/default.nix
+++ b/distros/noetic/cob-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-cob-msgs";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "f26d24ed18d504e15454b2f8fd856cd1f83e80cc703556594bb7eac60ccaf613";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for representing state information, such as battery information and emergency stop status.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-srvs/default.nix
+++ b/distros/noetic/cob-srvs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-cob-srvs";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/cob_srvs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "e629e41651cefbe3d6d5c974e4a967b828a394791292e9e0e947cba62559ce22";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This Package contains Care-O-bot specific service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cob-supported-robots/default.nix
+++ b/distros/noetic/cob-supported-robots/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-cob-supported-robots";
+  version = "0.6.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_supported_robots-release/archive/release/noetic/cob_supported_robots/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "2ce0e4b4b56c74b35c96a7f164889146a9b04afc2869c983d4c5852aa9d70fb2";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the list of supported robots within the care-o-bot family.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/gazebo-video-monitor-plugins/default.nix
+++ b/distros/noetic/gazebo-video-monitor-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, libyamlcpp, message-generation, message-runtime, opencv3, roscpp, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-video-monitor-plugins";
-  version = "0.4.2-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/nlamprian/gazebo_video_monitor_plugins-release/archive/release/noetic/gazebo_video_monitor_plugins/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "819039b058b29f41377ddfbf01e9bd14744c460c920d52ed435f8d5a5512dfe1";
+    url = "https://github.com/nlamprian/gazebo_video_monitor_plugins-release/archive/release/noetic/gazebo_video_monitor_plugins/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "f554e6eaeff123b3461130c6efba13d61c8747c6b6192ba9a3c6262baeb8a59b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -98,7 +98,27 @@ self: super: {
 
  cmake-modules = self.callPackage ./cmake-modules {};
 
+ cob-actions = self.callPackage ./cob-actions {};
+
+ cob-common = self.callPackage ./cob-common {};
+
+ cob-default-env-config = self.callPackage ./cob-default-env-config {};
+
+ cob-description = self.callPackage ./cob-description {};
+
+ cob-environments = self.callPackage ./cob-environments {};
+
  cob-extern = self.callPackage ./cob-extern {};
+
+ cob-gazebo-plugins = self.callPackage ./cob-gazebo-plugins {};
+
+ cob-gazebo-ros-control = self.callPackage ./cob-gazebo-ros-control {};
+
+ cob-msgs = self.callPackage ./cob-msgs {};
+
+ cob-srvs = self.callPackage ./cob-srvs {};
+
+ cob-supported-robots = self.callPackage ./cob-supported-robots {};
 
  code-coverage = self.callPackage ./code-coverage {};
 
@@ -664,6 +684,8 @@ self: super: {
 
  mapviz-plugins = self.callPackage ./mapviz-plugins {};
 
+ marker-msgs = self.callPackage ./marker-msgs {};
+
  marti-can-msgs = self.callPackage ./marti-can-msgs {};
 
  marti-common-msgs = self.callPackage ./marti-common-msgs {};
@@ -880,6 +902,8 @@ self: super: {
 
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
+ nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
+
  nodelet = self.callPackage ./nodelet {};
 
  nodelet-core = self.callPackage ./nodelet-core {};
@@ -1051,6 +1075,8 @@ self: super: {
  qwt-dependency = self.callPackage ./qwt-dependency {};
 
  random-numbers = self.callPackage ./random-numbers {};
+
+ raw-description = self.callPackage ./raw-description {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -1382,6 +1408,18 @@ self: super: {
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
 
+ schunk-description = self.callPackage ./schunk-description {};
+
+ schunk-libm5api = self.callPackage ./schunk-libm5api {};
+
+ schunk-modular-robotics = self.callPackage ./schunk-modular-robotics {};
+
+ schunk-powercube-chain = self.callPackage ./schunk-powercube-chain {};
+
+ schunk-sdh = self.callPackage ./schunk-sdh {};
+
+ schunk-simulated-tactile-sensors = self.callPackage ./schunk-simulated-tactile-sensors {};
+
  sdc21x0 = self.callPackage ./sdc21x0 {};
 
  sdhlibrary-cpp = self.callPackage ./sdhlibrary-cpp {};
@@ -1547,6 +1585,8 @@ self: super: {
  trajectory-tracker-rviz-plugins = self.callPackage ./trajectory-tracker-rviz-plugins {};
 
  transmission-interface = self.callPackage ./transmission-interface {};
+
+ tsid = self.callPackage ./tsid {};
 
  turtle-actionlib = self.callPackage ./turtle-actionlib {};
 

--- a/distros/noetic/geometric-shapes/default.nix
+++ b/distros/noetic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geometric-shapes";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/noetic/geometric_shapes/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "cc0824f12203c6dee1772cdacdbdd8e11a1b89334bd741762e7192e3c3a583f3";
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/noetic/geometric_shapes/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "9281180d07d4d7b92b16eb819841a3717820342125a50f94c1fd9af036e015b0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/marker-msgs/default.nix
+++ b/distros/noetic/marker-msgs/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-marker-msgs";
+  version = "0.0.6-r7";
+
+  src = fetchurl {
+    url = "https://github.com/tuw-robotics/marker_msgs-release/archive/release/noetic/marker_msgs/0.0.6-7.tar.gz";
+    name = "0.0.6-7.tar.gz";
+    sha256 = "5e6d538a7981661af4e75752a3a3d254b8f6f9afb79a7f3c5b6a55f1f38b2bce";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The marker_msgs package contains messages usable to setup a marker/fiducial system. 
+    The package distinguishes between two types of messages. 
+    First messages to describe the properties of a marker/fiducial detection system and the detected markers. 
+    Secondly messages used to represent a map of markers/features with covariances as it would be produced by a SLAM system or published by a map server for self-localization.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "729772651c8251ac0b47f356f681240f7457f9e438f53e4e62b5d6134648e0de";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "061d5bb2377d741b1b574f845b3f538ec202ec58fb484ac923da673e88b6062d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nmea-navsat-driver/default.nix
+++ b/distros/noetic/nmea-navsat-driver/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nmea-msgs, python3Packages, roslint, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-nmea-navsat-driver";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/nmea_navsat_driver-release/archive/release/noetic/nmea_navsat_driver/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "0f4ef3f997e211bffea6fea1b430e236039d4d42e20e75982171fd53583860ab";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.catkin-pkg ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ geometry-msgs nmea-msgs python3Packages.pyserial rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package to parse NMEA strings and publish a very simple GPS message. Does not
+    require or use the GPSD deamon.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/raw-description/default.nix
+++ b/distros/noetic/raw-description/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-description, gazebo-ros, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-raw-description";
+  version = "0.7.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_common-release/archive/release/noetic/raw_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "8332f8a31ef0c275225d9fd54601e235194d60849e5f9a921d46cce22a546f7c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-description gazebo-ros xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the description (mechanical, kinematic, visual,
+  etc.) of the Care-O-bot robot. The files in this package are parsed and used by
+  a variety of other components. Most users will not interact directly
+  with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/remote-rosbag-record/default.nix
+++ b/distros/noetic/remote-rosbag-record/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-remote-rosbag-record";
-  version = "0.0.2-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/noetic/remote_rosbag_record/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "2ee39861317e8d326b59c9c5e9df703ba2b648e2b49269690c603e509c1ee49b";
+    url = "https://github.com/yoshito-n-students/remote_rosbag_record-release/archive/release/noetic/remote_rosbag_record/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "2368a9fc7e072bf4aced606034a3cc0fe54c94e6fb09f522ac242fe7fbadc271";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-environment/default.nix
+++ b/distros/noetic/ros-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-ros-environment";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_environment-release/archive/release/noetic/ros_environment/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "506742b5cb529d28c78e18eab9a145d71fea185745788927322be23b4f945c3d";
+    url = "https://github.com/ros-gbp/ros_environment-release/archive/release/noetic/ros_environment/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "e662f6de77ecf5636ad97a2f7a61e588a64df62396c44e8c5cd3c14adefdf59d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "2c0cc911ea51054e78793030c2b15061a156e7619048bee51414c938cb16bd11";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "8a5a5c9371b115c2ba61093a714d50d30d6ba306d813046e3ebfea95bcfdb770";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "91350dc9d0d0ea75cd5b0217ddd55d95e68da44df1092dbd8e374c2e5ec16aa3";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "ae342273fce13575f5b3c8b29355fc0cd70a0b36cfb7aef0b83391732acbcb13";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "cf3676b2451f69b2846f166df9d5e0dcbda416f2a25a5e29163c8f8673a518c3";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "7785199b2fb11f649e2783d683b05cc1627213e9f14acece52ddb55e0d4dfe8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "bc2edd04f4f3a101fbc72d3f91bc9793964f1076c93ce348c0ee5665717265eb";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "b823264a4d9061dfad8bd240161be7a8976f6ea8c14dfd8936fa5b5df51cfd3c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "a8a84cc9c35608ce7385328bee77eae8b1d8d0b67d3cc68f6f5ff327522d0ba1";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "07f10331747829275619412337672b65f1718fdf2c29fdb3239b29afa186ee2d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "309506fb7cfba551d9a85cfd9836356a13b37bd665988a34cf49defec69cdd4e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "ee8eadf161fe8bb931ee07b2611c74613bdd5488a9713c5f42af61ffffd54434";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "4caa8df35ad733e457255f443f6087a8c376b8ed3581941fb92852fd64942aba";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "1dc142fe4396e3edfcd75777bf049cae4daa6d88ae445d8a08211c33ec277468";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "50f6144a8387442fc2d01d99df3b89b8834e7993bc296b1eec3c162f2c7f32b6";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "0655caaa3dd5b82f6255c4b61c3c50244785f4ca8ef4ae352485fbdfc2ac208e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "9514440419b8559d52e985f991009c96227b1e7148f07af5c502cea93663fbf0";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "ccf86e352c39bdf203c0465e1a154021e06d8f3b4face37269b1b01e3cba521e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.6-r1";
+  version = "1.15.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.6-1.tar.gz";
-    name = "1.15.6-1.tar.gz";
-    sha256 = "940ea2a6f157c659762f4a06cbbbbf55b8cc1a1fc81d8bbdbbfbd93220e19176";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.7-1.tar.gz";
+    name = "1.15.7-1.tar.gz";
+    sha256 = "37e53948063c7b37e461483fe40ae12168dc83f0a4211a40adc9aa8a809ed45f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/schunk-description/default.nix
+++ b/distros/noetic/schunk-description/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-description";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_description/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "b5d737097256f33d41fb8b196aca9c0b1121ddf0d50337a1ddfd71f0c283b10f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the description (mechanical, kinematic, visual,
+  etc.) of different schunk components. The files in this package are parsed and used by
+  a variety of other components. Most users will not interact directly
+  with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/schunk-libm5api/default.nix
+++ b/distros/noetic/schunk-libm5api/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libntcan, libpcan }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-libm5api";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_libm5api/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "e3fad08c1926bc24a510f7801c58b823c8790f8114f06747bbb7b6f3f033ce28";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libntcan libpcan ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package wraps the libm5api to use it as a ros dependency. Original sources from http://www.schunk-modular-robotics.com/fileadmin/user_upload/software/schunk_libm5api_source.zip.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/schunk-modular-robotics/default.nix
+++ b/distros/noetic/schunk-modular-robotics/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, schunk-description, schunk-libm5api, schunk-powercube-chain, schunk-sdh, schunk-simulated-tactile-sensors }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-modular-robotics";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_modular_robotics/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "9ddd2547360ffa6cc22bb481892941d8d8d0acfb8374ca95582bff6a5ba56665";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ schunk-description schunk-libm5api schunk-powercube-chain schunk-sdh schunk-simulated-tactile-sensors ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack includes packages that provide access to the Schunk hardware through ROS messages, services and actions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/schunk-powercube-chain/default.nix
+++ b/distros/noetic/schunk-powercube-chain/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cob-srvs, control-msgs, diagnostic-msgs, libntcan, libpcan, roscpp, schunk-libm5api, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-powercube-chain";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_powercube_chain/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "e96c4d110b2514e7b1374c5943958f9985714c686b223d494d16db0b06ced4c1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cob-srvs control-msgs diagnostic-msgs libntcan libpcan roscpp schunk-libm5api sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This packages provides a configurable driver of a chain
+  of Schunk powercubes. The powercube chain is configured
+  through parameters. Most users will not directly interact
+  with this package but with the corresponding launch files
+  in other packages, e.g. schunk_bringup, cob_bringup, ...'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/schunk-sdh/default.nix
+++ b/distros/noetic/schunk-sdh/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cob-srvs, control-msgs, diagnostic-msgs, dpkg, libntcan, libpcan, libusb, message-generation, message-runtime, roscpp, roslint, sdhlibrary-cpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-sdh";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_sdh/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "49ae4d8f97483a7b2349425c265470e6a00b4b7ed6eb138db59de12a73ecd496";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  propagatedBuildInputs = [ actionlib boost cob-srvs control-msgs diagnostic-msgs dpkg libntcan libpcan libusb message-runtime roscpp sdhlibrary-cpp sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides an interface for operating the schunk dexterous hand (SDH), including the tactile sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/schunk-simulated-tactile-sensors/default.nix
+++ b/distros/noetic/schunk-simulated-tactile-sensors/default.nix
@@ -1,0 +1,66 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-msgs, rospy, schunk-sdh }:
+buildRosPackage {
+  pname = "ros-noetic-schunk-simulated-tactile-sensors";
+  version = "0.6.14-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/schunk_modular_robotics-release/archive/release/noetic/schunk_simulated_tactile_sensors/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "acd19245c4b759137b30bf8b5df6542f58e406565615e59c3b7f5113badead76";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-msgs rospy schunk-sdh ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides simulated tactile sensors for the Schunk Dextrous
+     Hand (SDH) which is mounted on the Care-O-bot arm. The node subscribes to
+     the Gazebo bumper topics of the SDH. It transforms the Gazebo feedback to
+     the &quot;tactile_data&quot; topic to provide the same tactile sensor interface as
+     the schunk_sdh package.
+
+     The following parameters can be set:
+     * cells_x: The number of patches on the tactile sensor in the direction
+                perpendicular to the finger. Defaults to 6.
+     * cells_y: The number of patches on the tactile sensor along the direction
+                of the finger. Defaults to 14.
+     * output_range: The maximum output value of one patch. Defaults to 3500.
+     * sensitivity: The change of output in one patch per Newton. Defaults to
+                    350. The sensitivity can be approximated by the following
+                    formula: S = output_range / (measurement_range * cell_area)
+                    - The measurement range of the tactile pads is 250 kPa (from
+                      the data sheet).
+                    - The output range can be determined by experiment from the
+                      real SDH. It is about 3500.
+                    - The cell area is the size of one patch. Length and width
+                      of the area are determined by dividing the length/width
+                      of the collision surface by the number of cells in the
+                      respective direction.
+                      Important: In most cases this is NOT the cell area that is
+                                 given in the data sheet!
+     * filter_length: The length of the moving average filter which smoothes
+                      the values from simulation. Defaults to 10.
+
+     The node subscribes to the following topics to receive data from the
+     simulation:
+     * thumb_2/state
+     * thumb_3/state
+     * finger_12/state
+     * finger_13/state
+     * finger_22/state
+     * finger_23/state
+
+     The node publishes the processed data on the following topic:
+     * tactile_data
+
+     The simulated bumper must obtain the collision data in the link that the
+     sensor is attached to. This is achieved by setting the &quot;frameName&quot; property
+     in the gazebo_ros_bumper controller.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tsid/default.nix
+++ b/distros/noetic/tsid/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigenpy, eiquadprog, git, graphviz, pinocchio }:
+buildRosPackage {
+  pname = "ros-noetic-tsid";
+  version = "1.4.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/noetic/tsid/1.4.1-2.tar.gz";
+    name = "1.4.1-2.tar.gz";
+    sha256 = "5bb2ab81b9a5b12ce4bb9af81d82fe543386e123d522b950f80826fa76aec9ec";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ boost catkin eigenpy eiquadprog graphviz pinocchio ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Efficient Task Space Inverse Dynamics (TSID) based on Pinocchio'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit b06575ff4a07fbb511836ecc6e9fe9ef40ce4cd5.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --skip cross_compile --all
```

Changes:
========
Dashing Changes:
----------------
* *cloudwatch-logs-common 1.1.3-r1 --> 1.1.4-r1*
* *cloudwatch-metrics-common 1.1.3-r1 --> 1.1.4-r1*
* *dataflow-lite 1.1.3-r1 --> 1.1.4-r1*
* *file-management 1.1.3-r1 --> 1.1.4-r1*
* *mrt-cmake-modules 1.0.8-r1*

Eloquent Changes:
-----------------
* *lanelet2 1.1.1-r1*
* *lanelet2-core 1.1.1-r1*
* *lanelet2-examples 1.1.1-r1*
* *lanelet2-maps 1.1.1-r1*
* *lanelet2-projection 1.1.1-r1*
* *lanelet2-python 1.1.1-r1*
* *lanelet2-routing 1.1.1-r1*
* *lanelet2-traffic-rules 1.1.1-r1*
* *lanelet2-validation 1.1.1-r1*
* *mrt-cmake-modules 1.0.4-r1 --> 1.0.8-r1*

Foxy Changes:
-------------
* *apex-test-tools 0.0.1-r1 --> 0.0.2-r1*
* *lgsvl-bridge 0.1.2-r1 --> 0.1.3-r1*
* *mrt-cmake-modules 1.0.8-r1*
* *robot-state-publisher 2.4.0-r1 --> 2.4.1-r1*
* *test-apex-test-tools 0.0.1-r1 --> 0.0.2-r1*
* *v4l2-camera 0.2.1-r3 --> 0.3.0-r1*

Kinetic Changes:
----------------
* *cob-actions 0.7.2-r1 --> 0.7.3-r1*
* *cob-common 0.7.2-r1 --> 0.7.3-r1*
* *cob-default-env-config 0.6.11-r1 --> 0.6.12-r1*
* *cob-description 0.7.2-r1 --> 0.7.3-r1*
* *cob-environments 0.6.11-r1 --> 0.6.12-r1*
* *cob-gazebo-plugins 0.7.4-r1 --> 0.7.5-r1*
* *cob-gazebo-ros-control 0.7.4-r1 --> 0.7.5-r1*
* *cob-msgs 0.7.2-r1 --> 0.7.3-r1*
* *cob-srvs 0.7.2-r1 --> 0.7.3-r1*
* *cob-supported-robots 0.6.14-r1 --> 0.6.15-r1*
* *dynamixel-workbench 2.0.0 --> 2.2.0*
* *dynamixel-workbench-controllers 2.0.0 --> 2.2.0*
* *dynamixel-workbench-msgs 2.0.0 --> 2.0.1*
* *dynamixel-workbench-operators 2.0.0 --> 2.2.0*
* *dynamixel-workbench-toolbox 2.0.0 --> 2.2.0*
* *jackal-control 0.6.6-r1 --> 0.6.7-r1*
* *jackal-description 0.6.6-r1 --> 0.6.7-r1*
* *jackal-msgs 0.6.6-r1 --> 0.6.7-r1*
* *jackal-navigation 0.6.6-r1 --> 0.6.7-r1*
* *jackal-tutorials 0.6.6-r1 --> 0.6.7-r1*
* *raw-description 0.7.2-r1 --> 0.7.3-r1*
* *remote-rosbag-record 0.0.2-r1 --> 0.0.4-r1*
* *robotis-manipulator 1.0.0 --> 1.1.0*

Melodic Changes:
----------------
* *cob-actions 0.7.2-r1 --> 0.7.3-r1*
* *cob-common 0.7.2-r1 --> 0.7.3-r1*
* *cob-default-env-config 0.6.11-r1 --> 0.6.12-r1*
* *cob-description 0.7.2-r1 --> 0.7.3-r1*
* *cob-environments 0.6.11-r1 --> 0.6.12-r1*
* *cob-gazebo-plugins 0.7.4-r1 --> 0.7.5-r1*
* *cob-gazebo-ros-control 0.7.4-r1 --> 0.7.5-r1*
* *cob-msgs 0.7.2-r1 --> 0.7.3-r1*
* *cob-srvs 0.7.2-r1 --> 0.7.3-r1*
* *cob-supported-robots 0.6.14-r1 --> 0.6.15-r1*
* *dingo-control 0.1.1-r1 --> 0.1.3-r1*
* *dingo-description 0.1.1-r1 --> 0.1.3-r1*
* *dingo-msgs 0.1.1-r1 --> 0.1.3-r1*
* *dingo-navigation 0.1.1-r1 --> 0.1.3-r1*
* *dynamixel-workbench 2.0.0 --> 2.2.0*
* *dynamixel-workbench-controllers 2.0.0 --> 2.2.0*
* *dynamixel-workbench-msgs 2.0.0 --> 2.0.1*
* *dynamixel-workbench-operators 2.0.0 --> 2.2.0*
* *dynamixel-workbench-toolbox 2.0.0 --> 2.2.0*
* *euslime 1.0.1-r1 --> 1.1.0-r1*
* *gazebo-video-monitor-plugins 0.4.2-r1 --> 0.5.0-r2*
* *jackal-control 0.7.1-r1 --> 0.7.2-r1*
* *jackal-description 0.7.1-r1 --> 0.7.2-r1*
* *jackal-msgs 0.7.1-r1 --> 0.7.2-r1*
* *jackal-navigation 0.7.1-r1 --> 0.7.2-r1*
* *jackal-tutorials 0.7.1-r1 --> 0.7.2-r1*
* *raw-description 0.7.2-r1 --> 0.7.3-r1*
* *remote-rosbag-record 0.0.2-r1 --> 0.0.4-r1*
* *robotis-manipulator 1.0.0 --> 1.1.0*
* *ros-environment 1.2.2-r1 --> 1.2.3-r1*
* *sr-hand-detector 0.0.1-r3*
* *tsid 1.4.1-r3*

Noetic Changes:
---------------
* *cob-actions 0.7.3-r1*
* *cob-common 0.7.3-r1*
* *cob-default-env-config 0.6.12-r1*
* *cob-description 0.7.3-r1*
* *cob-environments 0.6.12-r1*
* *cob-gazebo-plugins 0.7.5-r1*
* *cob-gazebo-ros-control 0.7.5-r1*
* *cob-msgs 0.7.3-r1*
* *cob-srvs 0.7.3-r1*
* *cob-supported-robots 0.6.15-r1*
* *gazebo-video-monitor-plugins 0.4.2-r1 --> 0.5.0-r1*
* *geometric-shapes 0.7.1-r1 --> 0.7.2-r1*
* *marker-msgs 0.0.6-r7*
* *mk 1.15.6-r1 --> 1.15.7-r1*
* *nmea-navsat-driver 0.6.0-r1*
* *raw-description 0.7.3-r1*
* *remote-rosbag-record 0.0.2-r1 --> 0.0.4-r1*
* *ros 1.15.6-r1 --> 1.15.7-r1*
* *ros-environment 1.3.1-r1 --> 1.3.2-r1*
* *rosbash 1.15.6-r1 --> 1.15.7-r1*
* *rosboost-cfg 1.15.6-r1 --> 1.15.7-r1*
* *rosbuild 1.15.6-r1 --> 1.15.7-r1*
* *rosclean 1.15.6-r1 --> 1.15.7-r1*
* *roscreate 1.15.6-r1 --> 1.15.7-r1*
* *roslang 1.15.6-r1 --> 1.15.7-r1*
* *roslib 1.15.6-r1 --> 1.15.7-r1*
* *rosmake 1.15.6-r1 --> 1.15.7-r1*
* *rosunit 1.15.6-r1 --> 1.15.7-r1*
* *schunk-description 0.6.14-r1*
* *schunk-libm5api 0.6.14-r1*
* *schunk-modular-robotics 0.6.14-r1*
* *schunk-powercube-chain 0.6.14-r1*
* *schunk-sdh 0.6.14-r1*
* *schunk-simulated-tactile-sensors 0.6.14-r1*
* *tsid 1.4.1-r2*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] catkin
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] ignition-gazebo3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

