### PR TITLE
Fix: flake with devShell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/examples/turtlebot3-gazebo-shell.nix
+++ b/examples/turtlebot3-gazebo-shell.nix
@@ -1,0 +1,26 @@
+# Run:
+# roslaunch turtlebot3_gazebo turtlebot3_world.launch
+# roslaunch turtlebot3_teleop turtlebot3_teleop_key.launch
+{ pkgs,
+  rosPackages
+}:
+
+with rosPackages.melodic;
+with pythonPackages;
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.glibcLocales
+    (buildEnv { paths = [
+      turtlebot3-description
+      turtlebot3-teleop
+      turtlebot3-gazebo
+      gazebo-plugins
+      xacro
+    ]; })
+  ];
+
+  ROS_HOSTNAME = "localhost";
+  ROS_MASTER_URI = "http://localhost:11311";
+  TURTLEBOT3_MODEL = "burger";
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,7 @@
       };
     in {
       packages = pkgs.rosPackages;
+      devShell = import ./examples/turtlebot3-gazebo-shell.nix { inherit pkgs; rosPackages = pkgs.rosPackages;};
     }) // {
       overlay = import ./overlay.nix;
       nixosModule = import ./modules;


### PR DESCRIPTION
add devShell to flake

test output:
```
 nix develop -c rostest --help
Usage: rostest [options] [package] <filename>

Options:
  -h, --help            show this help message and exit
  -t, --text            Run with stdout output instead of XML output
  --pkgdir=PKG_DIR      package dir
  --package=PACKAGE     package
  --results-filename=RESULTS_FILENAME
                        results_filename
  --results-base-dir=RESULTS_BASE_DIR
                        The base directory of the test results. The test
                        result file is created in a subfolder name PKG_DIR.
  -r, --reuse-master    Connect to an existing ROS master instead of spawning
                        a new ROS master on a custom port
  -c, --clear           Clear all parameters when connecting to an existing
                        ROS master (only works with --reuse-master)

```
 TODO.
-  set `defaultPackage. ` for nix build
-  add CI  for Nix flake check such as `nix develop -c echo ok  and nix build nix-run`

 