### PR TITLE
rosdistro sync, Fri Oct 30 13:06:42 2020

### DIFF
--- a/distros/dashing/contracts-lite-vendor/default.nix
+++ b/distros/dashing/contracts-lite-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-contracts-lite-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/dashing/contracts_lite_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "53b27e165b2437a0a9eb021edaf6d5e698b0de0fd78593aebbad54ad7b102751";
+    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/dashing/contracts_lite_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "f05ebea5fb681c75837a7857eef2a8558210945bedfccaec6e518540a61d27b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/fastcdr/default.nix
+++ b/distros/dashing/fastcdr/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-dashing-fastcdr";
-  version = "1.0.11-r1";
+  version = "1.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/dashing/fastcdr/1.0.11-1.tar.gz";
-    name = "1.0.11-1.tar.gz";
-    sha256 = "6c08a1eaebd88e797c06d450449a0979fe1122046da0212280f76219d97c9a45";
+    url = "https://github.com/ros2-gbp/fastcdr-release/archive/release/dashing/fastcdr/1.0.13-1.tar.gz";
+    name = "1.0.13-1.tar.gz";
+    sha256 = "9af2cdb692aa08995d55773dbd863895c858ee463032c81340880c4166afe3c4";
   };
 
   buildType = "cmake";

--- a/distros/dashing/fastrtps/default.nix
+++ b/distros/dashing/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-dashing-fastrtps";
-  version = "1.8.2-r1";
+  version = "1.8.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/dashing/fastrtps/1.8.2-1.tar.gz";
-    name = "1.8.2-1.tar.gz";
-    sha256 = "59077766b9b801862280e898f06dad701d4b54f0fbf88ac387b725e08acc63df";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/dashing/fastrtps/1.8.4-1.tar.gz";
+    name = "1.8.4-1.tar.gz";
+    sha256 = "33b7d2d637ca29c50429d2dd8f44f7acff7583a5762780c13819cc0eebc496ab";
   };
 
   buildType = "cmake";

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -690,8 +690,6 @@ self: super: {
 
  poco-vendor = self.callPackage ./poco-vendor {};
 
- proj = self.callPackage ./proj {};
-
  px4-msgs = self.callPackage ./px4-msgs {};
 
  py-trees-ros = self.callPackage ./py-trees-ros {};

--- a/distros/dashing/rc-genicam-api/default.nix
+++ b/distros/dashing/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-dashing-rc-genicam-api";
-  version = "2.4.1-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/dashing/rc_genicam_api/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "1368107b46ae35bca57fea8995366b5b8b97f24fd0edb1fd15ca3ada557f297d";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/dashing/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "a5297c3f71fc1360a6507a93413996118f7c0ca4503cfd24f51572a25c1e2ca7";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/rc-genicam-api/default.nix
+++ b/distros/eloquent/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-eloquent-rc-genicam-api";
-  version = "2.4.1-r2";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/eloquent/rc_genicam_api/2.4.1-2.tar.gz";
-    name = "2.4.1-2.tar.gz";
-    sha256 = "07327a64970963325c8c2e60745a274f7c305568654426a9c9577d99612b75e1";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/eloquent/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "40a679f926279da27ee641e3529f9db2d750899b186731623ab59d3fe8423e94";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/rviz-assimp-vendor/default.nix
+++ b/distros/eloquent/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-assimp-vendor";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_assimp_vendor/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "cef94b0a93d522f94574cdd51b93d4425f83686fb32f46e307ed08c37d6e88e4";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_assimp_vendor/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "b7e4d5e8b9664516ee675080f3d38e59fc7e0c315033c4173ee9ca0885a23ca3";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-common/default.nix
+++ b/distros/eloquent/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-common";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_common/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "7c5cf07c8bf82f4a614f5c818d4ed7f02f9626eec04aa8ab488512b780163ade";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_common/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "48fb7a1932227a309e3b46b98b86fba2e7b574c9bf62dda37d242686b9f66910";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-default-plugins/default.nix
+++ b/distros/eloquent/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-default-plugins";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_default_plugins/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "26459b0f83a7de8cc96c78267004bee6f229a898963190629459f3790826a0ce";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_default_plugins/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "a1383faa586f3e80b95cd71a212c503993ce7b07cfe9077987c3f5dbbd267edc";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-ogre-vendor/default.nix
+++ b/distros/eloquent/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-ogre-vendor";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_ogre_vendor/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "8ad19747cf3fb3b30eb46bde3c61b11ccb23fb9f21eb75e4f324d2aefd0895fe";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_ogre_vendor/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "4eabfa987b643eed0e2a79e9d1dcc1d206fd2fc87a4e38159f8aafbb90bcd1bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-rendering-tests/default.nix
+++ b/distros/eloquent/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-rendering-tests";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering_tests/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "82042d6628a2189e2984527d94f8192d151112d1279d5dd0b7e44a7bc0f73713";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering_tests/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "3819c313b52c1a3430841e40e5be2d3addf4d7c68e5ac3079aff66e2a12a9c71";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-rendering/default.nix
+++ b/distros/eloquent/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-rendering";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "f91ffe4726c70e21b0df896e41e850dfb337c5a699f5a1413e7b7b27428ab211";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_rendering/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "e469e9f4c8f4877f8581ae87536f1013a3d36a3ece17fbe5d783ab6e71730f07";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz-visual-testing-framework/default.nix
+++ b/distros/eloquent/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-eloquent-rviz-visual-testing-framework";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_visual_testing_framework/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "fd5bcdd7082c161ed2da774d61fee1f71f31c5f049b0c76be2a1bf751150ddcc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz_visual_testing_framework/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "9e43dc58187353959ea177f18a7f5c1760eb12eda6f64562797f0482b7b00478";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/rviz2/default.nix
+++ b/distros/eloquent/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-eloquent-rviz2";
-  version = "7.0.5-r1";
+  version = "7.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz2/7.0.5-1.tar.gz";
-    name = "7.0.5-1.tar.gz";
-    sha256 = "18b0ad21c1cc2d8d2c95e6f4a1b3f88d334712d6ea5bffb85234a6b5ee3e7d42";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/eloquent/rviz2/7.0.6-1.tar.gz";
+    name = "7.0.6-1.tar.gz";
+    sha256 = "4c71cccd603e93ce6b3c88412296f323abeeed91832fcd65de671af8990667f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/contracts-lite-vendor/default.nix
+++ b/distros/foxy/contracts-lite-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-contracts-lite-vendor";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "e6265e1047982dee7b1c2778223e025e667b7f34bfd92817a616bd47ee3dbcc3";
+    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "98016a6194f9b9f14872d2223776144370788f0247391886046d2735ed0635c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/examples-tf2-py/default.nix
+++ b/distros/foxy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-examples-tf2-py";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "50db62fc7896ec3fcc3a12e7d94b4f525026af069dc98e6307188e06b5a016a2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "9176bc1fd544c598dda3e60b39646e283cc61e76e3b92d637b3729954403c156";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/geometry2/default.nix
+++ b/distros/foxy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-foxy-geometry2";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "1abd176e32b544f1cfc93b3bc06ffcc74f49dac19b39dce0fb7b8f9c6254469a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "210b202f8518607c9804f2c957f05b4d98da9a75e7c0a277af39e0ac3ddd635c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joy-teleop/default.nix
+++ b/distros/foxy/joy-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-tutorials-interfaces, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, control-msgs, example-interfaces, geometry-msgs, rclpy, sensor-msgs, std-msgs, std-srvs, teleop-tools-msgs, test-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joy-teleop";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/joy_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "7977507e651dad77569a0d1ccec5cfdf2dd1443aaeab8c809335b1daf1aa9b77";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/joy_teleop/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "8408ac5e86943bed92489316624c2900ad3c6a9aea3149745af3e16c0b38f807";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/key-teleop/default.nix
+++ b/distros/foxy/key-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-key-teleop";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/key_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e5794f264ee465d169cb12a1ece39053bfbcf65db7699cf0dcfe472927da4832";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/key_teleop/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "9b5f7789667d6c49591811a8f3ff2d8e90396a0d8256751b370593cfc0de67c2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-ros/default.nix
+++ b/distros/foxy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-launch-ros";
-  version = "0.10.3-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "2b292bf58f365a7fc974f91947ef329382dd282e90ecde7fa53a2cced81f275e";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "472cb6a766781c24472dc9ae6a9c5f0cb83dfa7d3f3c554c87ea1f9b188dad33";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing-ros/default.nix
+++ b/distros/foxy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ros";
-  version = "0.10.3-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "dcf2b75070274fe56b8f51451d9aee9d6adbc53e5e9923271f17374f64b210d7";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "aa7df125d5446e8ffe109219d2ddeea7763cb3b5b48699b8a29898ff22480f19";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/mouse-teleop/default.nix
+++ b/distros/foxy/mouse-teleop/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, pythonPackages, rclpy }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-mouse-teleop";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/mouse_teleop/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ed4138c16c43b0f13c1fbbbdfa3141dc7bbc969580f3d786d5791a138ec7ea91";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/mouse_teleop/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "7ca23eaee77e49bea52a99f265f463cb83134039cf80d9a5a438569b903cd872";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint ];
-  propagatedBuildInputs = [ geometry-msgs pythonPackages.numpy pythonPackages.tkinter rclpy ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.numpy python3Packages.tkinter rclpy ];
 
   meta = {
     description = ''A mouse teleop tool for holonomic mobile robots.'';

--- a/distros/foxy/rc-genicam-api/default.nix
+++ b/distros/foxy/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-api";
-  version = "2.4.1-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "769ba3c54a365bda5fa88477c18dcf4ec0e131c92dd5a3a23a367c7a97d9382a";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "a6391e42c080f4b9437d6364da972c53fee6674576e4f47e4eac3fa84fa31202";
   };
 
   buildType = "cmake";

--- a/distros/foxy/ros2launch/default.nix
+++ b/distros/foxy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2launch";
-  version = "0.10.3-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "be5e6a15dd3ccbe33a8899d11df71a96087f94f82dd86d998090b5cd5bb3300e";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "992a463820853751255a5de074674066cce0a1d9a32ba2a51f40484a7a767b40";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/teleop-tools-msgs/default.nix
+++ b/distros/foxy/teleop-tools-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-teleop-tools-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/teleop_tools_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "5bc5a3ef81f5083f1f2c42e32b4abee6094dadf6b56e7a9ea51bd6858bac9fd8";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/teleop_tools_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "7f2c3d627e3322119313cf3ec62df6f5b285592c39d1261bcc7730c5d60ad2a3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/teleop-tools/default.nix
+++ b/distros/foxy/teleop-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joy-teleop, key-teleop, teleop-tools-msgs }:
 buildRosPackage {
   pname = "ros-foxy-teleop-tools";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/teleop_tools/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "37a241d5e4ac9ab35dfde8d4d30729db83ba7cf0cb20a789cd7641d8e314e01f";
+    url = "https://github.com/ros-gbp/teleop_tools-release/archive/release/foxy/teleop_tools/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "a0c54c9ed6f818e8b5c0e12856ad1d74916be73a943e14be8b9e941e2b933a57";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-bullet/default.nix
+++ b/distros/foxy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-bullet";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "7de8518292c4834c8dbf47c424322c87673dac72e4c02c2c0e79e9ec39dfa5a1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "cd5b890e4e091ccc44618fbe1684ed8d5dfc8f0ab56d57ba293d230cbc1ad4ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen/default.nix
+++ b/distros/foxy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "1737acf0240569a496475b2644d3e809bd669c9cf41698f80cfc9966b9ccfe73";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "aadbbd860f6ca8cd827550e2ffb9c64e24da539ded44263f364177db48d72cd5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-geometry-msgs/default.nix
+++ b/distros/foxy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-geometry-msgs";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "0acfd92b020c33615279bbaf8dab90eceef018f4068c6e02e60f6205ba6d0451";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "4e0d814cd1f2e395e57e26756fed9549ffb9bfe96027270402e50f0065bf27a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-kdl/default.nix
+++ b/distros/foxy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-kdl";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "c03ae9884abf45b6a0f43dea01b07a94de529a53b09fbe5034b1b968d3ca2260";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "7f02fce28f65cd8e3c281b3641b62c5e3b9cba6e2af335e1646e6046918699b0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-msgs/default.nix
+++ b/distros/foxy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-tf2-msgs";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "28b719dd9d8d052a15a5b8fe36efaa8e39d6f292d514939ed233ec7a7603b1a6";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "e2b464e5a98b0a8d2bbd537aff539dcc2846b298a8c36fd5453dcb715dffa8c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-py/default.nix
+++ b/distros/foxy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-py";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "4299ce8e05cd9d9f87f0d5233faef1c4983de230c0ba94071758db8d434d8255";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "5af922fce58f9e5bcf81ab89801d3689e02f6393942e358200273c042f080e5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-ros/default.nix
+++ b/distros/foxy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, message-filters, python-cmake-module, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-foxy-tf2-ros";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "24df30aa635b306cc82051d93876b091bd4c2c4dfe9b4b0e66c73e17f0a389fa";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "df8108d31f108950bad9c6b65649b3b5635f913c2c6d9b52910fb63f538b27e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-sensor-msgs/default.nix
+++ b/distros/foxy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-sensor-msgs";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "554ed14aaf455dd26e338271c27cfa61885f8343e4fcfe9d1de3076e9cf7be65";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "8d379365508be9946c7e355f4063f2c9eb7d10a6d080b3ceac94cf1325793db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-tools/default.nix
+++ b/distros/foxy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-tools";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "b6cdaa8027435ce7fd88f86906a643e46a6ca335556472a241720217a9d51f25";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "e2162184fc82a56eaded99545824011698db887bf8e9b5df101ecc702a210c5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2/default.nix
+++ b/distros/foxy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-tf2";
-  version = "0.13.5-r1";
+  version = "0.13.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.5-1.tar.gz";
-    name = "0.13.5-1.tar.gz";
-    sha256 = "a88d47d76b22085a22ec35ccb9e861ac9ea0a69a76dc99798856181c5f709e06";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.6-1.tar.gz";
+    name = "0.13.6-1.tar.gz";
+    sha256 = "4fcacf611dc8dc4f66b715c9d0375bd1c7ce21da515e8506810c03abd522b09f";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -1706,6 +1706,12 @@ self: super: {
 
  ivcon = self.callPackage ./ivcon {};
 
+ ixblue-ins = self.callPackage ./ixblue-ins {};
+
+ ixblue-ins-driver = self.callPackage ./ixblue-ins-driver {};
+
+ ixblue-ins-msgs = self.callPackage ./ixblue-ins-msgs {};
+
  ixblue-stdbin-decoder = self.callPackage ./ixblue-stdbin-decoder {};
 
  jackal-control = self.callPackage ./jackal-control {};

--- a/distros/kinetic/ixblue-ins-driver/default.nix
+++ b/distros/kinetic/ixblue-ins-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-ixblue-ins-driver";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_driver/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "8fac6a5b192a8956a2b0cecc20893de7ed715fd5b5635db5c8f55a4c72d6e67d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ boost libpcap ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater ixblue-ins-msgs ixblue-stdbin-decoder nav-msgs roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The iXblue_ins_driver package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/ixblue-ins-msgs/default.nix
+++ b/distros/kinetic/ixblue-ins-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-ixblue-ins-msgs";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_msgs/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "02062df9c7ff3cf99fbc2e774fe804095edec72cfb3a5d7735e8e7fc183bd209";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ixblue INS defined messages package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/ixblue-ins/default.nix
+++ b/distros/kinetic/ixblue-ins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-ixblue-ins";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "20b054a6ead40117a92e189b3e2e003a0357870bc5d8e68ca2f8d42d0de68d86";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ixblue-ins-driver ixblue-ins-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for iXblue INS driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/kinetic/jsk-interactive-marker/default.nix
+++ b/distros/kinetic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roseus, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-interactive-marker";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive_marker/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "1e0ea7ee3a61a1dbd9b48d5c0ad7f8383dbf2dcab7ef75067f0b7d6878834c43";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive_marker/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "ef8d972b2a7678646e88ca651ae071ce295d35e4ee3977a59e54186fa2534189";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jsk-interactive-test/default.nix
+++ b/distros/kinetic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-interactive-test";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive_test/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "6c516534824c0e1772db45c2661a12ef20b6b7f93e89beee2edb7b8804e1fb2a";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive_test/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "eec4bbb224930e030ec9eeb2f7aeaf71316bda9546180481098227a3f6ac780c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jsk-interactive/default.nix
+++ b/distros/kinetic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-interactive";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "8eeaa648a8c988fc17c6a614e9dc5bed8a3172b12de1cbb1898d0f66d4227556";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_interactive/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "5013dbe3400246047a2507baa7b58dd4b17ffcae117562ccc68ac6cddb03ba8e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jsk-rqt-plugins/default.nix
+++ b/distros/kinetic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, pythonPackages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-rqt-plugins";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_rqt_plugins/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "065a6919232f9b5b3f0f4c92686f96cbb46b0c6640872786102a23d5a0527a27";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_rqt_plugins/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "ff03e8d5800ae6e604a15f871653d8cf3195b4d27b4b1e4c045b78d5329902f4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jsk-rviz-plugins/default.nix
+++ b/distros/kinetic/jsk-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, image-geometry, image-publisher, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-topic-tools, message-generation, mk, people-msgs, posedetection-msgs, pythonPackages, rosbuild, rviz, std-msgs, urdfdom-py, view-controller-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-rviz-plugins";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_rviz_plugins/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "76568fb8d11b828926bae3190b794a1ea5186162c0456c98cfd794b87f026d05";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_rviz_plugins/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "5fbdc323ce01f5a4c2c9f98062d803fbc4885574ee885788d37eb3ce6905aeea";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/jsk-visualization/default.nix
+++ b/distros/kinetic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-jsk-visualization";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_visualization/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "b36c3af462bf376b1a8c12cb607cdf0649db61f391f18093cbfe0be7993312fa";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/kinetic/jsk_visualization/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "829d6309aa8d735c1ef9e37308fbdcabfda3f5d5ecfd320c7b7ba5df3825d687";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.38.1-r1";
+  version = "2.39.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.38.1-1.tar.gz";
-    name = "2.38.1-1.tar.gz";
-    sha256 = "60827c0a6c60b0fbce93265cd2806ced4a577a334fc227b52fe17f91e13e9165";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.39.0-1.tar.gz";
+    name = "2.39.0-1.tar.gz";
+    sha256 = "4406615341410c0fb62d34c08e97e02ad10e4e299c9935b3623061d49d71fcc0";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "37a1f1fd7876b9e76091de6ed79b03c4a5dabe17933f89663dea290c61401a2b";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "f73eeadfe3c17ae4de9ed7c11b8f58f7e32a30b621201a13091f7e7aadfa8500";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-genicam-api/default.nix
+++ b/distros/kinetic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-kinetic-rc-genicam-api";
-  version = "2.4.1-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/kinetic/rc_genicam_api/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "3ded9771da36c5c543c5091759cde6cb6cfcc6aa6e69bf88034597d03103e70b";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/kinetic/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "d316ef9c8a0680ebeee018e2f18d69bf092db78969e00d3304a3106b2d2a722b";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.17-r1";
+  version = "2.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.17-1.tar.gz";
-    name = "2.2.17-1.tar.gz";
-    sha256 = "5eaa42a7eafda7effeb8ca5b4b27e198d666ae1f200ec1bd552febd84b58d6a3";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.18-1.tar.gz";
+    name = "2.2.18-1.tar.gz";
+    sha256 = "2595d07f1873ccc0a2b2d78739e1ce06c59c2fc0afb12089e25181e62b41abe7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.17-r1";
+  version = "2.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.17-1.tar.gz";
-    name = "2.2.17-1.tar.gz";
-    sha256 = "f77cef755431a5d3d59af21aea4cc9172d1f45d982da002c2871ef1fe30f676f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.18-1.tar.gz";
+    name = "2.2.18-1.tar.gz";
+    sha256 = "f985d9e9dc88e7f9caad841a9bda79753694dd2cca4ed163925c0aeb811dddac";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-introspection/default.nix
+++ b/distros/kinetic/ros-introspection/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslint, rosmsg }:
 buildRosPackage {
   pname = "ros-kinetic-ros-introspection";
-  version = "1.0.1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/ros_introspection/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "63dedc31de3bbaa2b47341ab8d220120175f509a1d967878a560d4adcd0901da";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/ros_introspection/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "40103621911e9b795a4215fca7cdfb8667b513b9ffc1a6fec251555d83829679";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint ];
-  propagatedBuildInputs = [ pythonPackages.requests rosmsg ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml pythonPackages.requests pythonPackages.rospkg rosmsg ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/roscompile/default.nix
+++ b/distros/kinetic/roscompile/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, ros-introspection, roslint, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, pluginlib-tutorials, python, pythonPackages, ros-introspection, roslint, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-roscompile";
-  version = "1.0.1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/roscompile/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "f82097dea3c6114b1012be659199e80b4307bb3d1f4b6edf2dd0a996987fd448";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/roscompile/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "cfe027f1f0b60ff37fc674d1f91eb5de45691ac553d86f558286392766c50e68";
   };
 
   buildType = "catkin";
-  checkInputs = [ geometry-msgs pluginlib roslint tf ];
-  propagatedBuildInputs = [ catkin ros-introspection ];
+  checkInputs = [ geometry-msgs pluginlib pluginlib-tutorials roslint stereo-msgs tf ];
+  propagatedBuildInputs = [ catkin python pythonPackages.click pythonPackages.pyyaml pythonPackages.rospkg ros-introspection ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/ypspur/default.nix
+++ b/distros/kinetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-kinetic-ypspur";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "4d6fc40e11875df74a8bfdf65bd5c79ae24c7725f81d920c89f70e5049a4f089";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "663ba5556d1e74927eafd40dc86854fbdc20abf53d9c047332fcf2237f582e03";
   };
 
   buildType = "cmake";

--- a/distros/melodic/automotive-autonomy-msgs/default.nix
+++ b/distros/melodic/automotive-autonomy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, automotive-navigation-msgs, automotive-platform-msgs, catkin, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-automotive-autonomy-msgs";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_autonomy_msgs/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e072ea7261f06ecc8c8b495647b72cf1dea3f2b9daabfc5082f35d500b52b838";
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_autonomy_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "2899316eab20c57ab7bcc0d5d8bdb46da42c9a66d94200376ead64b7ca74d6b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/automotive-navigation-msgs/default.nix
+++ b/distros/melodic/automotive-navigation-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-automotive-navigation-msgs";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_navigation_msgs/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "acad76a6269575909380ef612341a5a0dd066e32ea35455bb50624a8262d164b";
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_navigation_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "b1e197ff14c2d36b74e3a178147299f8b4edef50728854eed3198021e0849bdd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/automotive-platform-msgs/default.nix
+++ b/distros/melodic/automotive-platform-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-automotive-platform-msgs";
-  version = "3.0.3-r1";
+  version = "3.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_platform_msgs/3.0.3-1.tar.gz";
-    name = "3.0.3-1.tar.gz";
-    sha256 = "e6eaf1d66b72b30ac23d08b430c694376baab7ff22b05060a1cca0df279e984d";
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/melodic/automotive_platform_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "11b418be3ec5eb3c715e835c951d207cd632499e9a0fd4ca4ab740028e248905";
   };
 
   buildType = "catkin";

--- a/distros/melodic/boost-sml/default.nix
+++ b/distros/melodic/boost-sml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-boost-sml";
-  version = "0.1.0-r2";
+  version = "0.1.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/melodic/boost_sml/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "bc312f3caea5cf88e0c2b8ade1231eda35e695a513dcac61e520835a107aacca";
+    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/melodic/boost_sml/0.1.0-3.tar.gz";
+    name = "0.1.0-3.tar.gz";
+    sha256 = "5684c6e8c9430035a4b172f16ba480cb9cc2fd7db95f72253b291dd35e660f57";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-device-driver/default.nix
+++ b/distros/melodic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-melodic-bota-device-driver";
+  version = "0.5.2-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.2-2";
+    name = "archive.tar.gz";
+    sha256 = "4c380c66060b6f55a15dfac4f933dc7d98880761dd35c2681dc31eaf432eb7b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "0032d575f622fbd2047091fb97abf6eee6dbc1d829cf83c3d8cdda7b2f9c8380";
+    sha256 = "d995592d9c8d88918dfe61f23bae9881ed99cfd7011235578ed6a875ad89cbe3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-bota-node";
+  version = "0.5.2-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.2-2";
+    name = "archive.tar.gz";
+    sha256 = "6503b36a33795aded7042790d7e2fc8aae390819aac35da353816892c6b17110";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-bota-signal-handler";
+  version = "0.5.2-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.2-2";
+    name = "archive.tar.gz";
+    sha256 = "ee701a44c3c122d5ea4168b5698bcb012a1d093c7aec68129b6ed00495d94d39";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-bota-worker";
+  version = "0.5.2-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.2-2";
+    name = "archive.tar.gz";
+    sha256 = "103602543e1798a2d1d7a11c9ae5808cbd0f00b23e568d70970160a4451919e0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/ddynamic-reconfigure/default.nix
+++ b/distros/melodic/ddynamic-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gmock, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-ddynamic-reconfigure";
-  version = "0.3.1-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/ddynamic_reconfigure/archive/release/melodic/ddynamic_reconfigure/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "3e3de53b73c044195de287a8c5472cf36779a4017201d30fb47cef65a89123c3";
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure/archive/release/melodic/ddynamic_reconfigure/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "a8780576fba89c6bca7aa268f718041ab724d3f24ff44823b7dabee3f4b3315d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "cce63de3184c10892d63e6ef3ba42638398fd9fdeb108ed78e26b360f2e36977";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "42da85876c5670d83380035aeeb209f61dafdd55d2f92639fd0290304e6ef8d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "278046bca75cf452ce5c161c5588fa8138e6ea6a7f847ae9b6c69ea1c79140d8";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "1f31578a0f23b34d0fee3b20e56225e852afaf968e89021c3544e31507fe64ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "5d9283d4e8eecc722c26c726e4d0a522afdf021671d99dd006774f4a446d7da1";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "b3ad6906fdec43788e2f4a0ffdfa3fc9e0950efb4926c5d0b497273f3f7be862";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f55825fa1106223a4c27f8f7958749ea1d3cdcbed9241728be1dee64989c9a01";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "8ff41f9b66008c30207f6af85368c4e90b457a5da13df0d35df52098b5ad4cb0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -192,7 +192,15 @@ self: super: {
 
  boost-sml = self.callPackage ./boost-sml {};
 
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
  bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
 
  brics-actuator = self.callPackage ./brics-actuator {};
 
@@ -2945,6 +2953,8 @@ self: super: {
  rokubimini-examples = self.callPackage ./rokubimini-examples {};
 
  rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
 
  rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
 

--- a/distros/melodic/ixblue-ins-driver/default.nix
+++ b/distros/melodic/ixblue-ins-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins-driver";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_driver/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "cb792646f9d7574780e5c7cf8f56fc83b8d1ed526363e472121813c830b12a45";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_driver/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "19f76a53801661d1c5a65337fc7bf37aef1eca6d768bace9daf8b963ffaa484d";
   };
 
   buildType = "catkin";
   checkInputs = [ boost libpcap ];
-  propagatedBuildInputs = [ boost ixblue-ins-msgs ixblue-stdbin-decoder nav-msgs roscpp sensor-msgs ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater ixblue-ins-msgs ixblue-stdbin-decoder nav-msgs roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ixblue-ins-msgs/default.nix
+++ b/distros/melodic/ixblue-ins-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins-msgs";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "0fd1d81fd32dc6af45398cc46537ef973237838cae1da1e10eb8e1500117d44a";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_msgs/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "cd60c6db0588be82894c8648007101970a36353a7da0c340d6733ffd3a15bd90";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ixblue-ins/default.nix
+++ b/distros/melodic/ixblue-ins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "e462dfe827fe388a6256bbf04ba11247d8c0da13f9e940bb2b1401b42d26c6c6";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "a38ae8f03e93e071b2091e8335866b82ec60501ddefd0cd2df5d0fe8a51b7268";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive-marker/default.nix
+++ b/distros/melodic/jsk-interactive-marker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roseus, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-marker";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "e882a7922cb46c8c0b9df224969d3ee3e62e070146e8eedae17b2a0111c22ade";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_marker/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "aa813b4175c442c8130b352bbbe70c9ebb0299b9dfc63e6c74dd892ac343d991";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive-test/default.nix
+++ b/distros/melodic/jsk-interactive-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive-test";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "1062efda1c58f865d62cef6b7a9d26e3310272772b16b54a540315848298db62";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive_test/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "7e0a0fb246e712b8b7f56a170a046a771af8a4392486220ebb750aa13235c2ec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-interactive/default.nix
+++ b/distros/melodic/jsk-interactive/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-interactive";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "87c23a8b200b572da3b732b56bc921c84ddf2836a97792f1b330fd058943de3d";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_interactive/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "e70d0ac211e8eb19eec75bc00b77af7265da884a0c8a02626cfb684409b4d77f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-rqt-plugins/default.nix
+++ b/distros/melodic/jsk-rqt-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, pythonPackages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
 buildRosPackage {
   pname = "ros-melodic-jsk-rqt-plugins";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "83a2ed7bb2ebae5e57940f12a46d69129036f0701098c5de4e5be4a34c82e654";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rqt_plugins/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "b21d44eda2592de315538c55dac1eb0b28cf9de21ddb297afbb68cdde834afc0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-rviz-plugins/default.nix
+++ b/distros/melodic/jsk-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, image-geometry, image-publisher, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-topic-tools, message-generation, mk, people-msgs, posedetection-msgs, pythonPackages, rosbuild, rviz, std-msgs, urdfdom-py, view-controller-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jsk-rviz-plugins";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rviz_plugins/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "e38ba9e3d320ca900fa0ca6cb3b76e8208ebc41a4a517476e7d08788511ad0cf";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_rviz_plugins/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "40f58f1576fdeb6f212575c3550aa657ef4c3ffb384825af157a7145c43f5a88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-visualization/default.nix
+++ b/distros/melodic/jsk-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-jsk-visualization";
-  version = "2.1.7-r1";
+  version = "2.1.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.7-1.tar.gz";
-    name = "2.1.7-1.tar.gz";
-    sha256 = "ecd65c057c6986e987d6c94c975314f816c9b98396c4540d91e9d692187d8db2";
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/melodic/jsk_visualization/2.1.7-2.tar.gz";
+    name = "2.1.7-2.tar.gz";
+    sha256 = "6d8b429a38d572edddc49f424e51518dc67069ce373d7e423fb426ccdd1b8c84";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.38.1-r1";
+  version = "2.39.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.38.1-1.tar.gz";
-    name = "2.38.1-1.tar.gz";
-    sha256 = "c314886322a430b4a6d5470cbbab063de4601f6a3621822eed05fab62a898fc2";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.39.0-1.tar.gz";
+    name = "2.39.0-1.tar.gz";
+    sha256 = "c631e4a8bfd913be11eafcd47871e2e8ed3920c9ec96dd2238b7850dbca5d193";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "920f2a6d3ea039a5603447a339249dcf62c34b8bff0436b5a95f1481a15321dd";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "185a3980b5f290cd626ac36e2a68eed6216cdf75dc444e7b3d48a3409222e0ba";
   };
 
   buildType = "catkin";

--- a/distros/melodic/omnibase-control/default.nix
+++ b/distros/melodic/omnibase-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, effort-controllers, geometry-msgs, joint-state-controller, joint-trajectory-controller, nav-msgs, position-controllers, roscpp, rospy, std-msgs, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-omnibase-control";
-  version = "1.0.1-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_control/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "824731f03f53057a147b36fa605fd692a77fef89c1865e599e167c409318753e";
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_control/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "a6157c6071bd5a43916f3916d44a85bba3fb38da5b5fa4ae18f54d9b50e9cec0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/omnibase-description/default.nix
+++ b/distros/melodic/omnibase-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, effort-controllers, geometry-msgs, joint-state-controller, joint-trajectory-controller, position-controllers, roscpp, rospy, std-msgs, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-omnibase-description";
-  version = "1.0.1-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_description/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "e55ccf7a1a3f39b46525ddbff0035b60a66b55db477d19c64b7c32e67b3812f0";
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_description/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "5d890cefc30e7016110f00ee5972a77ca231c53f928357c4ff2187d437f15dab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/omnibase-gazebo/default.nix
+++ b/distros/melodic/omnibase-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, effort-controllers, gazebo-msgs, geometry-msgs, joint-state-controller, joint-trajectory-controller, position-controllers, roscpp, sensor-msgs, std-msgs, velocity-controllers }:
 buildRosPackage {
   pname = "ros-melodic-omnibase-gazebo";
-  version = "1.0.1-r1";
+  version = "1.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_gazebo/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "a67abd1f3c7f07cde4bdc72a83222d122a97b4cd3cfcc7286f870f3d40d6bbd2";
+    url = "https://github.com/ERC-BPGC/omnibase-release/archive/release/melodic/omnibase_gazebo/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "6acc71a06fd1ab2fb25b723825be7a258682f8b9dc3cfe9eccdff57f4ddd65c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan/default.nix
+++ b/distros/melodic/psen-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "a2e0047f4e44249571373f8cec48bb1d612e5f3bccf0e96cd1359e8a89de9289";
+    url = "https://github.com/PilzDE/psen_scan-release/archive/release/melodic/psen_scan/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "3832ccbea8e5d6cedd18abceb0d12cd451031c2e46879e984cc2930fdaf3eb16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-genicam-api/default.nix
+++ b/distros/melodic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
-  version = "2.4.1-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "1ba4fd0afdd122c9f21a0df6f078b614e94c2c7a2cb71347e5d4826065b9d9eb";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "67e2028a30bc44c397950eb191d98c5d9a03e08f295c167d04607d92c4c0b864";
   };
 
   buildType = "cmake";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "079416443768af43d9c225c26f8db8bf126e88c5978e068647cfdc99f77bc6cf";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "1b53ff7e32aad8604053299ccd0f0e937449dab5d31bd7ac0645dd5b2fa931ee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "a4e31475700cb0057d85fc961065d15742cd56f71e61fc91d5c3834d387a6954";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "6961b3e3ce720122ed2247faa3ef68d6e0627fa441166577dfc4c68ea81b1986";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-roi-manager-gui/default.nix
+++ b/distros/melodic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-melodic-rc-roi-manager-gui";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "bf8922cf068e1517ac176c42d58bf7791b91d810faef59a1c3fa09339efd81f8";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "4d9cf7a12b68a75401c4e95fed1cfe10fa067863857b51eb95b1325be94f4c36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "3e0cfc2c52c4329d5db974587b5047b81362e4d01ada858c6707a60d2c686c87";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d5fb094f7ddd5d43741f3ca693b15fab7f9e7e652a50c62ebb644bfa99042a85";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "f747d0f59d881cc8458bfdd333a6304a46a98feb3270e7ac4c2a5432e2ae49d9";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "009b3e1bb4f957852680248e77b98a3856852db29516d86f895f7e1bf286d3e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "75e034b3c413585592ab647e38324bc21447efe64c0afd5d8bd0d10570b26ec8";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "4265d59b3930fb73d956f3a0c10cc4e55a0050d6ee98eb4641710b0b88c68a3c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "7910906cf7d1f28c563997a99651b2c13dea8521969221cb853fe0d1c83f8e5a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "03003ef28596cfe626cec0ba646e2353cf61066e78e6b3f18c2db4c38ea41586";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "c7cf55a9679306b4b2719ffaff0fc2f1d38d4a619f06f923301a5656b7805ea1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c611df05465018a27cfe05966980f6df42aa13f3affcd61ae532a7cc964ee216";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.17-r1";
+  version = "2.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.17-1.tar.gz";
-    name = "2.2.17-1.tar.gz";
-    sha256 = "3fa17333b62b08b7ad481504337165d8e3541ee1a1a4a0b8dba867036fe8782c";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.18-1.tar.gz";
+    name = "2.2.18-1.tar.gz";
+    sha256 = "854eef2f1c16bc357613baec66164f2d3003d2166581b640a357a5a62feb95b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.17-r1";
+  version = "2.2.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.17-1.tar.gz";
-    name = "2.2.17-1.tar.gz";
-    sha256 = "e7487e9e50ae12e097716363ccd2e99661de8c4ecc9a1c61ddf3a5afaf473bb5";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.18-1.tar.gz";
+    name = "2.2.18-1.tar.gz";
+    sha256 = "af4e5bd50a0ddc7e83d0c8a6f38c3eed9b8f40beded41cad8333f340d27a3cbf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "1488f6d9b5028e52ffcaed5b85aa33fcc16790bce7863aa56a1a6354ce57404a";
+    sha256 = "3c40927408692de41673af26c9b169add09cf59c77194c8c71e55da1a81d8b7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "0318851a56293e60db8e9788febb11a2645a68304c8d692f1e781e1e76831044";
+    sha256 = "ae0f59984ef20e956f46873589426e2383d00299dbef87e415004affb6b4a070";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "8b330b84eadba5bcbef65575ebff79251b17ad56b5f48f1067078e6caf66840b";
+    sha256 = "0f6e9943bd52948738862d00b37c7f12f37c3ea2f40c576f910c3b433eac2b89";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-examples/default.nix
+++ b/distros/melodic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-examples";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "8572e65a62049c23465d7555d7bb89e522140b26ba3a6d609fc6b49222aa5b2f";
+    sha256 = "ece58bf00b38d219cbf07b66a9573d29298e3277ee4e81d46fca595076273e37";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-factory/default.nix
+++ b/distros/melodic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-factory";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "7a0ff8802f182adbf14b1362580ebfb1683a6a87230fda38fe9db49c2aa57d41";
+    sha256 = "d23777994e6ad6ce71c7c2c7a21be08bfea3c0ce0da6fe73a2824d4d5f85e93a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-manager/default.nix
+++ b/distros/melodic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-melodic-rokubimini-manager";
+  version = "0.5.2-r2";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.2-2";
+    name = "archive.tar.gz";
+    sha256 = "83eb2b0545da49e0c78cbd8583b9f13fcab9f9293f78e7e86eb387464db0df63";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "d988f962df8bbb514679eb4e70302cf10b125373ae737e9cf10359862f65d270";
+    sha256 = "b76bdddd1b353b057f96e6f588b1e0deeeef882a8f2a4321407c71f7e120cf55";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "5fd5d5212d828f828388bd09028356021af3f8a3369b2189b20bf18c58fa67a6";
+    sha256 = "17e9d3302bbe0477177d6b2bb425b213e5de4d9af19baf2f730b34eca7315a52";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.0-r6";
+  version = "0.5.2-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.0-6";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.2-2";
     name = "archive.tar.gz";
-    sha256 = "b551766f7934a2b380d012b6dad6fe4499806f8a87db9c747989ef465000cd20";
+    sha256 = "0b740616a3aa3f6b55a8f2ff5a614b6a1cd96dd6d35b52888457d04b648ac537";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/melodic/ros-babel-fish-test-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish-test-msgs";
-  version = "0.8.0-r3";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "a7781eef2850ed07e2dae2972c88cfe5eac1433cb7d2eb938c9db54bc6c82ed0";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish_test_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "038ad5070750b9751b0d6bd18052dfcf4ab5b2c0b4dd16f0051b092624d3b482";
   };
 
   buildType = "catkin";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''The ros_babel_fish_test_msgs package'';
-    license = with lib.licenses; [ "TODO" ];
+    license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/ros-babel-fish/default.nix
+++ b/distros/melodic/ros-babel-fish/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ros-babel-fish";
-  version = "0.8.0-r3";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.8.0-3.tar.gz";
-    name = "0.8.0-3.tar.gz";
-    sha256 = "1420b5c3884843bde2481add427340f5b3b69c6649e0a75acece91888a5796f1";
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/melodic/ros_babel_fish/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a77c88ba1fbe3131cb23d79a40eda505d5243dcd2439765f3f234b3fec442283";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-introspection/default.nix
+++ b/distros/melodic/ros-introspection/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslint, rosmsg }:
 buildRosPackage {
   pname = "ros-melodic-ros-introspection";
-  version = "1.0.1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/ros_introspection/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "becacb2e9cb821bffb018fe5bb49612b59152cd46067ab47a1fa5fbce2d9443a";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/ros_introspection/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6f75ce2caaf7ffc9c947a88644363a82ff8a6cd5be4f3abb933d073e8995daf1";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint ];
-  propagatedBuildInputs = [ pythonPackages.requests rosmsg ];
+  propagatedBuildInputs = [ pythonPackages.pyyaml pythonPackages.requests pythonPackages.rospkg rosmsg ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/roscompile/default.nix
+++ b/distros/melodic/roscompile/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, ros-introspection, roslint, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, pluginlib-tutorials, python, pythonPackages, ros-introspection, roslint, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-roscompile";
-  version = "1.0.1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/roscompile/1.0.1-0.tar.gz";
-    name = "1.0.1-0.tar.gz";
-    sha256 = "09449c45a4b93695d6faf539f2d2a59f91c971d54f38beb9b0ecd317f18e702c";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/roscompile/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c5f8fb99e38f6cbe0002f5d07d153fbc11baf8d8e29cf1f46b57bc345ccbfc16";
   };
 
   buildType = "catkin";
-  checkInputs = [ geometry-msgs pluginlib roslint tf ];
-  propagatedBuildInputs = [ catkin ros-introspection ];
+  checkInputs = [ geometry-msgs pluginlib pluginlib-tutorials roslint stereo-msgs tf ];
+  propagatedBuildInputs = [ catkin python pythonPackages.click pythonPackages.pyyaml pythonPackages.rospkg ros-introspection ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/urdfdom-py/default.nix
+++ b/distros/melodic/urdfdom-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-urdfdom-py";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "fa17c8b80a42f70c63b37729a6dfc6b71930cdb3f25df0aee577cd76a43936d9";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "333a2983d6cc779348c5874acb39b3a6912b862e8807eddbf9407739adb86291";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-node/default.nix
+++ b/distros/melodic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-melodic-urg-node";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "931f78afd03357bcaea2960c6e6c66a9e9d433d569b27551546ebb7b14dee0c9";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/melodic/urg_node/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "c68deea1e235f4aee409294b3b104f58be98c9e5bbb3802f3612a81ea8a9b480";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ypspur/default.nix
+++ b/distros/melodic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-melodic-ypspur";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "0e257544766ad78dfbf073aa2f6896255e02f69f9a64fd813da4689f643e399a";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "64d9f83ecdc7906944cb3d51701a91f8a9d06cf4eb9c39e326790b3f19045f8d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/automotive-autonomy-msgs/default.nix
+++ b/distros/noetic/automotive-autonomy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, automotive-navigation-msgs, automotive-platform-msgs, catkin, ros-environment }:
+buildRosPackage {
+  pname = "ros-noetic-automotive-autonomy-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/noetic/automotive_autonomy_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "5eee587986b5025f1686c5cfba6136629675942dd69467c2c5a81442cf8a1a0d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment ];
+  propagatedBuildInputs = [ automotive-navigation-msgs automotive-platform-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for vehicle automation'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/automotive-navigation-msgs/default.nix
+++ b/distros/noetic/automotive-navigation-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-automotive-navigation-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/noetic/automotive_navigation_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "d3836627522b715e7afddf0f40cf980f2f1d53dda2c685fca3a2baabe2ac5186";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rosbag-migration-rule std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic Messages for Navigation Objectives in Automotive Automation Software'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/automotive-platform-msgs/default.nix
+++ b/distros/noetic/automotive-platform-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-automotive-platform-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/noetic/automotive_platform_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "c23e8da3fd7506345d719d3ca818f8ea4d70f56c1f325e54c5f3b10a91ff8b9f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ros-environment ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic Messages for Communication with an Automotive Autonomous Platform'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/baldor/default.nix
+++ b/distros/noetic/baldor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-baldor";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/crigroup/baldor-release/archive/release/noetic/baldor/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "8972681a0bed3dd77a9ec679b4d7b22a957ab14eb9e62e1acbe29a343b8ed35d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.numpy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The baldor package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/boost-sml/default.nix
+++ b/distros/noetic/boost-sml/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp, roslint, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-boost-sml";
-  version = "0.1.0-r2";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/noetic/boost_sml/0.1.0-2.tar.gz";
-    name = "0.1.0-2.tar.gz";
-    sha256 = "2891cee5591557ee71954b873685dd2a9fbd99c81a05b175f777849c8eca83f6";
+    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/noetic/boost_sml/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f711e5bed75fd7d931b4db94f59f73e57b3af679f6525b01d4b0e1869f72f045";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ roscpp roslint ];
+  propagatedBuildInputs = [ boost roscpp roslint ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ddynamic-reconfigure/default.nix
+++ b/distros/noetic/ddynamic-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gmock, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-ddynamic-reconfigure";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/ddynamic_reconfigure/archive/release/noetic/ddynamic_reconfigure/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "68e903ec0a816737a7c736bdc833be8a06861d4fe3f9c2aab818ec1c6fac82c0";
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure/archive/release/noetic/ddynamic_reconfigure/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "1eb2ca206bff8c11dfc8522a25051d2f0ada8e36779e7c7f6f517ca3ac49a593";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -46,9 +46,17 @@ self: super: {
 
  audio-to-spectrogram = self.callPackage ./audio-to-spectrogram {};
 
+ automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
+
+ automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
+
+ automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
+
  auv-msgs = self.callPackage ./auv-msgs {};
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
+
+ baldor = self.callPackage ./baldor {};
 
  base-local-planner = self.callPackage ./base-local-planner {};
 
@@ -626,6 +634,8 @@ self: super: {
 
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
+ handeye = self.callPackage ./handeye {};
+
  hardware-interface = self.callPackage ./hardware-interface {};
 
  hebi-cpp-api = self.callPackage ./hebi-cpp-api {};
@@ -724,6 +734,12 @@ self: super: {
 
  jsk-hark-msgs = self.callPackage ./jsk-hark-msgs {};
 
+ jsk-interactive = self.callPackage ./jsk-interactive {};
+
+ jsk-interactive-marker = self.callPackage ./jsk-interactive-marker {};
+
+ jsk-interactive-test = self.callPackage ./jsk-interactive-test {};
+
  jsk-network-tools = self.callPackage ./jsk-network-tools {};
 
  jsk-recognition = self.callPackage ./jsk-recognition {};
@@ -732,9 +748,15 @@ self: super: {
 
  jsk-recognition-utils = self.callPackage ./jsk-recognition-utils {};
 
+ jsk-rqt-plugins = self.callPackage ./jsk-rqt-plugins {};
+
+ jsk-rviz-plugins = self.callPackage ./jsk-rviz-plugins {};
+
  jsk-tilt-laser = self.callPackage ./jsk-tilt-laser {};
 
  jsk-topic-tools = self.callPackage ./jsk-topic-tools {};
+
+ jsk-visualization = self.callPackage ./jsk-visualization {};
 
  julius = self.callPackage ./julius {};
 
@@ -1301,6 +1323,10 @@ self: super: {
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
 
  ros = self.callPackage ./ros {};
+
+ ros-babel-fish = self.callPackage ./ros-babel-fish {};
+
+ ros-babel-fish-test-msgs = self.callPackage ./ros-babel-fish-test-msgs {};
 
  ros-base = self.callPackage ./ros-base {};
 

--- a/distros/noetic/handeye/default.nix
+++ b/distros/noetic/handeye/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, baldor, catkin, criutils, geometry-msgs, message-generation, message-runtime, python3Packages, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-handeye";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/crigroup/handeye-release/archive/release/noetic/handeye/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e9bfb98b24529e1a17ee1da6241ec8f67b442438155b44afef74bfb647100fc0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ baldor criutils geometry-msgs message-runtime python3Packages.matplotlib python3Packages.numpy python3Packages.scipy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The handeye package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ixblue-ins-driver/default.nix
+++ b/distros/noetic/ixblue-ins-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins-driver";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_driver/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "9a5a6aa9060c09b77f8f3b04912a56958248a598f727b1ee5e4cc8d3e4fbc7c7";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_driver/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "5115c57a766a1ebfcd9b8fe2c53c5a53f5a6de5165962233bc411de74e273bc2";
   };
 
   buildType = "catkin";
   checkInputs = [ boost libpcap ];
-  propagatedBuildInputs = [ boost ixblue-ins-msgs ixblue-stdbin-decoder nav-msgs roscpp sensor-msgs ];
+  propagatedBuildInputs = [ boost diagnostic-msgs diagnostic-updater ixblue-ins-msgs ixblue-stdbin-decoder nav-msgs roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ixblue-ins-msgs/default.nix
+++ b/distros/noetic/ixblue-ins-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins-msgs";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "35ba474ae9b7fc24cc895e17221d7c3dc5d4d6dfde29347a0d18949daebe3b88";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_msgs/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "539788d59cfcc1e8262dbb1c49d18825b59fa4224bc260293830e7a59664a6ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ixblue-ins/default.nix
+++ b/distros/noetic/ixblue-ins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "249e093028b5387781517e6e1e1a9dd18ad1e4f9986af03e44a51e898cae4747";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "b3556595467ee028c39e2e1500bfce3fbb7a9d7e0804fefde04a79d812f0c812";
   };
 
   buildType = "catkin";

--- a/distros/noetic/jsk-interactive-marker/default.nix
+++ b/distros/noetic/jsk-interactive-marker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, dynamic-reconfigure, dynamic-tf-publisher, eigen-conversions, geometry-msgs, interactive-markers, jsk-footstep-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-rviz-plugins, jsk-topic-tools, libyamlcpp, message-filters, message-generation, message-runtime, mk, moveit-msgs, rosbuild, roscpp, roslib, rviz, sensor-msgs, tf, tf-conversions, tinyxml, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-interactive-marker";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_marker/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "d5ed235944b01bbd69328c8e4bb7c40c4fedcadfa660c1af7a08a9539a833c7f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules message-generation mk rosbuild ];
+  propagatedBuildInputs = [ actionlib dynamic-reconfigure dynamic-tf-publisher eigen-conversions geometry-msgs interactive-markers jsk-footstep-msgs jsk-recognition-msgs jsk-recognition-utils jsk-rviz-plugins jsk-topic-tools libyamlcpp message-filters message-runtime moveit-msgs roscpp roslib rviz sensor-msgs tf tf-conversions tinyxml urdf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''jsk interactive markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-interactive-test/default.nix
+++ b/distros/noetic/jsk-interactive-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, mk, rosbuild, rospy, rviz, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-interactive-test";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive_test/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "8a1abd37b377327aeb95660866c9d20a4c8466a18e01731be505a38fd68c8ea5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ mk rosbuild ];
+  propagatedBuildInputs = [ jsk-interactive jsk-interactive-marker rospy rviz visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''jsk_interactive_test'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-interactive/default.nix
+++ b/distros/noetic/jsk-interactive/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-tf-publisher, geometry-msgs, jsk-interactive-marker, mk, rosbuild, rospy, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-interactive";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_interactive/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "5b4aa542dace05afe868182a2bb272d3c3fe5e9abb47f332f9283c4838fc5e70";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ mk rosbuild ];
+  propagatedBuildInputs = [ actionlib dynamic-tf-publisher geometry-msgs jsk-interactive-marker rospy visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''jsk_interactive'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-rqt-plugins/default.nix
+++ b/distros/noetic/jsk-rqt-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, image-publisher, image-view2, jsk-gui-msgs, message-generation, message-runtime, mk, python3Packages, qt-gui-py-common, resource-retriever, rosbuild, roslaunch, rostest, rqt-gui, rqt-gui-py, rqt-image-view, rqt-plot }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-rqt-plugins";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rqt_plugins/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "527e86d54828430373f1b10433e964cf60589972c532d04c35bbad93391923d8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation mk rosbuild ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ cv-bridge image-publisher image-view2 jsk-gui-msgs message-runtime python3Packages.scikitlearn qt-gui-py-common resource-retriever rqt-gui rqt-gui-py rqt-image-view rqt-plot ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jsk_rqt_plugins package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-rviz-plugins/default.nix
+++ b/distros/noetic/jsk-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, image-geometry, image-publisher, jsk-footstep-msgs, jsk-gui-msgs, jsk-hark-msgs, jsk-recognition-msgs, jsk-recognition-utils, jsk-topic-tools, message-generation, mk, people-msgs, posedetection-msgs, python3Packages, rosbuild, rviz, std-msgs, urdfdom-py, view-controller-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-rviz-plugins";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_rviz_plugins/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "51e88e5884f1598d961db12396a4cc1716d4214852c6d17786bd7d56f517487e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ mk rosbuild ];
+  propagatedBuildInputs = [ cv-bridge diagnostic-msgs dynamic-reconfigure geometry-msgs image-geometry image-publisher jsk-footstep-msgs jsk-gui-msgs jsk-hark-msgs jsk-recognition-msgs jsk-recognition-utils jsk-topic-tools message-generation people-msgs posedetection-msgs python3Packages.scipy rviz std-msgs urdfdom-py view-controller-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jsk_rviz_plugins package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jsk-visualization/default.nix
+++ b/distros/noetic/jsk-visualization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, jsk-interactive, jsk-interactive-marker, jsk-interactive-test, jsk-rqt-plugins, jsk-rviz-plugins }:
+buildRosPackage {
+  pname = "ros-noetic-jsk-visualization";
+  version = "2.1.7-r4";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_visualization-release/archive/release/noetic/jsk_visualization/2.1.7-4.tar.gz";
+    name = "2.1.7-4.tar.gz";
+    sha256 = "4e37a0bf2e6e2082fc282223e08aecce116746a9d22ec457c067bbe8eda518ea";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ jsk-interactive jsk-interactive-marker jsk-interactive-test jsk-rqt-plugins jsk-rviz-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Metapackage that contains visualization package for jsk-ros-pkg</p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "3bc94cda3351844477ff5867b4affe51c7e2e8158365abee6d3df850775a3dfd";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ad6ef3e47083181160416341bd6397720411c549bf79125acde2de348e24dec7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.4.1-r1";
+  version = "2.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "c09506c1ac67706392602233c7d0d88acf3b66b375c05f7dd3400521295897a0";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.4.4-1.tar.gz";
+    name = "2.4.4-1.tar.gz";
+    sha256 = "a59af0e94c6da4e181f410df23e230edeb8bb122bd91c3eb12fe0877c8ae3428";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/noetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rc-hand-eye-calibration-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "42fed367015a0b913c1019cea3b7c1a158842a051467b4c1bbcce6256c0f3c78";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "a6196d7466ec9f0830bb216e0afa6ce939c88a5d9d303cccf87a760dbb187643";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-pick-client/default.nix
+++ b/distros/noetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-pick-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "a545bc438b103de27cdcf1e71db510abb507de9ac58442f76adddab5af05c4f3";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "42d6f34160333a7828d58c8c3af755cd87713a9e4d2047a0c4fbac78861e0119";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-roi-manager-gui/default.nix
+++ b/distros/noetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-noetic-rc-roi-manager-gui";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8196dcf46013683562dfc4e39fb058a4305a945eb0ce91c7f51730a50f841e75";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "467ec6903d2ff04a985c71c577c1c0174e8672dcab1ba5023e7c5751fce580e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-silhouettematch-client/default.nix
+++ b/distros/noetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-silhouettematch-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "bafa5cb1a54ddb79c9f7fcb1b3559fcf274cef15b0b7e8f97406000c6c7d49ca";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "33796fced5a0d34499d06ec9d7bc214f2b501d96b3221ac2404ab07117c0b2a6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-tagdetect-client/default.nix
+++ b/distros/noetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-tagdetect-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "d7cddec267d6469dba8d989f9280d3dcd793a3feb0210a1a1a31d7cec5d509fe";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "653047d53f5a452444fc13fe4cb5a6feb440c5bee70c1510a8073aac5897dc1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-description/default.nix
+++ b/distros/noetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8a089d0ced46a5b99fd22e50d746c2ccc9ab51b7b3b5dc928adb6fa8663aa508";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c8c9037f4b9f26a4d0ee6b12eca367f2d61c35efe826b7b840b9b017dc22fe61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-driver/default.nix
+++ b/distros/noetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "ceb670ddd3db7661732c5b777acba870dde599c25eb28d6f6f1d3b4bb91d1a8a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "1919feb23e6e83b22072b39126996facc7aa8937b6eb66b5a50c8d084e0c3499";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard/default.nix
+++ b/distros/noetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "59e3cbda00dde398afda1adcc3ea3a004ed883d549ada8893999157e9c2a07a0";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "d545a811d092cf0129896ebaea7278929a8acc67d1a9292d32a17dc93a13f5ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-babel-fish-test-msgs/default.nix
+++ b/distros/noetic/ros-babel-fish-test-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ros-babel-fish-test-msgs";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish_test_msgs/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "741c79ebcfdb4430e22134e95e6fec72d4c9978b557764196d49bbac1e44bf77";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Test messages for the ros_babel_fish project tests.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/ros-babel-fish/default.nix
+++ b/distros/noetic/ros-babel-fish/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, openssl, ros-babel-fish-test-msgs, rosapi, roscpp, roscpp-tutorials, rosgraph-msgs, roslib, rostest, std-msgs, std-srvs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ros-babel-fish";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/StefanFabian/ros_babel_fish-release/archive/release/noetic/ros_babel_fish/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "32967db537a618db2aa4701f35989cfe77bfc7317881537936ee29aee559705f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ geometry-msgs ros-babel-fish-test-msgs rosapi roscpp-tutorials rosgraph-msgs rostest std-msgs std-srvs visualization-msgs ];
+  propagatedBuildInputs = [ actionlib openssl roscpp roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A runtime message handler for ROS.
+    Allows subscription, publishing, calling of services and actions with messages known only at runtime.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/ros-numpy/default.nix
+++ b/distros/noetic/ros-numpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-ros-numpy";
-  version = "0.0.4-r4";
+  version = "0.0.4-r5";
 
   src = fetchurl {
-    url = "https://github.com/eric-wieser/ros_numpy-release/archive/release/noetic/ros_numpy/0.0.4-4.tar.gz";
-    name = "0.0.4-4.tar.gz";
-    sha256 = "5c7ca840934f6df9dfc0559ef0ff07c9fabaaae1cc20eaada127f61bf13b9b60";
+    url = "https://github.com/eric-wieser/ros_numpy-release/archive/release/noetic/ros_numpy/0.0.4-5.tar.gz";
+    name = "0.0.4-5.tar.gz";
+    sha256 = "180f2c1b702d154971d438181d55b6ee23748e1c14ce426f294f6bc6f0acbc9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urdfdom-py/default.nix
+++ b/distros/noetic/urdfdom-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-urdfdom-py";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/noetic/urdfdom_py/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b73b5c60376573171de75888399835d6845d07bbd70f4d7065b93d30fb994ef1";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/noetic/urdfdom_py/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "a6cfbfeea0b5bc7d96c4e29dd63e46da12f43799f5bb737fe3f2e0f1166a5233";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-node/default.nix
+++ b/distros/noetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-noetic-urg-node";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/noetic/urg_node/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "c49e047ac49d8e1e9c56f49d9be92f796c9342250596d1fbe00245d9aa4998ab";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/noetic/urg_node/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "e05efd7745b14085cadfad9e9660b6edaf919e3aed17a060b44c18f016f0d6e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur/default.nix
+++ b/distros/noetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-noetic-ypspur";
-  version = "1.19.0-r1";
+  version = "1.20.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.19.0-1.tar.gz";
-    name = "1.19.0-1.tar.gz";
-    sha256 = "7d6a7b5a91ef6e9d8bc79f102c5ac5412ec26b7fa486432ae8b78fe03c0e6306";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.0-1.tar.gz";
+    name = "1.20.0-1.tar.gz";
+    sha256 = "a5223be33258004a08da6931960c07008da0044d936fb0651005c9eedf04aab1";
   };
 
   buildType = "cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit e275dce414d9e7850e4287f5353d8a7c63491d8d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --skip cross_compile --all
```

Changes:
========
Dashing Changes:
----------------
* *contracts-lite-vendor 0.4.0-r1 --> 0.4.1-r1*
* *fastcdr 1.0.11-r1 --> 1.0.13-r1*
* *fastrtps 1.8.2-r1 --> 1.8.4-r1*
* *rc-genicam-api 2.4.1-r1 --> 2.4.4-r1*

Eloquent Changes:
-----------------
* *rc-genicam-api 2.4.1-r2 --> 2.4.4-r1*
* *rviz-assimp-vendor 7.0.5-r1 --> 7.0.6-r1*
* *rviz-common 7.0.5-r1 --> 7.0.6-r1*
* *rviz-default-plugins 7.0.5-r1 --> 7.0.6-r1*
* *rviz-ogre-vendor 7.0.5-r1 --> 7.0.6-r1*
* *rviz-rendering 7.0.5-r1 --> 7.0.6-r1*
* *rviz-rendering-tests 7.0.5-r1 --> 7.0.6-r1*
* *rviz-visual-testing-framework 7.0.5-r1 --> 7.0.6-r1*
* *rviz2 7.0.5-r1 --> 7.0.6-r1*

Foxy Changes:
-------------
* *contracts-lite-vendor 0.4.0-r1 --> 0.4.1-r1*
* *examples-tf2-py 0.13.5-r1 --> 0.13.6-r1*
* *geometry2 0.13.5-r1 --> 0.13.6-r1*
* *joy-teleop 1.2.0-r1 --> 1.2.1-r1*
* *key-teleop 1.2.0-r1 --> 1.2.1-r1*
* *launch-ros 0.10.3-r1 --> 0.11.0-r1*
* *launch-testing-ros 0.10.3-r1 --> 0.11.0-r1*
* *mouse-teleop 1.2.0-r1 --> 1.2.1-r1*
* *rc-genicam-api 2.4.1-r1 --> 2.4.4-r1*
* *ros2launch 0.10.3-r1 --> 0.11.0-r1*
* *teleop-tools 1.2.0-r1 --> 1.2.1-r1*
* *teleop-tools-msgs 1.2.0-r1 --> 1.2.1-r1*
* *tf2 0.13.5-r1 --> 0.13.6-r1*
* *tf2-bullet 0.13.5-r1 --> 0.13.6-r1*
* *tf2-eigen 0.13.5-r1 --> 0.13.6-r1*
* *tf2-geometry-msgs 0.13.5-r1 --> 0.13.6-r1*
* *tf2-kdl 0.13.5-r1 --> 0.13.6-r1*
* *tf2-msgs 0.13.5-r1 --> 0.13.6-r1*
* *tf2-py 0.13.5-r1 --> 0.13.6-r1*
* *tf2-ros 0.13.5-r1 --> 0.13.6-r1*
* *tf2-sensor-msgs 0.13.5-r1 --> 0.13.6-r1*
* *tf2-tools 0.13.5-r1 --> 0.13.6-r1*

Kinetic Changes:
----------------
* *ixblue-ins 0.1.4-r1*
* *ixblue-ins-driver 0.1.4-r1*
* *ixblue-ins-msgs 0.1.4-r1*
* *jsk-interactive 2.1.7-r1 --> 2.1.7-r2*
* *jsk-interactive-marker 2.1.7-r1 --> 2.1.7-r2*
* *jsk-interactive-test 2.1.7-r1 --> 2.1.7-r2*
* *jsk-rqt-plugins 2.1.7-r1 --> 2.1.7-r2*
* *jsk-rviz-plugins 2.1.7-r1 --> 2.1.7-r2*
* *jsk-visualization 2.1.7-r1 --> 2.1.7-r2*
* *librealsense2 2.38.1-r1 --> 2.39.0-r1*
* *mcl-3dl 0.5.0-r1 --> 0.5.1-r1*
* *rc-genicam-api 2.4.1-r1 --> 2.4.4-r1*
* *realsense2-camera 2.2.17-r1 --> 2.2.18-r1*
* *realsense2-description 2.2.17-r1 --> 2.2.18-r1*
* *ros-introspection 1.0.1 --> 1.0.3-r1*
* *roscompile 1.0.1 --> 1.0.3-r1*
* *ypspur 1.19.0-r1 --> 1.20.0-r1*

Melodic Changes:
----------------
* *automotive-autonomy-msgs 3.0.3-r1 --> 3.0.4-r1*
* *automotive-navigation-msgs 3.0.3-r1 --> 3.0.4-r1*
* *automotive-platform-msgs 3.0.3-r1 --> 3.0.4-r1*
* *boost-sml 0.1.0-r2 --> 0.1.0-r3*
* *bota-device-driver 0.5.2-r2*
* *bota-driver 0.5.0-r6 --> 0.5.2-r2*
* *bota-node 0.5.2-r2*
* *bota-signal-handler 0.5.2-r2*
* *bota-worker 0.5.2-r2*
* *ddynamic-reconfigure 0.3.1-r1 --> 0.3.2-r1*
* *dingo-control 0.1.3-r1 --> 0.1.4-r1*
* *dingo-description 0.1.3-r1 --> 0.1.4-r1*
* *dingo-msgs 0.1.3-r1 --> 0.1.4-r1*
* *dingo-navigation 0.1.3-r1 --> 0.1.4-r1*
* *ixblue-ins 0.1.3-r1 --> 0.1.4-r1*
* *ixblue-ins-driver 0.1.3-r1 --> 0.1.4-r1*
* *ixblue-ins-msgs 0.1.3-r1 --> 0.1.4-r1*
* *jsk-interactive 2.1.7-r1 --> 2.1.7-r2*
* *jsk-interactive-marker 2.1.7-r1 --> 2.1.7-r2*
* *jsk-interactive-test 2.1.7-r1 --> 2.1.7-r2*
* *jsk-rqt-plugins 2.1.7-r1 --> 2.1.7-r2*
* *jsk-rviz-plugins 2.1.7-r1 --> 2.1.7-r2*
* *jsk-visualization 2.1.7-r1 --> 2.1.7-r2*
* *librealsense2 2.38.1-r1 --> 2.39.0-r1*
* *mcl-3dl 0.5.0-r1 --> 0.5.1-r1*
* *omnibase-control 1.0.1-r1 --> 1.0.2-r2*
* *omnibase-description 1.0.1-r1 --> 1.0.2-r2*
* *omnibase-gazebo 1.0.1-r1 --> 1.0.2-r2*
* *psen-scan 1.0.7-r1 --> 1.0.8-r1*
* *rc-genicam-api 2.4.1-r1 --> 2.4.4-r1*
* *rc-hand-eye-calibration-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-pick-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-roi-manager-gui 3.0.4-r1 --> 3.0.5-r1*
* *rc-silhouettematch-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-tagdetect-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-description 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-driver 3.0.4-r1 --> 3.0.5-r1*
* *realsense2-camera 2.2.17-r1 --> 2.2.18-r1*
* *realsense2-description 2.2.17-r1 --> 2.2.18-r1*
* *rokubimini 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-bus-manager 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-description 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-ethercat 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-examples 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-factory 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-manager 0.5.2-r2*
* *rokubimini-msgs 0.5.0-r6 --> 0.5.2-r2*
* *rokubimini-serial 0.5.0-r6 --> 0.5.2-r2*
* *ros-babel-fish 0.8.0-r3 --> 0.9.0-r1*
* *ros-babel-fish-test-msgs 0.8.0-r3 --> 0.9.0-r1*
* *ros-introspection 1.0.1 --> 1.0.3-r1*
* *roscompile 1.0.1 --> 1.0.3-r1*
* *urdfdom-py 0.4.3-r1 --> 0.4.4-r1*
* *urg-node 0.1.14-r1 --> 0.1.15-r1*
* *ypspur 1.19.0-r1 --> 1.20.0-r1*

Noetic Changes:
---------------
* *automotive-autonomy-msgs 3.0.4-r1*
* *automotive-navigation-msgs 3.0.4-r1*
* *automotive-platform-msgs 3.0.4-r1*
* *baldor 0.1.3-r1*
* *boost-sml 0.1.0-r2 --> 0.1.1-r1*
* *ddynamic-reconfigure 0.3.0-r1 --> 0.3.2-r1*
* *handeye 0.1.2-r1*
* *ixblue-ins 0.1.3-r1 --> 0.1.4-r1*
* *ixblue-ins-driver 0.1.3-r1 --> 0.1.4-r1*
* *ixblue-ins-msgs 0.1.3-r1 --> 0.1.4-r1*
* *jsk-interactive 2.1.7-r4*
* *jsk-interactive-marker 2.1.7-r4*
* *jsk-interactive-test 2.1.7-r4*
* *jsk-rqt-plugins 2.1.7-r4*
* *jsk-rviz-plugins 2.1.7-r4*
* *jsk-visualization 2.1.7-r4*
* *mcl-3dl 0.5.0-r1 --> 0.5.1-r1*
* *rc-genicam-api 2.4.1-r1 --> 2.4.4-r1*
* *rc-hand-eye-calibration-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-pick-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-roi-manager-gui 3.0.4-r1 --> 3.0.5-r1*
* *rc-silhouettematch-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-tagdetect-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-description 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-driver 3.0.4-r1 --> 3.0.5-r1*
* *ros-babel-fish 0.9.1-r1*
* *ros-babel-fish-test-msgs 0.9.1-r1*
* *ros-numpy 0.0.4-r4 --> 0.0.4-r5*
* *urdfdom-py 0.4.3-r1 --> 0.4.4-r1*
* *urg-node 0.1.14-r1 --> 0.1.15-r1*
* *ypspur 1.19.0-r1 --> 1.20.0-r1*


Missing Dependencies:
=====================
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-whichcraft
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-h5py
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-mechanize
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

