### PR TITLE
rosdistro sync, Fri Nov  6 13:10:10 2020

### DIFF
--- a/distros/dashing/bond-core/default.nix
+++ b/distros/dashing/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-dashing-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "10c6660f117efc80e3ce007e513436e20e8e6534ce43f6822ee81c83ff154515";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bond/default.nix
+++ b/distros/dashing/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "45470a641f321480c3af295868addfceb1db8671f4c5721cbdccfda8889b207d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bondcpp/default.nix
+++ b/distros/dashing/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d3d04978c7615ad8a972815a80c284421cb55a0c7c2ae4008bd106c0cbc11059";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/cyclonedds-cmake-module/default.nix
+++ b/distros/dashing/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5416384adb666e9056fa4fbea26fddd5bede9918e8009310d0d198a3f2d12277";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c972ceab084dd87835ba3bcadb08ce4388530ca53bbad4a7d97737205c9b9912";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cyclonedds/default.nix
+++ b/distros/dashing/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "afbb1cd60046ac3513b78d22f26af23317414074cf00fe612708d56d1babe03e";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "07a49a0e992890c12f8dfbf99261756dfb150d3e2b33da102aaa28442f4a4bb2";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -148,6 +148,12 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -1004,6 +1010,8 @@ self: super: {
 
  slide-show = self.callPackage ./slide-show {};
 
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -1061,6 +1069,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/dashing/rmw-cyclonedds-cpp/default.nix
+++ b/distros/dashing/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5047cd3af861caa3ab566125ef59989cc67e66ca3a438d94e56208b06d5454f7";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "8d3419ca51b8e3f2cee05cb96b36f311337231069f6409c1b168b1c4aed15428";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/dashing/smclib/default.nix
+++ b/distros/dashing/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-dashing-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "09613f1e3e9b2b47e7b51eed9d1f9f5b488d576446dde8c5edc80afb524cebf1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/dashing/test-bond/default.nix
+++ b/distros/dashing/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a0a172654b7606d48c7b063e3c2eee433440fe6457f20148424f11bb420e4fcf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/cyclonedds-cmake-module/default.nix
+++ b/distros/eloquent/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6db8546cb9579bdf6d29f02e8e172a371b695a50f73d94eb50ab8ea31300be65";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "dc4d7ab18637edfc0589913bb07a38d40577d70624f47058baa0f28c89692f26";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cyclonedds/default.nix
+++ b/distros/eloquent/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds";
-  version = "0.5.1-r2";
+  version = "0.7.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "7377c71cbb406f7aeb8fcdf5678f79197ab00984a30851b2ab37e813e1e9ed5f";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.7.0-3.tar.gz";
+    name = "0.7.0-3.tar.gz";
+    sha256 = "d4a1dfced26d9e0fd541606a69668c0ef1ed8ddeaefd551d3bd64f900b53bbd6";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/eloquent/rmw-cyclonedds-cpp/default.nix
+++ b/distros/eloquent/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-eloquent-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a1c35e80ff458c5a3635b459717ed79f65054a24fcc215d2c1e9873ff26a7e4c";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bf5d2a594f12e2f3ed6478ab0d7dfdc02d11118e26285f8204952d49f2d5ccda";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/foxy/bond-core/default.nix
+++ b/distros/foxy/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-foxy-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "b5d98b85b71709d7e8eaf9c105f1c5c8c2380d82c26407a46c29c34bab9a4bd2";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bond/default.nix
+++ b/distros/foxy/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb74416f8ef1aea39bcf056ca961c4c37dd66ec18f81258374a897a1e0cd3b80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bondcpp/default.nix
+++ b/distros/foxy/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9cf5b6d9bb60b7aa21f0c4c6397f237ed6d6414efd3f71f656733de00eb3b72f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/cartographer-ros-msgs/default.nix
+++ b/distros/foxy/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros-msgs";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "cd9607611d053908f5360dd6356c4bb72a27c9468326e5e3e4d7c6b5701e134e";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "33e58b9796bdb026afb0acb4a2cbaded6604e729a46ce3eae1a41a953058beab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cartographer-ros/default.nix
+++ b/distros/foxy/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "f408e0d891a311d1dfeab930b1807e007e4c0da3a9cac1dd208a904b496174d8";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "cb23d500a2659e1661b8d0c6f7f1a3e2c5d2434416f34ae68068bf31169fa708";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/costmap-queue/default.nix
+++ b/distros/foxy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-costmap-queue";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "73f04603a3d44aed609d6d00eefd83fb3dbe43c8a37be13abfb0637736bc7abb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9b33a055fed3295e5f807e6c7384369d5e23f13a4cde9daebd34ea5c0f2dc32e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dsr-description2/default.nix
+++ b/distros/foxy/dsr-description2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-description2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_description2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "7776c814f0cfabf18ca111f5ca111216c0d69ab7a74e73f1ce14d785d1659037";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python joint-state-publisher-gui launch launch-ros robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''dsr_description2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dsr-msgs2/default.nix
+++ b/distros/foxy/dsr-msgs2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-msgs2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_msgs2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "e3abf123677415e8a45929d79d9b1df9bfe90b41aabbc798af452316433b4909";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rclcpp rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The dsr_msgs2 package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dwb-core/default.nix
+++ b/distros/foxy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "9163b7d7d5cea08364319ef98569164df42f7db85d558655473024aff745f8c6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ae657e44c068bae195413c68b0c7197f23616e1c4c3a623508b6a5b88975b9c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-critics/default.nix
+++ b/distros/foxy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-critics";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2628e42f3a0cf285d96007380e1817c58592a8f872e5552c98b8dadff23b07e0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "eabc166b4ba0a2b0a2960d42cef2744f59b841d873b37c1444e1cc6d8d49646c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-msgs/default.nix
+++ b/distros/foxy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8c31c65b2eaff57e003be677a1b25a8b08d17d9231d804ad306a8abc617d4565";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "bb65c572d1ab1eb04ef0f480d14a93a3b9a30568af322ba3964a1560a5b6b455";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-plugins/default.nix
+++ b/distros/foxy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dwb-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "5ea4805443ac57bae9c8c69ee566d4360bdf44c05f5972f2fee11fd80e1acdd1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9baa59496d7ddb38cfef9bc6cf5d858aaff4d2071567ee1d205ab130fc61eb60";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -148,6 +148,12 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -229,6 +235,10 @@ self: super: {
  dolly-ignition = self.callPackage ./dolly-ignition {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
+
+ dsr-description2 = self.callPackage ./dsr-description2 {};
+
+ dsr-msgs2 = self.callPackage ./dsr-msgs2 {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -1032,6 +1042,10 @@ self: super: {
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
+ smac-planner = self.callPackage ./smac-planner {};
+
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
@@ -1093,6 +1107,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/foxy/nav-2d-msgs/default.nix
+++ b/distros/foxy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3b89af67439ec4f78850a7a7d75840e6d22603ef682712f94d85ed8ee2eaa9bb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5b580043db92c1ec0a4f9851bdb0e8a224717b232979b815ee1214ac9c8669a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav-2d-utils/default.nix
+++ b/distros/foxy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-utils";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f16655ca6fce7766c7b66c80c51e0497f90209d66f7df0f7317fab4337a7a00b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "49fa98b744e4213441be0c281641f8abf00e21cd8bfd4df7c29271eb47f4acb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-amcl/default.nix
+++ b/distros/foxy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-amcl";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2a0f1291e7b426fe19119fc6451b8d00eca71a3eb242670d0d546d7b577ffdce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "14084e4785551129be1c77a74082bcf32d5a384bf3f57708c081ca36c48a142d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-behavior-tree/default.nix
+++ b/distros/foxy/nav2-behavior-tree/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-behavior-tree";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c602015b7a0b1f1ec20bf2c6056e56ba07c241f6c0d1e4a0756060fe687ef5d7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "585f0ef01a3a442c0065cb24818a6de2678996016e99be84cccbe82f38c443b9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ nav2-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/nav2-bringup/default.nix
+++ b/distros/foxy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bringup";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "07ecfe7c326dc04a43a9e618e88547f5511850e45f74450cf6ae33d316e3d2b7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6b5d1f7479ce8951e3a38bb7ee37f3de81d81d0886636558c33247d44ffa1c51";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-bt-navigator/default.nix
+++ b/distros/foxy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bt-navigator";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "370dfd22e521a4c0449e204b59d6a38ad2a1c9409e090e6a39af63e7a4d7ca15";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b985757ac5e11dc3e6d1ad1120d15c2066cc5c7ca245d6b68050ae4cde2405aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-common/default.nix
+++ b/distros/foxy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-nav2-common";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c6e5326de2ab71eab276b40630955746a2c20ac58efc6e8514d46d6ef4b4c2a0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c8428b79244d25c49920ced18ba6239974db7f389af7c2126f1da8ed612682f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-controller/default.nix
+++ b/distros/foxy/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "1c53325051e83c8725dafc98844444862fae43fe46257dbcffe01da6ed8193a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "599b6957dc8f3738655c7de8a899cd35588b23e356038d63ccc053d506527a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-core/default.nix
+++ b/distros/foxy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2ed09d28318045aef089bfadb0aa0e9f1a9ce850792e595b0b39c3cebbd98d6f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "138efd03903eaf6993fb7eb131b5760041f768278c2f9fd38e45cd405389461d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-costmap-2d/default.nix
+++ b/distros/foxy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-costmap-2d";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a56b52d88faf1709ffccd0c61b58c50046dae147747770815f5df725256e9b76";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ca0b70bb40ae31883cfbfc18b133ef6eb388fc724c8750accd4d1a52991d7941";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-dwb-controller/default.nix
+++ b/distros/foxy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-foxy-nav2-dwb-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "67b2001e7330ca110137228f57056742e890eef1d5906f33c00ad7010cdbc588";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "937caff30a10dd18729093e5f36c89b9c503ed85fa80028e7d957e75ffe03298";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-gazebo-spawner/default.nix
+++ b/distros/foxy/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-gazebo-spawner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "68fc9ab9c7d639ac8129702a45539467c5a6f83de30e0be5dc17bea75a66baf9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "769481b7b18aaeeb270bfbcb2f2d197173956997e6085c0bf7c54da756c84700";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/nav2-lifecycle-manager/default.nix
+++ b/distros/foxy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-lifecycle-manager";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3dd2d066c47e6db7866025b4b0dc0e80977604e460d5821f572796565a01042b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e0c15e7a5065b8e4e6e4ddba5dcca55aa4fb3957385a52fd59f543ab280fe77a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-map-server/default.nix
+++ b/distros/foxy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-nav2-map-server";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "35bfc4f13b089b0f99a30bfd37b43332be256710f34572609fa63645bca5981a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e8ffdea4aee1c1582aafdba18fcf84c47d3dbc7080ba7692fb7ba4009921deee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-msgs/default.nix
+++ b/distros/foxy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c79a891e10fb45734d3433a95bc459ba797d6b89cb9b2b22ec529dd65fbbe113";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "312fcb7e7544343a8a844281d813a2d9043229627e0bb4606cff80c5dd2c645d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-navfn-planner/default.nix
+++ b/distros/foxy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-navfn-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "09884506de6a2fcc6f0899ae79e695af5301332b429a2c57fd71a5c1c8cf3038";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "31ec2d8a2b0fa49611fd248b392dd03429210453f3961f865de45783a0fe140f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-planner/default.nix
+++ b/distros/foxy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "34fba1237eff23a27eda29de7a3be9ef1dfb76f739cdd09e82356e096389de9e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "d80b5b433355566ab8ac4cdfa7f7439b02102ac748018cf08ba0b322f15d7f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-recoveries/default.nix
+++ b/distros/foxy/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-recoveries";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f6c75f6633640d75fa534adfdf1c980cdf96ae2cc5fda317770bfcc64f15560d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "cabc151e4005cbdff5e6ce1a7f2e15ccc645b58591f89ed69c4739a5f18e3714";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-rviz-plugins/default.nix
+++ b/distros/foxy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-rviz-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e25190817b2c813189bf6331a99ef60fe07e6c73175344689b855f51d241b5df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b46c97f76cf4b1cea25a9bb213dce9fd2c3a7e57384032a8e92a33af6601193e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-system-tests/default.nix
+++ b/distros/foxy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-system-tests";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b61051a79e8491a74259a0c3fb0005dd47f15113b5dedf66397d80c1c34e6cb7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "2acdc3505dc75e58afacb534b244fa36d54251777c924620e529938752f6a36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-util/default.nix
+++ b/distros/foxy/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, launch, launch-testing-ament-cmake, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-util";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e111d2bfd0ddf1940b50d7bec15434a5a560270d7f8e7da52a67570343c1b08c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "a66c0ff09045030f310410989abd0520feb63630491ad29da1786adf73d277a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-voxel-grid/default.nix
+++ b/distros/foxy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-nav2-voxel-grid";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "cf77fce6757e428ca4b061308672c35fc2b6f6dc71e143cce4f31830209c3cc2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "3573db33d1e45ea6be9eb0adf06e44e473e76af533bb871b8676675fde01935d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-waypoint-follower/default.nix
+++ b/distros/foxy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-waypoint-follower";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f23fd4f0bd0a27df32dab929a259bf5fe107298d91ff0784d9a5fca434ee999a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5259db32f25ab9274b88567e4716fbce7f498c1474b84c348673bef79c15be61";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/navigation2/default.nix
+++ b/distros/foxy/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower, smac-planner }:
 buildRosPackage {
   pname = "ros-foxy-navigation2";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "72210833bc9284733350efc544d253d2ac80f7fa965e348be28acdbf43e37c6d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "f733da59e06355acb96c1640211b4a03ab7b800f1a68aeff0cf301699b3b7d52";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower smac-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-osqp-vendor";
-  version = "0.0.1-r3";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.1-3.tar.gz";
-    name = "0.0.1-3.tar.gz";
-    sha256 = "7603e1c8ef7cb2b492ed69a2f084e65978b63e4c365ae4dccb1abbdbbccf800b";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3b2a5e43a76c801a4709775861a65858de2141916dcef28804affad39b58b89b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "ca8d46c1573640f62d00e419e1a14871d7883d3529874465a3927422274f05e6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "45f86d024897962dc997ceb30cd54455261ab9b4e4e734c58093d77643fc0a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "89b5dfdb457e200aa033b712b72ee03600c1991fa036f1409569c32cba2aaaae";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "a9616d8a8e7825060a4ac65fd52c2ca190e1f2527f502ca29ae38f531139d41f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, osrf-testing-tools-cpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "04b3374dd306a4ec26c498fcd1b4bdfe93ff91448869906d8a0717eb9c4e424e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "fc67d4aace5d708457b2d855a9f6103ed1559d8f6a25509c1c06469468bfdd20";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rcutils ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture rcpputils ];
   propagatedBuildInputs = [ libyaml libyaml-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9259362d43aa7e308814dd8c55a656e19eee78774737019f3ee8ca8f72a6d721";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d411fa7e85ffefc4a15f371af8f7dd4caa013ca111977dc4c4d0ebf3f2097606";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
   propagatedBuildInputs = [ rcl-interfaces rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/smac-planner/default.nix
+++ b/distros/foxy/smac-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ceres-solver, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-smac-planner";
+  version = "0.4.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/smac_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c1929d32a3474ce35454aa8f4730d479c95873f4be3e1e0936d5f96641811991";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces ceres-solver eigen eigen3-cmake-module geometry-msgs nav-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util ompl pluginlib rclcpp rclcpp-action rclcpp-lifecycle tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Smac global planning plugin'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/smclib/default.nix
+++ b/distros/foxy/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "72315b444eeba5b8f9bb994e46639aac5999595a3791c32b6081560f73b4d227";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/foxy/test-bond/default.nix
+++ b/distros/foxy/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6efe0513889e9746b3bbf9ee097c9571db5ed14ee99c4e1bd57e3e9cf1420b6d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-device-driver/default.nix
+++ b/distros/kinetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-device-driver";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_device_driver/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "1b63a7554e96846d47bb81312a96b35d755f928b241d590f58d213c01976ab93";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-driver/default.nix
+++ b/distros/kinetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-driver";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_driver/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "e18f568ae442dc4449243e06e03df33e2c724ac1705010e23fa1c34325105d57";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-node/default.nix
+++ b/distros/kinetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-node";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_node/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "25924082df59dcbc3f9918e12f1289699d4d4177e6e9afd22bf3eaa29b63eb38";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-signal-handler/default.nix
+++ b/distros/kinetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-signal-handler";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_signal_handler/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "d2f69772458ce2e1141e985ba2cdfa0784f0928e25b18fc261f905658094053b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-worker/default.nix
+++ b/distros/kinetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-worker";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_worker/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "c35b6236b22e7bff081834041c30854fd51372cb18fa6e546c114eb9b69be688";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -250,6 +250,16 @@ self: super: {
 
  bondpy = self.callPackage ./bondpy {};
 
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
+
  brics-actuator = self.callPackage ./brics-actuator {};
 
  calibration = self.callPackage ./calibration {};
@@ -3751,6 +3761,24 @@ self: super: {
  rocon-uri = self.callPackage ./rocon-uri {};
 
  rodi-robot = self.callPackage ./rodi-robot {};
+
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
 
  romeo-bringup = self.callPackage ./romeo-bringup {};
 

--- a/distros/kinetic/map-msgs/default.nix
+++ b/distros/kinetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "d64d8011c9286a5ca31e055bbf201d5fee118e79851feade72e3b6c2faa1b20a";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "1c72c777862d13074551becfefdbfb3a7dfcc01f49d548693652fe25e139ec9a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-core/default.nix
+++ b/distros/kinetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "8718557c17fcd5eebc58aa18cecd379d25e6101834be280fe5bd6a65f61aee22";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "fdf43ee04d2d4c281474cc043895eadbd8cec9dbe0472d668562f94a41caba85";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-nav/default.nix
+++ b/distros/kinetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d1a6023ff353d18d173e9573c6f11bc65d1e783d5481b25b330739a8ab9b6c92";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "ee058a7ee3eb2f763c8d28dd9f3c3ec0e137ce3fcdbd6049433017d05e3df6cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-core/default.nix
+++ b/distros/kinetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "2ac0cafca70b0382f6d8acc0ff604dcd2159bac0963e60fa3c2c081f71f70dd2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "535cb2c281a9fa2054ecf2d3958e9bcebfe68aa4ec888e4a619d7ad9ee5d94bf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-nav/default.nix
+++ b/distros/kinetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a62d70772cc423caf139795d0d59937af0f8bc0cb4c01c828872a4eab13b42ee";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c82132225cab0a9261894e10900b6b787d831e473b39d84b1bfc45800ea6c0e7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-msgs/default.nix
+++ b/distros/kinetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "199b91621dc2a02b1f64d0e0f741433dff511693089400243baa7888bb35f23f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "d653651c01020a083851fdc219b9ccba01fde6477b5de29e7e190b7e31d3c7f3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-simple-nav/default.nix
+++ b/distros/kinetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c92635eba54649772659840a73156a0e5941d464c67cec9d5d45be0854cda626";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a006ba94981a31499333e3e95850c2d05314ba9b6865fe14269664d643bc2498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-utility/default.nix
+++ b/distros/kinetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "81c366c20496f1e1cbb670403bd72cea40be18ee065666ff65bb671a5db8ad66";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a4eb6ff871cac9102f55d117ecfc2406d8d11ce570ccf8c354ba75692e7981ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/message-filters/default.nix
+++ b/distros/kinetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-message-filters";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b663a931c219870a481fbe9b48b1eacc993ade635f29b94b61b5d0cb82545639";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "42b202727458a529debfb19a92b20303873c07b811f4bb5339e1e3f13cc62286";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base-flex/default.nix
+++ b/distros/kinetic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c83c3ec611b59746b6a0722b32d2dfab62de93e878ecab5f92422d4d7d6df6a2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "1f056bd5948e0fbd7051c3392a3235fe30c615a057d96b43cdd47eeb810a781e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/move-base-msgs/default.nix
+++ b/distros/kinetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "6f9cb9261d225727a7e0a9755d8ced29df60668c4a0cb1cb62e474ae0fe307f4";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "8481264739efdc10d67243b1d4039e2759bbb0e143f699e863fa7b8784da14fe";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/kinetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-rc-hand-eye-calibration-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47511b12228e4b9f3db3d4cc3403b47438e8f9c1b8d0eb5682f401356c73b132";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "04f5f5d4552ec09d236fc096d6b6f8da3c9c6647f3dc389a7c486821d94dc650";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-pick-client/default.nix
+++ b/distros/kinetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-pick-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "9ba9b4a4b3c5e3e8199c4985bed15e9aaf4ee4ce6cc8575da641736f24600e41";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b8ddefb6b4020a41ed4f2338730234ecceee51a973bba94b913c3a7cd260bce1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-roi-manager-gui/default.nix
+++ b/distros/kinetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-kinetic-rc-roi-manager-gui";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47190758fd397be16a969cacc66a0128025f69fea08865607312d2ff6c7a597c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ba4f022fc6aaca4fc6de70d261a08837e62618b102628c2cfa3eb2fd4bc5c05d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-silhouettematch-client/default.nix
+++ b/distros/kinetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-silhouettematch-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "ccae73cad1e0bfe9ed24200c12641154c67a018fa18b0421b8d4c3ef875a2eee";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "df817e687d4c0e74f931f726c14eb7fd95c2a08e69319de7cab39734fba0ab3c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-tagdetect-client/default.nix
+++ b/distros/kinetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-tagdetect-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8c6a2864c3ff2280ed11c2ff65ef25574b0024f34597c5f7d26e1c1985aa34f1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c30bbc806b4f8ca80a37c58d99842db1207f7ef4e0b7925138dfd92ad97ce151";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-description/default.nix
+++ b/distros/kinetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "3815b22655e87e2e6aee2d05568a6a35dd037fae7aedf916d811682ab04a093e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "eb081f5b195b4bedf091956caeaf9182af47d62dd12bbc37d6899c27ce9e6345";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-driver/default.nix
+++ b/distros/kinetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4beab502ca2d7346d2f25c5956ce93f702e64ea7419c430187308e0cf7abba62";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "efcf7f218cc8a6fe0f1c718f5e0a9d88fb965dedb4274e142b208e82fdea711c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard/default.nix
+++ b/distros/kinetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "f22f4c519ad2486430735f9812b2373509945ac74922daff2cccd8201eba79e5";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "72fa0c1686ba6b07dbde1482ef556fc1026d971d14dd45db0f6483403bfdfd78";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-bus-manager/default.nix
+++ b/distros/kinetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-bus-manager";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_bus_manager/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "5906fc50b9b8077b40eec36d9c97bbb5e20f5873643ce277d012d9c7892d0df2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-description/default.nix
+++ b/distros/kinetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-description";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_description/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "404af940d22ffdb8d09d3e1925afe38d854108edbb17b5bf2a7325af34ea5117";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-ethercat/default.nix
+++ b/distros/kinetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-ethercat";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_ethercat/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "6eff41322f0a4a1086e23d60b45b55c27e199b3b14ed381b510d2fe30a73ad24";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-examples/default.nix
+++ b/distros/kinetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-examples";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_examples/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "939322393a549710a0a00e4b89c5a7630439171d4ae768f264e80c5902c6ea1f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-factory/default.nix
+++ b/distros/kinetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-factory";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_factory/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "3068d95e235e78d418c5f0485da55d7eba66db90f27592231fc0ffe67fb8c8f1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-manager/default.nix
+++ b/distros/kinetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-manager";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_manager/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "df2c4805a683a85d3d3e26b3f47023e9d55fb283fb45b45ee34af30890801439";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-msgs/default.nix
+++ b/distros/kinetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-msgs";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_msgs/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "6c5ed68eafad7c83b775ef91a7e20e1d8c24910a9c9924b63d7ff01abba33906";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-serial/default.nix
+++ b/distros/kinetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-serial";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_serial/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "10d58f95952661aa172edfbd3c9ce4d5423f0919e9b604fa93035358f5a73c69";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini/default.nix
+++ b/distros/kinetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "100dab027bde760660d57ebb449849e0a54b490cd08e55d578b2b77c89f93d2f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/ros-comm/default.nix
+++ b/distros/kinetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-ros-comm";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "2aaa3d0571eb3986263f6e0dd9382e0f112c0bec937e21fb9c26149fefd4ca6c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "251da3087d8fae49abe732f2ff93252e81487c5d69a96e0c30cb2f3e317efb00";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-storage/default.nix
+++ b/distros/kinetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, roscpp-serialization, roscpp-traits, roslz4, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-storage";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "376c9d66af3591aa514a400c7a53b2197bafcc41be754e350d951359145b69f3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "cc0ba8c6a13b541381fbf8d9ae6c2e9a9a55b593831891edb6bcf9068d9b5ddc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag/default.nix
+++ b/distros/kinetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "aa3a9ed9ac9ccff11edb69eaac3545ae2b65af37fb478b397e9e3c874e0b787a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "530f841d0d329b6f651b9225017ea62093312ad4072c075f0aef41168254a642";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosconsole/default.nix
+++ b/distros/kinetic/rosconsole/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apr, boost, catkin, cpp-common, log4cxx, rosbuild, rostime, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rosconsole";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "ed0057e2c129ee74a997b5a517ace606bdf47de19e3170a41ad562cd9c57c5dd";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "7fcfa3051aa6fe27c8122015c6af08b7140758fd97c09d511dce4641b1c76cc7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roscpp/default.nix
+++ b/distros/kinetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-roscpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f486ed35e076e0950e9192a41a6cbfdc1c4bff7c25fb1134b08c0ab21c1ec2f0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "3676973d3e564c8590477cc2a005cac81c7b02f25b28ec4782186b0cde559b7c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosgraph/default.nix
+++ b/distros/kinetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-rosgraph";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "c2403dd9523387fa99f64924a7681e5653aad8e3e5a14d389133c5ded64667b4";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "43d6fb781882e5ce71345e15bf1be32457b270f7a229ff5ea1c00131679f58d7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslaunch/default.nix
+++ b/distros/kinetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslaunch";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "41a3913f4871c4c647c57cee5fb652a42a8fc81ca2af83b89321300284f5a35e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0e0f9367d3c13023fdd21bb26657fc5beeb09513a4c0b5462c9110c5cd9fc9d0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslz4/default.nix
+++ b/distros/kinetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslz4";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f4fd030bfd5bf613e39effa52042f4c8f615a22b84b2df515c3b4873c96f5e41";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0f55a2821108febf725792be25966bb0136d05bc80f00311225a58f819a6c892";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmaster/default.nix
+++ b/distros/kinetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosmaster";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "eed057b191aeb2e53bf963a0d32ebf6ee435aaa23309983a1da45d27c05aafe2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "273a3094b53b3aa0b542b76b69dc84fd482b99b670c36f461eccb14d92e3fb50";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmsg/default.nix
+++ b/distros/kinetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosmsg";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f0907cd996fe008658d3af3d5aba6747dda30767d03fb632a2e7b82c873be5d9";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d03ec9630f58015d7e5f536ef33b33ce6c773a95c36c3050c25c7e3cfc9aabad";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosnode/default.nix
+++ b/distros/kinetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-kinetic-rosnode";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "22cda46d4b51c01b9b2cc5031c8fec64fded6d31b42714cad976139790730c80";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "2bd70bb657e006be43dd5996a9dd9027122e927dd9f14147292b898fc653269e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosout/default.nix
+++ b/distros/kinetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosout";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b4a408241eca12ffd691882ecb1ef000a76cbf6b3b78fa684d2430c097ae8352";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "aa10e2e8cf9e8fcc57f5f90ac992c96c82c39c5b8762d6c05582ed77bd7f16c6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosparam/default.nix
+++ b/distros/kinetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosparam";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "da21cbd9ee89c39080c3496b6defae95794394fe1378ab07d0ec2b9241f20d97";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "1d6f465d685db5286520afa2e74445e97a003552dea0a8bba54133953b384498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy/default.nix
+++ b/distros/kinetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "a2d1d4bc6febc71e6daa05db982986063e7368483e797726577f0540c314ace7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "08a7e7c2dba29eb5e821d960233dd9bd2a9ed650cfa568acfdeaeb5eeb904d2e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosservice/default.nix
+++ b/distros/kinetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosservice";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f51d308e5ad0688f4b4e631745811b1306d1ced1d2a6386460f7d18fac108b44";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "854047e943366c00b162f55342c562daa82bb1f7f5f5ada34ff89929e929c252";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostest/default.nix
+++ b/distros/kinetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rostest";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "5c1ca6cd4f8be7d98b2ae2cea4d097c4a9c4f6b6ddc1a9162bb767b14f6a3e88";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "c25f1c491dcbaef71ee2c50b15c2b1feb8256511125818b82930a88769bc4e65";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostopic/default.nix
+++ b/distros/kinetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rostopic";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "d50a05c221c96e851759689c33da4c8698bf95b8e30a3f35509f365e8be8b6fe";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d476ccbc28d1276969c34af68b09ac65dcabf82ae8e81b798f6ea0ed90df27e9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roswtf/default.nix
+++ b/distros/kinetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbuild, rosgraph, roslaunch, roslib, rosnode, rosservice, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-roswtf";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "cefe1aeb678d9c0447a33c062a253164ec6e4c09f49470a5f37409d81454e1d3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "a184de1c25849b152acfb9a5fc9da9d1a65664b3a4b4a97d5a6941d975d8a7cc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/topic-tools/default.nix
+++ b/distros/kinetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-topic-tools";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "bfc3b7d5a7f42477bf02ab820ebdef837b2fb39f380c5f86ee199f2fc7df0798";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "89803ace2dd64ef62103b869e1e650c73782c972305f72199e1bb9e6f38e273e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "0bc507ce57d98ea3741301823fc5db80f521187f589944ea29d83bffe6b184d0";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "cf63043059b2420247180260ce9263e3610be901b8fdd7581d4349956c8f78ae";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/xmlrpcpp/default.nix
+++ b/distros/kinetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-xmlrpcpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "fb662c176ae22ba7aba147004f7586b4233afad433d3b3e9906624da9dadd835";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "65f58f680412c96e177aeaf6a287b6817861394dfa426e05eac72bcad0349d69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-device-driver/default.nix
+++ b/distros/melodic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-bota-device-driver";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "4c380c66060b6f55a15dfac4f933dc7d98880761dd35c2681dc31eaf432eb7b1";
+    sha256 = "6c912d90328433700afc7ae77987473e00b9c9944b0df413c12372347f15ca73";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "d995592d9c8d88918dfe61f23bae9881ed99cfd7011235578ed6a875ad89cbe3";
+    sha256 = "52abab58ccadc982af6735f861ee8336f9b37814aaad650b9a08e5076f7730f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "6503b36a33795aded7042790d7e2fc8aae390819aac35da353816892c6b17110";
+    sha256 = "ecc0f485f2e0281ce57ed4d4da3daf95b3b21415914405f174648efd42fad6e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "ee701a44c3c122d5ea4168b5698bcb012a1d093c7aec68129b6ed00495d94d39";
+    sha256 = "fc028401551008c00fe1de4adb0deaedf9b011f005e1f75f86f941657cbc508b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "103602543e1798a2d1d7a11c9ae5808cbd0f00b23e568d70970160a4451919e0";
+    sha256 = "4037c14d8437b56dce9efa422eba91d89afd3f7e02520ec13f856768a60a6f2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "42da85876c5670d83380035aeeb209f61dafdd55d2f92639fd0290304e6ef8d3";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "b95e6a1b69a60017158c5016ede4e437a00794d359312b9131d063fd97c13132";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "1f31578a0f23b34d0fee3b20e56225e852afaf968e89021c3544e31507fe64ce";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "354bfc89159892347217515c553e8d5efa73848adaca75d6028a1d868f287661";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b3ad6906fdec43788e2f4a0ffdfa3fc9e0950efb4926c5d0b497273f3f7be862";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "2cd473c0658237f414c248d4e7b788a36d9d8873b4d04cf6a2df7b382c70e976";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8ff41f9b66008c30207f6af85368c4e90b457a5da13df0d35df52098b5ad4cb0";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e2f9df40b800630d5bb9c34708e5eebbf915947bbf4b65538ce806a42137412d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/extest/default.nix
+++ b/distros/melodic/extest/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-extest";
+  version = "0.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/nakakura/extest-release/archive/release/melodic/extest/0.0.1-3.tar.gz";
+    name = "0.0.1-3.tar.gz";
+    sha256 = "5906e54a081617deda9be1e1cd4b7fcd8fe9b4cf0c2f2ee1792da5b5b557b0e7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''control Telubee Head'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "750fbb51252fba2e6705d6a180fde509cf1907cc9770898ba61172e7f9275614";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b9d68a934b7729c3b519eb66126eda7e61b6237a1f96cec651b983f8e9bd4e93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "0a3d7a6220a9fcfecdf31ce7463934bc8515a1bc4fc307dc811369d9e76b3a84";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b765c7e0ec121d981ac2f6a9b91599cad5db173b9d8ad6d64b50f1a53f559d59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -902,6 +902,8 @@ self: super: {
 
  exotica-val-description = self.callPackage ./exotica-val-description {};
 
+ extest = self.callPackage ./extest {};
+
  face-detector = self.callPackage ./face-detector {};
 
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
@@ -2900,6 +2902,8 @@ self: super: {
 
  robotis-manipulator = self.callPackage ./robotis-manipulator {};
 
+ robotont-description = self.callPackage ./robotont-description {};
+
  rocon-app-manager-msgs = self.callPackage ./rocon-app-manager-msgs {};
 
  rocon-bubble-icons = self.callPackage ./rocon-bubble-icons {};
@@ -3653,6 +3657,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
 

--- a/distros/melodic/jackal-gazebo/default.nix
+++ b/distros/melodic/jackal-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, jackal-control, jackal-description, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-jackal-gazebo";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "8364a4349df4bc2d6bed5c7c2d0e7dc1f1baf5ff6e9669b138ab9a3d785cdcd7";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "202c29adfd750e5043f10171294ca27c0a310aa44a99ea46afebbc269ec9bbef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-simulator/default.nix
+++ b/distros/melodic/jackal-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jackal-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-jackal-simulator";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "e9e14150e70e7c51cd6fa674af8c0bae82aedd156e8bf0019774448d6b1a915a";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "adf0d04519d339a355293cb30113435a4a4575adc65b4690681977ed1e4b900f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-msgs/default.nix
+++ b/distros/melodic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a0b7044c2fd59448eb714ce14d60c5ff2d0073962e011e6549c7dd99fc916ffc";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f9258be961e164b60e94b10e2965dc703d8614d360645717d099b40c2ea71de0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base-msgs/default.nix
+++ b/distros/melodic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a9b1ee115c3252718a9915a94ba16421a39309ed237a33d790f486d468f8a1ef";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f221272c2819180557e5c21b79dd30f34d9ac83503595c6132f9fecc7b48cfcc";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "8aa932a83ec1488c67647070770efd2241c5c652f44aa9b7dd76bc1e34182b4a";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f7ad438cebdd4c0e631471ff463aee3afd4a53fe69cbd662c78c99be29b3aaca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "0f1548a3bcd88d07310993c9f28dead1bce7eaca3590986a6959a58968ba6f90";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "d705f4093051c90fef5837cf427685444bf5d3c4a17aada13efb9b4f2211ea56";
   };
 
   buildType = "catkin";
-  buildInputs = [ gflags ];
   checkInputs = [ code-coverage ];
-  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/robotont-description/default.nix
+++ b/distros/melodic/robotont-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-robotont-description";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/robotont-release/robotont_description-release/archive/release/melodic/robotont_description/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "ec713b9ea6cf9f2c84409f1b5bc9dd6e1f4722d3ffec37f698dc10930a1a2b00";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robotont_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "3c40927408692de41673af26c9b169add09cf59c77194c8c71e55da1a81d8b7d";
+    sha256 = "4574afa812820b7b1a8628a07d04f36fef98f1404471c611b0295dfe4294d7db";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "ae0f59984ef20e956f46873589426e2383d00299dbef87e415004affb6b4a070";
+    sha256 = "6232f570f42871993d0701244de45ae6de7ee26c28c47ed6d9a363cfe900bad0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "0f6e9943bd52948738862d00b37c7f12f37c3ea2f40c576f910c3b433eac2b89";
+    sha256 = "483770e8283c95b9720c2d56597813fc269fc285b7590eed41f44bcf866e241b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-examples/default.nix
+++ b/distros/melodic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-examples";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "ece58bf00b38d219cbf07b66a9573d29298e3277ee4e81d46fca595076273e37";
+    sha256 = "4ad3498283374d257901b67f51043195c95b86225ae36f7f25c331d98a56b303";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-factory/default.nix
+++ b/distros/melodic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-factory";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "d23777994e6ad6ce71c7c2c7a21be08bfea3c0ce0da6fe73a2824d4d5f85e93a";
+    sha256 = "6ec18d29edb446584faaa411d00b7aa5b3b0d1af1d64bef0bba6b898d9ae4c6b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-manager/default.nix
+++ b/distros/melodic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-manager";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "83eb2b0545da49e0c78cbd8583b9f13fcab9f9293f78e7e86eb387464db0df63";
+    sha256 = "5ef3395c753612a49d52344aea7e6f33f3c32a2629a4427a9a1124bad77d6e7a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "b76bdddd1b353b057f96e6f588b1e0deeeef882a8f2a4321407c71f7e120cf55";
+    sha256 = "e18b9005cf190cfcde5a9f93adcb403877e16c42dd197db2c6da962d15a96067";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "17e9d3302bbe0477177d6b2bb425b213e5de4d9af19baf2f730b34eca7315a52";
+    sha256 = "a527dbc3a0900dd918b0bd8c29bf0184420f834f14e19e1967c93496fe090fe2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.2-r2";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.5-1";
     name = "archive.tar.gz";
-    sha256 = "0b740616a3aa3f6b55a8f2ff5a614b6a1cd96dd6d35b52888457d04b648ac537";
+    sha256 = "88636454ff450b0499d999c3e44161ff07ae25c13087c7a98589de29bbcf60e7";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-bringup/default.nix
+++ b/distros/melodic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "8070e4fc87ea31059e71d41c0961b6ab39ef6feed24b667207c3a9d8a5e44d66";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/toposens-description/default.nix
+++ b/distros/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "9449bf971c63000bcf088ece79703def3d1cd7189b4c19e4b872e56556389000";
+    sha256 = "1bd77a491c96473f5a1bb563090149c58c421324891f14a3681fc3103e0e553e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-driver/default.nix
+++ b/distros/melodic/toposens-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs, turtlebot3-bringup }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c85f8b7bb6cd4fbf18fbc15a9602d2e4098310a632d56e2be1a8e6de54dfaab1";
+    sha256 = "fa52fa15587860d0f954e2da53460251dd6f788bf7e696bf46f9ac8ed9f2b334";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy toposens-msgs turtlebot3-bringup ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-markers/default.nix
+++ b/distros/melodic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "135dd96e3468ab3caf9e08a9e0cd8cc7cf93070c075aed26f1e8ec18b270de6b";
+    sha256 = "caa8dc40b5a17cd9f98149587ef3afeb0191599c4cf0aa5ef2bd5beaeb9cafa6";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy rviz rviz-visual-tools toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-msgs/default.nix
+++ b/distros/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "77964b3ea4262c128f14a4f6ffb5e0fbb525f0e15bd73cb598471daa9b9640a4";
+    sha256 = "e74ec8411e4507b36e9cf326903e425c90f4b02e24541d39bb30980ad9b15730";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-pointcloud/default.nix
+++ b/distros/melodic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, robot-state-publisher, roscpp, roslaunch, rospy, rostest, rviz, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, turtlebot3-teleop, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "f534b81233f4e2fd347254c66cfd16d52e028c2ef5a1fbf17f47560bd8c75461";
+    sha256 = "d720d6d42394732c5d894e904bed47a21b3b04cf5bd3faed434e661105e9bad0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros robot-state-publisher roscpp rospy rviz tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs turtlebot3-teleop visualization-msgs xacro ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-sync/default.nix
+++ b/distros/melodic/toposens-sync/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "34473cd0343a4ecfd449d11e7440e3bc0bbfcaadef3980429cf91b43db06e4eb";
+    sha256 = "449c7fbdc4adefc79797eb9a74f9c2a86daae76a9a5e365872bdc056adcbec65";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens/default.nix
+++ b/distros/melodic/toposens/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "6dc77e60003b588730aff6d6fd8e38d95ae946e85dcb066ff61ba60b4f4c7be0";
+    sha256 = "703e1844de02b4ebaa27df9a4f71822c1848d00cf9e3ae62e7f970a81867c50a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/autoware-can-msgs/default.nix
+++ b/distros/noetic/autoware-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-can-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_can_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f7b4868e4fb6ce3d591b53a3f9e744e9a1a3194ccba26b63dc4540ad5491f0b3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_can_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-config-msgs/default.nix
+++ b/distros/noetic/autoware-config-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-config-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_config_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "eafaea3c8e37f57ddb46a1f4b9cb3152ba49dec22a3cf4b13e538c70c2947ccf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_config_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-external-msgs/default.nix
+++ b/distros/noetic/autoware-external-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lgsvl-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-external-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_external_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "9e46e8c0fb4b274a632a42d058fe1b33b556a809f602ec8a9567c468c719b2a6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lgsvl-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package to contain an install external message dependencies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-lanelet2-msgs/default.nix
+++ b/distros/noetic/autoware-lanelet2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-lanelet2-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "fa2a058aa23ed50120b0e7ac33a75dfe637ea301578124929ab0126de9f61f43";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_lanelet2_msgs package. Contains messages for lanelet2 maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-map-msgs/default.nix
+++ b/distros/noetic/autoware-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "dfea163b4bd892c5a7cbd519885e309449e6a0f21fe088bd91ce9836b0b68247";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Includes messages to handle each class in Autoware Map Format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-msgs/default.nix
+++ b/distros/noetic/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, jsk-recognition-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f445a6713e8764e34e58f34fc1f8ad56637b3699546b7912baba2cd05c7b31ee";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs jsk-recognition-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-system-msgs/default.nix
+++ b/distros/noetic/autoware-system-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-system-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_system_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "7bc5e114a49f6224db2da7cba91ce2e05baf589858391e1366616066a8ded740";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosgraph-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_system_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-device-driver/default.nix
+++ b/distros/noetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-bota-device-driver";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_device_driver/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "32a445c312f5a9060dcfd973022f856aaea4e1588d58369dd6e8c12c904d31c5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-bota-driver";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_driver/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "da4060aaca6e752bb9a781cde7fb8db5c65f043f7e69e7c1aff35f6a4f396cae";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-node";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_node/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "6e6356e1ea652a7c6481afd7dca911617cd0ebdbe9346ffa39a6178109c8a369";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-signal-handler";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_signal_handler/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "2a78e6f6be821f29b148f1b280c5ec8a1e643532e6b3ed7d1495ca4e217258fb";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-worker";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_worker/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "64817e86a64272ff6c0366ad8979f84e4b6ceebf47371570d493f4ca771bdd4c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/code-coverage/default.nix
+++ b/distros/noetic/code-coverage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-code-coverage";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8cd4d5c421532b7b8bb57563cd3cbbf6fd5edce3830da323f18b72d0a9bd9a1f";
+    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "9b9a65c55bcf50a7a90c55a13d0376e59aa1d331a6a2ae75d1c452caa9cb03f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ddynamic-reconfigure-python/default.nix
+++ b/distros/noetic/ddynamic-reconfigure-python/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ddynamic-reconfigure-python";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure_python-release/archive/release/noetic/ddynamic_reconfigure_python/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b99b19d692984bb83a34afb74dbe92b3d4e7bde5e89afd47cacbc57e3963df5a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ddynamic_reconfigure_python package contains
+    a class to instantiate dynamic reconfigure servers on the fly
+    registering variables'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "109358fbe47d2113a169631ae42fad3f410d93c4a22f5e0143be153435d0ef0b";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "8127adc92c19930bb41d8e332f94febe5256a04402970b18f20f10e6c7155874";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "d304fd952659e934321b489879180dda5755dfff7e64b68ba7999b8e13db21a3";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "28181b950a206e9a148f5ca518685914dea85e236395da30472890925c973efb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -52,6 +52,20 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ autoware-can-msgs = self.callPackage ./autoware-can-msgs {};
+
+ autoware-config-msgs = self.callPackage ./autoware-config-msgs {};
+
+ autoware-external-msgs = self.callPackage ./autoware-external-msgs {};
+
+ autoware-lanelet2-msgs = self.callPackage ./autoware-lanelet2-msgs {};
+
+ autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
+
+ autoware-system-msgs = self.callPackage ./autoware-system-msgs {};
+
  auv-msgs = self.callPackage ./auv-msgs {};
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
@@ -73,6 +87,16 @@ self: super: {
  bondpy = self.callPackage ./bondpy {};
 
  boost-sml = self.callPackage ./boost-sml {};
+
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
 
@@ -364,6 +388,8 @@ self: super: {
 
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
+ ddynamic-reconfigure-python = self.callPackage ./ddynamic-reconfigure-python {};
+
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
  delphi-mrr-msgs = self.callPackage ./delphi-mrr-msgs {};
@@ -632,6 +658,8 @@ self: super: {
 
  graph-msgs = self.callPackage ./graph-msgs {};
 
+ grasping-msgs = self.callPackage ./grasping-msgs {};
+
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  handeye = self.callPackage ./handeye {};
@@ -685,6 +713,12 @@ self: super: {
  imu-tools = self.callPackage ./imu-tools {};
 
  imu-transformer = self.callPackage ./imu-transformer {};
+
+ industrial-msgs = self.callPackage ./industrial-msgs {};
+
+ industrial-robot-status-controller = self.callPackage ./industrial-robot-status-controller {};
+
+ industrial-robot-status-interface = self.callPackage ./industrial-robot-status-interface {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
@@ -1110,6 +1144,10 @@ self: super: {
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -1312,6 +1350,10 @@ self: super: {
 
  robot = self.callPackage ./robot {};
 
+ robot-calibration = self.callPackage ./robot-calibration {};
+
+ robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-navigation = self.callPackage ./robot-navigation {};
@@ -1321,6 +1363,24 @@ self: super: {
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
+
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
 
  ros = self.callPackage ./ros {};
 
@@ -1746,6 +1806,8 @@ self: super: {
 
  swri-yaml-util = self.callPackage ./swri-yaml-util {};
 
+ tablet-socket-msgs = self.callPackage ./tablet-socket-msgs {};
+
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
@@ -1877,6 +1939,8 @@ self: super: {
  usb-cam-hardware-interface = self.callPackage ./usb-cam-hardware-interface {};
 
  uuid-msgs = self.callPackage ./uuid-msgs {};
+
+ vector-map-msgs = self.callPackage ./vector-map-msgs {};
 
  velocity-controllers = self.callPackage ./velocity-controllers {};
 

--- a/distros/noetic/grasping-msgs/default.nix
+++ b/distros/noetic/grasping-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, moveit-msgs, sensor-msgs, shape-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-grasping-msgs";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mikeferguson/grasping_msgs-gbp/archive/release/noetic/grasping_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "87a1982676f3578bf4799db82e984990dec14eab6d9df3a98ab13b4d4a2d6c33";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib geometry-msgs message-runtime moveit-msgs sensor-msgs shape-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for describing objects and how to grasp them.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-msgs/default.nix
+++ b/distros/noetic/industrial-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-msgs";
+  version = "0.7.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "c1cc02b17cffe63eacfb0ba825cde514478f3c405ced7b8e63c5756085b50554";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The industrial message package containes industrial specific messages 
+	definitions. This package is part of the ROS-Industrial program.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-controller/default.nix
+++ b/distros/noetic/industrial-robot-status-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, industrial-msgs, industrial-robot-status-interface, pluginlib, realtime-tools }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-controller";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "6f9dcec5e3bff7ae4470fc249277610e11b04451cdb06c053d663ffab0bf1bc0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ industrial-robot-status-interface ];
+  propagatedBuildInputs = [ controller-interface hardware-interface industrial-msgs pluginlib realtime-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller that reports robot status using the ROS-Industrial RobotStatus message.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-interface/default.nix
+++ b/distros/noetic/industrial-robot-status-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-interface";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_interface/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "c1b73b8150bcb01b2bee3263026aa99571d1dcbdd4237e30ec9bafbed2938bcf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hardware-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Exposes ROS-Industrial's RobotStatus info from hardware_interfaces for consumption by ros_control controllers.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/map-msgs/default.nix
+++ b/distros/noetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-map-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "a4f536d85ba775adbb06217eff50d3ed057d4bd87ef42c38e4c0523dc5b79d74";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "e9ae695b8c3f745dc6c3878810a97546c4dd528000a0c8058d6f1f41983df432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-base-msgs/default.nix
+++ b/distros/noetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-move-base-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "f7778f0c15c1e93642f7f3b52abb03a9072bece78530660576a93bc2a354671c";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "a3cfcbeed9a83959c3a7b12abf8737062bee94c627d1a961be4ff589a4c4ad7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-driver/default.nix
+++ b/distros/noetic/novatel-oem7-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, rostest, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-driver";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "31177a28c690bbe9df9b89d554af623b43cbcd195a290336083e307396754378";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost gps-common nodelet novatel-oem7-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NovAtel Oem7 ROS Driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/novatel-oem7-msgs/default.nix
+++ b/distros/noetic/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "99cd8fe9aee43c2f2252b1542adec52cecbc9d03bfbe10b8703679bc23cb04f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for NovAtel Oem7 family of receivers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration-msgs";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "90dcef12df3501596deef0b54aecae6da568f24a0702d533a16f3503dace8215";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for calibrating a robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f90812efe92713874c112e6a8dc83efde3ce72915f102dfcd4f1a8db8e057883";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Calibrate a Robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-bus-manager";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_bus_manager/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "de8031d4bf0817cd91aa9e5f29b766e1dca00c1f359cdbed10be6b955222f633";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-description";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_description/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "9e767c63e25c31eea0596d82b493f23edb4fc3cd1e3f6cc2833cff2cea9c16d4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-ethercat";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_ethercat/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "500b683d5446747f3f4e2204fb5e414d01933084ed15b2d07a431457c43970a4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-examples/default.nix
+++ b/distros/noetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-examples";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_examples/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "d9b46620259af8b6a88a4711502153586d6a73e8fb1268cea216c1e2b6eca10b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-factory/default.nix
+++ b/distros/noetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-factory";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_factory/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "52910f670debb88126bf4b016398815fe1d5e8685345770f5b83a0ee424d6d31";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-manager/default.nix
+++ b/distros/noetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-manager";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_manager/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "4770e4902618655054fa62913c1180282c51a084aa5bbd091746a5da80915b2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-msgs";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_msgs/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "55741663df340750754bc7ecdfdf36b3cb76c2185ee1484199b9fa3c0a454ab5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-serial";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_serial/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "78f032100480a1e7d92f9e89a9760ec76712f8268b668467a8e023d3c0de90a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "adbd191ea10b4dd3253f74cfc4259c7d1238c5b9766fd6ebcdd4b1da46ba2140";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tablet-socket-msgs/default.nix
+++ b/distros/noetic/tablet-socket-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-tablet-socket-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/tablet_socket_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "6bf111b0e4f1332a69414b38dbed9f61247e048b4018e882997ad99a93fd90f8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tablet_socket_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-vector-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The vector_map_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 1f2193c9440f65c3a75c96ae4a1138a9802c9667.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --skip cross_compile --all
```

Changes:
========
Dashing Changes:
----------------
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cyclonedds 0.5.1-r1 --> 0.7.0-r1*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*
* *smclib 2.0.0-r1*
* *test-bond 2.0.0-r1*

Eloquent Changes:
-----------------
* *cyclonedds 0.5.1-r2 --> 0.7.0-r3*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*

Foxy Changes:
-------------
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cartographer-ros 1.0.9001-r1 --> 1.0.9002-r1*
* *cartographer-ros-msgs 1.0.9001-r1 --> 1.0.9002-r1*
* *costmap-queue 0.4.3-r1 --> 0.4.5-r1*
* *dsr-description2 0.1.1-r4*
* *dsr-msgs2 0.1.1-r4*
* *dwb-core 0.4.3-r1 --> 0.4.5-r1*
* *dwb-critics 0.4.3-r1 --> 0.4.5-r1*
* *dwb-msgs 0.4.3-r1 --> 0.4.5-r1*
* *dwb-plugins 0.4.3-r1 --> 0.4.5-r1*
* *nav-2d-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav-2d-utils 0.4.3-r1 --> 0.4.5-r1*
* *nav2-amcl 0.4.3-r1 --> 0.4.5-r1*
* *nav2-behavior-tree 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bringup 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bt-navigator 0.4.3-r1 --> 0.4.5-r1*
* *nav2-common 0.4.3-r1 --> 0.4.5-r1*
* *nav2-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-core 0.4.3-r1 --> 0.4.5-r1*
* *nav2-costmap-2d 0.4.3-r1 --> 0.4.5-r1*
* *nav2-dwb-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-gazebo-spawner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-lifecycle-manager 0.4.3-r1 --> 0.4.5-r1*
* *nav2-map-server 0.4.3-r1 --> 0.4.5-r1*
* *nav2-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav2-navfn-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-recoveries 0.4.3-r1 --> 0.4.5-r1*
* *nav2-rviz-plugins 0.4.3-r1 --> 0.4.5-r1*
* *nav2-system-tests 0.4.3-r1 --> 0.4.5-r1*
* *nav2-util 0.4.3-r1 --> 0.4.5-r1*
* *nav2-voxel-grid 0.4.3-r1 --> 0.4.5-r1*
* *nav2-waypoint-follower 0.4.3-r1 --> 0.4.5-r1*
* *navigation2 0.4.3-r1 --> 0.4.5-r1*
* *osqp-vendor 0.0.1-r3 --> 0.0.2-r1*
* *rcl 1.1.8-r1 --> 1.1.9-r1*
* *rcl-action 1.1.8-r1 --> 1.1.9-r1*
* *rcl-lifecycle 1.1.8-r1 --> 1.1.9-r1*
* *rcl-yaml-param-parser 1.1.8-r1 --> 1.1.9-r1*
* *smac-planner 0.4.5-r1*
* *smclib 2.0.0-r1*
* *test-bond 2.0.0-r1*

Kinetic Changes:
----------------
* *bota-device-driver 0.5.6-r1*
* *bota-driver 0.5.6-r1*
* *bota-node 0.5.6-r1*
* *bota-signal-handler 0.5.6-r1*
* *bota-worker 0.5.6-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *message-filters 1.12.16-r1 --> 1.12.17-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *rc-hand-eye-calibration-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-pick-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-roi-manager-gui 3.0.4-r1 --> 3.0.5-r1*
* *rc-silhouettematch-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-tagdetect-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-description 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-driver 3.0.4-r1 --> 3.0.5-r1*
* *rokubimini 0.5.6-r1*
* *rokubimini-bus-manager 0.5.6-r1*
* *rokubimini-description 0.5.6-r1*
* *rokubimini-ethercat 0.5.6-r1*
* *rokubimini-examples 0.5.6-r1*
* *rokubimini-factory 0.5.6-r1*
* *rokubimini-manager 0.5.6-r1*
* *rokubimini-msgs 0.5.6-r1*
* *rokubimini-serial 0.5.6-r1*
* *ros-comm 1.12.16-r1 --> 1.12.17-r1*
* *rosbag 1.12.16-r1 --> 1.12.17-r1*
* *rosbag-storage 1.12.16-r1 --> 1.12.17-r1*
* *rosconsole 1.12.16-r1 --> 1.12.17-r1*
* *roscpp 1.12.16-r1 --> 1.12.17-r1*
* *rosgraph 1.12.16-r1 --> 1.12.17-r1*
* *roslaunch 1.12.16-r1 --> 1.12.17-r1*
* *roslz4 1.12.16-r1 --> 1.12.17-r1*
* *rosmaster 1.12.16-r1 --> 1.12.17-r1*
* *rosmsg 1.12.16-r1 --> 1.12.17-r1*
* *rosnode 1.12.16-r1 --> 1.12.17-r1*
* *rosout 1.12.16-r1 --> 1.12.17-r1*
* *rosparam 1.12.16-r1 --> 1.12.17-r1*
* *rospy 1.12.16-r1 --> 1.12.17-r1*
* *rosservice 1.12.16-r1 --> 1.12.17-r1*
* *rostest 1.12.16-r1 --> 1.12.17-r1*
* *rostopic 1.12.16-r1 --> 1.12.17-r1*
* *roswtf 1.12.16-r1 --> 1.12.17-r1*
* *topic-tools 1.12.16-r1 --> 1.12.17-r1*
* *urg-node 0.1.14-r1 --> 0.1.15-r1*
* *xmlrpcpp 1.12.16-r1 --> 1.12.17-r1*

Melodic Changes:
----------------
* *bota-device-driver 0.5.2-r2 --> 0.5.5-r1*
* *bota-driver 0.5.2-r2 --> 0.5.5-r1*
* *bota-node 0.5.2-r2 --> 0.5.5-r1*
* *bota-signal-handler 0.5.2-r2 --> 0.5.5-r1*
* *bota-worker 0.5.2-r2 --> 0.5.5-r1*
* *dingo-control 0.1.4-r1 --> 0.1.5-r1*
* *dingo-description 0.1.4-r1 --> 0.1.5-r1*
* *dingo-msgs 0.1.4-r1 --> 0.1.5-r1*
* *dingo-navigation 0.1.4-r1 --> 0.1.5-r1*
* *extest 0.0.1-r3*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *jackal-gazebo 0.3.0-r2 --> 0.4.0-r1*
* *jackal-simulator 0.3.0-r2 --> 0.4.0-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *robot-calibration 0.6.3-r1 --> 0.6.4-r1*
* *robot-calibration-msgs 0.6.3-r1 --> 0.6.4-r1*
* *robotont-description 0.0.5-r2*
* *rokubimini 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-bus-manager 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-description 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-ethercat 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-examples 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-factory 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-manager 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-msgs 0.5.2-r2 --> 0.5.5-r1*
* *rokubimini-serial 0.5.2-r2 --> 0.5.5-r1*
* *toposens 2.0.4-r1 --> 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.0.4-r1 --> 2.1.0-r1*
* *toposens-driver 2.0.4-r1 --> 2.1.0-r1*
* *toposens-markers 2.0.4-r1 --> 2.1.0-r1*
* *toposens-msgs 2.0.4-r1 --> 2.1.0-r1*
* *toposens-pointcloud 2.0.4-r1 --> 2.1.0-r1*
* *toposens-sync 2.0.4-r1 --> 2.1.0-r1*

Noetic Changes:
---------------
* *autoware-can-msgs 1.14.0-r1*
* *autoware-config-msgs 1.14.0-r1*
* *autoware-external-msgs 1.14.0-r1*
* *autoware-lanelet2-msgs 1.14.0-r1*
* *autoware-map-msgs 1.14.0-r1*
* *autoware-msgs 1.14.0-r1*
* *autoware-system-msgs 1.14.0-r1*
* *bota-device-driver 0.5.7-r1*
* *bota-driver 0.5.7-r1*
* *bota-node 0.5.7-r1*
* *bota-signal-handler 0.5.7-r1*
* *bota-worker 0.5.7-r1*
* *code-coverage 0.4.3-r1 --> 0.4.4-r1*
* *ddynamic-reconfigure-python 0.0.1-r1*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *grasping-msgs 0.3.1-r1*
* *industrial-msgs 0.7.1-r1*
* *industrial-robot-status-controller 0.1.2-r1*
* *industrial-robot-status-interface 0.1.2-r1*
* *map-msgs 1.14.0-r1 --> 1.14.1-r1*
* *move-base-msgs 1.14.0-r1 --> 1.14.1-r1*
* *novatel-oem7-driver 1.1.0-r1*
* *novatel-oem7-msgs 1.1.0-r1*
* *robot-calibration 0.6.4-r1*
* *robot-calibration-msgs 0.6.4-r1*
* *rokubimini 0.5.7-r1*
* *rokubimini-bus-manager 0.5.7-r1*
* *rokubimini-description 0.5.7-r1*
* *rokubimini-ethercat 0.5.7-r1*
* *rokubimini-examples 0.5.7-r1*
* *rokubimini-factory 0.5.7-r1*
* *rokubimini-manager 0.5.7-r1*
* *rokubimini-msgs 0.5.7-r1*
* *rokubimini-serial 0.5.7-r1*
* *tablet-socket-msgs 1.14.0-r1*
* *vector-map-msgs 1.14.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] controller_manager
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] hardware_interface
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-whichcraft
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-h5py
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-mechanize
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

