### PR TITLE
rosdistro sync, Fri Nov 13 13:08:14 2020

### DIFF
--- a/distros/dashing/bond-core/default.nix
+++ b/distros/dashing/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-dashing-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "10c6660f117efc80e3ce007e513436e20e8e6534ce43f6822ee81c83ff154515";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bond/default.nix
+++ b/distros/dashing/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "45470a641f321480c3af295868addfceb1db8671f4c5721cbdccfda8889b207d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bondcpp/default.nix
+++ b/distros/dashing/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d3d04978c7615ad8a972815a80c284421cb55a0c7c2ae4008bd106c0cbc11059";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/cyclonedds-cmake-module/default.nix
+++ b/distros/dashing/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5416384adb666e9056fa4fbea26fddd5bede9918e8009310d0d198a3f2d12277";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c972ceab084dd87835ba3bcadb08ce4388530ca53bbad4a7d97737205c9b9912";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cyclonedds/default.nix
+++ b/distros/dashing/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "afbb1cd60046ac3513b78d22f26af23317414074cf00fe612708d56d1babe03e";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "07a49a0e992890c12f8dfbf99261756dfb150d3e2b33da102aaa28442f4a4bb2";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -148,6 +148,12 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -1004,6 +1010,8 @@ self: super: {
 
  slide-show = self.callPackage ./slide-show {};
 
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -1061,6 +1069,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/dashing/rmw-cyclonedds-cpp/default.nix
+++ b/distros/dashing/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5047cd3af861caa3ab566125ef59989cc67e66ca3a438d94e56208b06d5454f7";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "8d3419ca51b8e3f2cee05cb96b36f311337231069f6409c1b168b1c4aed15428";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/dashing/smclib/default.nix
+++ b/distros/dashing/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-dashing-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "09613f1e3e9b2b47e7b51eed9d1f9f5b488d576446dde8c5edc80afb524cebf1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/dashing/test-bond/default.nix
+++ b/distros/dashing/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a0a172654b7606d48c7b063e3c2eee433440fe6457f20148424f11bb420e4fcf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/eloquent/cyclonedds-cmake-module/default.nix
+++ b/distros/eloquent/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6db8546cb9579bdf6d29f02e8e172a371b695a50f73d94eb50ab8ea31300be65";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "dc4d7ab18637edfc0589913bb07a38d40577d70624f47058baa0f28c89692f26";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cyclonedds/default.nix
+++ b/distros/eloquent/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds";
-  version = "0.5.1-r2";
+  version = "0.7.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "7377c71cbb406f7aeb8fcdf5678f79197ab00984a30851b2ab37e813e1e9ed5f";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.7.0-3.tar.gz";
+    name = "0.7.0-3.tar.gz";
+    sha256 = "d4a1dfced26d9e0fd541606a69668c0ef1ed8ddeaefd551d3bd64f900b53bbd6";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/eloquent/rmw-cyclonedds-cpp/default.nix
+++ b/distros/eloquent/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-eloquent-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a1c35e80ff458c5a3635b459717ed79f65054a24fcc215d2c1e9873ff26a7e4c";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bf5d2a594f12e2f3ed6478ab0d7dfdc02d11118e26285f8204952d49f2d5ccda";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/foxy/bond-core/default.nix
+++ b/distros/foxy/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-foxy-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "b5d98b85b71709d7e8eaf9c105f1c5c8c2380d82c26407a46c29c34bab9a4bd2";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bond/default.nix
+++ b/distros/foxy/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb74416f8ef1aea39bcf056ca961c4c37dd66ec18f81258374a897a1e0cd3b80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bondcpp/default.nix
+++ b/distros/foxy/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9cf5b6d9bb60b7aa21f0c4c6397f237ed6d6414efd3f71f656733de00eb3b72f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/cartographer-ros-msgs/default.nix
+++ b/distros/foxy/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros-msgs";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "cd9607611d053908f5360dd6356c4bb72a27c9468326e5e3e4d7c6b5701e134e";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "33e58b9796bdb026afb0acb4a2cbaded6604e729a46ce3eae1a41a953058beab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cartographer-ros/default.nix
+++ b/distros/foxy/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "f408e0d891a311d1dfeab930b1807e007e4c0da3a9cac1dd208a904b496174d8";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "cb23d500a2659e1661b8d0c6f7f1a3e2c5d2434416f34ae68068bf31169fa708";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/costmap-queue/default.nix
+++ b/distros/foxy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-costmap-queue";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "73f04603a3d44aed609d6d00eefd83fb3dbe43c8a37be13abfb0637736bc7abb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9b33a055fed3295e5f807e6c7384369d5e23f13a4cde9daebd34ea5c0f2dc32e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dsr-description2/default.nix
+++ b/distros/foxy/dsr-description2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-description2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_description2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "7776c814f0cfabf18ca111f5ca111216c0d69ab7a74e73f1ce14d785d1659037";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python joint-state-publisher-gui launch launch-ros robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''dsr_description2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dsr-msgs2/default.nix
+++ b/distros/foxy/dsr-msgs2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-msgs2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_msgs2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "e3abf123677415e8a45929d79d9b1df9bfe90b41aabbc798af452316433b4909";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rclcpp rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The dsr_msgs2 package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dwb-core/default.nix
+++ b/distros/foxy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "9163b7d7d5cea08364319ef98569164df42f7db85d558655473024aff745f8c6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ae657e44c068bae195413c68b0c7197f23616e1c4c3a623508b6a5b88975b9c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-critics/default.nix
+++ b/distros/foxy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-critics";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2628e42f3a0cf285d96007380e1817c58592a8f872e5552c98b8dadff23b07e0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "eabc166b4ba0a2b0a2960d42cef2744f59b841d873b37c1444e1cc6d8d49646c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-msgs/default.nix
+++ b/distros/foxy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8c31c65b2eaff57e003be677a1b25a8b08d17d9231d804ad306a8abc617d4565";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "bb65c572d1ab1eb04ef0f480d14a93a3b9a30568af322ba3964a1560a5b6b455";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-plugins/default.nix
+++ b/distros/foxy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dwb-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "5ea4805443ac57bae9c8c69ee566d4360bdf44c05f5972f2fee11fd80e1acdd1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9baa59496d7ddb38cfef9bc6cf5d858aaff4d2071567ee1d205ab130fc61eb60";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -148,6 +148,12 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -229,6 +235,10 @@ self: super: {
  dolly-ignition = self.callPackage ./dolly-ignition {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
+
+ dsr-description2 = self.callPackage ./dsr-description2 {};
+
+ dsr-msgs2 = self.callPackage ./dsr-msgs2 {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -1032,6 +1042,10 @@ self: super: {
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
+ smac-planner = self.callPackage ./smac-planner {};
+
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
@@ -1093,6 +1107,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2020.10.11-r1";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2020.10.11-1.tar.gz";
-    name = "2020.10.11-1.tar.gz";
-    sha256 = "f23467c613353f2cd7048972f930ca92b71950cd08790fc93af98a92ac748c79";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "04bc450e02a260334d6a60883418f66f135534de8b4a69d81e698f6f44fe6637";
   };
 
   buildType = "cmake";

--- a/distros/foxy/nav-2d-msgs/default.nix
+++ b/distros/foxy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3b89af67439ec4f78850a7a7d75840e6d22603ef682712f94d85ed8ee2eaa9bb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5b580043db92c1ec0a4f9851bdb0e8a224717b232979b815ee1214ac9c8669a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav-2d-utils/default.nix
+++ b/distros/foxy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-utils";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f16655ca6fce7766c7b66c80c51e0497f90209d66f7df0f7317fab4337a7a00b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "49fa98b744e4213441be0c281641f8abf00e21cd8bfd4df7c29271eb47f4acb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-amcl/default.nix
+++ b/distros/foxy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-amcl";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2a0f1291e7b426fe19119fc6451b8d00eca71a3eb242670d0d546d7b577ffdce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "14084e4785551129be1c77a74082bcf32d5a384bf3f57708c081ca36c48a142d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-behavior-tree/default.nix
+++ b/distros/foxy/nav2-behavior-tree/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-behavior-tree";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c602015b7a0b1f1ec20bf2c6056e56ba07c241f6c0d1e4a0756060fe687ef5d7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "585f0ef01a3a442c0065cb24818a6de2678996016e99be84cccbe82f38c443b9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ nav2-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/nav2-bringup/default.nix
+++ b/distros/foxy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bringup";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "07ecfe7c326dc04a43a9e618e88547f5511850e45f74450cf6ae33d316e3d2b7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6b5d1f7479ce8951e3a38bb7ee37f3de81d81d0886636558c33247d44ffa1c51";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-bt-navigator/default.nix
+++ b/distros/foxy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bt-navigator";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "370dfd22e521a4c0449e204b59d6a38ad2a1c9409e090e6a39af63e7a4d7ca15";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b985757ac5e11dc3e6d1ad1120d15c2066cc5c7ca245d6b68050ae4cde2405aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-common/default.nix
+++ b/distros/foxy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-nav2-common";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c6e5326de2ab71eab276b40630955746a2c20ac58efc6e8514d46d6ef4b4c2a0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c8428b79244d25c49920ced18ba6239974db7f389af7c2126f1da8ed612682f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-controller/default.nix
+++ b/distros/foxy/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "1c53325051e83c8725dafc98844444862fae43fe46257dbcffe01da6ed8193a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "599b6957dc8f3738655c7de8a899cd35588b23e356038d63ccc053d506527a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-core/default.nix
+++ b/distros/foxy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2ed09d28318045aef089bfadb0aa0e9f1a9ce850792e595b0b39c3cebbd98d6f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "138efd03903eaf6993fb7eb131b5760041f768278c2f9fd38e45cd405389461d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-costmap-2d/default.nix
+++ b/distros/foxy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-costmap-2d";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a56b52d88faf1709ffccd0c61b58c50046dae147747770815f5df725256e9b76";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ca0b70bb40ae31883cfbfc18b133ef6eb388fc724c8750accd4d1a52991d7941";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-dwb-controller/default.nix
+++ b/distros/foxy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-foxy-nav2-dwb-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "67b2001e7330ca110137228f57056742e890eef1d5906f33c00ad7010cdbc588";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "937caff30a10dd18729093e5f36c89b9c503ed85fa80028e7d957e75ffe03298";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-gazebo-spawner/default.nix
+++ b/distros/foxy/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-gazebo-spawner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "68fc9ab9c7d639ac8129702a45539467c5a6f83de30e0be5dc17bea75a66baf9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "769481b7b18aaeeb270bfbcb2f2d197173956997e6085c0bf7c54da756c84700";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/nav2-lifecycle-manager/default.nix
+++ b/distros/foxy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-lifecycle-manager";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3dd2d066c47e6db7866025b4b0dc0e80977604e460d5821f572796565a01042b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e0c15e7a5065b8e4e6e4ddba5dcca55aa4fb3957385a52fd59f543ab280fe77a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-map-server/default.nix
+++ b/distros/foxy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-nav2-map-server";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "35bfc4f13b089b0f99a30bfd37b43332be256710f34572609fa63645bca5981a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e8ffdea4aee1c1582aafdba18fcf84c47d3dbc7080ba7692fb7ba4009921deee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-msgs/default.nix
+++ b/distros/foxy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c79a891e10fb45734d3433a95bc459ba797d6b89cb9b2b22ec529dd65fbbe113";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "312fcb7e7544343a8a844281d813a2d9043229627e0bb4606cff80c5dd2c645d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-navfn-planner/default.nix
+++ b/distros/foxy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-navfn-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "09884506de6a2fcc6f0899ae79e695af5301332b429a2c57fd71a5c1c8cf3038";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "31ec2d8a2b0fa49611fd248b392dd03429210453f3961f865de45783a0fe140f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-planner/default.nix
+++ b/distros/foxy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "34fba1237eff23a27eda29de7a3be9ef1dfb76f739cdd09e82356e096389de9e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "d80b5b433355566ab8ac4cdfa7f7439b02102ac748018cf08ba0b322f15d7f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-recoveries/default.nix
+++ b/distros/foxy/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-recoveries";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f6c75f6633640d75fa534adfdf1c980cdf96ae2cc5fda317770bfcc64f15560d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "cabc151e4005cbdff5e6ce1a7f2e15ccc645b58591f89ed69c4739a5f18e3714";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-rviz-plugins/default.nix
+++ b/distros/foxy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-rviz-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e25190817b2c813189bf6331a99ef60fe07e6c73175344689b855f51d241b5df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b46c97f76cf4b1cea25a9bb213dce9fd2c3a7e57384032a8e92a33af6601193e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-system-tests/default.nix
+++ b/distros/foxy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-system-tests";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b61051a79e8491a74259a0c3fb0005dd47f15113b5dedf66397d80c1c34e6cb7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "2acdc3505dc75e58afacb534b244fa36d54251777c924620e529938752f6a36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-util/default.nix
+++ b/distros/foxy/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, launch, launch-testing-ament-cmake, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-util";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e111d2bfd0ddf1940b50d7bec15434a5a560270d7f8e7da52a67570343c1b08c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "a66c0ff09045030f310410989abd0520feb63630491ad29da1786adf73d277a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-voxel-grid/default.nix
+++ b/distros/foxy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-nav2-voxel-grid";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "cf77fce6757e428ca4b061308672c35fc2b6f6dc71e143cce4f31830209c3cc2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "3573db33d1e45ea6be9eb0adf06e44e473e76af533bb871b8676675fde01935d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-waypoint-follower/default.nix
+++ b/distros/foxy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-waypoint-follower";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f23fd4f0bd0a27df32dab929a259bf5fe107298d91ff0784d9a5fca434ee999a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5259db32f25ab9274b88567e4716fbce7f498c1474b84c348673bef79c15be61";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/navigation2/default.nix
+++ b/distros/foxy/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower, smac-planner }:
 buildRosPackage {
   pname = "ros-foxy-navigation2";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "72210833bc9284733350efc544d253d2ac80f7fa965e348be28acdbf43e37c6d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "f733da59e06355acb96c1640211b4a03ab7b800f1a68aeff0cf301699b3b7d52";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower smac-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-osqp-vendor";
-  version = "0.0.1-r3";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.1-3.tar.gz";
-    name = "0.0.1-3.tar.gz";
-    sha256 = "7603e1c8ef7cb2b492ed69a2f084e65978b63e4c365ae4dccb1abbdbbccf800b";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3b2a5e43a76c801a4709775861a65858de2141916dcef28804affad39b58b89b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "ca8d46c1573640f62d00e419e1a14871d7883d3529874465a3927422274f05e6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "45f86d024897962dc997ceb30cd54455261ab9b4e4e734c58093d77643fc0a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "89b5dfdb457e200aa033b712b72ee03600c1991fa036f1409569c32cba2aaaae";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "a9616d8a8e7825060a4ac65fd52c2ca190e1f2527f502ca29ae38f531139d41f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, osrf-testing-tools-cpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "04b3374dd306a4ec26c498fcd1b4bdfe93ff91448869906d8a0717eb9c4e424e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "fc67d4aace5d708457b2d855a9f6103ed1559d8f6a25509c1c06469468bfdd20";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rcutils ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture rcpputils ];
   propagatedBuildInputs = [ libyaml libyaml-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9259362d43aa7e308814dd8c55a656e19eee78774737019f3ee8ca8f72a6d721";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d411fa7e85ffefc4a15f371af8f7dd4caa013ca111977dc4c4d0ebf3f2097606";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
   propagatedBuildInputs = [ rcl-interfaces rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rmw-dds-common/default.nix
+++ b/distros/foxy/rmw-dds-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-dds-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "678e09398385f0f4714e0ad084b0d8ba016e92a8d508e12bc5ac040e7c392a69";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "654496e63a60cb583415a80dc5858e885d371ed8c0f15f7a90c38f18bdf0a6e8";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common osrf-testing-tools-cpp performance-test-fixture ];
   propagatedBuildInputs = [ rcpputils rcutils rmw rosidl-default-runtime rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "65a3008594cbbf2278aac0a1a02c0557043c45390a53f86a0fb313a8f0135ca7";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7b1bde3656b7569c391cabfea83e63de70d72f9da377fe9147ecfea870201e5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "0c941172952bc660abb5d70f6488cf16118146559a80eba0d24492d5e987d945";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "58eee77968cffb80a3c8513be721aa5722d92c10541537dc4661c07185a8caee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "7845541976c2305f23feaf907c260ba8671e6f8956b1dafb656ee26a7b483393";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "8502eda9ac05734b877d92d1a1385976d965dd78d4668cc1f749c3ddda12d96f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/smac-planner/default.nix
+++ b/distros/foxy/smac-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ceres-solver, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-smac-planner";
+  version = "0.4.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/smac_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c1929d32a3474ce35454aa8f4730d479c95873f4be3e1e0936d5f96641811991";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces ceres-solver eigen eigen3-cmake-module geometry-msgs nav-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util ompl pluginlib rclcpp rclcpp-action rclcpp-lifecycle tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Smac global planning plugin'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/smclib/default.nix
+++ b/distros/foxy/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "72315b444eeba5b8f9bb994e46639aac5999595a3791c32b6081560f73b4d227";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/foxy/teleop-twist-joy/default.nix
+++ b/distros/foxy/teleop-twist-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, joy, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-teleop-twist-joy";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "b9866ff97533ba2da7eb8bd76e5b82098a9e6bf9474ad2c42347e9f0f3f54583";
+    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a1bf57da8fba2b7e13a3754304458ae2153004918e8cb3951119c2ef265ea94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-bond/default.nix
+++ b/distros/foxy/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6efe0513889e9746b3bbf9ee097c9571db5ed14ee99c4e1bd57e3e9cf1420b6d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/v4l2-camera/default.nix
+++ b/distros/foxy/v4l2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-v4l2-camera";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.3.0-1";
-    name = "archive.tar.gz";
-    sha256 = "538e02de489d0117527eddfd7ff342fde67599fdef31386e3d415bb4c69a22a7";
+    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/foxy/v4l2_camera/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "2ec6457368c1c8b639539737d165fe796505c2045d9240fae3173fe451252816";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/bota-device-driver/default.nix
+++ b/distros/kinetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-device-driver";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_device_driver/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "1b63a7554e96846d47bb81312a96b35d755f928b241d590f58d213c01976ab93";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-driver/default.nix
+++ b/distros/kinetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-driver";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_driver/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "e18f568ae442dc4449243e06e03df33e2c724ac1705010e23fa1c34325105d57";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-node/default.nix
+++ b/distros/kinetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-node";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_node/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "25924082df59dcbc3f9918e12f1289699d4d4177e6e9afd22bf3eaa29b63eb38";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-signal-handler/default.nix
+++ b/distros/kinetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-signal-handler";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_signal_handler/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "d2f69772458ce2e1141e985ba2cdfa0784f0928e25b18fc261f905658094053b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-worker/default.nix
+++ b/distros/kinetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-worker";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_worker/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "c35b6236b22e7bff081834041c30854fd51372cb18fa6e546c114eb9b69be688";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/exotica-aico-solver/default.nix
+++ b/distros/kinetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-aico-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "708cf024f510d19ecaec42229977c8c0287c85ef2027e47086504cde469c8f57";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "d8360495cb113062d650b161d7c33c8acb3008b85f80275e09e6977929555e86";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-cartpole-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_cartpole_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "1ecf2db3f075a814ac8479fbca225e4308f131e8877c5249f7204449ac5e798c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_cartpole_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "78b8a7a0330a66e64f6198284b67e5ff191b0ee4917ef56ad0d69c07c2097434";
   };
 
   buildType = "catkin";
+  checkInputs = [ exotica-python ];
   propagatedBuildInputs = [ exotica-core roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-collision-scene-fcl-latest";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "0ee03e0d1f0571c797c13629e4f15b4aba9de9592cd2ded98a0efc0afbab7897";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "caae6bfa90ef8823e73c390c01ed95759ece63a61b1a3cd350a5153ff59d7855";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-core-task-maps/default.nix
+++ b/distros/kinetic/exotica-core-task-maps/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core-task-maps";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "7907f65456f3e72ae98dd38c4169696aea15c8ea453d2220f102b244d522862a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a0cc7f5a034cde25eebf8238004489702f012a8441000c9f6d31d7ed7d49a13b";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen-conversions ];
-  checkInputs = [ rosunit ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/exotica-core/default.nix
+++ b/distros/kinetic/exotica-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "a93f1c3b11b39fefbe92c4817c7bc8463546359ebcde0ae8c5daf1b2c3a6147f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "96b4ded0c23f5b80431540aeda8c670b0c08c85f7e07e7b75b7d9288be01042b";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ddp-solver/default.nix
+++ b/distros/kinetic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ddp-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ddp_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "66b54fb007dd3d00a302b0569b7514722c8fb8e8c6e6bc36563790fdad1cd117";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ddp_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6b9f05d3b942e7aa7f13f8447bcc2cc32a0568c4a91b8ff89d16eda7b56ceb51";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-double-integrator-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_double_integrator_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "41d25fff9a399fe3108f099096adcbc29a1e29e9d002c0e4d63deaee765cc01c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_double_integrator_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "485e452340b37497a1b979408af606b74d15a314e23309dc64e4154ed8f6320d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-dynamics-solvers/default.nix
+++ b/distros/kinetic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-dynamics-solvers";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_dynamics_solvers/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "440c181e1317367a34ca3c637f38473de77c641f30b0b1ff401e2d5527844128";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_dynamics_solvers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "186617055d0d25a98f28bbefc6fcf56771f8e66f02df5851620391c7ae321329";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-examples/default.nix
+++ b/distros/kinetic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-examples";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "029538f988c913bb1975ec8b93158583500199ca91cf7288cc0a8900c0d339d8";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "8b3de23d7772f3c0cb0f561dccc987021b52e5d16e0ecc7f31746ed2287c25df";
   };
 
   buildType = "catkin";
   checkInputs = [ exotica-val-description rostest rosunit ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ik-solver/default.nix
+++ b/distros/kinetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ik-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "6c98b087038486b89e7c314bac2bd996a5aea42be7cd547d833d511a6274e305";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "aefe5708a7e81927ea26ab2c18629788ab6dad1660734d68829fb29f4cec18ff";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Pseudo-inverse unconstrained end-pose solver'';
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/exotica-ilqg-solver/default.nix
+++ b/distros/kinetic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ilqg-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqg_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "a39a0be4c5369350fe70be43e897016107e3eeb0289def87a714b566313d95f3";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqg_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "853a22a708b11b87f6ea058ac2e99a119ef195b6e0ab1159019968ab4686bb81";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ilqr-solver/default.nix
+++ b/distros/kinetic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ilqr-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqr_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "9f35aef66cd7bbb30a10ee3602d2d45c7a8b88f05c27eae242485acb769a658c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqr_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "e255d8808559869e3f2f708456ac7ee09792d1180d4061d65f2beb72b76efd2c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-levenberg-marquardt-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "bf2bb3264c9845bb92067b62c24dd38006c65dca697c550c3b921ace9721349f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "4a647c984725ee95af7d1712fff2242f36c0eac203d6f49d0f6f24ec92e76984";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ompl-control-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ompl-control-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_control_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "aa8804ff9e628307967c4ba20f7f51827732ebce76da472c215c7968e8f595fb";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_control_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "61109ca9373e5163783057afc7c8ae12b9258431c17af4c33c1db29956f6f98e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ompl-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ompl-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "37c5e45f430e8b6fb18a18cdf91931cc6c2d75e629011499187bdb0a47887826";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "297d342d1f53df3943da86288efb9537b6fba84cde3b16ccd9aba89cdb8006f6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-pendulum-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pendulum_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "24148169f2a720e75792fb2627b2a2f843a3bd6b934476a2ec09c804ab51985e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pendulum_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "02eeea5656e447ac7d45b0d3a7b902b289dcdeba09664f47ff5bd65db4696290";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-pinocchio-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pinocchio_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "23b1028add47a816c472fd051c9e950f968488c3c8b601263166a81be1ed2731";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pinocchio_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b8e26f57ed1408395a53c1057999ddad0ea4fc6ff178ded355e6b8dbb600be0a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-quadrotor-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_quadrotor_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "27fd9a8655b8ba1a0890a483f6ae5899fbcbacd6abadef083813e6c795e35995";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_quadrotor_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "239aaa7d181df4d6214a1cdbb2c2be1bb58d699b3c286b9939dbfdfcd153ce15";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-scipy-solver/default.nix
+++ b/distros/kinetic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-scipy-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_scipy_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "16aefbee63612dcae3bf9f777d50ff9aa94983289a9eec850b3072e572ab8096";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_scipy_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "2fe724e6fc62f8314b0870511968ef03610426a9c371dc50884475b00fe488c0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "3a767882cb81ee4def7f1ba2b485efbb62cde4f68591c3a0ac7c0e76308a8b82";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "c57108c094022f9296535dd067ebfeb1706fcf70e169e2d8fbcbf681ca0d2890";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica/default.nix
+++ b/distros/kinetic/exotica/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-kinetic-exotica";
-  version = "5.1.3-r1";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "e1f0b657a45fdc9f1eafb26655f0445ac3bdaec9f884d24f5e5e7f4076e14af0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "91e3a9a4dece9f458e067aab502ca510da4cd9bd704d937be49673bb6ed69ffb";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -250,6 +250,16 @@ self: super: {
 
  bondpy = self.callPackage ./bondpy {};
 
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
+
  brics-actuator = self.callPackage ./brics-actuator {};
 
  calibration = self.callPackage ./calibration {};
@@ -3752,6 +3762,24 @@ self: super: {
 
  rodi-robot = self.callPackage ./rodi-robot {};
 
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
+
  romeo-bringup = self.callPackage ./romeo-bringup {};
 
  romeo-control = self.callPackage ./romeo-control {};
@@ -4719,6 +4747,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
 

--- a/distros/kinetic/map-msgs/default.nix
+++ b/distros/kinetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "d64d8011c9286a5ca31e055bbf201d5fee118e79851feade72e3b6c2faa1b20a";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "1c72c777862d13074551becfefdbfb3a7dfcc01f49d548693652fe25e139ec9a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-core/default.nix
+++ b/distros/kinetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "8718557c17fcd5eebc58aa18cecd379d25e6101834be280fe5bd6a65f61aee22";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "fdf43ee04d2d4c281474cc043895eadbd8cec9dbe0472d668562f94a41caba85";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-nav/default.nix
+++ b/distros/kinetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d1a6023ff353d18d173e9573c6f11bc65d1e783d5481b25b330739a8ab9b6c92";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "ee058a7ee3eb2f763c8d28dd9f3c3ec0e137ce3fcdbd6049433017d05e3df6cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-core/default.nix
+++ b/distros/kinetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "2ac0cafca70b0382f6d8acc0ff604dcd2159bac0963e60fa3c2c081f71f70dd2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "535cb2c281a9fa2054ecf2d3958e9bcebfe68aa4ec888e4a619d7ad9ee5d94bf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-nav/default.nix
+++ b/distros/kinetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a62d70772cc423caf139795d0d59937af0f8bc0cb4c01c828872a4eab13b42ee";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c82132225cab0a9261894e10900b6b787d831e473b39d84b1bfc45800ea6c0e7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-msgs/default.nix
+++ b/distros/kinetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "199b91621dc2a02b1f64d0e0f741433dff511693089400243baa7888bb35f23f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "d653651c01020a083851fdc219b9ccba01fde6477b5de29e7e190b7e31d3c7f3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-simple-nav/default.nix
+++ b/distros/kinetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c92635eba54649772659840a73156a0e5941d464c67cec9d5d45be0854cda626";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a006ba94981a31499333e3e95850c2d05314ba9b6865fe14269664d643bc2498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-utility/default.nix
+++ b/distros/kinetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "81c366c20496f1e1cbb670403bd72cea40be18ee065666ff65bb671a5db8ad66";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a4eb6ff871cac9102f55d117ecfc2406d8d11ce570ccf8c354ba75692e7981ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/message-filters/default.nix
+++ b/distros/kinetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-message-filters";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b663a931c219870a481fbe9b48b1eacc993ade635f29b94b61b5d0cb82545639";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "42b202727458a529debfb19a92b20303873c07b811f4bb5339e1e3f13cc62286";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base-flex/default.nix
+++ b/distros/kinetic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c83c3ec611b59746b6a0722b32d2dfab62de93e878ecab5f92422d4d7d6df6a2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "1f056bd5948e0fbd7051c3392a3235fe30c615a057d96b43cdd47eeb810a781e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/move-base-msgs/default.nix
+++ b/distros/kinetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "6f9cb9261d225727a7e0a9755d8ced29df60668c4a0cb1cb62e474ae0fe307f4";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "8481264739efdc10d67243b1d4039e2759bbb0e143f699e863fa7b8784da14fe";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/kinetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-rc-hand-eye-calibration-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47511b12228e4b9f3db3d4cc3403b47438e8f9c1b8d0eb5682f401356c73b132";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "04f5f5d4552ec09d236fc096d6b6f8da3c9c6647f3dc389a7c486821d94dc650";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-pick-client/default.nix
+++ b/distros/kinetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-pick-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "9ba9b4a4b3c5e3e8199c4985bed15e9aaf4ee4ce6cc8575da641736f24600e41";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b8ddefb6b4020a41ed4f2338730234ecceee51a973bba94b913c3a7cd260bce1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-roi-manager-gui/default.nix
+++ b/distros/kinetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-kinetic-rc-roi-manager-gui";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47190758fd397be16a969cacc66a0128025f69fea08865607312d2ff6c7a597c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ba4f022fc6aaca4fc6de70d261a08837e62618b102628c2cfa3eb2fd4bc5c05d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-silhouettematch-client/default.nix
+++ b/distros/kinetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-silhouettematch-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "ccae73cad1e0bfe9ed24200c12641154c67a018fa18b0421b8d4c3ef875a2eee";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "df817e687d4c0e74f931f726c14eb7fd95c2a08e69319de7cab39734fba0ab3c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-tagdetect-client/default.nix
+++ b/distros/kinetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-tagdetect-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8c6a2864c3ff2280ed11c2ff65ef25574b0024f34597c5f7d26e1c1985aa34f1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c30bbc806b4f8ca80a37c58d99842db1207f7ef4e0b7925138dfd92ad97ce151";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-description/default.nix
+++ b/distros/kinetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "3815b22655e87e2e6aee2d05568a6a35dd037fae7aedf916d811682ab04a093e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "eb081f5b195b4bedf091956caeaf9182af47d62dd12bbc37d6899c27ce9e6345";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-driver/default.nix
+++ b/distros/kinetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4beab502ca2d7346d2f25c5956ce93f702e64ea7419c430187308e0cf7abba62";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "efcf7f218cc8a6fe0f1c718f5e0a9d88fb965dedb4274e142b208e82fdea711c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard/default.nix
+++ b/distros/kinetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "f22f4c519ad2486430735f9812b2373509945ac74922daff2cccd8201eba79e5";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "72fa0c1686ba6b07dbde1482ef556fc1026d971d14dd45db0f6483403bfdfd78";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-bus-manager/default.nix
+++ b/distros/kinetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-bus-manager";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_bus_manager/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "5906fc50b9b8077b40eec36d9c97bbb5e20f5873643ce277d012d9c7892d0df2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-description/default.nix
+++ b/distros/kinetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-description";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_description/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "404af940d22ffdb8d09d3e1925afe38d854108edbb17b5bf2a7325af34ea5117";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-ethercat/default.nix
+++ b/distros/kinetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-ethercat";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_ethercat/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "6eff41322f0a4a1086e23d60b45b55c27e199b3b14ed381b510d2fe30a73ad24";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-examples/default.nix
+++ b/distros/kinetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-examples";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_examples/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "939322393a549710a0a00e4b89c5a7630439171d4ae768f264e80c5902c6ea1f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-factory/default.nix
+++ b/distros/kinetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-factory";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_factory/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "3068d95e235e78d418c5f0485da55d7eba66db90f27592231fc0ffe67fb8c8f1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-manager/default.nix
+++ b/distros/kinetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-manager";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_manager/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "df2c4805a683a85d3d3e26b3f47023e9d55fb283fb45b45ee34af30890801439";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-msgs/default.nix
+++ b/distros/kinetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-msgs";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_msgs/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "6c5ed68eafad7c83b775ef91a7e20e1d8c24910a9c9924b63d7ff01abba33906";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-serial/default.nix
+++ b/distros/kinetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-serial";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_serial/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "10d58f95952661aa172edfbd3c9ce4d5423f0919e9b604fa93035358f5a73c69";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini/default.nix
+++ b/distros/kinetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini";
+  version = "0.5.6-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini/0.5.6-1";
+    name = "archive.tar.gz";
+    sha256 = "100dab027bde760660d57ebb449849e0a54b490cd08e55d578b2b77c89f93d2f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/ros-comm/default.nix
+++ b/distros/kinetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-ros-comm";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "2aaa3d0571eb3986263f6e0dd9382e0f112c0bec937e21fb9c26149fefd4ca6c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "251da3087d8fae49abe732f2ff93252e81487c5d69a96e0c30cb2f3e317efb00";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/kinetic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-snapshot-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ded34f220aa8b9039be8ccbe049fb63d8e0434afbf3046b624ba3bbdb84d94ff";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d868758abb291d3c117e1d8a2e1ba4ec723dce497474678902813f025603ae6b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-snapshot/default.nix
+++ b/distros/kinetic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-snapshot";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "8e6fb5c71485e28f72b6194ba995b5d29e26438cb63567918357443e5b0c6421";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "55ba79bf6f6ec9054caf37e19d3ab4ad70567659c972ebab4a6090bf7bda3459";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-storage/default.nix
+++ b/distros/kinetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, roscpp-serialization, roscpp-traits, roslz4, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-storage";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "376c9d66af3591aa514a400c7a53b2197bafcc41be754e350d951359145b69f3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "cc0ba8c6a13b541381fbf8d9ae6c2e9a9a55b593831891edb6bcf9068d9b5ddc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag/default.nix
+++ b/distros/kinetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "aa3a9ed9ac9ccff11edb69eaac3545ae2b65af37fb478b397e9e3c874e0b787a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "530f841d0d329b6f651b9225017ea62093312ad4072c075f0aef41168254a642";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosconsole/default.nix
+++ b/distros/kinetic/rosconsole/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apr, boost, catkin, cpp-common, log4cxx, rosbuild, rostime, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rosconsole";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "ed0057e2c129ee74a997b5a517ace606bdf47de19e3170a41ad562cd9c57c5dd";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "7fcfa3051aa6fe27c8122015c6af08b7140758fd97c09d511dce4641b1c76cc7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roscpp/default.nix
+++ b/distros/kinetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-roscpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f486ed35e076e0950e9192a41a6cbfdc1c4bff7c25fb1134b08c0ab21c1ec2f0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "3676973d3e564c8590477cc2a005cac81c7b02f25b28ec4782186b0cde559b7c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosgraph/default.nix
+++ b/distros/kinetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-rosgraph";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "c2403dd9523387fa99f64924a7681e5653aad8e3e5a14d389133c5ded64667b4";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "43d6fb781882e5ce71345e15bf1be32457b270f7a229ff5ea1c00131679f58d7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslaunch/default.nix
+++ b/distros/kinetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslaunch";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "41a3913f4871c4c647c57cee5fb652a42a8fc81ca2af83b89321300284f5a35e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0e0f9367d3c13023fdd21bb26657fc5beeb09513a4c0b5462c9110c5cd9fc9d0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslz4/default.nix
+++ b/distros/kinetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslz4";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f4fd030bfd5bf613e39effa52042f4c8f615a22b84b2df515c3b4873c96f5e41";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0f55a2821108febf725792be25966bb0136d05bc80f00311225a58f819a6c892";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmaster/default.nix
+++ b/distros/kinetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosmaster";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "eed057b191aeb2e53bf963a0d32ebf6ee435aaa23309983a1da45d27c05aafe2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "273a3094b53b3aa0b542b76b69dc84fd482b99b670c36f461eccb14d92e3fb50";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmsg/default.nix
+++ b/distros/kinetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosmsg";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f0907cd996fe008658d3af3d5aba6747dda30767d03fb632a2e7b82c873be5d9";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d03ec9630f58015d7e5f536ef33b33ce6c773a95c36c3050c25c7e3cfc9aabad";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosnode/default.nix
+++ b/distros/kinetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-kinetic-rosnode";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "22cda46d4b51c01b9b2cc5031c8fec64fded6d31b42714cad976139790730c80";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "2bd70bb657e006be43dd5996a9dd9027122e927dd9f14147292b898fc653269e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosout/default.nix
+++ b/distros/kinetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosout";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b4a408241eca12ffd691882ecb1ef000a76cbf6b3b78fa684d2430c097ae8352";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "aa10e2e8cf9e8fcc57f5f90ac992c96c82c39c5b8762d6c05582ed77bd7f16c6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosparam/default.nix
+++ b/distros/kinetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosparam";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "da21cbd9ee89c39080c3496b6defae95794394fe1378ab07d0ec2b9241f20d97";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "1d6f465d685db5286520afa2e74445e97a003552dea0a8bba54133953b384498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy-message-converter/default.nix
+++ b/distros/kinetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "8b0bca7ee697ad4812e674546407c24f07aed5f99566a9099b8b54df596cb352";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "b408446cb6167cb0c3d83ea8cec046971ac82ad84a81baa55057d3f12c094661";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy/default.nix
+++ b/distros/kinetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "a2d1d4bc6febc71e6daa05db982986063e7368483e797726577f0540c314ace7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "08a7e7c2dba29eb5e821d960233dd9bd2a9ed650cfa568acfdeaeb5eeb904d2e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosservice/default.nix
+++ b/distros/kinetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosservice";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f51d308e5ad0688f4b4e631745811b1306d1ced1d2a6386460f7d18fac108b44";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "854047e943366c00b162f55342c562daa82bb1f7f5f5ada34ff89929e929c252";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostest/default.nix
+++ b/distros/kinetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rostest";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "5c1ca6cd4f8be7d98b2ae2cea4d097c4a9c4f6b6ddc1a9162bb767b14f6a3e88";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "c25f1c491dcbaef71ee2c50b15c2b1feb8256511125818b82930a88769bc4e65";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostopic/default.nix
+++ b/distros/kinetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rostopic";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "d50a05c221c96e851759689c33da4c8698bf95b8e30a3f35509f365e8be8b6fe";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d476ccbc28d1276969c34af68b09ac65dcabf82ae8e81b798f6ea0ed90df27e9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roswtf/default.nix
+++ b/distros/kinetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbuild, rosgraph, roslaunch, roslib, rosnode, rosservice, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-roswtf";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "cefe1aeb678d9c0447a33c062a253164ec6e4c09f49470a5f37409d81454e1d3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "a184de1c25849b152acfb9a5fc9da9d1a65664b3a4b4a97d5a6941d975d8a7cc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/seed-smartactuator-sdk/default.nix
+++ b/distros/kinetic/seed-smartactuator-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-seed-smartactuator-sdk";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/seed-solutions/seed_smartactuator_sdk-release/archive/release/kinetic/seed_smartactuator_sdk/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "e929721fb71d738544622d61a33a4947283d215c72b3960d8e5f6d2a1518fb85";
+    url = "https://github.com/seed-solutions/seed_smartactuator_sdk-release/archive/release/kinetic/seed_smartactuator_sdk/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "147e8a0b76d3431fb6e657f5afdd8bb272aa45b541595829fa90ab8933201258";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/topic-tools/default.nix
+++ b/distros/kinetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-topic-tools";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "bfc3b7d5a7f42477bf02ab820ebdef837b2fb39f380c5f86ee199f2fc7df0798";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "89803ace2dd64ef62103b869e1e650c73782c972305f72199e1bb9e6f38e273e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-bringup/default.nix
+++ b/distros/kinetic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "8c4b5e2c9388accb1f26364fd706db0ece583098e4460025b8d78a2957c74e03";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/toposens-description/default.nix
+++ b/distros/kinetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-description";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c3f84919a724591f6579e30ece912171d4115a9a0ce7233cf605c54933f8bf5c";
+    sha256 = "f8c3b276441692895e4cde86bded0b18d200ee466067898ff13e37c5bf10210b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-driver/default.nix
+++ b/distros/kinetic/toposens-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs, turtlebot3-bringup }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-driver";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "cb5fe3da603f34d57d1f69150f255490e0a86ed64af9e85ef22965544a06328b";
+    sha256 = "91ba54fcbf9cbdf7485b5c99cf7d448a139365f4835616629019f8578cf26fc5";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy toposens-msgs turtlebot3-bringup ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-markers/default.nix
+++ b/distros/kinetic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-markers";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "4e1f41ee78d30ccf6a0dbb7a6a83f51b8e734ac14a89d522c922050780bdb560";
+    sha256 = "f6ae455663166bb99aacd30142a288bd82a5f9eee69fdf891c7379d5e77d7f95";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy rviz rviz-visual-tools toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-msgs/default.nix
+++ b/distros/kinetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-msgs";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "eadedf6fd2676fa2321ab0650ea89283865b8647dfcd9a10c45770c4fb5e20d4";
+    sha256 = "cdb2290d521b9868889cbdde38df76f74d7c6f6f17a2864164cac6ba946afd0e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-pointcloud/default.nix
+++ b/distros/kinetic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, robot-state-publisher, roscpp, roslaunch, rospy, rostest, rviz, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, turtlebot3-teleop, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-pointcloud";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "f8d0e200492ef0209a9b61ed19b370dbcdf34c75ed9e32f22b4b020f309007d3";
+    sha256 = "740c24224e2254fddfb065089704c834ed42867a6e60286debd82eb811df9e54";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros robot-state-publisher roscpp rospy rviz tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs turtlebot3-teleop visualization-msgs xacro ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-sync/default.nix
+++ b/distros/kinetic/toposens-sync/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-sync";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c22660383dfbb7f66853c2d4ed497f635bbd454dfaf63050399c726290719122";
+    sha256 = "41f8942e434f8575d6769c93843559629a213ae1cd546c796bf894df772f6aa8";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens/default.nix
+++ b/distros/kinetic/toposens/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-kinetic-toposens";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "5cc78eb7e78010a819d5646c8f21bff639d1d076f159a28302092d600b706184";
+    sha256 = "a18227cb76e4490b0a427fdd8047124afa4439d878260c259db696634c213637";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "0bc507ce57d98ea3741301823fc5db80f521187f589944ea29d83bffe6b184d0";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "cf63043059b2420247180260ce9263e3610be901b8fdd7581d4349956c8f78ae";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/xmlrpcpp/default.nix
+++ b/distros/kinetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-xmlrpcpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "fb662c176ae22ba7aba147004f7586b4233afad433d3b3e9906624da9dadd835";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "65f58f680412c96e177aeaf6a287b6817861394dfa426e05eac72bcad0349d69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-device-driver/default.nix
+++ b/distros/melodic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-bota-device-driver";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "4c380c66060b6f55a15dfac4f933dc7d98880761dd35c2681dc31eaf432eb7b1";
+    sha256 = "15ce8533cb7add411d82d2e1856461582fd6a0fe32145e895770300fe9b0b0ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "d995592d9c8d88918dfe61f23bae9881ed99cfd7011235578ed6a875ad89cbe3";
+    sha256 = "915e93ba3f9c40de9f999bdf9c4a282faa8281e52a69fefc6c9903ee0046f635";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "6503b36a33795aded7042790d7e2fc8aae390819aac35da353816892c6b17110";
+    sha256 = "92fad314711e13eb4d69ed2fc7bf47c2505ea2400866a5e8ba4ca5545ec5b1e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "ee701a44c3c122d5ea4168b5698bcb012a1d093c7aec68129b6ed00495d94d39";
+    sha256 = "86b31d57dea2cbf0e42fdf2d764b363a9353ae9ceb88a47b436ffec61c7dccc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "103602543e1798a2d1d7a11c9ae5808cbd0f00b23e568d70970160a4451919e0";
+    sha256 = "b4b06344682e04cefaa328d020b5e6748b01c40b09ac79a40872ac4d5736c0e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "42da85876c5670d83380035aeeb209f61dafdd55d2f92639fd0290304e6ef8d3";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "b95e6a1b69a60017158c5016ede4e437a00794d359312b9131d063fd97c13132";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "1f31578a0f23b34d0fee3b20e56225e852afaf968e89021c3544e31507fe64ce";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "354bfc89159892347217515c553e8d5efa73848adaca75d6028a1d868f287661";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b3ad6906fdec43788e2f4a0ffdfa3fc9e0950efb4926c5d0b497273f3f7be862";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "2cd473c0658237f414c248d4e7b788a36d9d8873b4d04cf6a2df7b382c70e976";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8ff41f9b66008c30207f6af85368c4e90b457a5da13df0d35df52098b5ad4cb0";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e2f9df40b800630d5bb9c34708e5eebbf915947bbf4b65538ce806a42137412d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "39cfa431d55b8d9852dfd0d2e3d4eea53e439fa95cb0f092a7458f747fba2632";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "185888c588219301fb357ed384eb4994c44023bbcbbe3321087d0ba5f5af2e88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "b6782b0e0cde5a78e3cf468e40a70e95136db336ab2a89f154288362d93fb25c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6cc00eeaf2288d34744064b57be0e8ddb679ab68bfe651f310fdf65e2817eaca";
   };
 
   buildType = "catkin";
+  checkInputs = [ exotica-python ];
   propagatedBuildInputs = [ exotica-core roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "d3b03d6778e8ab4e509245977fd1703bc9ffaddb66f5ffc2c5e6e23b6d172b3f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a8e70b1d43ad3f4036a1d8279616877d2b6b6c22cf2b48dc9ee6b99298ac3497";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "cb9230100c4a7a2f0ccb68b713bc5cecf570beb887025b18943353fac54515db";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "75e62e07272caa34d2e0dbf0c86a76aa24039eaa66f59e70f7556a3dc85ad347";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen-conversions ];
-  checkInputs = [ rosunit ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "3df8d716a7d34a58746962a1c7229bce9455bebd0246de0e9a49be628d28303f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "23ab85adf28c31786e34e5354300bdcdff0370ccc3574724f5419473fefbc00e";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "1fcf2a9fb9871aaf86e29a4cf1ba2981a780d3ba9cdb6cb1406f29e12ead952a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "bcc1db77ba896033fc553f413645e4885d8b163402231cf1fc91764fa88c889b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "78ca9fe0345fbb35ebd6a2d5579c9c8ab518d58d2f92ba0ee4d779c887f30f01";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "4b48c49e099a8a79a13cfee1dda845b2b7cec5a65f9b299be6a7ddfbf9983c4d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "9df5028b2245caf4045ae4f1da68b3eaf2582b6df67417a1b6f0226290814b4a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ff879be3a92c833cd74a6f339ec3c28cbd94f958a48c80b88e5deb3f2ed3090e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "d9d221cafa1290cde1c8d9e285cd7a1793d7fcd23eff5b59a074907c033ee295";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ece29106ebf0a4e050bb1c1139acd1229ceda94781037182d0c3ebb3f703157f";
   };
 
   buildType = "catkin";
   checkInputs = [ exotica-val-description rostest rosunit ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8999b2bcbb97a6cc6ebc5b0e3b5ff8b28d154a11d86d79cefad8512a9bc97a1f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "e0a286426c0eb0ec1009ab76bcda34f46774c6048a9749ecb5decae018290f7c";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Pseudo-inverse unconstrained end-pose solver'';
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "15d310fba58eb7eb7d766585210654a94c08282b723489e1c8867c8b7750075e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "2fadb114792c676d0da60f959dec596a75dbf59db1e56b28cd03b15bab6c9c83";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "e5a0298a4a186bbe0d60b03c6dd7412457061955e9265c1c85b5d680079d6859";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dd24747a2e73fded78b640d682e946fcb7d0794a4b32e4b1be7dfba846cd181a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "2782ec425a5659acb31d3492e8999a765fd7654e35b2fd41361018e0e58587c6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b13b9c12f8257e8df3b5f27987bb429b7f8cf40e408a39009ea2b3a91b6d246f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "93d0a10086b45bb8a3d761b09408eb1b3428c68c9c5e9ced735df3e34b67fc27";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b355f1956cdd378aa722bde736f08d3d193811d3d5c03753591d3094a7f7aa91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "692432ad32c66690874b48d3fbb721c192e87664f38ce20263e17a593703190c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "317748c85c76ac619e91b886d05d3db27d20c5cbf44408eb90c60042d1b3c356";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8203597e8d8b34785c89db31621d949d964a1a4692c85a7c0aac39b89c089186";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "e552cd01f7ae31c86e4b0aea41e196300f01bf861d57e9c5591ad9ea213b0e9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "9a7ec88e3788da0ea147ce0d7eb2ee4c4bbd7fd3de6eaf9ac3796f18fb6dc5c9";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "467d5c5f247efe1c1925e77302fb200678f532bab5da50de8d165db59482d8a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "542fde5cde5a4465137774f6cf527950109d670672971d690e89fbf4e65ccf9f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dc8d2df841550cde9237f892004ad4182595c64b9eb142d5329176c5f0102509";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8fb8a94b7adea8edc0f68b6574abb48089fed5b02551a040fa7dc0d1cab585c0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "62180a4a1169e70c6cfed7dd5879776b423cf47c15914d4309a4c6ed564ab43c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "738b1d76c6ace5a5385eef6bddcf758f58a1c7d066e9dd2daca20d35687c59f4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "3a849b661885b5c7d846bbfc08d34924ee1635c125027eed742383cf0e9283b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "a743c4a29edc8eb2f269cf4f39b7a0795998a58ba971e512610ea87c0a3b5efa";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "51329f641b9ab7dfa9be74dc0b943aa7d7cde16198ab78a8ccb28e6a7ca13f34";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/extest/default.nix
+++ b/distros/melodic/extest/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-extest";
+  version = "0.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/nakakura/extest-release/archive/release/melodic/extest/0.0.1-3.tar.gz";
+    name = "0.0.1-3.tar.gz";
+    sha256 = "a202e4d5ded9ed92f2216397014a057b72eb2e86411305045deda791a00dec66";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Hello World with rosrust'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "750fbb51252fba2e6705d6a180fde509cf1907cc9770898ba61172e7f9275614";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b9d68a934b7729c3b519eb66126eda7e61b6237a1f96cec651b983f8e9bd4e93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "0a3d7a6220a9fcfecdf31ce7463934bc8515a1bc4fc307dc811369d9e76b3a84";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b765c7e0ec121d981ac2f6a9b91599cad5db173b9d8ad6d64b50f1a53f559d59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -902,6 +902,8 @@ self: super: {
 
  exotica-val-description = self.callPackage ./exotica-val-description {};
 
+ extest = self.callPackage ./extest {};
+
  face-detector = self.callPackage ./face-detector {};
 
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
@@ -2900,6 +2902,8 @@ self: super: {
 
  robotis-manipulator = self.callPackage ./robotis-manipulator {};
 
+ robotont-description = self.callPackage ./robotont-description {};
+
  rocon-app-manager-msgs = self.callPackage ./rocon-app-manager-msgs {};
 
  rocon-bubble-icons = self.callPackage ./rocon-bubble-icons {};
@@ -3183,6 +3187,8 @@ self: super: {
  rostate-machine = self.callPackage ./rostate-machine {};
 
  rostest = self.callPackage ./rostest {};
+
+ rostest-node-interface-validation = self.callPackage ./rostest-node-interface-validation {};
 
  rosthrottle = self.callPackage ./rosthrottle {};
 
@@ -3653,6 +3659,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
 

--- a/distros/melodic/jackal-gazebo/default.nix
+++ b/distros/melodic/jackal-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, jackal-control, jackal-description, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-jackal-gazebo";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "8364a4349df4bc2d6bed5c7c2d0e7dc1f1baf5ff6e9669b138ab9a3d785cdcd7";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "202c29adfd750e5043f10171294ca27c0a310aa44a99ea46afebbc269ec9bbef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-simulator/default.nix
+++ b/distros/melodic/jackal-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jackal-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-jackal-simulator";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "e9e14150e70e7c51cd6fa674af8c0bae82aedd156e8bf0019774448d6b1a915a";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "adf0d04519d339a355293cb30113435a4a4575adc65b4690681977ed1e4b900f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-msgs/default.nix
+++ b/distros/melodic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a0b7044c2fd59448eb714ce14d60c5ff2d0073962e011e6549c7dd99fc916ffc";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f9258be961e164b60e94b10e2965dc703d8614d360645717d099b40c2ea71de0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-core/default.nix
+++ b/distros/melodic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "59edfe99fab5417c478bbe7adbe2082191898ae7f486e1b39339d580f882fc09";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a696a873e440ea24e136cef9b9d45a4db16d8d57ebc47011cdc8b79449d08082";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-nav/default.nix
+++ b/distros/melodic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "34c8bc49b61b4bfbdf54badb5ac8901819a389f181e13abe7f12719b87e9f284";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "d0ed780f0b9a18312ce1ba5ae676bcb06e4bb8c3518577ea4fb2ee80e7797f2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-core/default.nix
+++ b/distros/melodic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ab6a7064b0169cfe4c61611dc36bc0c7f887fe232819872ea3547c0746496d62";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c82a471481fe829a900c96c633b5f5957824ca4e82a2a2768f569be75fc6249b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-nav/default.nix
+++ b/distros/melodic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "0605b881744f00116a3fe4c1a2a8d4620288e2229bc492c1fee448f3df56e05f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c007af4116e035165fbad6724da6a6823417b188127e2c2613d035e667ea5beb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-msgs/default.nix
+++ b/distros/melodic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "80181a8a4b0eb59ec113ff61ece66c6fdd2d58e652cc299a023b59257b2f2c52";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "dd3643142b07d929a1badaa271fefdb78b322628d86beaedf2d9ede9b27ac1e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-simple-nav/default.nix
+++ b/distros/melodic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "f09d2300a7f151743be743a8ed38a69ee9c856cec9277d9d1969a796b3c6db97";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "49f7277cbc1dd9285a0ddf36689b2d0230c101e9cd8822aef40d8eb5e837c810";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-utility/default.nix
+++ b/distros/melodic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "19d944f0d4cce88d7d9f481c45287e83164496d1836346bdae868c055e5b926d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "99201d09d272fd06ea04b04f9a3f7413be3fae46497fd0c930f87d474ffe2f14";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base-flex/default.nix
+++ b/distros/melodic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-melodic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6d3674af1d438357a5e6b236a28995a77a5f7c324abac3b51d7f8d0cc610ba0b";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "b60e1d7a80952be12ad6b6d56b060346a422120413282745f0a819b76e675a40";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/move-base-msgs/default.nix
+++ b/distros/melodic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a9b1ee115c3252718a9915a94ba16421a39309ed237a33d790f486d468f8a1ef";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f221272c2819180557e5c21b79dd30f34d9ac83503595c6132f9fecc7b48cfcc";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/open-karto/default.nix
+++ b/distros/melodic/open-karto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-melodic-open-karto";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "1e6c4eb4da8553c8f14b62ec29b1fa0ec2eaf88edce2b75c668ebda566e6e27c";
+    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "9441edebe6265db0419ca9fca4e85578413ff700953145d4d22fe8d2202a0c92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, robot-state-publisher, rosconsole-bridge, roscpp, rosfmt, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, rosfmt, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "24789bb519f88eb2f18b97f400e19886c6843409e7acfead8821993eae2ed29c";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "c01af2f67a442b3ae098cc3ad159de1a7cd66480d19d09205d06d16c525fcff8";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage pilz-testutils roslaunch rostest rosunit ];
+  checkInputs = [ code-coverage pilz-testutils rosbag roslaunch rostest rosunit ];
   propagatedBuildInputs = [ robot-state-publisher rosconsole-bridge roscpp rosfmt roslaunch rviz sensor-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "8aa932a83ec1488c67647070770efd2241c5c652f44aa9b7dd76bc1e34182b4a";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f7ad438cebdd4c0e631471ff463aee3afd4a53fe69cbd662c78c99be29b3aaca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "0f1548a3bcd88d07310993c9f28dead1bce7eaca3590986a6959a58968ba6f90";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "d705f4093051c90fef5837cf427685444bf5d3c4a17aada13efb9b4f2211ea56";
   };
 
   buildType = "catkin";
-  buildInputs = [ gflags ];
   checkInputs = [ code-coverage ];
-  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/robotont-description/default.nix
+++ b/distros/melodic/robotont-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-robotont-description";
+  version = "0.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotont-release/robotont_description-release/archive/release/melodic/robotont_description/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "d95ec61d0bfab76ba98bdf48cf9f7b5f0104e28252a6964fbdee9fb9a008f2a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robotont_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "3c40927408692de41673af26c9b169add09cf59c77194c8c71e55da1a81d8b7d";
+    sha256 = "f864ab82bd5881d4e5507458dfe434703044f7005d00b7cc7756c6b1bae7a7bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "ae0f59984ef20e956f46873589426e2383d00299dbef87e415004affb6b4a070";
+    sha256 = "9bc426ff33694bf992b7fd28f21b5fc9c85f64d48fbed54871102d175e788f18";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "0f6e9943bd52948738862d00b37c7f12f37c3ea2f40c576f910c3b433eac2b89";
+    sha256 = "5ba1fa20abf054b0cdeaf2e4c4d5c8dad37efd2b036857daa3d9af4e82358cd9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-examples/default.nix
+++ b/distros/melodic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-examples";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "ece58bf00b38d219cbf07b66a9573d29298e3277ee4e81d46fca595076273e37";
+    sha256 = "99cfcb70d5f3fc90d9154256f57429920e541bbbddaf3d3240a9146d98ef841c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-factory/default.nix
+++ b/distros/melodic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-factory";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "d23777994e6ad6ce71c7c2c7a21be08bfea3c0ce0da6fe73a2824d4d5f85e93a";
+    sha256 = "e9b37d2ec7ff3f415bdf63c35396a6f2a3233f1f1cd26a56adf4192c77f515d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-manager/default.nix
+++ b/distros/melodic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-manager";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "83eb2b0545da49e0c78cbd8583b9f13fcab9f9293f78e7e86eb387464db0df63";
+    sha256 = "fe58c73f4be04765232bdc61e618b6e01587519e3788e9a2f544d4cffb88be29";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "b76bdddd1b353b057f96e6f588b1e0deeeef882a8f2a4321407c71f7e120cf55";
+    sha256 = "3a5d31d2a02a98b8451b4cd239e480126f49d2bfca15fef29d879ea0b23e5404";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "17e9d3302bbe0477177d6b2bb425b213e5de4d9af19baf2f730b34eca7315a52";
+    sha256 = "dd895c27531382b5f5a282b3ae32c508861236810a87fb537b8036bc7d989689";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.2-r2";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.7-1";
     name = "archive.tar.gz";
-    sha256 = "0b740616a3aa3f6b55a8f2ff5a614b6a1cd96dd6d35b52888457d04b648ac537";
+    sha256 = "13b699fa6a8ecdf35727f0b8662c7140b96477a6781f87ae8ab809d349fcc0de";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbag-snapshot-msgs/default.nix
+++ b/distros/melodic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "3d5c6a3fafa000c6cd9619405354dbde5bf1440749bb730db9c32cad581e0994";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7dfcfda926b100b95b36509fd0e05e2988d23fcdde8f2c116802da67d96c4bc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-snapshot/default.nix
+++ b/distros/melodic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "15bc7f1085ad63e259c0843d9d901ae9207707ebf5e4e7ac248bf6f6613d4ae6";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1e6ebfa8f2773794f99a2379a42b9ca80ad6aea174b24626f6f5a32044f3c23a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "02ab2ca86f2b1ef188676a3c5d2133813f883b0f0fc43d90a27785e3200a7b20";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "051cb5fcc3c00598cf4c225e77bf6a71a14bda79bd90376c305e7a7921eb9dd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostest-node-interface-validation/default.nix
+++ b/distros/melodic/rostest-node-interface-validation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rospy-message-converter, rosservice, rostest, rostopic, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-rostest-node-interface-validation";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation-release/archive/release/melodic/rostest_node_interface_validation/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "04d36f1346f96b88c4bcbece65fa1917697ffc129132adf4a307e8bd44dc18dc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest std-srvs ];
+  propagatedBuildInputs = [ rospy rospy-message-converter rosservice rostopic ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Additiional testing tools at node level'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/toposens-bringup/default.nix
+++ b/distros/melodic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "8070e4fc87ea31059e71d41c0961b6ab39ef6feed24b667207c3a9d8a5e44d66";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/toposens-description/default.nix
+++ b/distros/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "9449bf971c63000bcf088ece79703def3d1cd7189b4c19e4b872e56556389000";
+    sha256 = "1bd77a491c96473f5a1bb563090149c58c421324891f14a3681fc3103e0e553e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-driver/default.nix
+++ b/distros/melodic/toposens-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs, turtlebot3-bringup }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c85f8b7bb6cd4fbf18fbc15a9602d2e4098310a632d56e2be1a8e6de54dfaab1";
+    sha256 = "fa52fa15587860d0f954e2da53460251dd6f788bf7e696bf46f9ac8ed9f2b334";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy toposens-msgs turtlebot3-bringup ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-markers/default.nix
+++ b/distros/melodic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "135dd96e3468ab3caf9e08a9e0cd8cc7cf93070c075aed26f1e8ec18b270de6b";
+    sha256 = "caa8dc40b5a17cd9f98149587ef3afeb0191599c4cf0aa5ef2bd5beaeb9cafa6";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy rviz rviz-visual-tools toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-msgs/default.nix
+++ b/distros/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "77964b3ea4262c128f14a4f6ffb5e0fbb525f0e15bd73cb598471daa9b9640a4";
+    sha256 = "e74ec8411e4507b36e9cf326903e425c90f4b02e24541d39bb30980ad9b15730";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-pointcloud/default.nix
+++ b/distros/melodic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, robot-state-publisher, roscpp, roslaunch, rospy, rostest, rviz, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, turtlebot3-teleop, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "f534b81233f4e2fd347254c66cfd16d52e028c2ef5a1fbf17f47560bd8c75461";
+    sha256 = "d720d6d42394732c5d894e904bed47a21b3b04cf5bd3faed434e661105e9bad0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros robot-state-publisher roscpp rospy rviz tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs turtlebot3-teleop visualization-msgs xacro ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-sync/default.nix
+++ b/distros/melodic/toposens-sync/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "34473cd0343a4ecfd449d11e7440e3bc0bbfcaadef3980429cf91b43db06e4eb";
+    sha256 = "449c7fbdc4adefc79797eb9a74f9c2a86daae76a9a5e365872bdc056adcbec65";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens/default.nix
+++ b/distros/melodic/toposens/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "6dc77e60003b588730aff6d6fd8e38d95ae946e85dcb066ff61ba60b4f4c7be0";
+    sha256 = "703e1844de02b4ebaa27df9a4f71822c1848d00cf9e3ae62e7f970a81867c50a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/autoware-can-msgs/default.nix
+++ b/distros/noetic/autoware-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-can-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_can_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f7b4868e4fb6ce3d591b53a3f9e744e9a1a3194ccba26b63dc4540ad5491f0b3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_can_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-config-msgs/default.nix
+++ b/distros/noetic/autoware-config-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-config-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_config_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "eafaea3c8e37f57ddb46a1f4b9cb3152ba49dec22a3cf4b13e538c70c2947ccf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_config_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-external-msgs/default.nix
+++ b/distros/noetic/autoware-external-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lgsvl-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-external-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_external_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "9e46e8c0fb4b274a632a42d058fe1b33b556a809f602ec8a9567c468c719b2a6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lgsvl-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package to contain an install external message dependencies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-lanelet2-msgs/default.nix
+++ b/distros/noetic/autoware-lanelet2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-lanelet2-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "fa2a058aa23ed50120b0e7ac33a75dfe637ea301578124929ab0126de9f61f43";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_lanelet2_msgs package. Contains messages for lanelet2 maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-map-msgs/default.nix
+++ b/distros/noetic/autoware-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "dfea163b4bd892c5a7cbd519885e309449e6a0f21fe088bd91ce9836b0b68247";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Includes messages to handle each class in Autoware Map Format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-msgs/default.nix
+++ b/distros/noetic/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, jsk-recognition-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f445a6713e8764e34e58f34fc1f8ad56637b3699546b7912baba2cd05c7b31ee";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs jsk-recognition-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-system-msgs/default.nix
+++ b/distros/noetic/autoware-system-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-system-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_system_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "7bc5e114a49f6224db2da7cba91ce2e05baf589858391e1366616066a8ded740";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosgraph-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_system_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/backward-ros/default.nix
+++ b/distros/noetic/backward-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, elfutils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-backward-ros";
+  version = "0.1.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/backward_ros-release/archive/release/noetic/backward_ros/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "64789ad4703518a057483120d2df9ef2780f4f4436e1752311bd62e46368309c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ elfutils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The backward_ros package is a ros wrapper of backward-cpp from https://github.com/bombela/backward-cpp'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/bota-device-driver/default.nix
+++ b/distros/noetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-bota-device-driver";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_device_driver/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "32a445c312f5a9060dcfd973022f856aaea4e1588d58369dd6e8c12c904d31c5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-bota-driver";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_driver/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "da4060aaca6e752bb9a781cde7fb8db5c65f043f7e69e7c1aff35f6a4f396cae";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-node";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_node/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "6e6356e1ea652a7c6481afd7dca911617cd0ebdbe9346ffa39a6178109c8a369";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-signal-handler";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_signal_handler/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "2a78e6f6be821f29b148f1b280c5ec8a1e643532e6b3ed7d1495ca4e217258fb";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-worker";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_worker/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "64817e86a64272ff6c0366ad8979f84e4b6ceebf47371570d493f4ca771bdd4c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/code-coverage/default.nix
+++ b/distros/noetic/code-coverage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-code-coverage";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8cd4d5c421532b7b8bb57563cd3cbbf6fd5edce3830da323f18b72d0a9bd9a1f";
+    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "9b9a65c55bcf50a7a90c55a13d0376e59aa1d331a6a2ae75d1c452caa9cb03f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ddynamic-reconfigure-python/default.nix
+++ b/distros/noetic/ddynamic-reconfigure-python/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ddynamic-reconfigure-python";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure_python-release/archive/release/noetic/ddynamic_reconfigure_python/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b99b19d692984bb83a34afb74dbe92b3d4e7bde5e89afd47cacbc57e3963df5a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ddynamic_reconfigure_python package contains
+    a class to instantiate dynamic reconfigure servers on the fly
+    registering variables'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-aico-solver/default.nix
+++ b/distros/noetic/exotica-aico-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-aico-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "babad9a7bc81d4de08fe0863e4693fd2b43f1835fb8935c02fc4dd8a042a2d51";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of the Approximate Inference Control algorithm (AICO)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-cartpole-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a19d6c63cb7f91a8003f8bdae0f096f971c406bfe85c14c467922f32a71d9b6d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ exotica-python ];
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartpole dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-collision-scene-fcl-latest";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6a068dd35a2b865d83803b9743c2a10b8d4db856bff6bff828e98defda07573c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core fcl-catkin geometric-shapes ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Collision checking and distance computation using the latest version of the FCL library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-core-task-maps/default.nix
+++ b/distros/noetic/exotica-core-task-maps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-core-task-maps";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ac1b5a19508c57b345a794abaa701c48ae163511db3bf51bbaaaf7f1f23715a2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
+  propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Common taskmaps provided with EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-core/default.nix
+++ b/distros/noetic/exotica-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-core";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dbceb5d9bb097357508a127b29c19bb06d100aea401434317d7af68cf3b731cf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Extensible Optimization Toolset (EXOTica) is a library for defining problems for robot motion planning.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ddp-solver/default.nix
+++ b/distros/noetic/exotica-ddp-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ddp-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "752cd837531b317dbea29065f8a1f2f4fbac7e294ada4f3a3e649c3f72f3d869";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various DDP Solvers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-double-integrator-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "14985f8c402c30ce483b4841f92783717767004bb13081420127b86f3d6d6c31";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Double integrator dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-dynamics-solvers/default.nix
+++ b/distros/noetic/exotica-dynamics-solvers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-dynamics-solvers";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "04f1a58969af8a3b73737000d720d20d36cd5e3c1e478fdb6c1c17112506333e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-cartpole-dynamics-solver exotica-double-integrator-dynamics-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-quadrotor-dynamics-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for all dynamics solvers bundled with core EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-examples/default.nix
+++ b/distros/noetic/exotica-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python3Packages, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-examples";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a5be687d3f439d47fe2c1f25da58f45332f4ecd8c97ddcb5edb8116601c1b02c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ exotica-val-description rostest rosunit ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python3Packages.pykdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package containing examples and system tests for EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ik-solver/default.nix
+++ b/distros/noetic/exotica-ik-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ik-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "f4f57db036fda82b40aab770293214b7469dde20ccf07e00fe36d87631b018c2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ilqg-solver/default.nix
+++ b/distros/noetic/exotica-ilqg-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ilqg-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ade567828ea1045ec1eb7e5e068563d8abfcb50e24101bef6cf6fc88e018890e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQG Solver (Todorov and Li, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ilqr-solver/default.nix
+++ b/distros/noetic/exotica-ilqr-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ilqr-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "5682e03d18233d0b722f4c92e1d658694408da476d12ea094bc0628c9ca2deef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQR Solver (Li and Todorov, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-levenberg-marquardt-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "d6ec17486e0ff0917b9a58441c5b6d02fbebaee63c29f1939b1a3bfdc5c04d93";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Levenberg-Marquardt solver for EXOTica'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/exotica-ompl-control-solver/default.nix
+++ b/distros/noetic/exotica-ompl-control-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ompl-control-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "4c962316ab3e0e3d4a676a58019d2e43c13a227b327d6fd47cfb09ec46ed3c28";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Kinodynamic Control Solvers from OMPL'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ompl-solver/default.nix
+++ b/distros/noetic/exotica-ompl-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ompl-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "78769d3f5e6521fa2985ac14177a57c344f7a5935c2732e3456c3c15c6ca5692";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Exotica solvers based on the Open Motion Planning Libary (OMPL)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-pendulum-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "1bd6b0c394c65b493db0b40dd99bae5e2c6e989ecef1a179886dc9079131cf85";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Pendulum dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-pinocchio-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ee8b73f8c05508acd87e7e9e8d1f94b810e9661cd9a1483cd94a67239a83ff67";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Dynamics solver plug-in using Pinocchio for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-quadrotor-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "455dc38180053f01302690816d9c5750f38eade007d65067411da03b6b7dccef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Quadrotor dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-scipy-solver/default.nix
+++ b/distros/noetic/exotica-scipy-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-scipy-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "5475439a6d874f0a093c9e84c4ee975fcc54ca25bb19eb9caca140822cdfc72d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core python3Packages.numpy python3Packages.scipy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''SciPy-based Python solvers for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-time-indexed-rrt-connect-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "063cfddfaa00d3aeb807117810e5936dd4e9dc294d1d0ff5980b4eae489c8d07";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Time-Indexed RRT-Connect solver (Humanoids 2018)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica/default.nix
+++ b/distros/noetic/exotica/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+buildRosPackage {
+  pname = "ros-noetic-exotica";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6eba3dc9fbbbd6ed0f89385945fdc16c107684407e56d10be5a38b34b5d5d814";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Extensible Optimization Toolset (EXOTica) is a library for defining problems for robot motion planning. This package serves similar to a metapackage and contains dependencies onto all core-released exotica packages. It also builds the documentation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "109358fbe47d2113a169631ae42fad3f410d93c4a22f5e0143be153435d0ef0b";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "8127adc92c19930bb41d8e332f94febe5256a04402970b18f20f10e6c7155874";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "d304fd952659e934321b489879180dda5755dfff7e64b68ba7999b8e13db21a3";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "28181b950a206e9a148f5ca518685914dea85e236395da30472890925c973efb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -52,9 +52,25 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ autoware-can-msgs = self.callPackage ./autoware-can-msgs {};
+
+ autoware-config-msgs = self.callPackage ./autoware-config-msgs {};
+
+ autoware-external-msgs = self.callPackage ./autoware-external-msgs {};
+
+ autoware-lanelet2-msgs = self.callPackage ./autoware-lanelet2-msgs {};
+
+ autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
+
+ autoware-system-msgs = self.callPackage ./autoware-system-msgs {};
+
  auv-msgs = self.callPackage ./auv-msgs {};
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
+
+ backward-ros = self.callPackage ./backward-ros {};
 
  baldor = self.callPackage ./baldor {};
 
@@ -73,6 +89,16 @@ self: super: {
  bondpy = self.callPackage ./bondpy {};
 
  boost-sml = self.callPackage ./boost-sml {};
+
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
 
@@ -364,6 +390,8 @@ self: super: {
 
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
+ ddynamic-reconfigure-python = self.callPackage ./ddynamic-reconfigure-python {};
+
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
  delphi-mrr-msgs = self.callPackage ./delphi-mrr-msgs {};
@@ -516,6 +544,48 @@ self: super: {
 
  executive-smach-visualization = self.callPackage ./executive-smach-visualization {};
 
+ exotica = self.callPackage ./exotica {};
+
+ exotica-aico-solver = self.callPackage ./exotica-aico-solver {};
+
+ exotica-cartpole-dynamics-solver = self.callPackage ./exotica-cartpole-dynamics-solver {};
+
+ exotica-collision-scene-fcl-latest = self.callPackage ./exotica-collision-scene-fcl-latest {};
+
+ exotica-core = self.callPackage ./exotica-core {};
+
+ exotica-core-task-maps = self.callPackage ./exotica-core-task-maps {};
+
+ exotica-ddp-solver = self.callPackage ./exotica-ddp-solver {};
+
+ exotica-double-integrator-dynamics-solver = self.callPackage ./exotica-double-integrator-dynamics-solver {};
+
+ exotica-dynamics-solvers = self.callPackage ./exotica-dynamics-solvers {};
+
+ exotica-examples = self.callPackage ./exotica-examples {};
+
+ exotica-ik-solver = self.callPackage ./exotica-ik-solver {};
+
+ exotica-ilqg-solver = self.callPackage ./exotica-ilqg-solver {};
+
+ exotica-ilqr-solver = self.callPackage ./exotica-ilqr-solver {};
+
+ exotica-levenberg-marquardt-solver = self.callPackage ./exotica-levenberg-marquardt-solver {};
+
+ exotica-ompl-control-solver = self.callPackage ./exotica-ompl-control-solver {};
+
+ exotica-ompl-solver = self.callPackage ./exotica-ompl-solver {};
+
+ exotica-pendulum-dynamics-solver = self.callPackage ./exotica-pendulum-dynamics-solver {};
+
+ exotica-pinocchio-dynamics-solver = self.callPackage ./exotica-pinocchio-dynamics-solver {};
+
+ exotica-quadrotor-dynamics-solver = self.callPackage ./exotica-quadrotor-dynamics-solver {};
+
+ exotica-scipy-solver = self.callPackage ./exotica-scipy-solver {};
+
+ exotica-time-indexed-rrt-connect-solver = self.callPackage ./exotica-time-indexed-rrt-connect-solver {};
+
  exotica-val-description = self.callPackage ./exotica-val-description {};
 
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
@@ -632,6 +702,8 @@ self: super: {
 
  graph-msgs = self.callPackage ./graph-msgs {};
 
+ grasping-msgs = self.callPackage ./grasping-msgs {};
+
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  handeye = self.callPackage ./handeye {};
@@ -651,6 +723,8 @@ self: super: {
  ifm3d = self.callPackage ./ifm3d {};
 
  image-common = self.callPackage ./image-common {};
+
+ image-exposure-msgs = self.callPackage ./image-exposure-msgs {};
 
  image-geometry = self.callPackage ./image-geometry {};
 
@@ -685,6 +759,12 @@ self: super: {
  imu-tools = self.callPackage ./imu-tools {};
 
  imu-transformer = self.callPackage ./imu-transformer {};
+
+ industrial-msgs = self.callPackage ./industrial-msgs {};
+
+ industrial-robot-status-controller = self.callPackage ./industrial-robot-status-controller {};
+
+ industrial-robot-status-interface = self.callPackage ./industrial-robot-status-interface {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
@@ -1110,6 +1190,10 @@ self: super: {
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -1220,6 +1304,10 @@ self: super: {
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
+ pointgrey-camera-description = self.callPackage ./pointgrey-camera-description {};
+
+ pointgrey-camera-driver = self.callPackage ./pointgrey-camera-driver {};
+
  polled-camera = self.callPackage ./polled-camera {};
 
  pose-base-controller = self.callPackage ./pose-base-controller {};
@@ -1312,6 +1400,10 @@ self: super: {
 
  robot = self.callPackage ./robot {};
 
+ robot-calibration = self.callPackage ./robot-calibration {};
+
+ robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-navigation = self.callPackage ./robot-navigation {};
@@ -1321,6 +1413,24 @@ self: super: {
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
+
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
 
  ros = self.callPackage ./ros {};
 
@@ -1698,6 +1808,8 @@ self: super: {
 
  stage-ros = self.callPackage ./stage-ros {};
 
+ statistics-msgs = self.callPackage ./statistics-msgs {};
+
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
@@ -1746,6 +1858,8 @@ self: super: {
 
  swri-yaml-util = self.callPackage ./swri-yaml-util {};
 
+ tablet-socket-msgs = self.callPackage ./tablet-socket-msgs {};
+
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
@@ -1789,6 +1903,22 @@ self: super: {
  tile-map = self.callPackage ./tile-map {};
 
  topic-tools = self.callPackage ./topic-tools {};
+
+ toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
+
+ toposens-description = self.callPackage ./toposens-description {};
+
+ toposens-driver = self.callPackage ./toposens-driver {};
+
+ toposens-markers = self.callPackage ./toposens-markers {};
+
+ toposens-msgs = self.callPackage ./toposens-msgs {};
+
+ toposens-pointcloud = self.callPackage ./toposens-pointcloud {};
+
+ toposens-sync = self.callPackage ./toposens-sync {};
 
  track-odometry = self.callPackage ./track-odometry {};
 
@@ -1878,6 +2008,8 @@ self: super: {
 
  uuid-msgs = self.callPackage ./uuid-msgs {};
 
+ vector-map-msgs = self.callPackage ./vector-map-msgs {};
+
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
  velodyne = self.callPackage ./velodyne {};
@@ -1921,6 +2053,8 @@ self: super: {
  warehouse-ros = self.callPackage ./warehouse-ros {};
 
  webots-ros = self.callPackage ./webots-ros {};
+
+ wfov-camera-msgs = self.callPackage ./wfov-camera-msgs {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/noetic/grasping-msgs/default.nix
+++ b/distros/noetic/grasping-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, moveit-msgs, sensor-msgs, shape-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-grasping-msgs";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mikeferguson/grasping_msgs-gbp/archive/release/noetic/grasping_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "87a1982676f3578bf4799db82e984990dec14eab6d9df3a98ab13b4d4a2d6c33";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib geometry-msgs message-runtime moveit-msgs sensor-msgs shape-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for describing objects and how to grasp them.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-exposure-msgs/default.nix
+++ b/distros/noetic/image-exposure-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-image-exposure-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "2b9a6a7f16a46e84d8daa950430e3b3cdbe23ab5399ab6dde4161e3509fb705a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime statistics-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-msgs/default.nix
+++ b/distros/noetic/industrial-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-msgs";
+  version = "0.7.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "c1cc02b17cffe63eacfb0ba825cde514478f3c405ced7b8e63c5756085b50554";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The industrial message package containes industrial specific messages 
+	definitions. This package is part of the ROS-Industrial program.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-controller/default.nix
+++ b/distros/noetic/industrial-robot-status-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, industrial-msgs, industrial-robot-status-interface, pluginlib, realtime-tools }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-controller";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "6f9dcec5e3bff7ae4470fc249277610e11b04451cdb06c053d663ffab0bf1bc0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ industrial-robot-status-interface ];
+  propagatedBuildInputs = [ controller-interface hardware-interface industrial-msgs pluginlib realtime-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller that reports robot status using the ROS-Industrial RobotStatus message.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-interface/default.nix
+++ b/distros/noetic/industrial-robot-status-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-interface";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_interface/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "c1b73b8150bcb01b2bee3263026aa99571d1dcbdd4237e30ec9bafbed2938bcf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hardware-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Exposes ROS-Industrial's RobotStatus info from hardware_interfaces for consumption by ros_control controllers.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/map-msgs/default.nix
+++ b/distros/noetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-map-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "a4f536d85ba775adbb06217eff50d3ed057d4bd87ef42c38e4c0523dc5b79d74";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "e9ae695b8c3f745dc6c3878810a97546c4dd528000a0c8058d6f1f41983df432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-base-msgs/default.nix
+++ b/distros/noetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-move-base-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "f7778f0c15c1e93642f7f3b52abb03a9072bece78530660576a93bc2a354671c";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "a3cfcbeed9a83959c3a7b12abf8737062bee94c627d1a961be4ff589a4c4ad7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-driver/default.nix
+++ b/distros/noetic/novatel-oem7-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, rostest, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-driver";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "31177a28c690bbe9df9b89d554af623b43cbcd195a290336083e307396754378";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost gps-common nodelet novatel-oem7-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NovAtel Oem7 ROS Driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/novatel-oem7-msgs/default.nix
+++ b/distros/noetic/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "99cd8fe9aee43c2f2252b1542adec52cecbc9d03bfbe10b8703679bc23cb04f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for NovAtel Oem7 family of receivers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/pointgrey-camera-description/default.nix
+++ b/distros/noetic/pointgrey-camera-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pointgrey-camera-description";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "0d0bd0da10b7a6f888abbac3b5f79360df4b6dac1949ace934a684f760ff1e0b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF descriptions for Point Grey cameras'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pointgrey-camera-driver/default.nix
+++ b/distros/noetic/pointgrey-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pointgrey-camera-driver";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "70339f114659294dcdcb58bd3e8db2a80eac8a1f537dc84693a94e54a672ae27";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ curl dpkg ];
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-exposure-msgs image-proc image-transport libraw1394 libusb1 nodelet roscpp sensor-msgs stereo-image-proc wfov-camera-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Point Grey camera driver based on libflycapture2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration-msgs";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "90dcef12df3501596deef0b54aecae6da568f24a0702d533a16f3503dace8215";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for calibrating a robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f90812efe92713874c112e6a8dc83efde3ce72915f102dfcd4f1a8db8e057883";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Calibrate a Robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-bus-manager";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_bus_manager/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "de8031d4bf0817cd91aa9e5f29b766e1dca00c1f359cdbed10be6b955222f633";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-description";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_description/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "9e767c63e25c31eea0596d82b493f23edb4fc3cd1e3f6cc2833cff2cea9c16d4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-ethercat";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_ethercat/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "500b683d5446747f3f4e2204fb5e414d01933084ed15b2d07a431457c43970a4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-examples/default.nix
+++ b/distros/noetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-examples";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_examples/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "d9b46620259af8b6a88a4711502153586d6a73e8fb1268cea216c1e2b6eca10b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-factory/default.nix
+++ b/distros/noetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-factory";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_factory/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "52910f670debb88126bf4b016398815fe1d5e8685345770f5b83a0ee424d6d31";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-manager/default.nix
+++ b/distros/noetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-manager";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_manager/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "4770e4902618655054fa62913c1180282c51a084aa5bbd091746a5da80915b2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-msgs";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_msgs/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "55741663df340750754bc7ecdfdf36b3cb76c2185ee1484199b9fa3c0a454ab5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-serial";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_serial/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "78f032100480a1e7d92f9e89a9760ec76712f8268b668467a8e023d3c0de90a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini";
+  version = "0.5.7-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini/0.5.7-1";
+    name = "archive.tar.gz";
+    sha256 = "adbd191ea10b4dd3253f74cfc4259c7d1238c5b9766fd6ebcdd4b1da46ba2140";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/noetic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "1a6edd6ee7603c84ae671597872637e9496dbfd5636c6ebc0fb13883cf59a9a8";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f43930793890f754f95889a127475ee48672b05660aaaf28cf2ed6d962288fad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-snapshot/default.nix
+++ b/distros/noetic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5cc66d1435efb3483a207ddb125ed0a07b8903f719ca415c557ffc0caa136e8e";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "aeeacd6ab144acbc737b6f5cb8d6199f7d822dcd0887f176b3766f495952e060";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "4f25539887d9b7f6ae1b0c5fdf836d08fc9a4f741b9a4687f374ff9560494852";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "e9be4a0711b9268d8c7f3c875d2fbb1d787aaa43f7907e08e4204dcbb9a178ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/statistics-msgs/default.nix
+++ b/distros/noetic/statistics-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-statistics-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "5eb0ddd6586f00d4ce5baf52af1eea155449e3bbbb1ddc668ccfc402a57d95c0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/tablet-socket-msgs/default.nix
+++ b/distros/noetic/tablet-socket-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-tablet-socket-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/tablet_socket_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "6bf111b0e4f1332a69414b38dbed9f61247e048b4018e882997ad99a93fd90f8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tablet_socket_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/toposens-bringup/default.nix
+++ b/distros/noetic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "efe7df738acf96ae0db6743081dde793ed4b0f59b0d0ee777bf7d1f170fe5a3e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-description/default.nix
+++ b/distros/noetic/toposens-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-description";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_description/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "7382b0380ebc322f9048da8cafae81500b3f38dafd6cb077ce45697c8c18e9ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''3D models of the sensor for visualization.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-driver/default.nix
+++ b/distros/noetic/toposens-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_driver/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "61a68366695b41b35f2db96c2044ed7463011b4b6eebe86c49072ca911482729";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS device driver for communication with TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-markers/default.nix
+++ b/distros/noetic/toposens-markers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-markers";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_markers/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "b13697c65debd53352283e9cdf9ac40360388023bc97bd7aaa5e7d96b78ffa4a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rviz integration for TS sensor data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-msgs/default.nix
+++ b/distros/noetic/toposens-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_msgs/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "b3ef9b6944cc3ca9049c41def4e8ca50ab6d71f184d88c15b352e515cb33c661";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message definitions for TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-pointcloud/default.nix
+++ b/distros/noetic/toposens-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-pointcloud";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_pointcloud/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "91acf806538ab42f694b5a05849e0c67cd90a58c3750edc57db77e48c2fcdfb6";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''PCL integration for TS sensors mounted on Turtlebot3.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-sync/default.nix
+++ b/distros/noetic/toposens-sync/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-sync";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_sync/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "c7fba8d2196e90029ac42cda4287f6dedc29b2cb562b3c1c18734ffc4a46e0e1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage roslaunch rostest ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Operational sync of multiple TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens/default.nix
+++ b/distros/noetic/toposens/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+buildRosPackage {
+  pname = "ros-noetic-toposens";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "351b1c1ea2c15c083ca0387ef8096cfd19a6e62f6d211dc59dc9531e1fa71bc1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS support for Toposens 3D Ultrasound sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-vector-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The vector_map_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/velodyne-driver/default.nix
+++ b/distros/noetic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libpcap, nodelet, roscpp, roslaunch, roslint, rostest, tf, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-driver";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a81f0c6824c1ac06ee5d2f5abd7cf48d2d5661a93dc5e08381df8eff9c220c59";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "d0ac953f3a48c3e13e60a94fb9ed768ea22699004bc7c62a638785dc37f1ffea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-laserscan/default.nix
+++ b/distros/noetic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nodelet, roscpp, roslaunch, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-laserscan";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "b41a82000caa5ffb71abef4e56447be313859394d948d68ce6d22691c5d7f521";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "bbe1d9264cf193a2b2610fa19280c3a7a57f0de6c3d4c1a037ba713127e63438";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-msgs/default.nix
+++ b/distros/noetic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "563078f455430be8e3aad7225c51d74994d12c72b259d6f7c79b585378b269ea";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "fb3b32e45e68234f8e01121aeee2e8d33966379c3a5ce4c2365e3751ee284e2f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pcl/default.nix
+++ b/distros/noetic/velodyne-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, roslint }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pcl";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "4e9f1613629cc23ce3c56ffda7b0cfeb1abe11ff1994cb505fc4b31ec7d07f23";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "08d0a84826d952dc1b0ae6cec5909fcb70a291dcd96f817cf54a34e24024751e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pointcloud";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "39b31cb1d871a82d5a7a1c24ce6119588bbd310b3dec7a49e91f2e7827f5a9b4";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "49cf0b37a42143d5cbbc93086d4a478372201ef6b758891a06807abba7e16c29";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne/default.nix
+++ b/distros/noetic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-noetic-velodyne";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "c8f5e8a30661b80796005171875f1db08536c6e6562680c419ea7b23a18920c0";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "20968c2bc112c14694268e3b421517184a68bec969904cb167c7c14ab11b415a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/wfov-camera-msgs/default.nix
+++ b/distros/noetic/wfov-camera-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-wfov-camera-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "fa2494db9b9b17f019705378aae3e21916120d81e7b0b6ed58382186e34267fb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 1f2193c9440f65c3a75c96ae4a1138a9802c9667.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --skip cross_compile --all
```

Changes:
========
Dashing Changes:
----------------
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cyclonedds 0.5.1-r1 --> 0.7.0-r1*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*
* *smclib 2.0.0-r1*
* *test-bond 2.0.0-r1*

Eloquent Changes:
-----------------
* *cyclonedds 0.5.1-r2 --> 0.7.0-r3*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*

Foxy Changes:
-------------
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cartographer-ros 1.0.9001-r1 --> 1.0.9002-r1*
* *cartographer-ros-msgs 1.0.9001-r1 --> 1.0.9002-r1*
* *costmap-queue 0.4.3-r1 --> 0.4.5-r1*
* *dsr-description2 0.1.1-r4*
* *dsr-msgs2 0.1.1-r4*
* *dwb-core 0.4.3-r1 --> 0.4.5-r1*
* *dwb-critics 0.4.3-r1 --> 0.4.5-r1*
* *dwb-msgs 0.4.3-r1 --> 0.4.5-r1*
* *dwb-plugins 0.4.3-r1 --> 0.4.5-r1*
* *mavlink 2020.10.11-r1 --> 2020.11.11-r1*
* *nav-2d-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav-2d-utils 0.4.3-r1 --> 0.4.5-r1*
* *nav2-amcl 0.4.3-r1 --> 0.4.5-r1*
* *nav2-behavior-tree 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bringup 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bt-navigator 0.4.3-r1 --> 0.4.5-r1*
* *nav2-common 0.4.3-r1 --> 0.4.5-r1*
* *nav2-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-core 0.4.3-r1 --> 0.4.5-r1*
* *nav2-costmap-2d 0.4.3-r1 --> 0.4.5-r1*
* *nav2-dwb-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-gazebo-spawner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-lifecycle-manager 0.4.3-r1 --> 0.4.5-r1*
* *nav2-map-server 0.4.3-r1 --> 0.4.5-r1*
* *nav2-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav2-navfn-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-recoveries 0.4.3-r1 --> 0.4.5-r1*
* *nav2-rviz-plugins 0.4.3-r1 --> 0.4.5-r1*
* *nav2-system-tests 0.4.3-r1 --> 0.4.5-r1*
* *nav2-util 0.4.3-r1 --> 0.4.5-r1*
* *nav2-voxel-grid 0.4.3-r1 --> 0.4.5-r1*
* *nav2-waypoint-follower 0.4.3-r1 --> 0.4.5-r1*
* *navigation2 0.4.3-r1 --> 0.4.5-r1*
* *osqp-vendor 0.0.1-r3 --> 0.0.2-r1*
* *rcl 1.1.8-r1 --> 1.1.9-r1*
* *rcl-action 1.1.8-r1 --> 1.1.9-r1*
* *rcl-lifecycle 1.1.8-r1 --> 1.1.9-r1*
* *rcl-yaml-param-parser 1.1.8-r1 --> 1.1.9-r1*
* *rmw-dds-common 1.0.1-r1 --> 1.0.2-r1*
* *rmw-fastrtps-cpp 1.2.2-r1 --> 1.2.3-r1*
* *rmw-fastrtps-dynamic-cpp 1.2.2-r1 --> 1.2.3-r1*
* *rmw-fastrtps-shared-cpp 1.2.2-r1 --> 1.2.3-r1*
* *smac-planner 0.4.5-r1*
* *smclib 2.0.0-r1*
* *teleop-twist-joy 2.3.0-r1 --> 2.4.0-r1*
* *test-bond 2.0.0-r1*
* *v4l2-camera 0.3.0-r1 --> 0.3.1-r1*

Kinetic Changes:
----------------
* *bota-device-driver 0.5.6-r1*
* *bota-driver 0.5.6-r1*
* *bota-node 0.5.6-r1*
* *bota-signal-handler 0.5.6-r1*
* *bota-worker 0.5.6-r1*
* *exotica 5.1.3-r1 --> 6.0.0-r1*
* *exotica-aico-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-cartpole-dynamics-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-collision-scene-fcl-latest 5.1.3-r1 --> 6.0.0-r1*
* *exotica-core 5.1.3-r1 --> 6.0.0-r1*
* *exotica-core-task-maps 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ddp-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-double-integrator-dynamics-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-dynamics-solvers 5.1.3-r1 --> 6.0.0-r1*
* *exotica-examples 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ik-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ilqg-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ilqr-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-levenberg-marquardt-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ompl-control-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-ompl-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-pendulum-dynamics-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-pinocchio-dynamics-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-quadrotor-dynamics-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-scipy-solver 5.1.3-r1 --> 6.0.0-r1*
* *exotica-time-indexed-rrt-connect-solver 5.1.3-r1 --> 6.0.0-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *message-filters 1.12.16-r1 --> 1.12.17-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *rc-hand-eye-calibration-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-pick-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-roi-manager-gui 3.0.4-r1 --> 3.0.5-r1*
* *rc-silhouettematch-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-tagdetect-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-description 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-driver 3.0.4-r1 --> 3.0.5-r1*
* *rokubimini 0.5.6-r1*
* *rokubimini-bus-manager 0.5.6-r1*
* *rokubimini-description 0.5.6-r1*
* *rokubimini-ethercat 0.5.6-r1*
* *rokubimini-examples 0.5.6-r1*
* *rokubimini-factory 0.5.6-r1*
* *rokubimini-manager 0.5.6-r1*
* *rokubimini-msgs 0.5.6-r1*
* *rokubimini-serial 0.5.6-r1*
* *ros-comm 1.12.16-r1 --> 1.12.17-r1*
* *rosbag 1.12.16-r1 --> 1.12.17-r1*
* *rosbag-snapshot 1.0.2-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.2-r1 --> 1.0.3-r1*
* *rosbag-storage 1.12.16-r1 --> 1.12.17-r1*
* *rosconsole 1.12.16-r1 --> 1.12.17-r1*
* *roscpp 1.12.16-r1 --> 1.12.17-r1*
* *rosgraph 1.12.16-r1 --> 1.12.17-r1*
* *roslaunch 1.12.16-r1 --> 1.12.17-r1*
* *roslz4 1.12.16-r1 --> 1.12.17-r1*
* *rosmaster 1.12.16-r1 --> 1.12.17-r1*
* *rosmsg 1.12.16-r1 --> 1.12.17-r1*
* *rosnode 1.12.16-r1 --> 1.12.17-r1*
* *rosout 1.12.16-r1 --> 1.12.17-r1*
* *rosparam 1.12.16-r1 --> 1.12.17-r1*
* *rospy 1.12.16-r1 --> 1.12.17-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *rosservice 1.12.16-r1 --> 1.12.17-r1*
* *rostest 1.12.16-r1 --> 1.12.17-r1*
* *rostopic 1.12.16-r1 --> 1.12.17-r1*
* *roswtf 1.12.16-r1 --> 1.12.17-r1*
* *seed-smartactuator-sdk 0.0.4-r1 --> 0.0.5-r1*
* *topic-tools 1.12.16-r1 --> 1.12.17-r1*
* *toposens 2.0.4-r1 --> 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.0.4-r1 --> 2.1.0-r1*
* *toposens-driver 2.0.4-r1 --> 2.1.0-r1*
* *toposens-markers 2.0.4-r1 --> 2.1.0-r1*
* *toposens-msgs 2.0.4-r1 --> 2.1.0-r1*
* *toposens-pointcloud 2.0.4-r1 --> 2.1.0-r1*
* *toposens-sync 2.0.4-r1 --> 2.1.0-r1*
* *urg-node 0.1.14-r1 --> 0.1.15-r1*
* *xmlrpcpp 1.12.16-r1 --> 1.12.17-r1*

Melodic Changes:
----------------
* *bota-device-driver 0.5.2-r2 --> 0.5.7-r1*
* *bota-driver 0.5.2-r2 --> 0.5.7-r1*
* *bota-node 0.5.2-r2 --> 0.5.7-r1*
* *bota-signal-handler 0.5.2-r2 --> 0.5.7-r1*
* *bota-worker 0.5.2-r2 --> 0.5.7-r1*
* *dingo-control 0.1.4-r1 --> 0.1.5-r1*
* *dingo-description 0.1.4-r1 --> 0.1.5-r1*
* *dingo-msgs 0.1.4-r1 --> 0.1.5-r1*
* *dingo-navigation 0.1.4-r1 --> 0.1.5-r1*
* *exotica 5.1.3-r3 --> 6.0.0-r1*
* *exotica-aico-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-cartpole-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-collision-scene-fcl-latest 5.1.3-r3 --> 6.0.0-r1*
* *exotica-core 5.1.3-r3 --> 6.0.0-r1*
* *exotica-core-task-maps 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ddp-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-double-integrator-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-dynamics-solvers 5.1.3-r3 --> 6.0.0-r1*
* *exotica-examples 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ik-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ilqg-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ilqr-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-levenberg-marquardt-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ompl-control-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ompl-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-pendulum-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-pinocchio-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-quadrotor-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-scipy-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-time-indexed-rrt-connect-solver 5.1.3-r3 --> 6.0.0-r1*
* *extest 0.0.1-r3*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *jackal-gazebo 0.3.0-r2 --> 0.4.0-r1*
* *jackal-simulator 0.3.0-r2 --> 0.4.0-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *open-karto 1.2.2-r1 --> 1.2.3-r1*
* *psen-scan-v2 0.1.0-r1 --> 0.1.1-r1*
* *robot-calibration 0.6.3-r1 --> 0.6.4-r1*
* *robot-calibration-msgs 0.6.3-r1 --> 0.6.4-r1*
* *robotont-description 0.0.7-r1*
* *rokubimini 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-bus-manager 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-description 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-ethercat 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-examples 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-factory 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-manager 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-msgs 0.5.2-r2 --> 0.5.7-r1*
* *rokubimini-serial 0.5.2-r2 --> 0.5.7-r1*
* *rosbag-snapshot 1.0.1-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.1-r1 --> 1.0.3-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *rostest-node-interface-validation 0.2.0-r1*
* *toposens 2.0.4-r1 --> 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.0.4-r1 --> 2.1.0-r1*
* *toposens-driver 2.0.4-r1 --> 2.1.0-r1*
* *toposens-markers 2.0.4-r1 --> 2.1.0-r1*
* *toposens-msgs 2.0.4-r1 --> 2.1.0-r1*
* *toposens-pointcloud 2.0.4-r1 --> 2.1.0-r1*
* *toposens-sync 2.0.4-r1 --> 2.1.0-r1*

Noetic Changes:
---------------
* *autoware-can-msgs 1.14.0-r1*
* *autoware-config-msgs 1.14.0-r1*
* *autoware-external-msgs 1.14.0-r1*
* *autoware-lanelet2-msgs 1.14.0-r1*
* *autoware-map-msgs 1.14.0-r1*
* *autoware-msgs 1.14.0-r1*
* *autoware-system-msgs 1.14.0-r1*
* *backward-ros 0.1.7-r1*
* *bota-device-driver 0.5.7-r1*
* *bota-driver 0.5.7-r1*
* *bota-node 0.5.7-r1*
* *bota-signal-handler 0.5.7-r1*
* *bota-worker 0.5.7-r1*
* *code-coverage 0.4.3-r1 --> 0.4.4-r1*
* *ddynamic-reconfigure-python 0.0.1-r1*
* *exotica 6.0.0-r1*
* *exotica-aico-solver 6.0.0-r1*
* *exotica-cartpole-dynamics-solver 6.0.0-r1*
* *exotica-collision-scene-fcl-latest 6.0.0-r1*
* *exotica-core 6.0.0-r1*
* *exotica-core-task-maps 6.0.0-r1*
* *exotica-ddp-solver 6.0.0-r1*
* *exotica-double-integrator-dynamics-solver 6.0.0-r1*
* *exotica-dynamics-solvers 6.0.0-r1*
* *exotica-examples 6.0.0-r1*
* *exotica-ik-solver 6.0.0-r1*
* *exotica-ilqg-solver 6.0.0-r1*
* *exotica-ilqr-solver 6.0.0-r1*
* *exotica-levenberg-marquardt-solver 6.0.0-r1*
* *exotica-ompl-control-solver 6.0.0-r1*
* *exotica-ompl-solver 6.0.0-r1*
* *exotica-pendulum-dynamics-solver 6.0.0-r1*
* *exotica-pinocchio-dynamics-solver 6.0.0-r1*
* *exotica-quadrotor-dynamics-solver 6.0.0-r1*
* *exotica-scipy-solver 6.0.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.0.0-r1*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *grasping-msgs 0.3.1-r1*
* *image-exposure-msgs 0.15.0-r1*
* *industrial-msgs 0.7.1-r1*
* *industrial-robot-status-controller 0.1.2-r1*
* *industrial-robot-status-interface 0.1.2-r1*
* *map-msgs 1.14.0-r1 --> 1.14.1-r1*
* *move-base-msgs 1.14.0-r1 --> 1.14.1-r1*
* *novatel-oem7-driver 1.1.0-r1*
* *novatel-oem7-msgs 1.1.0-r1*
* *pointgrey-camera-description 0.15.0-r1*
* *pointgrey-camera-driver 0.15.0-r1*
* *robot-calibration 0.6.4-r1*
* *robot-calibration-msgs 0.6.4-r1*
* *rokubimini 0.5.7-r1*
* *rokubimini-bus-manager 0.5.7-r1*
* *rokubimini-description 0.5.7-r1*
* *rokubimini-ethercat 0.5.7-r1*
* *rokubimini-examples 0.5.7-r1*
* *rokubimini-factory 0.5.7-r1*
* *rokubimini-manager 0.5.7-r1*
* *rokubimini-msgs 0.5.7-r1*
* *rokubimini-serial 0.5.7-r1*
* *rosbag-snapshot 1.0.1-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.1-r1 --> 1.0.3-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *statistics-msgs 0.15.0-r1*
* *tablet-socket-msgs 1.14.0-r1*
* *toposens 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.1.0-r1*
* *toposens-driver 2.1.0-r1*
* *toposens-markers 2.1.0-r1*
* *toposens-msgs 2.1.0-r1*
* *toposens-pointcloud 2.1.0-r1*
* *toposens-sync 2.1.0-r1*
* *vector-map-msgs 1.14.0-r1*
* *velodyne 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-driver 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-laserscan 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-msgs 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-pcl 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-pointcloud 1.6.0-r1 --> 1.6.1-r1*
* *wfov-camera-msgs 0.15.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] controller_manager
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] hardware_interface
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-whichcraft
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-h5py
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-mechanize
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

