### PR TITLE
rosdistro sync, Fri Nov 20 13:09:59 2020

### DIFF
--- a/.github/actions/nix-ros-build-action/dist/index.js
+++ b/.github/actions/nix-ros-build-action/dist/index.js
@@ -972,10 +972,72 @@ module.exports.default = pTry;
 
 /***/ }),
 
+/***/ 82:
+/***/ (function(__unusedmodule, exports) {
+
+"use strict";
+
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+Object.defineProperty(exports, "__esModule", { value: true });
+/**
+ * Sanitizes an input into a string so it can be passed into issueCommand safely
+ * @param input input to sanitize into a string
+ */
+function toCommandValue(input) {
+    if (input === null || input === undefined) {
+        return '';
+    }
+    else if (typeof input === 'string' || input instanceof String) {
+        return input;
+    }
+    return JSON.stringify(input);
+}
+exports.toCommandValue = toCommandValue;
+//# sourceMappingURL=utils.js.map
+
+/***/ }),
+
 /***/ 87:
 /***/ (function(module) {
 
 module.exports = require("os");
+
+/***/ }),
+
+/***/ 102:
+/***/ (function(__unusedmodule, exports, __webpack_require__) {
+
+"use strict";
+
+// For internal use, subject to change.
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+// We use any as a valid input type
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const fs = __importStar(__webpack_require__(747));
+const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
+function issueCommand(command, message) {
+    const filePath = process.env[`GITHUB_${command}`];
+    if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+    }
+    if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+    }
+    fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+    });
+}
+exports.issueCommand = issueCommand;
+//# sourceMappingURL=file-command.js.map
 
 /***/ }),
 
@@ -1442,6 +1504,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const os = __importStar(__webpack_require__(87));
+const utils_1 = __webpack_require__(82);
 /**
  * Commands
  *
@@ -1495,28 +1558,14 @@ class Command {
         return cmdStr;
     }
 }
-/**
- * Sanitizes an input into a string so it can be passed into issueCommand safely
- * @param input input to sanitize into a string
- */
-function toCommandValue(input) {
-    if (input === null || input === undefined) {
-        return '';
-    }
-    else if (typeof input === 'string' || input instanceof String) {
-        return input;
-    }
-    return JSON.stringify(input);
-}
-exports.toCommandValue = toCommandValue;
 function escapeData(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A');
 }
 function escapeProperty(s) {
-    return toCommandValue(s)
+    return utils_1.toCommandValue(s)
         .replace(/%/g, '%25')
         .replace(/\r/g, '%0D')
         .replace(/\n/g, '%0A')
@@ -1998,6 +2047,12 @@ function convertBody(buffer, headers) {
 	// html4
 	if (!res && str) {
 		res = /<meta[\s]+?http-equiv=(['"])content-type\1[\s]+?content=(['"])(.+?)\2/i.exec(str);
+		if (!res) {
+			res = /<meta[\s]+?content=(['"])(.+?)\1[\s]+?http-equiv=(['"])content-type\3/i.exec(str);
+			if (res) {
+				res.pop(); // drop last quote
+			}
+		}
 
 		if (res) {
 			res = /charset=(.*)/i.exec(res.pop());
@@ -3005,7 +3060,7 @@ function fetch(url, opts) {
 				// HTTP fetch step 5.5
 				switch (request.redirect) {
 					case 'error':
-						reject(new FetchError(`redirect mode is set to error: ${request.url}`, 'no-redirect'));
+						reject(new FetchError(`uri requested responds with a redirect, redirect mode is set to error: ${request.url}`, 'no-redirect'));
 						finalize();
 						return;
 					case 'manual':
@@ -3044,7 +3099,8 @@ function fetch(url, opts) {
 							method: request.method,
 							body: request.body,
 							signal: request.signal,
-							timeout: request.timeout
+							timeout: request.timeout,
+							size: request.size
 						};
 
 						// HTTP-redirect fetch step 9
@@ -3200,6 +3256,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const command_1 = __webpack_require__(431);
+const file_command_1 = __webpack_require__(102);
+const utils_1 = __webpack_require__(82);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 /**
@@ -3226,9 +3284,17 @@ var ExitCode;
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function exportVariable(name, val) {
-    const convertedVal = command_1.toCommandValue(val);
+    const convertedVal = utils_1.toCommandValue(val);
     process.env[name] = convertedVal;
-    command_1.issueCommand('set-env', { name }, convertedVal);
+    const filePath = process.env['GITHUB_ENV'] || '';
+    if (filePath) {
+        const delimiter = '_GitHubActionsFileCommandDelimeter_';
+        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
+        file_command_1.issueCommand('ENV', commandValue);
+    }
+    else {
+        command_1.issueCommand('set-env', { name }, convertedVal);
+    }
 }
 exports.exportVariable = exportVariable;
 /**
@@ -3244,7 +3310,13 @@ exports.setSecret = setSecret;
  * @param inputPath
  */
 function addPath(inputPath) {
-    command_1.issueCommand('add-path', {}, inputPath);
+    const filePath = process.env['GITHUB_PATH'] || '';
+    if (filePath) {
+        file_command_1.issueCommand('PATH', inputPath);
+    }
+    else {
+        command_1.issueCommand('add-path', {}, inputPath);
+    }
     process.env['PATH'] = `${inputPath}${path.delimiter}${process.env['PATH']}`;
 }
 exports.addPath = addPath;

--- a/.github/actions/nix-ros-build-action/package-lock.json
+++ b/.github/actions/nix-ros-build-action/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/exec": {
       "version": "1.0.4",
@@ -55,9 +55,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
-      "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ=="
+      "version": "12.19.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.6.tgz",
+      "integrity": "sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -824,9 +824,9 @@
       "dev": true
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "once": {
       "version": "1.4.0",

--- a/.github/actions/nix-ros-build-action/package.json
+++ b/.github/actions/nix-ros-build-action/package.json
@@ -22,15 +22,15 @@
   "author": "Ben Wolsieffer",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.3",
+    "@actions/core": "^1.2.6",
     "@actions/exec": "^1.0.4",
     "@actions/io": "^1.0.2",
     "@types/node-fetch": "^2.5.7",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "p-limit": "^2.3.0"
   },
   "devDependencies": {
-    "@types/node": "^12.12.53",
+    "@types/node": "^12.19.6",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "@zeit/ncc": "^0.20.5",

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,9 @@ jobs:
           - eloquent
           - foxy
     steps:
-    - uses: actions/checkout@v1
-    - uses: cachix/install-nix-action@v8
-    - uses: cachix/cachix-action@v6
+    - uses: actions/checkout@v2
+    - uses: cachix/install-nix-action@v12
+    - uses: cachix/cachix-action@v8
       with:
         name: ros
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: "3.x"
       - name: Install Superflore

--- a/distros/dashing/aws-robomaker-simulation-ros-pkgs/default.nix
+++ b/distros/dashing/aws-robomaker-simulation-ros-pkgs/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-dashing-aws-robomaker-simulation-ros-pkgs";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/dashing/aws_robomaker_simulation_ros_pkgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "d543709e2fbc1e36950267504bfab4cc88eac90db78627f592f8bada199d5379";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''AWS RoboMaker package for accessing the simulation service.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/bond-core/default.nix
+++ b/distros/dashing/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-dashing-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "10c6660f117efc80e3ce007e513436e20e8e6534ce43f6822ee81c83ff154515";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bond/default.nix
+++ b/distros/dashing/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "45470a641f321480c3af295868addfceb1db8671f4c5721cbdccfda8889b207d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/bondcpp/default.nix
+++ b/distros/dashing/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d3d04978c7615ad8a972815a80c284421cb55a0c7c2ae4008bd106c0cbc11059";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/cyclonedds-cmake-module/default.nix
+++ b/distros/dashing/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5416384adb666e9056fa4fbea26fddd5bede9918e8009310d0d198a3f2d12277";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c972ceab084dd87835ba3bcadb08ce4388530ca53bbad4a7d97737205c9b9912";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cyclonedds/default.nix
+++ b/distros/dashing/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-dashing-cyclonedds";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "afbb1cd60046ac3513b78d22f26af23317414074cf00fe612708d56d1babe03e";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/dashing/cyclonedds/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "07a49a0e992890c12f8dfbf99261756dfb150d3e2b33da102aaa28442f4a4bb2";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -142,11 +142,19 @@ self: super: {
 
  aws-common = self.callPackage ./aws-common {};
 
+ aws-robomaker-simulation-ros-pkgs = self.callPackage ./aws-robomaker-simulation-ros-pkgs {};
+
  aws-ros2-common = self.callPackage ./aws-ros2-common {};
 
  behaviortree-cpp = self.callPackage ./behaviortree-cpp {};
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
+
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
 
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
@@ -790,6 +798,8 @@ self: super: {
 
  rmw-opensplice-cpp = self.callPackage ./rmw-opensplice-cpp {};
 
+ robomaker-simulation-msgs = self.callPackage ./robomaker-simulation-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
@@ -1004,6 +1014,8 @@ self: super: {
 
  slide-show = self.callPackage ./slide-show {};
 
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
@@ -1061,6 +1073,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/dashing/rmw-cyclonedds-cpp/default.nix
+++ b/distros/dashing/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-dashing-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "5047cd3af861caa3ab566125ef59989cc67e66ca3a438d94e56208b06d5454f7";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/dashing/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "8d3419ca51b8e3f2cee05cb96b36f311337231069f6409c1b168b1c4aed15428";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/dashing/robomaker-simulation-msgs/default.nix
+++ b/distros/dashing/robomaker-simulation-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-dashing-robomaker-simulation-msgs";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/dashing/robomaker_simulation_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "dbbe15372ddbac35418c92bb20c3749fd5c92e9661dbc8d4b4a8363716e5ee44";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''AWS RoboMaker package containing ROS service definitions for service endpoints provided inside of an AWS RoboMaker simulation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/smclib/default.nix
+++ b/distros/dashing/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-dashing-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "09613f1e3e9b2b47e7b51eed9d1f9f5b488d576446dde8c5edc80afb524cebf1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/dashing/test-bond/default.nix
+++ b/distros/dashing/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-dashing-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/dashing/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a0a172654b7606d48c7b063e3c2eee433440fe6457f20148424f11bb420e4fcf";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/dashing/xacro/default.nix
+++ b/distros/dashing/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-xacro";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "1f80f6bdc44f2bef9a6ac24c326ec76062292d69337df52ec1de3d30e1bdd267";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "0ada324dbe09600c9700687752f7885cab696de06a8438e0d624c0bf2d522a23";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cyclonedds-cmake-module/default.nix
+++ b/distros/eloquent/cyclonedds-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds-cmake-module";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "6db8546cb9579bdf6d29f02e8e172a371b695a50f73d94eb50ab8ea31300be65";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/cyclonedds_cmake_module/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "dc4d7ab18637edfc0589913bb07a38d40577d70624f47058baa0f28c89692f26";
   };
 
   buildType = "ament_cmake";

--- a/distros/eloquent/cyclonedds/default.nix
+++ b/distros/eloquent/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cunit, openssl }:
 buildRosPackage {
   pname = "ros-eloquent-cyclonedds";
-  version = "0.5.1-r2";
+  version = "0.7.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.5.1-2.tar.gz";
-    name = "0.5.1-2.tar.gz";
-    sha256 = "7377c71cbb406f7aeb8fcdf5678f79197ab00984a30851b2ab37e813e1e9ed5f";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/eloquent/cyclonedds/0.7.0-3.tar.gz";
+    name = "0.7.0-3.tar.gz";
+    sha256 = "d4a1dfced26d9e0fd541606a69668c0ef1ed8ddeaefd551d3bd64f900b53bbd6";
   };
 
   buildType = "cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''Eclipse Cyclone DDS is a very performant and robust open-source DDS implementation. Cyclone DDS is developed completely in the open as an Eclipse IoT project.'';
-    license = with lib.licenses; [ "Eclipse Public License 2.0" ];
+    license = with lib.licenses; [ "Eclipse Public License 2.0" "Eclipse Distribution License 1.0" ];
   };
 }

--- a/distros/eloquent/mavlink/default.nix
+++ b/distros/eloquent/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-eloquent-mavlink";
-  version = "2020.10.11-r1";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/eloquent/mavlink/2020.10.11-1.tar.gz";
-    name = "2020.10.11-1.tar.gz";
-    sha256 = "e244a00b6830c2cc2c309d752edda0cc382e1bb1bb7a54479102bf33e4728f71";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/eloquent/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "e5008a455444a37f0f4c337f24afda22b240a6d4dc237c80e362a0df4a3b274b";
   };
 
   buildType = "cmake";

--- a/distros/eloquent/rmw-cyclonedds-cpp/default.nix
+++ b/distros/eloquent/rmw-cyclonedds-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, cyclonedds-cmake-module, rcutils, rmw, rosidl-generator-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-eloquent-rmw-cyclonedds-cpp";
-  version = "0.5.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a1c35e80ff458c5a3635b459717ed79f65054a24fcc215d2c1e9873ff26a7e4c";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/eloquent/rmw_cyclonedds_cpp/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bf5d2a594f12e2f3ed6478ab0d7dfdc02d11118e26285f8204952d49f2d5ccda";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
+  propagatedBuildInputs = [ cyclonedds cyclonedds-cmake-module rcutils rmw rosidl-generator-c rosidl-typesupport-introspection-c rosidl-typesupport-introspection-cpp ];
   nativeBuildInputs = [ ament-cmake-ros cyclonedds-cmake-module ];
 
   meta = {

--- a/distros/eloquent/xacro/default.nix
+++ b/distros/eloquent/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-eloquent-xacro";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/eloquent/xacro/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "6344ded2944fc965d2ef5a370c9c0e08080e2678b401aee81df823aa2888a3de";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/eloquent/xacro/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "9de252b857e8c45f295ce27c7bbefdb9317b2553473335f676d1a03b01f045a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/bond-core/default.nix
+++ b/distros/foxy/bond-core/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, bond, bondcpp, smclib, test-bond }:
+buildRosPackage {
+  pname = "ros-foxy-bond-core";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond_core/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "b5d98b85b71709d7e8eaf9c105f1c5c8c2380d82c26407a46c29c34bab9a4bd2";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ bond bondcpp smclib test-bond ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing. The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bond/default.nix
+++ b/distros/foxy/bond/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "bb74416f8ef1aea39bcf056ca961c4c37dd66ec18f81258374a897a1e0cd3b80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A bond allows two processes, A and B, to know when the other has
+    terminated, either cleanly or by crashing.  The bond remains
+    connected until it is either broken explicitly or until a
+    heartbeat times out.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/bondcpp/default.nix
+++ b/distros/foxy/bondcpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-bondcpp";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/bondcpp/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "9cf5b6d9bb60b7aa21f0c4c6397f237ed6d6414efd3f71f656733de00eb3b72f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''C++ implementation of bond, a mechanism for checking when
+    another process has terminated.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/cartographer-ros-msgs/default.nix
+++ b/distros/foxy/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros-msgs";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "cd9607611d053908f5360dd6356c4bb72a27c9468326e5e3e4d7c6b5701e134e";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "33e58b9796bdb026afb0acb4a2cbaded6604e729a46ce3eae1a41a953058beab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cartographer-ros/default.nix
+++ b/distros/foxy/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros";
-  version = "1.0.9001-r1";
+  version = "1.0.9002-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9001-1.tar.gz";
-    name = "1.0.9001-1.tar.gz";
-    sha256 = "f408e0d891a311d1dfeab930b1807e007e4c0da3a9cac1dd208a904b496174d8";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9002-1.tar.gz";
+    name = "1.0.9002-1.tar.gz";
+    sha256 = "cb23d500a2659e1661b8d0c6f7f1a3e2c5d2434416f34ae68068bf31169fa708";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/costmap-queue/default.nix
+++ b/distros/foxy/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-costmap-queue";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "73f04603a3d44aed609d6d00eefd83fb3dbe43c8a37be13abfb0637736bc7abb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/costmap_queue/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9b33a055fed3295e5f807e6c7384369d5e23f13a4cde9daebd34ea5c0f2dc32e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dsr-description2/default.nix
+++ b/distros/foxy/dsr-description2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-ros, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-description2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_description2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "7776c814f0cfabf18ca111f5ca111216c0d69ab7a74e73f1ce14d785d1659037";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python joint-state-publisher-gui launch launch-ros robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''dsr_description2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dsr-msgs2/default.nix
+++ b/distros/foxy/dsr-msgs2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-dsr-msgs2";
+  version = "0.1.1-r4";
+
+  src = fetchurl {
+    url = "https://github.com/doosan-robotics/doosan-robot2-release/archive/release/foxy/dsr_msgs2/0.1.1-4.tar.gz";
+    name = "0.1.1-4.tar.gz";
+    sha256 = "e3abf123677415e8a45929d79d9b1df9bfe90b41aabbc798af452316433b4909";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces rclcpp rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''The dsr_msgs2 package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/dwb-core/default.nix
+++ b/distros/foxy/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "9163b7d7d5cea08364319ef98569164df42f7db85d558655473024aff745f8c6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ae657e44c068bae195413c68b0c7197f23616e1c4c3a623508b6a5b88975b9c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-critics/default.nix
+++ b/distros/foxy/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-critics";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2628e42f3a0cf285d96007380e1817c58592a8f872e5552c98b8dadff23b07e0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_critics/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "eabc166b4ba0a2b0a2960d42cef2744f59b841d873b37c1444e1cc6d8d49646c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-msgs/default.nix
+++ b/distros/foxy/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-dwb-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8c31c65b2eaff57e003be677a1b25a8b08d17d9231d804ad306a8abc617d4565";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "bb65c572d1ab1eb04ef0f480d14a93a3b9a30568af322ba3964a1560a5b6b455";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dwb-plugins/default.nix
+++ b/distros/foxy/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dwb-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "5ea4805443ac57bae9c8c69ee566d4360bdf44c05f5972f2fee11fd80e1acdd1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/dwb_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "9baa59496d7ddb38cfef9bc6cf5d858aaff4d2071567ee1d205ab130fc61eb60";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/examples-tf2-py/default.nix
+++ b/distros/foxy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-examples-tf2-py";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "9176bc1fd544c598dda3e60b39646e283cc61e76e3b92d637b3729954403c156";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "9a8bed3e95efe8871237835d6de8fdd0ff22bd21fda7cea65fcd02d2e48f1ed5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "811e81b7858d73cffed9984d6075451a1e92a5a8cf881e3ec0f05947c77ddd30";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "ed5b0af5ca9257b9b83f527ff2e835da45153e74f405d64a08be2980deaee420";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -148,6 +148,12 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bond = self.callPackage ./bond {};
+
+ bond-core = self.callPackage ./bond-core {};
+
+ bondcpp = self.callPackage ./bondcpp {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -229,6 +235,10 @@ self: super: {
  dolly-ignition = self.callPackage ./dolly-ignition {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
+
+ dsr-description2 = self.callPackage ./dsr-description2 {};
+
+ dsr-msgs2 = self.callPackage ./dsr-msgs2 {};
 
  dummy-map-server = self.callPackage ./dummy-map-server {};
 
@@ -1032,6 +1042,10 @@ self: super: {
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
+ smac-planner = self.callPackage ./smac-planner {};
+
+ smclib = self.callPackage ./smclib {};
+
  sophus = self.callPackage ./sophus {};
 
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
@@ -1093,6 +1107,8 @@ self: super: {
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
 
  test-apex-test-tools = self.callPackage ./test-apex-test-tools {};
+
+ test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
 

--- a/distros/foxy/geometry2/default.nix
+++ b/distros/foxy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-foxy-geometry2";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "210b202f8518607c9804f2c957f05b4d98da9a75e7c0a277af39e0ac3ddd635c";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "b93dd8d5c50b8718f2f670cc753430ecee336a5a0fa888329206e8dbbc979473";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-can-msgs/default.nix
+++ b/distros/foxy/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-can-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2055ae7cb3dc0fb9e5c5ac7c1865fa5c6769a1a3d747a786bf834b0b28d2ecf5";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e4a3a9871888963ce96e4dd7a31bab93c90aa6456a0b8d12d8880a40f1e0a049";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-common-msgs/default.nix
+++ b/distros/foxy/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-common-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0af800714c3fcbe7c3d58fb113a46835afc9362dddba4a706d8b3caca1dbdbba";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "92c19118cbe50cf76047f1ebf2543952f4cb0584f45a5da58ad90b930b3b118c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-dbw-msgs/default.nix
+++ b/distros/foxy/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-dbw-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1783336bad218ab15b140fb68c7506945156205382239de7ecc3f2208d4e00e7";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a92839b609b425d4ac56f9904630f74ac48ee8b4ba63f16c3d4d69b9c219e119";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-nav-msgs/default.nix
+++ b/distros/foxy/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geographic-msgs, geometry-msgs, marti-common-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-nav-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "97c8363ea55142e9f3a5d8777f4e066640a6135108e4bad37acca0e35dc71871";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5f1d3b0d852da6735c561b7a6886e1aa412a65592a8b40d1054f19217a3c141f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-perception-msgs/default.nix
+++ b/distros/foxy/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-perception-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "216bbbccaddcb5394959c693af32c338eabc3a73dd7bea9d145622fe8041f627";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fe2e9840b60079964bd83c07bd5bb9e01bbd3b0b33095301510c06e609f030cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-sensor-msgs/default.nix
+++ b/distros/foxy/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-marti-sensor-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6c70f7451d46016ab8c55f4e8190debd92b09d83dc62ef618446f9a855189d64";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "83f60894f864fc337c8062b43dd8882b8c6049633820048a1cad35988eb0d682";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-status-msgs/default.nix
+++ b/distros/foxy/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-status-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "fc597eb11e7084c878643923dff958793059e0b6cea3f18b764af4c590527a57";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ce0887450594257488da2c152d966dbdc97e3cb65181f036ccd9e91140d2efa0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-visualization-msgs/default.nix
+++ b/distros/foxy/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-marti-visualization-msgs";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "bf4d84487a544ecfd44425c46e0f7cebd2f19f580a324ddb5c1e1b60d2926678";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bd7e870ac87fe110ff8dadafd2da2e4de67c89da2f1c036755d603a8070fee53";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2020.10.11-r1";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2020.10.11-1.tar.gz";
-    name = "2020.10.11-1.tar.gz";
-    sha256 = "f23467c613353f2cd7048972f930ca92b71950cd08790fc93af98a92ac748c79";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "04bc450e02a260334d6a60883418f66f135534de8b4a69d81e698f6f44fe6637";
   };
 
   buildType = "cmake";

--- a/distros/foxy/nav-2d-msgs/default.nix
+++ b/distros/foxy/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3b89af67439ec4f78850a7a7d75840e6d22603ef682712f94d85ed8ee2eaa9bb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5b580043db92c1ec0a4f9851bdb0e8a224717b232979b815ee1214ac9c8669a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav-2d-utils/default.nix
+++ b/distros/foxy/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-2d-utils";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f16655ca6fce7766c7b66c80c51e0497f90209d66f7df0f7317fab4337a7a00b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav_2d_utils/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "49fa98b744e4213441be0c281641f8abf00e21cd8bfd4df7c29271eb47f4acb0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-amcl/default.nix
+++ b/distros/foxy/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-amcl";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2a0f1291e7b426fe19119fc6451b8d00eca71a3eb242670d0d546d7b577ffdce";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_amcl/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "14084e4785551129be1c77a74082bcf32d5a384bf3f57708c081ca36c48a142d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-behavior-tree/default.nix
+++ b/distros/foxy/nav2-behavior-tree/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-behavior-tree";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c602015b7a0b1f1ec20bf2c6056e56ba07c241f6c0d1e4a0756060fe687ef5d7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_behavior_tree/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "585f0ef01a3a442c0065cb24818a6de2678996016e99be84cccbe82f38c443b9";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ nav2-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ behaviortree-cpp-v3 builtin-interfaces geometry-msgs lifecycle-msgs nav-msgs nav2-msgs nav2-util rclcpp rclcpp-action rclcpp-lifecycle sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/nav2-bringup/default.nix
+++ b/distros/foxy/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bringup";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "07ecfe7c326dc04a43a9e618e88547f5511850e45f74450cf6ae33d316e3d2b7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bringup/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "6b5d1f7479ce8951e3a38bb7ee37f3de81d81d0886636558c33247d44ffa1c51";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-bt-navigator/default.nix
+++ b/distros/foxy/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-bt-navigator";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "370dfd22e521a4c0449e204b59d6a38ad2a1c9409e090e6a39af63e7a4d7ca15";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_bt_navigator/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b985757ac5e11dc3e6d1ad1120d15c2066cc5c7ca245d6b68050ae4cde2405aa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-common/default.nix
+++ b/distros/foxy/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-nav2-common";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c6e5326de2ab71eab276b40630955746a2c20ac58efc6e8514d46d6ef4b4c2a0";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_common/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c8428b79244d25c49920ced18ba6239974db7f389af7c2126f1da8ed612682f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-controller/default.nix
+++ b/distros/foxy/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "1c53325051e83c8725dafc98844444862fae43fe46257dbcffe01da6ed8193a5";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "599b6957dc8f3738655c7de8a899cd35588b23e356038d63ccc053d506527a92";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-core/default.nix
+++ b/distros/foxy/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-core";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "2ed09d28318045aef089bfadb0aa0e9f1a9ce850792e595b0b39c3cebbd98d6f";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_core/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "138efd03903eaf6993fb7eb131b5760041f768278c2f9fd38e45cd405389461d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-costmap-2d/default.nix
+++ b/distros/foxy/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-costmap-2d";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "a56b52d88faf1709ffccd0c61b58c50046dae147747770815f5df725256e9b76";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_costmap_2d/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "ca0b70bb40ae31883cfbfc18b133ef6eb388fc724c8750accd4d1a52991d7941";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-dwb-controller/default.nix
+++ b/distros/foxy/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-foxy-nav2-dwb-controller";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "67b2001e7330ca110137228f57056742e890eef1d5906f33c00ad7010cdbc588";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_dwb_controller/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "937caff30a10dd18729093e5f36c89b9c503ed85fa80028e7d957e75ffe03298";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-gazebo-spawner/default.nix
+++ b/distros/foxy/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-gazebo-spawner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "68fc9ab9c7d639ac8129702a45539467c5a6f83de30e0be5dc17bea75a66baf9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_gazebo_spawner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "769481b7b18aaeeb270bfbcb2f2d197173956997e6085c0bf7c54da756c84700";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/nav2-lifecycle-manager/default.nix
+++ b/distros/foxy/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-lifecycle-manager";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "3dd2d066c47e6db7866025b4b0dc0e80977604e460d5821f572796565a01042b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_lifecycle_manager/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e0c15e7a5065b8e4e6e4ddba5dcca55aa4fb3957385a52fd59f543ab280fe77a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-map-server/default.nix
+++ b/distros/foxy/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-nav2-map-server";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "35bfc4f13b089b0f99a30bfd37b43332be256710f34572609fa63645bca5981a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_map_server/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "e8ffdea4aee1c1582aafdba18fcf84c47d3dbc7080ba7692fb7ba4009921deee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-msgs/default.nix
+++ b/distros/foxy/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-msgs";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "c79a891e10fb45734d3433a95bc459ba797d6b89cb9b2b22ec529dd65fbbe113";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_msgs/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "312fcb7e7544343a8a844281d813a2d9043229627e0bb4606cff80c5dd2c645d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-navfn-planner/default.nix
+++ b/distros/foxy/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-navfn-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "09884506de6a2fcc6f0899ae79e695af5301332b429a2c57fd71a5c1c8cf3038";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_navfn_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "31ec2d8a2b0fa49611fd248b392dd03429210453f3961f865de45783a0fe140f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-planner/default.nix
+++ b/distros/foxy/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-planner";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "34fba1237eff23a27eda29de7a3be9ef1dfb76f739cdd09e82356e096389de9e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "d80b5b433355566ab8ac4cdfa7f7439b02102ac748018cf08ba0b322f15d7f5f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-recoveries/default.nix
+++ b/distros/foxy/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-recoveries";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f6c75f6633640d75fa534adfdf1c980cdf96ae2cc5fda317770bfcc64f15560d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_recoveries/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "cabc151e4005cbdff5e6ce1a7f2e15ccc645b58591f89ed69c4739a5f18e3714";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-rviz-plugins/default.nix
+++ b/distros/foxy/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-rviz-plugins";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e25190817b2c813189bf6331a99ef60fe07e6c73175344689b855f51d241b5df";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_rviz_plugins/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "b46c97f76cf4b1cea25a9bb213dce9fd2c3a7e57384032a8e92a33af6601193e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-system-tests/default.nix
+++ b/distros/foxy/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav2-system-tests";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "b61051a79e8491a74259a0c3fb0005dd47f15113b5dedf66397d80c1c34e6cb7";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_system_tests/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "2acdc3505dc75e58afacb534b244fa36d54251777c924620e529938752f6a36c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-util/default.nix
+++ b/distros/foxy/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, geometry-msgs, launch, launch-testing-ament-cmake, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-util";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e111d2bfd0ddf1940b50d7bec15434a5a560270d7f8e7da52a67570343c1b08c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_util/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "a66c0ff09045030f310410989abd0520feb63630491ad29da1786adf73d277a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-voxel-grid/default.nix
+++ b/distros/foxy/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-nav2-voxel-grid";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "cf77fce6757e428ca4b061308672c35fc2b6f6dc71e143cce4f31830209c3cc2";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_voxel_grid/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "3573db33d1e45ea6be9eb0adf06e44e473e76af533bb871b8676675fde01935d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nav2-waypoint-follower/default.nix
+++ b/distros/foxy/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nav2-waypoint-follower";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "f23fd4f0bd0a27df32dab929a259bf5fe107298d91ff0784d9a5fca434ee999a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/nav2_waypoint_follower/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "5259db32f25ab9274b88567e4716fbce7f498c1474b84c348673bef79c15be61";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/navigation2/default.nix
+++ b/distros/foxy/navigation2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-rviz-plugins, nav2-util, nav2-voxel-grid, nav2-waypoint-follower, smac-planner }:
 buildRosPackage {
   pname = "ros-foxy-navigation2";
-  version = "0.4.3-r1";
+  version = "0.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "72210833bc9284733350efc544d253d2ac80f7fa965e348be28acdbf43e37c6d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/navigation2/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "f733da59e06355acb96c1640211b4a03ab7b800f1a68aeff0cf301699b3b7d52";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower ];
+  propagatedBuildInputs = [ nav2-amcl nav2-behavior-tree nav2-bt-navigator nav2-controller nav2-core nav2-costmap-2d nav2-dwb-controller nav2-lifecycle-manager nav2-map-server nav2-msgs nav2-navfn-planner nav2-planner nav2-recoveries nav2-rviz-plugins nav2-util nav2-voxel-grid nav2-waypoint-follower smac-planner ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-osqp-vendor";
-  version = "0.0.1-r3";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.1-3.tar.gz";
-    name = "0.0.1-3.tar.gz";
-    sha256 = "7603e1c8ef7cb2b492ed69a2f084e65978b63e4c365ae4dccb1abbdbbccf800b";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "3b2a5e43a76c801a4709775861a65858de2141916dcef28804affad39b58b89b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "ca8d46c1573640f62d00e419e1a14871d7883d3529874465a3927422274f05e6";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "45f86d024897962dc997ceb30cd54455261ab9b4e4e734c58093d77643fc0a2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "89b5dfdb457e200aa033b712b72ee03600c1991fa036f1409569c32cba2aaaae";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "a9616d8a8e7825060a4ac65fd52c2ca190e1f2527f502ca29ae38f531139d41f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, osrf-testing-tools-cpp, rcutils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "04b3374dd306a4ec26c498fcd1b4bdfe93ff91448869906d8a0717eb9c4e424e";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "fc67d4aace5d708457b2d855a9f6103ed1559d8f6a25509c1c06469468bfdd20";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rcutils ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common mimick-vendor osrf-testing-tools-cpp performance-test-fixture rcpputils ];
   propagatedBuildInputs = [ libyaml libyaml-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.8-r1";
+  version = "1.1.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9259362d43aa7e308814dd8c55a656e19eee78774737019f3ee8ca8f72a6d721";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d411fa7e85ffefc4a15f371af8f7dd4caa013ca111977dc4c4d0ebf3f2097606";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake mimick-vendor osrf-testing-tools-cpp rcpputils rmw rmw-implementation-cmake test-msgs ];
   propagatedBuildInputs = [ rcl-interfaces rcl-logging-spdlog rcl-yaml-param-parser rcutils rmw rmw-implementation rosidl-runtime-c tracetools ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/foxy/rmw-dds-common/default.nix
+++ b/distros/foxy/rmw-dds-common/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-cpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-dds-common";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "678e09398385f0f4714e0ad084b0d8ba016e92a8d508e12bc5ac040e7c392a69";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "654496e63a60cb583415a80dc5858e885d371ed8c0f15f7a90c38f18bdf0a6e8";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common osrf-testing-tools-cpp performance-test-fixture ];
   propagatedBuildInputs = [ rcpputils rcutils rmw rosidl-default-runtime rosidl-runtime-cpp ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "65a3008594cbbf2278aac0a1a02c0557043c45390a53f86a0fb313a8f0135ca7";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7b1bde3656b7569c391cabfea83e63de70d72f9da377fe9147ecfea870201e5c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "0c941172952bc660abb5d70f6488cf16118146559a80eba0d24492d5e987d945";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "58eee77968cffb80a3c8513be721aa5722d92c10541537dc4661c07185a8caee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "7845541976c2305f23feaf907c260ba8671e6f8956b1dafb656ee26a7b483393";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "8502eda9ac05734b877d92d1a1385976d965dd78d4668cc1f749c3ddda12d96f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/smac-planner/default.nix
+++ b/distros/foxy/smac-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ceres-solver, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-smac-planner";
+  version = "0.4.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/foxy/smac_planner/0.4.5-1.tar.gz";
+    name = "0.4.5-1.tar.gz";
+    sha256 = "c1929d32a3474ce35454aa8f4730d479c95873f4be3e1e0936d5f96641811991";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces ceres-solver eigen eigen3-cmake-module geometry-msgs nav-msgs nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util ompl pluginlib rclcpp rclcpp-action rclcpp-lifecycle tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Smac global planning plugin'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/smclib/default.nix
+++ b/distros/foxy/smclib/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-smclib";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/smclib/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "72315b444eeba5b8f9bb994e46639aac5999595a3791c32b6081560f73b4d227";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
+
+  meta = {
+    description = ''The State Machine Compiler (SMC) from http://smc.sourceforge.net/
+    converts a language-independent description of a state machine
+    into the source code to support that state machine.
+
+    This package contains the libraries that a compiled state machine
+    depends on, but it does not contain the compiler itself.'';
+    license = with lib.licenses; [ mpl11 ];
+  };
+}

--- a/distros/foxy/sros2-cmake/default.nix
+++ b/distros/foxy/sros2-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-test, ament-lint-auto, ament-lint-common, ros2cli, sros2 }:
 buildRosPackage {
   pname = "ros-foxy-sros2-cmake";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/foxy/sros2_cmake/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "be19a8c14f292ae8f121abeecb64339cdebfbcfb8e9d618827a74b8556c29568";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/foxy/sros2_cmake/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "438eda96901566a1a9cdb98acb7405951aa00685792c0c820e7ca0fd0c4cc6c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sros2/default.nix
+++ b/distros/foxy/sros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-mypy, ament-pep257, python3Packages, pythonPackages, rclpy, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-sros2";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/sros2-release/archive/release/foxy/sros2/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "d91ac3924f5fba4c06bce64e8a7af3eb09e9d933f709b556b7a3578cafb370c4";
+    url = "https://github.com/ros2-gbp/sros2-release/archive/release/foxy/sros2/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "f5a0f86337d7d4a6950558300f2ef1a4fcd2f7885b855064bc43747f917deb31";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/teleop-twist-joy/default.nix
+++ b/distros/foxy/teleop-twist-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, joy, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-teleop-twist-joy";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "b9866ff97533ba2da7eb8bd76e5b82098a9e6bf9474ad2c42347e9f0f3f54583";
+    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a1bf57da8fba2b7e13a3754304458ae2153004918e8cb3951119c2ef265ea94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-bond/default.nix
+++ b/distros/foxy/test-bond/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+buildRosPackage {
+  pname = "ros-foxy-test-bond";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/bond_core-release/archive/release/foxy/test_bond/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "6efe0513889e9746b3bbf9ee097c9571db5ed14ee99c4e1bd57e3e9cf1420b6d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake rclcpp-lifecycle ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Contains tests for [[bond]], including tests for [[bondcpp]].'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/tf2-bullet/default.nix
+++ b/distros/foxy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-bullet";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "cd5b890e4e091ccc44618fbe1684ed8d5dfc8f0ab56d57ba293d230cbc1ad4ba";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "c58e4f10df68790bd8fe8bd851396fa9e0c6e91203377d549d157db6731eeba0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen/default.nix
+++ b/distros/foxy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "aadbbd860f6ca8cd827550e2ffb9c64e24da539ded44263f364177db48d72cd5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "cd12432b4f397ea05cae9a9f024f02cb48436533783c52b9f7ca2aaa6ec77b5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-geometry-msgs/default.nix
+++ b/distros/foxy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-geometry-msgs";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "4e0d814cd1f2e395e57e26756fed9549ffb9bfe96027270402e50f0065bf27a8";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "6a53098e577e2bb8531ca99032bc20d7c98a51261b2b8d888bab86aa9b538b9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-kdl/default.nix
+++ b/distros/foxy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-kdl";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "7f02fce28f65cd8e3c281b3641b62c5e3b9cba6e2af335e1646e6046918699b0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "1efd49b486cb3ead211abbffd1fb4ab5e72a13f32f3a0bb2402cd27a139b613e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-msgs/default.nix
+++ b/distros/foxy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-tf2-msgs";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "e2b464e5a98b0a8d2bbd537aff539dcc2846b298a8c36fd5453dcb715dffa8c3";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "a2b8d48baf65626224c9b5d7811f047ca0a025382a35a0b3ed9b006eca972bc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-py/default.nix
+++ b/distros/foxy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-py";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "5af922fce58f9e5bcf81ab89801d3689e02f6393942e358200273c042f080e5d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "0cc7c00bf0494a22f681419e0155c2efc26cf9ea15c6186986e9856925347bac";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-ros/default.nix
+++ b/distros/foxy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, message-filters, python-cmake-module, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-foxy-tf2-ros";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "df8108d31f108950bad9c6b65649b3b5635f913c2c6d9b52910fb63f538b27e9";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "591fe1fd86776cfa1f077f38288e279825abaf78b8437e6eda81084bc5340bf2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-sensor-msgs/default.nix
+++ b/distros/foxy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-sensor-msgs";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "8d379365508be9946c7e355f4063f2c9eb7d10a6d080b3ceac94cf1325793db0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "8458ed2904285b9667938e68348815f1fc9312880fc17803e93581b78657a9b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-tools/default.nix
+++ b/distros/foxy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-tools";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "e2162184fc82a56eaded99545824011698db887bf8e9b5df101ecc702a210c5d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "b0734ba6efe89b793ef335d9238b64ddb63f5bc95d9044d7cc4fb5e23cf9be26";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2/default.nix
+++ b/distros/foxy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-tf2";
-  version = "0.13.6-r1";
+  version = "0.13.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.6-1.tar.gz";
-    name = "0.13.6-1.tar.gz";
-    sha256 = "4fcacf611dc8dc4f66b715c9d0375bd1c7ce21da515e8506810c03abd522b09f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.7-1.tar.gz";
+    name = "0.13.7-1.tar.gz";
+    sha256 = "7573ffdb8373dff1420b9068f3e6e35fcb6df673756d736b145d4ea128adf1f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/v4l2-camera/default.nix
+++ b/distros/foxy/v4l2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, camera-info-manager, image-transport, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-v4l2-camera";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/boldhearts/releases/ros2_v4l2_camera-release/repository/archive.tar.gz?ref=release/foxy/v4l2_camera/0.3.0-1";
-    name = "archive.tar.gz";
-    sha256 = "538e02de489d0117527eddfd7ff342fde67599fdef31386e3d415bb4c69a22a7";
+    url = "https://github.com/ros2-gbp/ros2_v4l2_camera-release/archive/release/foxy/v4l2_camera/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "2ec6457368c1c8b639539737d165fe796505c2045d9240fae3173fe451252816";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/xacro/default.nix
+++ b/distros/foxy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-xacro";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f8160f1a9f47df64921f7fe5ecbd35036b10eaefd93a4ea0ff14a9a0ce50e1fa";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "8587a520398bf2811e889c3dd40a2f3a03ba6476e0bfdbf5e36db88eca05ce05";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/aws-robomaker-simulation-ros-pkgs/default.nix
+++ b/distros/kinetic/aws-robomaker-simulation-ros-pkgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robomaker-simulation-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-aws-robomaker-simulation-ros-pkgs";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/kinetic/aws_robomaker_simulation_ros_pkgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "5862b3d07c17752ed8d4b02d5a8bcd7b9c93a43a855af96b8478e33d70a72d0b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robomaker-simulation-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AWS RoboMaker package for accessing the simulation service.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-device-driver/default.nix
+++ b/distros/kinetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-device-driver";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_device_driver/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "c15cc8c2917e484145cac8b3b9aec9c25780cb589a4729202495615a91ef62e5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-driver/default.nix
+++ b/distros/kinetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-driver";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_driver/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "e3e34c342e91618835aa8f7d4645cd10dd4f7c8d11a002ee0c342b19a6850354";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/bota-node/default.nix
+++ b/distros/kinetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-node";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_node/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "b15f4142e13f5fd815adf8ce74560fee2e9ebde8d3b30ba1c3e6598dd9c6e0dd";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-signal-handler/default.nix
+++ b/distros/kinetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-signal-handler";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_signal_handler/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "2898209f5099d79ea1f3022945673387409adf20b389cfe441a2f9333cac1c46";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/bota-worker/default.nix
+++ b/distros/kinetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-kinetic-bota-worker";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_worker/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "b801775322a6da4a59d61eaf814c5fa4ae3f9fa3ef6e442b382d754d459d300a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "170ee897d6538d08cdb47cb25443b288d61d4c832b80996ab15bba16204e097c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "802ab3af878158fc817fcadc001ddb2026871bf0fe8c9dfdc9ad60d9f48eb095";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-aico-solver/default.nix
+++ b/distros/kinetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-aico-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "708cf024f510d19ecaec42229977c8c0287c85ef2027e47086504cde469c8f57";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_aico_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "62c61f833b560ffd2acca18e5ba13ca92504561723e0ceaa2e4a3b32872ba3ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-cartpole-dynamics-solver/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-cartpole-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_cartpole_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "1ecf2db3f075a814ac8479fbca225e4308f131e8877c5249f7204449ac5e798c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_cartpole_dynamics_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "ded3c2415eb7dd5c959af79cb787444815fd7857b3bda24abda896ded6599ce4";
   };
 
   buildType = "catkin";
+  checkInputs = [ exotica-python ];
   propagatedBuildInputs = [ exotica-core roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/kinetic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-collision-scene-fcl-latest";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "0ee03e0d1f0571c797c13629e4f15b4aba9de9592cd2ded98a0efc0afbab7897";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_collision_scene_fcl_latest/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "23a9407ca3d998d44b5c00e2dcd1f251dc3d1685622d093d47705e9472a2e362";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-core-task-maps/default.nix
+++ b/distros/kinetic/exotica-core-task-maps/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core-task-maps";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "7907f65456f3e72ae98dd38c4169696aea15c8ea453d2220f102b244d522862a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core_task_maps/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "30d6f0246419e37538a0efcba7e1c7fc8c4c947527de522684dece2e5eb2a010";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen-conversions ];
-  checkInputs = [ rosunit ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/exotica-core/default.nix
+++ b/distros/kinetic/exotica-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-core";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "a93f1c3b11b39fefbe92c4817c7bc8463546359ebcde0ae8c5daf1b2c3a6147f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_core/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "84bd5c879120912c0bd09df606b1f78237419948ef0e1fc3f615d406411ec4bb";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ddp-solver/default.nix
+++ b/distros/kinetic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ddp-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ddp_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "66b54fb007dd3d00a302b0569b7514722c8fb8e8c6e6bc36563790fdad1cd117";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ddp_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "9d0da0d122a2de42e3b34f9f55d1ffeb1c6728133a54a6ef1792ade4a1488286";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-double-integrator-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_double_integrator_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "41d25fff9a399fe3108f099096adcbc29a1e29e9d002c0e4d63deaee765cc01c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_double_integrator_dynamics_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "24fe9b78bead94ac94cc5769bcad9292aaa49f55de849bdb49d86c05019f6933";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-dynamics-solvers/default.nix
+++ b/distros/kinetic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-dynamics-solvers";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_dynamics_solvers/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "440c181e1317367a34ca3c637f38473de77c641f30b0b1ff401e2d5527844128";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_dynamics_solvers/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "caa5ac71e7bd983b413e92b9aef78786a7944722dcbc135b91eea27b108b80d6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-examples/default.nix
+++ b/distros/kinetic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-examples";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "029538f988c913bb1975ec8b93158583500199ca91cf7288cc0a8900c0d339d8";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_examples/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "708d97481c852453a74be91f57df9ab2907f068694b3d621ef4c2f47f9b53712";
   };
 
   buildType = "catkin";
   checkInputs = [ exotica-val-description rostest rosunit ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/exotica-ik-solver/default.nix
+++ b/distros/kinetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ik-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "6c98b087038486b89e7c314bac2bd996a5aea42be7cd547d833d511a6274e305";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ik_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "6190b27a782b7ee3879907e4d384c7d72e5eab1cd235b66881219070fa8b6bec";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Pseudo-inverse unconstrained end-pose solver'';
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/exotica-ilqg-solver/default.nix
+++ b/distros/kinetic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ilqg-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqg_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "a39a0be4c5369350fe70be43e897016107e3eeb0289def87a714b566313d95f3";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqg_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "9cb08f8f5c5ccea85c5842c33977bcf31e9bab0e96f881b956ecd8f6d2412e02";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ilqr-solver/default.nix
+++ b/distros/kinetic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ilqr-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqr_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "9f35aef66cd7bbb30a10ee3602d2d45c7a8b88f05c27eae242485acb769a658c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ilqr_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "50f6c9027523e098cfe0566422758dfd31e8ae312c98577cf98353518464e366";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/kinetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-levenberg-marquardt-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "bf2bb3264c9845bb92067b62c24dd38006c65dca697c550c3b921ace9721349f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_levenberg_marquardt_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "448f4e7644469ccd654265befd4357589ae8921093056ff5dcddc8f2689bdd9a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ompl-control-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ompl-control-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_control_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "aa8804ff9e628307967c4ba20f7f51827732ebce76da472c215c7968e8f595fb";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_control_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "bcf901a34896e16ec4720a2a6ab25988199bd683f7cc32b7fd6fa44e921e107f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-ompl-solver/default.nix
+++ b/distros/kinetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-ompl-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "37c5e45f430e8b6fb18a18cdf91931cc6c2d75e629011499187bdb0a47887826";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_ompl_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "86c1eb308787ed5a7eced5477202b37d2c05b4e9dc1ffbdc9fd60eaa2d30260a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-pendulum-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pendulum_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "24148169f2a720e75792fb2627b2a2f843a3bd6b934476a2ec09c804ab51985e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pendulum_dynamics_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "d2369d02eabd74ab481e49174f37333d1007dc0f2b53d7a323588c9a14a95b7d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-pinocchio-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pinocchio_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "23b1028add47a816c472fd051c9e950f968488c3c8b601263166a81be1ed2731";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_pinocchio_dynamics_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "306f5b6e7c381a5bddbee1c82567c7abced0c8bb3b39a23b0b4693ad96cbf83f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/kinetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-quadrotor-dynamics-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_quadrotor_dynamics_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "27fd9a8655b8ba1a0890a483f6ae5899fbcbacd6abadef083813e6c795e35995";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_quadrotor_dynamics_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "9e67d1aaf3729ac4c7f8ca6f7bc58693296dbaaef6f29d068fe76b2739f12594";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-scipy-solver/default.nix
+++ b/distros/kinetic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-scipy-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_scipy_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "16aefbee63612dcae3bf9f777d50ff9aa94983289a9eec850b3072e572ab8096";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_scipy_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "d706e19b9ecc4ee0dff144b5d214916ed6e89b03205d4789c9e0e99a0a9d73da";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/kinetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-kinetic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "3a767882cb81ee4def7f1ba2b485efbb62cde4f68591c3a0ac7c0e76308a8b82";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica_time_indexed_rrt_connect_solver/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "6851e01c9ab97b9145822eb5f3e612320f9ccfe20a50057c973aad8d9b107227";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/exotica/default.nix
+++ b/distros/kinetic/exotica/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-kinetic-exotica";
-  version = "5.1.3-r1";
+  version = "6.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/5.1.3-1.tar.gz";
-    name = "5.1.3-1.tar.gz";
-    sha256 = "e1f0b657a45fdc9f1eafb26655f0445ac3bdaec9f884d24f5e5e7f4076e14af0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/kinetic/exotica/6.0.1-1.tar.gz";
+    name = "6.0.1-1.tar.gz";
+    sha256 = "1ee5a9958b92514bc1eb9b114153d8b352186ecfd0e959138feffc76f345a216";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-behavior-engine/default.nix
+++ b/distros/kinetic/flexbe-behavior-engine/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-input, flexbe-mirror, flexbe-msgs, flexbe-onboard, flexbe-states, flexbe-testing, flexbe-widget }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-behavior-engine";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "dd270872c43100381b5d978ccae06502e8f22a44a62b1133f9f842fab023b475";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_behavior_engine/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "e577e677cb02771c1e6d0b33b8e5d19cd3e256e8151c421234ea1d10ed44fd1f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/flexbe-core/default.nix
+++ b/distros/kinetic/flexbe-core/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, rostest, smach-ros, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, flexbe-msgs, rospy, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-core";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "3b1d29d34f7208f8772dfcf910f39bc0b0c53ba95a7c97bf49b224d972803f87";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_core/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "22b8972e2d75c43d1cadd821479dfe9760027266a9fba6af6c308bb44402f07b";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs flexbe-msgs rospy smach-ros tf ];
+  propagatedBuildInputs = [ diagnostic-msgs flexbe-msgs rospy tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''flexbe_core provides the core smach extension for the FlexBE behavior engine.'';
+    description = ''flexbe_core provides the core components for the FlexBE behavior engine.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/flexbe-input/default.nix
+++ b/distros/kinetic/flexbe-input/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, pythonPackages, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, flexbe-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-input";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "17b22061ee5bbe600f1632eeeefa3617b3a47c2ee3992a9959b592bc3a40a3be";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_input/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c2a7a01393ecd040fc1c6776b94e150a376a0ba032a6fcc8005876301bb8c079";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib flexbe-msgs pythonPackages.six rospy smach-ros ];
+  propagatedBuildInputs = [ actionlib flexbe-msgs pythonPackages.six rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-mirror/default.nix
+++ b/distros/kinetic/flexbe-mirror/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-mirror";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "4c9464985cd2167304fbd00a71a72c17f45aa9e948fc5e672806853f1f969400";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_mirror/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "dde9591fac85b46ef35b11224827f083ddc566a029af3bfe2859b89aef6891f6";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-msgs/default.nix
+++ b/distros/kinetic/flexbe-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, message-generation, message-runtime, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-msgs";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "2a359eb5f21788b1db8404bc0a88c189895c59b1f290ee38582239c93e0ba4ed";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9f66118aef344ae1e4ac9db2d27d3b331b20801237c4db86d9a01906551e17bb";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime rospy smach-ros ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs message-runtime rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-onboard/default.nix
+++ b/distros/kinetic/flexbe-onboard/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-onboard";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "47ba62809691d63df576f52be7b49af74c8df364c5ce7bdd7aab81476d8b8216";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_onboard/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "8f75c8f2fbf5ff7af0637ccc35c80779c0113f593a3fd4cb3b5be26bc7c4612c";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-states/default.nix
+++ b/distros/kinetic/flexbe-states/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, flexbe-testing, geometry-msgs, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-states";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "078d89131588b4d0e576a32ce54a4de6eca6dd86bd9189eaecfa641987e8f616";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_states/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "2d1f88e457e3f2158b38f8d422b11f409407a46053b35d1e26e18f77343e3c92";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
   checkInputs = [ geometry-msgs ];
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rosbag rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs flexbe-testing rosbag rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-testing/default.nix
+++ b/distros/kinetic/flexbe-testing/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, smach-ros, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-msgs, rospy, rostest, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-testing";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "bbe6b3471afe5fa5d0d05994113ea8d018d7c0c46a8a8858e63fe9087b79a888";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_testing/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "198e25d7f6c5657fcd1a55c4a284ba54b48ddafe0e57a905e57a4fcf5fb50d09";
   };
 
   buildType = "catkin";
   buildInputs = [ rostest ];
   checkInputs = [ rosunit std-msgs ];
-  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-msgs rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/flexbe-widget/default.nix
+++ b/distros/kinetic/flexbe-widget/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy, smach-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, flexbe-core, flexbe-mirror, flexbe-msgs, flexbe-onboard, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-flexbe-widget";
-  version = "1.2.5-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "b5115fc90bd080d53fd9e0e8cd6d9e41a3e9a4d27d58c265f78eed8289cf1db3";
+    url = "https://github.com/FlexBE/flexbe_behavior_engine-release/archive/release/kinetic/flexbe_widget/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "5460e0aaaa168911d5de9b5daed59d3a914f14c597f616dfc9ce20a7e76aabc6";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard rospy smach-ros ];
+  propagatedBuildInputs = [ flexbe-core flexbe-mirror flexbe-msgs flexbe-onboard rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -188,6 +188,8 @@ self: super: {
 
  aws-common = self.callPackage ./aws-common {};
 
+ aws-robomaker-simulation-ros-pkgs = self.callPackage ./aws-robomaker-simulation-ros-pkgs {};
+
  aws-ros1-common = self.callPackage ./aws-ros1-common {};
 
  axcli = self.callPackage ./axcli {};
@@ -249,6 +251,16 @@ self: super: {
  bondcpp = self.callPackage ./bondcpp {};
 
  bondpy = self.callPackage ./bondpy {};
+
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
 
  brics-actuator = self.callPackage ./brics-actuator {};
 
@@ -3570,6 +3582,8 @@ self: super: {
 
  ridgeback-viz = self.callPackage ./ridgeback-viz {};
 
+ robomaker-simulation-msgs = self.callPackage ./robomaker-simulation-msgs {};
+
  robot = self.callPackage ./robot {};
 
  robot-activity = self.callPackage ./robot-activity {};
@@ -3751,6 +3765,24 @@ self: super: {
  rocon-uri = self.callPackage ./rocon-uri {};
 
  rodi-robot = self.callPackage ./rodi-robot {};
+
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
 
  romeo-bringup = self.callPackage ./romeo-bringup {};
 
@@ -4720,6 +4752,8 @@ self: super: {
 
  toposens = self.callPackage ./toposens {};
 
+ toposens-bringup = self.callPackage ./toposens-bringup {};
+
  toposens-description = self.callPackage ./toposens-description {};
 
  toposens-driver = self.callPackage ./toposens-driver {};
@@ -5115,6 +5149,22 @@ self: super: {
  viz = self.callPackage ./viz {};
 
  voice-text = self.callPackage ./voice-text {};
+
+ volta-base = self.callPackage ./volta-base {};
+
+ volta-control = self.callPackage ./volta-control {};
+
+ volta-description = self.callPackage ./volta-description {};
+
+ volta-localization = self.callPackage ./volta-localization {};
+
+ volta-msgs = self.callPackage ./volta-msgs {};
+
+ volta-navigation = self.callPackage ./volta-navigation {};
+
+ volta-rules = self.callPackage ./volta-rules {};
+
+ volta-teleoperator = self.callPackage ./volta-teleoperator {};
 
  voxel-grid = self.callPackage ./voxel-grid {};
 

--- a/distros/kinetic/ixblue-ins-driver/default.nix
+++ b/distros/kinetic/ixblue-ins-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ixblue-ins-driver";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_driver/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8fac6a5b192a8956a2b0cecc20893de7ed715fd5b5635db5c8f55a4c72d6e67d";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_driver/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "1c11dcf92e9880ac5cebbcd8d8f33ad5461f10542ab272871e8ec3e0f6a7b214";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ixblue-ins-msgs/default.nix
+++ b/distros/kinetic/ixblue-ins-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ixblue-ins-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "02062df9c7ff3cf99fbc2e774fe804095edec72cfb3a5d7735e8e7fc183bd209";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "9758f7bd04d619a307cb3077860480ec1c40e991a320fb33cd857d3af08018b5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ixblue-ins/default.nix
+++ b/distros/kinetic/ixblue-ins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ixblue-ins";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "20b054a6ead40117a92e189b3e2e003a0357870bc5d8e68ca2f8d42d0de68d86";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/kinetic/ixblue_ins/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "9a07840d6689ad23623fa8665ef092a1b1246ae8a96dd499cf21b18bac68e4d2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ixblue-stdbin-decoder/default.nix
+++ b/distros/kinetic/ixblue-stdbin-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, git, gtest }:
 buildRosPackage {
   pname = "ros-kinetic-ixblue-stdbin-decoder";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/kinetic/ixblue_stdbin_decoder/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "2ce0952fb15f8fdd681e6cd1a1c3facbacbc3774bf8d2cb21683506df0ad881c";
+    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/kinetic/ixblue_stdbin_decoder/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "740cdbd204a1f7b5fd476a8e61b94f86b9e4a1b17a45c340c2b1b70ff64210fb";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "d5bab26e97a7bb89b0fcee1ceb96bba655e84be7bf28acf5406f11000f1280d1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "79e98597d2f5be63d8266cdaea50e6f4959cdf222020d0c1918b53bd57397177";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/libmavconn/default.nix
+++ b/distros/kinetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-libmavconn";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "30f3fdca9e223bc1fcae133e57e194b81e53cfd8bded6f146148cfa90a617a11";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "2e9e5b6bee7a1be787550ff4495a0559cbb69e6c4ab30d6ac8ea3d6dcb1772d2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,17 +5,16 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.39.0-r1";
+  version = "2.40.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.39.0-1.tar.gz";
-    name = "2.39.0-1.tar.gz";
-    sha256 = "4406615341410c0fb62d34c08e97e02ad10e4e299c9935b3623061d49d71fcc0";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.40.0-1.tar.gz";
+    name = "2.40.0-1.tar.gz";
+    sha256 = "a8bcd9d71cdecc93e2f18692345114ec6bca0e35dd829319af963622362ca950";
   };
 
   buildType = "cmake";
-  buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ libusb1 openssl udev ];
+  buildInputs = [ libusb1 openssl pkg-config udev ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/map-msgs/default.nix
+++ b/distros/kinetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "d64d8011c9286a5ca31e055bbf201d5fee118e79851feade72e3b6c2faa1b20a";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "1c72c777862d13074551becfefdbfb3a7dfcc01f49d548693652fe25e139ec9a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "64dea002474f25b9b4c74ae5bba3d58c60eecddf27f0a685e5d22adae80d1d43";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "ac5605f6703d5c827ad97100e6c21fc2ab7240886bbaa976b06268e03fed2049";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-can-msgs/default.nix
+++ b/distros/kinetic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-can-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_can_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "a363704713353b216256bae9bc626291b659cc896d2359e6fef693c3b700a3d7";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_can_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "165e9e4c3ca3d084a5c2d1c02d7ba81c09ebda681de32241eae8694881597faf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-common-msgs/default.nix
+++ b/distros/kinetic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-common-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_common_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "d3294826d2f5e7ddcd10b6f80fb0bda1e48afbdc0c3972401fe51e7e4ba75cf7";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_common_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c94c2192841a47d1b6b63ee740955b4aa30758b0a1a7db444b529592abb43343";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-dbw-msgs/default.nix
+++ b/distros/kinetic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-dbw-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_dbw_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "8757ff729394a0b93b99ae019df302a2a92c96750bf677a0849ed86177c58e52";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_dbw_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "73196b2f43969bab6cf4363e75db37fe6f37a45afdc476bddd80ad9291d8a4f6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-nav-msgs/default.nix
+++ b/distros/kinetic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-nav-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_nav_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "8a6fac040223a4d032ee52de0e95f334c6352b4e427164e5dd142e9a12838f4c";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_nav_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "f72988a19e12fd449c9e19c7206a793125a86c5d9b44b47a51774960daad57fd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-perception-msgs/default.nix
+++ b/distros/kinetic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-perception-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_perception_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "20a925fb327e260fe432a100217b06ac1ef1870d0b6490929d78af6d955adb9e";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_perception_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "0967dd1a23edc2612a82a1a4efbd198fb1a535e991a1e6ca56d3b08c9624bb0a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-sensor-msgs/default.nix
+++ b/distros/kinetic/marti-sensor-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-sensor-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_sensor_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "4b5a3442bde877f722fb82cc012ae2e32af5c70f3f4993507a4a69a13975b2c8";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_sensor_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "c1bc1e5a3bf4fd6c849d6854a30cc852c4d95461eff043a37030eb5eda648d5b";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/marti-status-msgs/default.nix
+++ b/distros/kinetic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-status-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_status_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "3ab2a6a7dfd3f829c3b8d311dab0122d74c959bb68e0c38078ef190442f208ed";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_status_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "9622d25910ed4b6c025c2fe800ce6eeea76f6935f17fe66310d47f1c1f348ff5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/marti-visualization-msgs/default.nix
+++ b/distros/kinetic/marti-visualization-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-marti-visualization-msgs";
-  version = "0.9.0-r1";
+  version = "0.10.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_visualization_msgs/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "fad92357d34e7107892a890c967f4e83d069c030e2f5f1c8bb441ea8f0233eee";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/kinetic/marti_visualization_msgs/0.10.0-1.tar.gz";
+    name = "0.10.0-1.tar.gz";
+    sha256 = "2f55911242454e87e7cbc9bad554d533a102f98f9253b856d820faaeba5e58ce";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2020.10.11-r1";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.10.11-1.tar.gz";
-    name = "2020.10.11-1.tar.gz";
-    sha256 = "e8cf629722b09e6555b4c54e3112255fffc56c2b7c2f5d1a5d35761e1f656c9b";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "63cc127256d37c9b188b6004ea33452cb092995c7121050594fbaa7040c18935";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mavros-extras/default.nix
+++ b/distros/kinetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-extras";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "bd18aed1d4ffebd9aaa7517b438d667ef0cdd9a59f5fa585232936f5b81faf15";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "59c8861bf790e09dd6481ad98a506b06feb7afd1f50941eb05e5507bb36f9ab7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros-msgs/default.nix
+++ b/distros/kinetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "5a4695be4b59e6beefbb3a4805aaaa2ea0d1ac65c5d8bda50a921dd6f4086063";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "c86bf5c93ca87a5b78ce0305812e50944cbd538537b18c11b670a30afa812694";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros/default.nix
+++ b/distros/kinetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "462dfa2104326b3945a7ac16065e46bddf1c3866d4fbf4f1460b942284d5f681";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "fe663ff2d0149ac494b5495c7fbbc963d3020f096c2e856d8905f8418fb3206a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-core/default.nix
+++ b/distros/kinetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "8718557c17fcd5eebc58aa18cecd379d25e6101834be280fe5bd6a65f61aee22";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "fdf43ee04d2d4c281474cc043895eadbd8cec9dbe0472d668562f94a41caba85";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-abstract-nav/default.nix
+++ b/distros/kinetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "d1a6023ff353d18d173e9573c6f11bc65d1e783d5481b25b330739a8ab9b6c92";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "ee058a7ee3eb2f763c8d28dd9f3c3ec0e137ce3fcdbd6049433017d05e3df6cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-core/default.nix
+++ b/distros/kinetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "2ac0cafca70b0382f6d8acc0ff604dcd2159bac0963e60fa3c2c081f71f70dd2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "535cb2c281a9fa2054ecf2d3958e9bcebfe68aa4ec888e4a619d7ad9ee5d94bf";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-costmap-nav/default.nix
+++ b/distros/kinetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "a62d70772cc423caf139795d0d59937af0f8bc0cb4c01c828872a4eab13b42ee";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c82132225cab0a9261894e10900b6b787d831e473b39d84b1bfc45800ea6c0e7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-msgs/default.nix
+++ b/distros/kinetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "199b91621dc2a02b1f64d0e0f741433dff511693089400243baa7888bb35f23f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "d653651c01020a083851fdc219b9ccba01fde6477b5de29e7e190b7e31d3c7f3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-simple-nav/default.nix
+++ b/distros/kinetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c92635eba54649772659840a73156a0e5941d464c67cec9d5d45be0854cda626";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a006ba94981a31499333e3e95850c2d05314ba9b6865fe14269664d643bc2498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mbf-utility/default.nix
+++ b/distros/kinetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "81c366c20496f1e1cbb670403bd72cea40be18ee065666ff65bb671a5db8ad66";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a4eb6ff871cac9102f55d117ecfc2406d8d11ce570ccf8c354ba75692e7981ce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/message-filters/default.nix
+++ b/distros/kinetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-message-filters";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b663a931c219870a481fbe9b48b1eacc993ade635f29b94b61b5d0cb82545639";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/message_filters/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "42b202727458a529debfb19a92b20303873c07b811f4bb5339e1e3f13cc62286";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/move-base-flex/default.nix
+++ b/distros/kinetic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c83c3ec611b59746b6a0722b32d2dfab62de93e878ecab5f92422d4d7d6df6a2";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/kinetic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "1f056bd5948e0fbd7051c3392a3235fe30c615a057d96b43cdd47eeb810a781e";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/move-base-msgs/default.nix
+++ b/distros/kinetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "6f9cb9261d225727a7e0a9755d8ced29df60668c4a0cb1cb62e474ae0fe307f4";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/kinetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "8481264739efdc10d67243b1d4039e2759bbb0e143f699e863fa7b8784da14fe";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "1183592ee8596e10107c6ed4639253d2f16f2c8fafe2810dc5d698e43c41f707";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "95aaa0e059bb4aa9c84b33061db5e27d7ae90552e295ffd7fb6ede0fdea34da5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "c7229d64d829cf898a2ed1dc2ac8c6c76dc56b7168dcb0580c3a45180f78392b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "77924698beb86f6e445f49afa79929142d8478c123c6f7f11e6bdd3e88c05027";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "f22df908d18c3376d5da7044de8ad401bef28d3bbb2991ed1fff9a918fda5fcb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "79b4cc2d96d677d2ee480d04921dedc6ef54f6c8b72e0f07af541ebc7b9271e1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "871b805291b5e3fd831ddd7aa5c00e955779db6fa8d9826398fcdd8d7300f291";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "8f30394044d7a0deaf99d7fd7e83239b2a5ba1a9fd703bec2e79b2a40b253d06";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "801616ccfa7b34e8286d180c54615d7daa5d9836bb8031c88425d5bf22683e4c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "0a5b8d5cc9118fea3e87ff4888fac9d1ac384117aed02a24db53c66d8d1436e5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/kinetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-rc-hand-eye-calibration-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47511b12228e4b9f3db3d4cc3403b47438e8f9c1b8d0eb5682f401356c73b132";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_hand_eye_calibration_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "04f5f5d4552ec09d236fc096d6b6f8da3c9c6647f3dc389a7c486821d94dc650";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-pick-client/default.nix
+++ b/distros/kinetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-pick-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "9ba9b4a4b3c5e3e8199c4985bed15e9aaf4ee4ce6cc8575da641736f24600e41";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_pick_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "b8ddefb6b4020a41ed4f2338730234ecceee51a973bba94b913c3a7cd260bce1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-roi-manager-gui/default.nix
+++ b/distros/kinetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-kinetic-rc-roi-manager-gui";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "47190758fd397be16a969cacc66a0128025f69fea08865607312d2ff6c7a597c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_roi_manager_gui/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "ba4f022fc6aaca4fc6de70d261a08837e62618b102628c2cfa3eb2fd4bc5c05d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-silhouettematch-client/default.nix
+++ b/distros/kinetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-silhouettematch-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "ccae73cad1e0bfe9ed24200c12641154c67a018fa18b0421b8d4c3ef875a2eee";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_silhouettematch_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "df817e687d4c0e74f931f726c14eb7fd95c2a08e69319de7cab39734fba0ab3c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-tagdetect-client/default.nix
+++ b/distros/kinetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-tagdetect-client";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "8c6a2864c3ff2280ed11c2ff65ef25574b0024f34597c5f7d26e1c1985aa34f1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_tagdetect_client/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "c30bbc806b4f8ca80a37c58d99842db1207f7ef4e0b7925138dfd92ad97ce151";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-description/default.nix
+++ b/distros/kinetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-description";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "3815b22655e87e2e6aee2d05568a6a35dd037fae7aedf916d811682ab04a093e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_description/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "eb081f5b195b4bedf091956caeaf9182af47d62dd12bbc37d6899c27ce9e6345";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard-driver/default.nix
+++ b/distros/kinetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard-driver";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "4beab502ca2d7346d2f25c5956ce93f702e64ea7419c430187308e0cf7abba62";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard_driver/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "efcf7f218cc8a6fe0f1c718f5e0a9d88fb965dedb4274e142b208e82fdea711c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-visard/default.nix
+++ b/distros/kinetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-kinetic-rc-visard";
-  version = "3.0.4-r1";
+  version = "3.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.4-1.tar.gz";
-    name = "3.0.4-1.tar.gz";
-    sha256 = "f22f4c519ad2486430735f9812b2373509945ac74922daff2cccd8201eba79e5";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/kinetic/rc_visard/3.0.5-1.tar.gz";
+    name = "3.0.5-1.tar.gz";
+    sha256 = "72fa0c1686ba6b07dbde1482ef556fc1026d971d14dd45db0f6483403bfdfd78";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.18-r1";
+  version = "2.2.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.18-1.tar.gz";
-    name = "2.2.18-1.tar.gz";
-    sha256 = "2595d07f1873ccc0a2b2d78739e1ce06c59c2fc0afb12089e25181e62b41abe7";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.20-1.tar.gz";
+    name = "2.2.20-1.tar.gz";
+    sha256 = "dc035ea01274b6f842827468ab143c28df1f1cb63716c524209ddf18a0ac95cd";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.18-r1";
+  version = "2.2.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.18-1.tar.gz";
-    name = "2.2.18-1.tar.gz";
-    sha256 = "f985d9e9dc88e7f9caad841a9bda79753694dd2cca4ed163925c0aeb811dddac";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.20-1.tar.gz";
+    name = "2.2.20-1.tar.gz";
+    sha256 = "ecc93f2c41284ac5af76b6d96d8fa9d005210cc47e85c5f837093fddf7949982";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robomaker-simulation-msgs/default.nix
+++ b/distros/kinetic/robomaker-simulation-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-robomaker-simulation-msgs";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/kinetic/robomaker_simulation_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d70ade5a4b71772970a66967ced12149fc7ad45ca00d66bed8de77108b170920";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AWS RoboMaker package containing ROS service definitions for service endpoints provided inside of an AWS RoboMaker simulation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-bus-manager/default.nix
+++ b/distros/kinetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-bus-manager";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_bus_manager/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "ec288b09feefd1aef51b6647ba5096eae65dbd331fdf9811f20f8865039f517c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-description/default.nix
+++ b/distros/kinetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-description";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_description/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "a47b63478f05867ce85495259bfc8cdc58de3fac4c4951e013fd7a399f1525a2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-ethercat/default.nix
+++ b/distros/kinetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-ethercat";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_ethercat/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "fe69110b5525013f48e077e460356d8da09e90032142ffcc3149a831869f5d0f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-examples/default.nix
+++ b/distros/kinetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-examples";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_examples/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "cc0b75c56ef8a2881f43442e6eba4b9339b9e3bd30c9afd5113be19b320e9e85";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-factory/default.nix
+++ b/distros/kinetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-factory";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_factory/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "1a5b09c9df32e5252e240836a140ece0f58247557a59f1fad1905eedd4317bb6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-manager/default.nix
+++ b/distros/kinetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-manager";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_manager/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "634f287ac2962b4f1efcdd498361e414dba213356c21625826ca7c02853eabee";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-msgs/default.nix
+++ b/distros/kinetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-msgs";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_msgs/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "3d46f9b7af38013a92652422d43c399609c2c13f12209cd2d785bd3f0fde4bce";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini-serial/default.nix
+++ b/distros/kinetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini-serial";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_serial/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "1f6a3d14fdd9ee509891b6d92356904e57afd195805150adc92e307eb4b77e85";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/rokubimini/default.nix
+++ b/distros/kinetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-rokubimini";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "1ce3c4930dd5cb63b8ac6d414ecc953e2ef85e8615a93fc26effdde1101c2442";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/ros-comm/default.nix
+++ b/distros/kinetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-ros-comm";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "2aaa3d0571eb3986263f6e0dd9382e0f112c0bec937e21fb9c26149fefd4ca6c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/ros_comm/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "251da3087d8fae49abe732f2ff93252e81487c5d69a96e0c30cb2f3e317efb00";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-introspection/default.nix
+++ b/distros/kinetic/ros-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslint, rosmsg }:
 buildRosPackage {
   pname = "ros-kinetic-ros-introspection";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/ros_introspection/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "40103621911e9b795a4215fca7cdfb8667b513b9ffc1a6fec251555d83829679";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/ros_introspection/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "75fb94a80296f042faf47233152dc7a651b7f910a62ee3f0c4de9b99e302451d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/kinetic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-snapshot-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ded34f220aa8b9039be8ccbe049fb63d8e0434afbf3046b624ba3bbdb84d94ff";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d868758abb291d3c117e1d8a2e1ba4ec723dce497474678902813f025603ae6b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-snapshot/default.nix
+++ b/distros/kinetic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-snapshot";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "8e6fb5c71485e28f72b6194ba995b5d29e26438cb63567918357443e5b0c6421";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/kinetic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "55ba79bf6f6ec9054caf37e19d3ab4ad70567659c972ebab4a6090bf7bda3459";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag-storage/default.nix
+++ b/distros/kinetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, roscpp-serialization, roscpp-traits, roslz4, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag-storage";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "376c9d66af3591aa514a400c7a53b2197bafcc41be754e350d951359145b69f3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag_storage/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "cc0ba8c6a13b541381fbf8d9ae6c2e9a9a55b593831891edb6bcf9068d9b5ddc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosbag/default.nix
+++ b/distros/kinetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-rosbag";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "aa3a9ed9ac9ccff11edb69eaac3545ae2b65af37fb478b397e9e3c874e0b787a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosbag/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "530f841d0d329b6f651b9225017ea62093312ad4072c075f0aef41168254a642";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roscompile/default.nix
+++ b/distros/kinetic/roscompile/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, pluginlib-tutorials, python, pythonPackages, ros-introspection, roslint, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-roscompile";
-  version = "1.0.3-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/roscompile/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "cfe027f1f0b60ff37fc674d1f91eb5de45691ac553d86f558286392766c50e68";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/kinetic/roscompile/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "72ea838c434c7af7fb9c2dbca01b019ebf5ed1308b0bacbe7f3d68ef7e73781e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosconsole/default.nix
+++ b/distros/kinetic/rosconsole/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, apr, boost, catkin, cpp-common, log4cxx, rosbuild, rostime, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rosconsole";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "ed0057e2c129ee74a997b5a517ace606bdf47de19e3170a41ad562cd9c57c5dd";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosconsole/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "7fcfa3051aa6fe27c8122015c6af08b7140758fd97c09d511dce4641b1c76cc7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roscpp/default.nix
+++ b/distros/kinetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-roscpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f486ed35e076e0950e9192a41a6cbfdc1c4bff7c25fb1134b08c0ab21c1ec2f0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roscpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "3676973d3e564c8590477cc2a005cac81c7b02f25b28ec4782186b0cde559b7c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosgraph/default.nix
+++ b/distros/kinetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-rosgraph";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "c2403dd9523387fa99f64924a7681e5653aad8e3e5a14d389133c5ded64667b4";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosgraph/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "43d6fb781882e5ce71345e15bf1be32457b270f7a229ff5ea1c00131679f58d7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslaunch/default.nix
+++ b/distros/kinetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslaunch";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "41a3913f4871c4c647c57cee5fb652a42a8fc81ca2af83b89321300284f5a35e";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslaunch/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0e0f9367d3c13023fdd21bb26657fc5beeb09513a4c0b5462c9110c5cd9fc9d0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roslz4/default.nix
+++ b/distros/kinetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-roslz4";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f4fd030bfd5bf613e39effa52042f4c8f615a22b84b2df515c3b4873c96f5e41";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roslz4/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "0f55a2821108febf725792be25966bb0136d05bc80f00311225a58f819a6c892";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmaster/default.nix
+++ b/distros/kinetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosmaster";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "eed057b191aeb2e53bf963a0d32ebf6ee435aaa23309983a1da45d27c05aafe2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmaster/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "273a3094b53b3aa0b542b76b69dc84fd482b99b670c36f461eccb14d92e3fb50";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosmsg/default.nix
+++ b/distros/kinetic/rosmsg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosmsg";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f0907cd996fe008658d3af3d5aba6747dda30767d03fb632a2e7b82c873be5d9";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosmsg/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d03ec9630f58015d7e5f536ef33b33ce6c773a95c36c3050c25c7e3cfc9aabad";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosnode/default.nix
+++ b/distros/kinetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-kinetic-rosnode";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "22cda46d4b51c01b9b2cc5031c8fec64fded6d31b42714cad976139790730c80";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosnode/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "2bd70bb657e006be43dd5996a9dd9027122e927dd9f14147292b898fc653269e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosout/default.nix
+++ b/distros/kinetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rosout";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "b4a408241eca12ffd691882ecb1ef000a76cbf6b3b78fa684d2430c097ae8352";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosout/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "aa10e2e8cf9e8fcc57f5f90ac992c96c82c39c5b8762d6c05582ed77bd7f16c6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosparam/default.nix
+++ b/distros/kinetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-kinetic-rosparam";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "da21cbd9ee89c39080c3496b6defae95794394fe1378ab07d0ec2b9241f20d97";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosparam/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "1d6f465d685db5286520afa2e74445e97a003552dea0a8bba54133953b384498";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy-message-converter/default.nix
+++ b/distros/kinetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "8b0bca7ee697ad4812e674546407c24f07aed5f99566a9099b8b54df596cb352";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "b408446cb6167cb0c3d83ea8cec046971ac82ad84a81baa55057d3f12c094661";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy/default.nix
+++ b/distros/kinetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "a2d1d4bc6febc71e6daa05db982986063e7368483e797726577f0540c314ace7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rospy/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "08a7e7c2dba29eb5e821d960233dd9bd2a9ed650cfa568acfdeaeb5eeb904d2e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rosservice/default.nix
+++ b/distros/kinetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-rosservice";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "f51d308e5ad0688f4b4e631745811b1306d1ced1d2a6386460f7d18fac108b44";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rosservice/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "854047e943366c00b162f55342c562daa82bb1f7f5f5ada34ff89929e929c252";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostest/default.nix
+++ b/distros/kinetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-rostest";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "5c1ca6cd4f8be7d98b2ae2cea4d097c4a9c4f6b6ddc1a9162bb767b14f6a3e88";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostest/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "c25f1c491dcbaef71ee2c50b15c2b1feb8256511125818b82930a88769bc4e65";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rostopic/default.nix
+++ b/distros/kinetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-rostopic";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "d50a05c221c96e851759689c33da4c8698bf95b8e30a3f35509f365e8be8b6fe";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/rostopic/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "d476ccbc28d1276969c34af68b09ac65dcabf82ae8e81b798f6ea0ed90df27e9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/roswtf/default.nix
+++ b/distros/kinetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbuild, rosgraph, roslaunch, roslib, rosnode, rosservice, rostest }:
 buildRosPackage {
   pname = "ros-kinetic-roswtf";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "cefe1aeb678d9c0447a33c062a253164ec6e4c09f49470a5f37409d81454e1d3";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/roswtf/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "a184de1c25849b152acfb9a5fc9da9d1a65664b3a4b4a97d5a6941d975d8a7cc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rqt-bag-plugins/default.nix
+++ b/distros/kinetic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-bag-plugins";
-  version = "0.4.14-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/kinetic/rqt_bag_plugins/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "2244c50fef56accefa69f5696c15b0b55d4d4ecd56cdf3e6459354f5c7377c7a";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/kinetic/rqt_bag_plugins/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "a4a6c826d51a7a4d2b79ee1db4f385bb4522c1a6e6c2ad27a61c56c4b9d6afa1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rqt-bag/default.nix
+++ b/distros/kinetic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-bag";
-  version = "0.4.14-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/kinetic/rqt_bag/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "d5315bf86036e003eede8479530f1d76a0405d24517f7a5f73016dcdd3824720";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/kinetic/rqt_bag/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "72ca5eb5aa06e05d5c3c37a2b126b84f00584ef16bc8fb7b2bf95f1483454814";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "d7bbcb1b0128ce5a507832c5a111a12bced498660c7d14cfd0f89653035e084e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "c2a868a0cdb38e6e7e0425efd53d867c2ac9b6627b610c1c1a64e2ecc4349579";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/seed-smartactuator-sdk/default.nix
+++ b/distros/kinetic/seed-smartactuator-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-kinetic-seed-smartactuator-sdk";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/seed-solutions/seed_smartactuator_sdk-release/archive/release/kinetic/seed_smartactuator_sdk/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "e929721fb71d738544622d61a33a4947283d215c72b3960d8e5f6d2a1518fb85";
+    url = "https://github.com/seed-solutions/seed_smartactuator_sdk-release/archive/release/kinetic/seed_smartactuator_sdk/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "147e8a0b76d3431fb6e657f5afdd8bb272aa45b541595829fa90ab8933201258";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-safetyscanners/default.nix
+++ b/distros/kinetic/sick-safetyscanners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-safetyscanners";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/kinetic/sick_safetyscanners/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "5c82033b6884e01ac4af3554bd2b82ef699afb490ca6d4d298a1155a34823728";
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/kinetic/sick_safetyscanners/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "60aceb5402e469cdde237e884ce0d0ebdcde76812f25b2cbf309aab2174b68c6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/test-mavros/default.nix
+++ b/distros/kinetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-test-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "9d1a6b677141c027e902776c127ed2f8138c6940714e956eda267b78952c0603";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "1d5f9c1ae6db8d94042fedde0187dbcbdb89a49d649e9a6ee4e471f39634604c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/topic-tools/default.nix
+++ b/distros/kinetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-topic-tools";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "bfc3b7d5a7f42477bf02ab820ebdef837b2fb39f380c5f86ee199f2fc7df0798";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/topic_tools/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "89803ace2dd64ef62103b869e1e650c73782c972305f72199e1bb9e6f38e273e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-bringup/default.nix
+++ b/distros/kinetic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-kinetic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "8c4b5e2c9388accb1f26364fd706db0ece583098e4460025b8d78a2957c74e03";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/toposens-description/default.nix
+++ b/distros/kinetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-description";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c3f84919a724591f6579e30ece912171d4115a9a0ce7233cf605c54933f8bf5c";
+    sha256 = "f8c3b276441692895e4cde86bded0b18d200ee466067898ff13e37c5bf10210b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-driver/default.nix
+++ b/distros/kinetic/toposens-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs, turtlebot3-bringup }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-driver";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "cb5fe3da603f34d57d1f69150f255490e0a86ed64af9e85ef22965544a06328b";
+    sha256 = "91ba54fcbf9cbdf7485b5c99cf7d448a139365f4835616629019f8578cf26fc5";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy toposens-msgs turtlebot3-bringup ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-markers/default.nix
+++ b/distros/kinetic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-markers";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "4e1f41ee78d30ccf6a0dbb7a6a83f51b8e734ac14a89d522c922050780bdb560";
+    sha256 = "f6ae455663166bb99aacd30142a288bd82a5f9eee69fdf891c7379d5e77d7f95";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy rviz rviz-visual-tools toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-msgs/default.nix
+++ b/distros/kinetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-msgs";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "eadedf6fd2676fa2321ab0650ea89283865b8647dfcd9a10c45770c4fb5e20d4";
+    sha256 = "cdb2290d521b9868889cbdde38df76f74d7c6f6f17a2864164cac6ba946afd0e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-pointcloud/default.nix
+++ b/distros/kinetic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, robot-state-publisher, roscpp, roslaunch, rospy, rostest, rviz, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, turtlebot3-teleop, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-pointcloud";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "f8d0e200492ef0209a9b61ed19b370dbcdf34c75ed9e32f22b4b020f309007d3";
+    sha256 = "740c24224e2254fddfb065089704c834ed42867a6e60286debd82eb811df9e54";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros robot-state-publisher roscpp rospy rviz tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs turtlebot3-teleop visualization-msgs xacro ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-sync/default.nix
+++ b/distros/kinetic/toposens-sync/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-sync";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c22660383dfbb7f66853c2d4ed497f635bbd454dfaf63050399c726290719122";
+    sha256 = "41f8942e434f8575d6769c93843559629a213ae1cd546c796bf894df772f6aa8";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens/default.nix
+++ b/distros/kinetic/toposens/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-kinetic-toposens";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "5cc78eb7e78010a819d5646c8f21bff639d1d076f159a28302092d600b706184";
+    sha256 = "a18227cb76e4490b0a427fdd8047124afa4439d878260c259db696634c213637";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "dc231792fae711771d4fae4b2072bf991d7384fd7b84a462b4c2bfdf98f11ae1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "f231a39cf6950b800d4235e3608dfca78a8f02bfcd8fdad48d62ef68a536effb";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "1f4f2a2e99f2fc41998e370442c41ca9614e281dd532f7e84f329bb5b6912387";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "a70fdf7b190d3e6e202e5dbd02984cb6c11482b42ab50024f0fd01fbf768019f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-node/default.nix
+++ b/distros/kinetic/urg-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, laser-proc, message-generation, message-runtime, nodelet, rosconsole, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, urg-c }:
 buildRosPackage {
   pname = "ros-kinetic-urg-node";
-  version = "0.1.14-r1";
+  version = "0.1.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.14-1.tar.gz";
-    name = "0.1.14-1.tar.gz";
-    sha256 = "0bc507ce57d98ea3741301823fc5db80f521187f589944ea29d83bffe6b184d0";
+    url = "https://github.com/ros-gbp/urg_node-release/archive/release/kinetic/urg_node/0.1.15-1.tar.gz";
+    name = "0.1.15-1.tar.gz";
+    sha256 = "cf63043059b2420247180260ce9263e3610be901b8fdd7581d4349956c8f78ae";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/volta-base/default.nix
+++ b/distros/kinetic/volta-base/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-base";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_base/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e472ff308a257ff5654da25a23b57e9d5632086de5968f639df58e48324d23a8";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_base package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-control/default.nix
+++ b/distros/kinetic/volta-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, joint-state-controller, twist-mux }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-control";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "da7014b73a556268f2a3a5899c680d0854e25a73093879646e87811d6f6217f6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-controller twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_control package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-description/default.nix
+++ b/distros/kinetic/volta-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hector-gazebo-plugins, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-description";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "844f1f7cfd8c10e1223536890ce66fef9b5e915b1aad6169c2f02a11b4e2ece9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hector-gazebo-plugins roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-localization/default.nix
+++ b/distros/kinetic/volta-localization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-localization }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-localization";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_localization/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a466544d0b53a06d65192253298316e0194323ee5f2a7a72d55315d05bebbcd0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-localization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_localization package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-msgs/default.nix
+++ b/distros/kinetic/volta-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5f4f17517c4bc2f55ba214811071d43582c7557a79d91e785270dc98c8bc6fd6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-generation std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-navigation/default.nix
+++ b/distros/kinetic/volta-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, dwa-local-planner, global-planner, gmapping, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-navigation";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_navigation/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7d0e020355cbd333b4e14096108fc925cc0e005c58adb7d800927be1c37a5d3b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl dwa-local-planner global-planner gmapping map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-rules/default.nix
+++ b/distros/kinetic/volta-rules/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-rules";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_rules/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ba655be5a1974d5bfad6c9a57b23e49ec65e52f5b656a8c76f16ae8534b5891d";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_rules package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/volta-teleoperator/default.nix
+++ b/distros/kinetic/volta-teleoperator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, sensor-msgs, teleop-twist-joy, teleop-twist-keyboard, volta-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-volta-teleoperator";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/kinetic/volta_teleoperator/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9eab38801278a76d6d08c853c2056d7a1a1b77536329b265946c0da94dcea70c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs sensor-msgs teleop-twist-joy teleop-twist-keyboard volta-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_teleoperator package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/xmlrpcpp/default.nix
+++ b/distros/kinetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-kinetic-xmlrpcpp";
-  version = "1.12.16-r1";
+  version = "1.12.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.16-1.tar.gz";
-    name = "1.12.16-1.tar.gz";
-    sha256 = "fb662c176ae22ba7aba147004f7586b4233afad433d3b3e9906624da9dadd835";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/kinetic/xmlrpcpp/1.12.17-1.tar.gz";
+    name = "1.12.17-1.tar.gz";
+    sha256 = "65f58f680412c96e177aeaf6a287b6817861394dfa426e05eac72bcad0349d69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/aws-robomaker-simulation-ros-pkgs/default.nix
+++ b/distros/melodic/aws-robomaker-simulation-ros-pkgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robomaker-simulation-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-aws-robomaker-simulation-ros-pkgs";
+  version = "1.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/melodic/aws_robomaker_simulation_ros_pkgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "5e0601fa00843ff7ac138fe81b6a8f97242aaaf2648aee4a870b21bc9055ae8e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robomaker-simulation-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AWS RoboMaker package for accessing the simulation service.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/bota-device-driver/default.nix
+++ b/distros/melodic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-bota-device-driver";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "4c380c66060b6f55a15dfac4f933dc7d98880761dd35c2681dc31eaf432eb7b1";
+    sha256 = "16055aea61b57d38557728e0012c23bc6aa0769522edbfa9abe3a92b1b486446";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "d995592d9c8d88918dfe61f23bae9881ed99cfd7011235578ed6a875ad89cbe3";
+    sha256 = "8daee59cf0a68ccb10b21a4d4078e2af2447b64415eda86f7a91c28d79545ff5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "6503b36a33795aded7042790d7e2fc8aae390819aac35da353816892c6b17110";
+    sha256 = "4e7cb8094782f0970d5429c14eb3f0079a0e3bcf4d4ec7dc0a287cd72a9ec430";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "ee701a44c3c122d5ea4168b5698bcb012a1d093c7aec68129b6ed00495d94d39";
+    sha256 = "1fd27aa27200b4257cc3daeeb613b97f8570b6f802284ca53d95b88c5439b7d3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "103602543e1798a2d1d7a11c9ae5808cbd0f00b23e568d70970160a4451919e0";
+    sha256 = "6c14dcaaf0f153867ebd920ffeb6d2ff41d5872666f1a4b32e5adaf3fcf77885";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "864780149a804c7361697c216184acb3820007083870600fe761b8b2eb9e06e4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "c7802458fa7b2309adaa4174b677afeb7d8fea09c3671ff300a160ab34a32ad9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dataspeed-pds-can/default.nix
+++ b/distros/melodic/dataspeed-pds-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-can";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d943dd26424108c58985aa8bbe67ada3a8a4e5129665cae3eb42e6802be650fb";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_can/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "b42f60bb65943a05e8c78a89fd67db3cd2fe7641cf3a29e52300dffa71b34965";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS) via CAN'';
+    description = ''Interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS) via CAN'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/dataspeed-pds-msgs/default.nix
+++ b/distros/melodic/dataspeed-pds-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "3889e17470cdd02f0981c6c65bafbea53f37957d75894845e7273cf32570caa1";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "e2ad5cfa58bbe84eaef998882e1f513cd9d94096f20ab89fb49e51098a790891";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Messages for the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Messages for the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/dataspeed-pds-rqt/default.nix
+++ b/distros/melodic/dataspeed-pds-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, pythonPackages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-rqt";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "da1e4ad1cf20e0a19ef065e28493df792a26ea74c0b41eed90e7a0a85e504bd5";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_rqt/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "45e42d4c5a45175fd962ada3e558210b104c34af8c6214bec8ad26230be40a40";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {
-    description = ''ROS rqt GUI for the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''ROS rqt GUI for the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/dataspeed-pds-scripts/default.nix
+++ b/distros/melodic/dataspeed-pds-scripts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds-scripts";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "6cfcb7335515928b72d166d9713846d5c8f3637f976b3b854215a15e3f11b7dc";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds_scripts/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "78f2746975c73faea61d3614a764e97f8554eb00955f97014b64ba8cc5578e99";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Test scripts to interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Test scripts to interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/dataspeed-pds/default.nix
+++ b/distros/melodic/dataspeed-pds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-lcm, dataspeed-pds-msgs, dataspeed-pds-scripts }:
 buildRosPackage {
   pname = "ros-melodic-dataspeed-pds";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "253a81c72bcb54895740d27a7549df1a418efd9410bae579e953a63be98a087f";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/melodic/dataspeed_pds/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "235dc999c5c316d866364e8e26e40d313fdce4930bb8608452465416a0f11a11";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "42da85876c5670d83380035aeeb209f61dafdd55d2f92639fd0290304e6ef8d3";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "b95e6a1b69a60017158c5016ede4e437a00794d359312b9131d063fd97c13132";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "1f31578a0f23b34d0fee3b20e56225e852afaf968e89021c3544e31507fe64ce";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "354bfc89159892347217515c553e8d5efa73848adaca75d6028a1d868f287661";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b3ad6906fdec43788e2f4a0ffdfa3fc9e0950efb4926c5d0b497273f3f7be862";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "2cd473c0658237f414c248d4e7b788a36d9d8873b4d04cf6a2df7b382c70e976";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "8ff41f9b66008c30207f6af85368c4e90b457a5da13df0d35df52098b5ad4cb0";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e2f9df40b800630d5bb9c34708e5eebbf915947bbf4b65538ce806a42137412d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-graph-python/default.nix
+++ b/distros/melodic/dynamic-graph-python/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, git, roscpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph-python";
-  version = "3.5.3-r2";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/3.5.3-2.tar.gz";
-    name = "3.5.3-2.tar.gz";
-    sha256 = "13545602485a4127a069c383f39e937df533f9253c408465fde9cfc3ed89f73f";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "158a2774643b8697772ec940d99383d845d006fea9cb7cc6a7a5699593b9f66c";
   };
 
   buildType = "cmake";
   buildInputs = [ doxygen git ];
-  propagatedBuildInputs = [ boost catkin dynamic-graph roscpp ];
+  propagatedBuildInputs = [ boost catkin dynamic-graph eigenpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/dynamic-graph/default.nix
+++ b/distros/melodic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph";
-  version = "4.2.2-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "07bccde8806aa97248cec22b34d777d3bf072a1f6ca8a3954a150baf275bdf96";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "f76f385247b7afb60637ef3a42b1e6b01c2875c4f6d6106bb1f6e5a977f1773e";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eiquadprog/default.nix
+++ b/distros/melodic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-eiquadprog";
-  version = "1.2.2-r1";
+  version = "1.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "5be85014c6b487c75ac71c31cb205cb92fc137008d435793953e07d5de4340af";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.2-2.tar.gz";
+    name = "1.2.2-2.tar.gz";
+    sha256 = "5e30b47aad8598eeda3301ef6a834392123d3a2f1c3ba9a112b32cc4844158ca";
   };
 
   buildType = "cmake";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "39cfa431d55b8d9852dfd0d2e3d4eea53e439fa95cb0f092a7458f747fba2632";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "185888c588219301fb357ed384eb4994c44023bbcbbe3321087d0ba5f5af2e88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "b6782b0e0cde5a78e3cf468e40a70e95136db336ab2a89f154288362d93fb25c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6cc00eeaf2288d34744064b57be0e8ddb679ab68bfe651f310fdf65e2817eaca";
   };
 
   buildType = "catkin";
+  checkInputs = [ exotica-python ];
   propagatedBuildInputs = [ exotica-core roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "d3b03d6778e8ab4e509245977fd1703bc9ffaddb66f5ffc2c5e6e23b6d172b3f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a8e70b1d43ad3f4036a1d8279616877d2b6b6c22cf2b48dc9ee6b99298ac3497";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-core, exotica-python, geometry-msgs, rosunit }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "cb9230100c4a7a2f0ccb68b713bc5cecf570beb887025b18943353fac54515db";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "75e62e07272caa34d2e0dbf0c86a76aa24039eaa66f59e70f7556a3dc85ad347";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen-conversions ];
-  checkInputs = [ rosunit ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
   propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "3df8d716a7d34a58746962a1c7229bce9455bebd0246de0e9a49be628d28303f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "23ab85adf28c31786e34e5354300bdcdff0370ccc3574724f5419473fefbc00e";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
   checkInputs = [ rosunit ];
-  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "1fcf2a9fb9871aaf86e29a4cf1ba2981a780d3ba9cdb6cb1406f29e12ead952a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "bcc1db77ba896033fc553f413645e4885d8b163402231cf1fc91764fa88c889b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "78ca9fe0345fbb35ebd6a2d5579c9c8ab518d58d2f92ba0ee4d779c887f30f01";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "4b48c49e099a8a79a13cfee1dda845b2b7cec5a65f9b299be6a7ddfbf9983c4d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "9df5028b2245caf4045ae4f1da68b3eaf2582b6df67417a1b6f0226290814b4a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ff879be3a92c833cd74a6f339ec3c28cbd94f958a48c80b88e5deb3f2ed3090e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python-orocos-kdl, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "d9d221cafa1290cde1c8d9e285cd7a1793d7fcd23eff5b59a074907c033ee295";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ece29106ebf0a4e050bb1c1139acd1229ceda94781037182d0c3ebb3f703157f";
   };
 
   buildType = "catkin";
   checkInputs = [ exotica-val-description rostest rosunit ];
-  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python-orocos-kdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers robot-state-publisher rviz sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8999b2bcbb97a6cc6ebc5b0e3b5ff8b28d154a11d86d79cefad8512a9bc97a1f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "e0a286426c0eb0ec1009ab76bcda34f46774c6048a9749ecb5decae018290f7c";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Pseudo-inverse unconstrained end-pose solver'';
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "15d310fba58eb7eb7d766585210654a94c08282b723489e1c8867c8b7750075e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "2fadb114792c676d0da60f959dec596a75dbf59db1e56b28cd03b15bab6c9c83";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "e5a0298a4a186bbe0d60b03c6dd7412457061955e9265c1c85b5d680079d6859";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dd24747a2e73fded78b640d682e946fcb7d0794a4b32e4b1be7dfba846cd181a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "2782ec425a5659acb31d3492e8999a765fd7654e35b2fd41361018e0e58587c6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b13b9c12f8257e8df3b5f27987bb429b7f8cf40e408a39009ea2b3a91b6d246f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "93d0a10086b45bb8a3d761b09408eb1b3428c68c9c5e9ced735df3e34b67fc27";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "b355f1956cdd378aa722bde736f08d3d193811d3d5c03753591d3094a7f7aa91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "692432ad32c66690874b48d3fbb721c192e87664f38ce20263e17a593703190c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "317748c85c76ac619e91b886d05d3db27d20c5cbf44408eb90c60042d1b3c356";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8203597e8d8b34785c89db31621d949d964a1a4692c85a7c0aac39b89c089186";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "e552cd01f7ae31c86e4b0aea41e196300f01bf861d57e9c5591ad9ea213b0e9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "9a7ec88e3788da0ea147ce0d7eb2ee4c4bbd7fd3de6eaf9ac3796f18fb6dc5c9";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "467d5c5f247efe1c1925e77302fb200678f532bab5da50de8d165db59482d8a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "542fde5cde5a4465137774f6cf527950109d670672971d690e89fbf4e65ccf9f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dc8d2df841550cde9237f892004ad4182595c64b9eb142d5329176c5f0102509";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "8fb8a94b7adea8edc0f68b6574abb48089fed5b02551a040fa7dc0d1cab585c0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "62180a4a1169e70c6cfed7dd5879776b423cf47c15914d4309a4c6ed564ab43c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "738b1d76c6ace5a5385eef6bddcf758f58a1c7d066e9dd2daca20d35687c59f4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "3a849b661885b5c7d846bbfc08d34924ee1635c125027eed742383cf0e9283b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "5.1.3-r3";
+  version = "6.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/5.1.3-3.tar.gz";
-    name = "5.1.3-3.tar.gz";
-    sha256 = "a743c4a29edc8eb2f269cf4f39b7a0795998a58ba971e512610ea87c0a3b5efa";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "51329f641b9ab7dfa9be74dc0b943aa7d7cde16198ab78a8ccb28e6a7ca13f34";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "750fbb51252fba2e6705d6a180fde509cf1907cc9770898ba61172e7f9275614";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b9d68a934b7729c3b519eb66126eda7e61b6237a1f96cec651b983f8e9bd4e93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "0a3d7a6220a9fcfecdf31ce7463934bc8515a1bc4fc307dc811369d9e76b3a84";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b765c7e0ec121d981ac2f6a9b91599cad5db173b9d8ad6d64b50f1a53f559d59";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -160,6 +160,8 @@ self: super: {
 
  aws-common = self.callPackage ./aws-common {};
 
+ aws-robomaker-simulation-ros-pkgs = self.callPackage ./aws-robomaker-simulation-ros-pkgs {};
+
  aws-ros1-common = self.callPackage ./aws-ros1-common {};
 
  axis-camera = self.callPackage ./axis-camera {};
@@ -1822,6 +1824,8 @@ self: super: {
 
  mesh-msgs = self.callPackage ./mesh-msgs {};
 
+ mesh-msgs-conversions = self.callPackage ./mesh-msgs-conversions {};
+
  mesh-msgs-hdf5 = self.callPackage ./mesh-msgs-hdf5 {};
 
  mesh-msgs-transform = self.callPackage ./mesh-msgs-transform {};
@@ -2358,6 +2362,12 @@ self: super: {
 
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 
+ pal-carbon-collector = self.callPackage ./pal-carbon-collector {};
+
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
+
  panda-moveit-config = self.callPackage ./panda-moveit-config {};
 
  parameter-assertions = self.callPackage ./parameter-assertions {};
@@ -2854,6 +2864,8 @@ self: super: {
 
  ridgeback-viz = self.callPackage ./ridgeback-viz {};
 
+ robomaker-simulation-msgs = self.callPackage ./robomaker-simulation-msgs {};
+
  robosense-description = self.callPackage ./robosense-description {};
 
  robosense-gazebo-plugins = self.callPackage ./robosense-gazebo-plugins {};
@@ -2894,11 +2906,15 @@ self: super: {
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
+ robot-statemachine = self.callPackage ./robot-statemachine {};
+
  robot-upstart = self.callPackage ./robot-upstart {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
 
  robotis-manipulator = self.callPackage ./robotis-manipulator {};
+
+ robotont-description = self.callPackage ./robotont-description {};
 
  rocon-app-manager-msgs = self.callPackage ./rocon-app-manager-msgs {};
 
@@ -3184,6 +3200,8 @@ self: super: {
 
  rostest = self.callPackage ./rostest {};
 
+ rostest-node-interface-validation = self.callPackage ./rostest-node-interface-validation {};
+
  rosthrottle = self.callPackage ./rosthrottle {};
 
  rostime = self.callPackage ./rostime {};
@@ -3339,6 +3357,16 @@ self: super: {
  rslidar-msgs = self.callPackage ./rslidar-msgs {};
 
  rslidar-pointcloud = self.callPackage ./rslidar-pointcloud {};
+
+ rsm-additions = self.callPackage ./rsm-additions {};
+
+ rsm-core = self.callPackage ./rsm-core {};
+
+ rsm-msgs = self.callPackage ./rsm-msgs {};
+
+ rsm-rqt-plugins = self.callPackage ./rsm-rqt-plugins {};
+
+ rsm-rviz-plugins = self.callPackage ./rsm-rviz-plugins {};
 
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 
@@ -3653,6 +3681,8 @@ self: super: {
  topic-tools = self.callPackage ./topic-tools {};
 
  toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
 
  toposens-description = self.callPackage ./toposens-description {};
 

--- a/distros/melodic/hdf5-map-io/default.nix
+++ b/distros/melodic/hdf5-map-io/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, hdf5 }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, lvr2 }:
 buildRosPackage {
   pname = "ros-melodic-hdf5-map-io";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/hdf5_map_io/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "4b25fc9823b115e2ffddf5f274ec81719b69c4b1761564c11072e0cdde9514fd";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/hdf5_map_io/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5805cfb79152f8350b95260d2eec609ac0292fe571e89f62cdc656454d84f819";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost hdf5 ];
+  propagatedBuildInputs = [ boost lvr2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ixblue-ins-driver/default.nix
+++ b/distros/melodic/ixblue-ins-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins-driver";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_driver/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "19f76a53801661d1c5a65337fc7bf37aef1eca6d768bace9daf8b963ffaa484d";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_driver/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e8c2cf9338a916824a0ac0eb1cf6a32dba409954dd4c76cf0196c27e9fb4813e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ixblue-ins-msgs/default.nix
+++ b/distros/melodic/ixblue-ins-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "cd60c6db0588be82894c8648007101970a36353a7da0c340d6733ffd3a15bd90";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "08c1cb7de51604655cffee31329002fe4064cda296ca35f165da2bc21bdca8a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ixblue-ins/default.nix
+++ b/distros/melodic/ixblue-ins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-ins";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "a38ae8f03e93e071b2091e8335866b82ec60501ddefd0cd2df5d0fe8a51b7268";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/melodic/ixblue_ins/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "69760d7da2a07f7d39257f057ce47e0ced915cc333912737f046931d708a98ec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ixblue-stdbin-decoder/default.nix
+++ b/distros/melodic/ixblue-stdbin-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, git, gtest }:
 buildRosPackage {
   pname = "ros-melodic-ixblue-stdbin-decoder";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/melodic/ixblue_stdbin_decoder/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "ca06b4c6776c6bd419b46546cbbbb709b8a229d876c4b6958c13eaee9ef65bca";
+    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/melodic/ixblue_stdbin_decoder/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "7e0f3d91ae4c3d9349e4cf450439284061c27f00c84ee94069daaf12e26c8988";
   };
 
   buildType = "cmake";

--- a/distros/melodic/jackal-gazebo/default.nix
+++ b/distros/melodic/jackal-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, jackal-control, jackal-description, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-jackal-gazebo";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "8364a4349df4bc2d6bed5c7c2d0e7dc1f1baf5ff6e9669b138ab9a3d785cdcd7";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_gazebo/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "202c29adfd750e5043f10171294ca27c0a310aa44a99ea46afebbc269ec9bbef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-simulator/default.nix
+++ b/distros/melodic/jackal-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, jackal-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-jackal-simulator";
-  version = "0.3.0-r2";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.3.0-2.tar.gz";
-    name = "0.3.0-2.tar.gz";
-    sha256 = "e9e14150e70e7c51cd6fa674af8c0bae82aedd156e8bf0019774448d6b1a915a";
+    url = "https://github.com/clearpath-gbp/jackal_simulator-release/archive/release/melodic/jackal_simulator/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "adf0d04519d339a355293cb30113435a4a4575adc65b4690681977ed1e4b900f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "a56d983336c677f88de17426fdeecf7e35e6faff4cc0f06a4ae92874e2463b9d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "a222bd38b5fa402a7869bf91f8d96863cce9d2183571397426bcf31d0d1435f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/label-manager/default.nix
+++ b/distros/melodic/label-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, genmsg, mesh-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-label-manager";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/label_manager/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "97b371fb101be7bf59209d81b3c9780abe22d1a78eeb2555a86a320e754c03b7";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/label_manager/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "774bbccc5440c62f0a98678e812e4dc07ec909d0d5345cb4d56f867ca2d985b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "9344bb68b21e3605106dfc1d1fd666a0ba2d756ef02b0b024631bd693699e51d";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "d568941c7d2a4c80dc960a9e889ed8b505e9a190c2dadb968f98367df8c561c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-msgs/default.nix
+++ b/distros/melodic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-map-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a0b7044c2fd59448eb714ce14d60c5ff2d0073962e011e6549c7dd99fc916ffc";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f9258be961e164b60e94b10e2965dc703d8614d360645717d099b40c2ea71de0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "ff8d0eae550d67517924a4ea07e2b59c97b7dec209130f00af3486ead611f2e0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "fdc5b9a39577aa59ef583f15f8218fe7617400d72e9a78f50958a7b4cff0ed7c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2020.10.11-r1";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.10.11-1.tar.gz";
-    name = "2020.10.11-1.tar.gz";
-    sha256 = "fd9c52f31c93b758650b4625f00dae12ea0fa44c6102bcb0d7dd3a334b09fc58";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "bada2901df30654db92fc55cfa785e157c9c50a37cb42d133fb380f8cb924cc2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "350addbaadd1b5cb961e3d3caa692a9153b44996fc75e8a843ea20bc9f3004f2";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "340fa3ece896f853c7c4a7b98e22c7010dfdc4045742b572d74f3b0058722a92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f8ebf0ac98ff1c8876ad9d29bbcc421c2f172507f1eba700c046334275f24d8e";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "8afe6a116343d7641a9349917b8f959b0b365841c27945979da4e6e373d7925f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "d3e882fcd600b85d85f9725f135515da722779bb46d60b1e7f22d92e936345d0";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e04a1115d1d0c7b5b66b20209f69319b8ab511dc337b114d6cff7b4e8eaf6994";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-core/default.nix
+++ b/distros/melodic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "59edfe99fab5417c478bbe7adbe2082191898ae7f486e1b39339d580f882fc09";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a696a873e440ea24e136cef9b9d45a4db16d8d57ebc47011cdc8b79449d08082";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-abstract-nav/default.nix
+++ b/distros/melodic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "34c8bc49b61b4bfbdf54badb5ac8901819a389f181e13abe7f12719b87e9f284";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "d0ed780f0b9a18312ce1ba5ae676bcb06e4bb8c3518577ea4fb2ee80e7797f2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-core/default.nix
+++ b/distros/melodic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "ab6a7064b0169cfe4c61611dc36bc0c7f887fe232819872ea3547c0746496d62";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c82a471481fe829a900c96c633b5f5957824ca4e82a2a2768f569be75fc6249b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-costmap-nav/default.nix
+++ b/distros/melodic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "0605b881744f00116a3fe4c1a2a8d4620288e2229bc492c1fee448f3df56e05f";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c007af4116e035165fbad6724da6a6823417b188127e2c2613d035e667ea5beb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-msgs/default.nix
+++ b/distros/melodic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "80181a8a4b0eb59ec113ff61ece66c6fdd2d58e652cc299a023b59257b2f2c52";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "dd3643142b07d929a1badaa271fefdb78b322628d86beaedf2d9ede9b27ac1e6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-simple-nav/default.nix
+++ b/distros/melodic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "f09d2300a7f151743be743a8ed38a69ee9c856cec9277d9d1969a796b3c6db97";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "49f7277cbc1dd9285a0ddf36689b2d0230c101e9cd8822aef40d8eb5e837c810";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mbf-utility/default.nix
+++ b/distros/melodic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "19d944f0d4cce88d7d9f481c45287e83164496d1836346bdae868c055e5b926d";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "99201d09d272fd06ea04b04f9a3f7413be3fae46497fd0c930f87d474ffe2f14";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs-conversions/default.nix
+++ b/distros/melodic/mesh-msgs-conversions/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lvr2, mesh-msgs, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mesh-msgs-conversions";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_conversions/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "64768b67d148491af1cd698e8a4b9aa78856e14a3d7af935c7ca801c498550e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lvr2 mesh-msgs roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''converts point clouds and attributes into meshes and mesh attributes'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/mesh-msgs-hdf5/default.nix
+++ b/distros/melodic/mesh-msgs-hdf5/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs-hdf5";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_hdf5/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "d405f421ec7bff3d7b22d58e86d613174332b3fadbffff4f04b402413fbf6dc6";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_hdf5/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b1cef484da7c668517763d575498a79ac83ab91031385970f8c036c91327a12c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs-transform/default.nix
+++ b/distros/melodic/mesh-msgs-transform/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, mesh-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs-transform";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_transform/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "774eb5801a209f2939d76b1d058112b2472405fa5790d28c7e9bcf4375e0810d";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs_transform/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "aa1f0d44f36bffd971f57edfa10ae9523774dd81a8304381292c349e434ec69f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-msgs/default.nix
+++ b/distros/melodic/mesh-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mesh-msgs";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "d120ce3a5e6b61a59a4e0d959d0d62575be556f0172cd5860b5e4ece4c9996e6";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ba6c804561859c215f9c3cd004171cb5590ec74a942cd4a8f52f5ca8946e6a53";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mesh-tools/default.nix
+++ b/distros/melodic/mesh-tools/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs, mesh-msgs-transform, rviz-map-plugin, rviz-mesh-plugin }:
+{ lib, buildRosPackage, fetchurl, catkin, hdf5-map-io, label-manager, mesh-msgs, mesh-msgs-conversions, mesh-msgs-transform, rviz-map-plugin, rviz-mesh-plugin }:
 buildRosPackage {
   pname = "ros-melodic-mesh-tools";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_tools/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "ab25a7aa81386ca73f2978593edcaa93a85ca3108815c4ac5fd68d58c877dfa1";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/mesh_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c88c21c4baedd66a1ae639de307c6ba45a2f4d4d118cae74a23fbed9687d4719";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ hdf5-map-io label-manager mesh-msgs mesh-msgs-transform rviz-map-plugin rviz-mesh-plugin ];
+  propagatedBuildInputs = [ hdf5-map-io label-manager mesh-msgs mesh-msgs-conversions mesh-msgs-transform rviz-map-plugin rviz-mesh-plugin ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/move-base-flex/default.nix
+++ b/distros/melodic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-melodic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6d3674af1d438357a5e6b236a28995a77a5f7c324abac3b51d7f8d0cc610ba0b";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/melodic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "b60e1d7a80952be12ad6b6d56b060346a422120413282745f0a819b76e675a40";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/move-base-msgs/default.nix
+++ b/distros/melodic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-move-base-msgs";
-  version = "1.13.0";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.13.0-0.tar.gz";
-    name = "1.13.0-0.tar.gz";
-    sha256 = "a9b1ee115c3252718a9915a94ba16421a39309ed237a33d790f486d468f8a1ef";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/melodic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "f221272c2819180557e5c21b79dd30f34d9ac83503595c6132f9fecc7b48cfcc";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Holds the action description and relevant messages for the move_base package'';
+    description = ''Holds the action description and relevant messages for the move_base package.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "acc5a994e393af1d319750399ee0bacc7efff235a4c18030c4aba2d90d6cc2cd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "34f45e08b6befc4860591982dc3388c0c1eed925ded4b46e5a66a63f59bbba7e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "a0983a61884a4ef83c6c861d3fbbc224d311d43bf3b2f9a6114abd2d54f6b77e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "cac96e6b25db706045e77424a2b24c992e3c3aae25399c854a2c62840ba98d78";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "655ed548e899572b6636d6744fb8e808ac1f9983f199c1ac8b660b3494ac0de1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "084db5feaa2a28ef521ab6cbb3ff3de341d83004f2f0dde9ed8ea1f479b3ace1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "bb9e70e42062b2b2c98f086951e6c060f77294d653724309803a30eef4865c65";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "550a17f2b4f5cac63bd28d253b916df2b280c4bcae063e8dafca07557c614568";
   };
 
   buildType = "catkin";

--- a/distros/melodic/open-karto/default.nix
+++ b/distros/melodic/open-karto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin }:
 buildRosPackage {
   pname = "ros-melodic-open-karto";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "1e6c4eb4da8553c8f14b62ec29b1fa0ec2eaf88edce2b75c668ebda566e6e27c";
+    url = "https://github.com/ros-gbp/open_karto-release/archive/release/melodic/open_karto/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "9441edebe6265db0419ca9fca4e85578413ff700953145d4d22fe8d2202a0c92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pal-carbon-collector/default.nix
+++ b/distros/melodic/pal-carbon-collector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pal-statistics-msgs, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-pal-carbon-collector";
+  version = "1.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/melodic/pal_carbon_collector/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "f8b1a9f99ca84937c402791de83cca7525b73fec5cf35238d0f49dc6eba42f94";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ pal-statistics-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node that collects statistics from topics and sends them to carbon'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/pal-statistics-msgs/default.nix
+++ b/distros/melodic/pal-statistics-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-pal-statistics-msgs";
+  version = "1.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/melodic/pal_statistics_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "ede295cc48b9ffa94006a5b58b768cb20b698d0d37580e927a05052a9b065a10";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/pal-statistics/default.nix
+++ b/distros/melodic/pal-statistics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gmock, pal-statistics-msgs, roscpp, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-pal-statistics";
+  version = "1.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/melodic/pal_statistics/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "e5fd44e5ee34381c90c5beadf22ea46cdab7332b0e168cc1bd802012f34c0cda";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gmock rostest ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "0264ebce24d886a9f84b1b72704da8e12edf69ba66e9fead42da21462539a3ec";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "76f09d89fdefe6a04124d2a68ad67a9a227fd61431c327f6a1a55a6706179b60";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, robot-state-publisher, rosconsole-bridge, roscpp, rosfmt, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, rosfmt, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "24789bb519f88eb2f18b97f400e19886c6843409e7acfead8821993eae2ed29c";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "c01af2f67a442b3ae098cc3ad159de1a7cd66480d19d09205d06d16c525fcff8";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage pilz-testutils roslaunch rostest rosunit ];
+  checkInputs = [ code-coverage pilz-testutils rosbag roslaunch rostest rosunit ];
   propagatedBuildInputs = [ robot-state-publisher rosconsole-bridge roscpp rosfmt roslaunch rviz sensor-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/robomaker-simulation-msgs/default.nix
+++ b/distros/melodic/robomaker-simulation-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-robomaker-simulation-msgs";
+  version = "1.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_simulation_ros_pkgs-release/archive/release/melodic/robomaker_simulation_msgs/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "51c3f5d70c599369c912d428ae4a12cfbc97930e27714f041c58fb0c47449233";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AWS RoboMaker package containing ROS service definitions for service endpoints provided inside of an AWS RoboMaker simulation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/robot-calibration-msgs/default.nix
+++ b/distros/melodic/robot-calibration-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration-msgs";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "8aa932a83ec1488c67647070770efd2241c5c652f44aa9b7dd76bc1e34182b4a";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f7ad438cebdd4c0e631471ff463aee3afd4a53fe69cbd662c78c99be29b3aaca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-calibration/default.nix
+++ b/distros/melodic/robot-calibration/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-calibration";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "0f1548a3bcd88d07310993c9f28dead1bce7eaca3590986a6959a58968ba6f90";
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/melodic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "d705f4093051c90fef5837cf427685444bf5d3c4a17aada13efb9b4f2211ea56";
   };
 
   buildType = "catkin";
-  buildInputs = [ gflags ];
   checkInputs = [ code-coverage ];
-  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/robot-statemachine/default.nix
+++ b/distros/melodic/robot-statemachine/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rsm-additions, rsm-core, rsm-msgs, rsm-rqt-plugins, rsm-rviz-plugins }:
+buildRosPackage {
+  pname = "ros-melodic-robot-statemachine";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/robot_statemachine/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ebddbe2287aded77a9ba2763f2b0c29fd8a330beb2d0f1718d2ee229a43e2848";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rsm-additions rsm-core rsm-msgs rsm-rqt-plugins rsm-rviz-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robot_statemachine package bundles all functionalities and the GUI'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/robotont-description/default.nix
+++ b/distros/melodic/robotont-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-robotont-description";
+  version = "0.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotont-release/robotont_description-release/archive/release/melodic/robotont_description/0.0.7-1.tar.gz";
+    name = "0.0.7-1.tar.gz";
+    sha256 = "d95ec61d0bfab76ba98bdf48cf9f7b5f0104e28252a6964fbdee9fb9a008f2a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robotont_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "3c40927408692de41673af26c9b169add09cf59c77194c8c71e55da1a81d8b7d";
+    sha256 = "dfaae0604c6789f77d4d12edd3dc101e0c0aecf2aaeed2054333982348622b84";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "ae0f59984ef20e956f46873589426e2383d00299dbef87e415004affb6b4a070";
+    sha256 = "9e55902a11a52812580ebd57ddf6e19280e32ae3bc1f935e401c7230475b218f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "0f6e9943bd52948738862d00b37c7f12f37c3ea2f40c576f910c3b433eac2b89";
+    sha256 = "a8a7d89bbc37d8a9d3ec09e153606e23e550a173c7d3f2d43871b466d83afe00";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-examples/default.nix
+++ b/distros/melodic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-examples";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "ece58bf00b38d219cbf07b66a9573d29298e3277ee4e81d46fca595076273e37";
+    sha256 = "31d6f42572d4617e96e8ee5e3463c21858c4209a19b3f92038eaf7a6c20fced9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-factory/default.nix
+++ b/distros/melodic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-factory";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "d23777994e6ad6ce71c7c2c7a21be08bfea3c0ce0da6fe73a2824d4d5f85e93a";
+    sha256 = "31f5306165a8514b119d8b368f22ca9be401adba4ba7dc904c8887dfc6d9a571";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-manager/default.nix
+++ b/distros/melodic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-manager";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "83eb2b0545da49e0c78cbd8583b9f13fcab9f9293f78e7e86eb387464db0df63";
+    sha256 = "3ab6842e3499ce5e6dffe21121836340e0c8b6f41ac56558425c5ad84940df50";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "b76bdddd1b353b057f96e6f588b1e0deeeef882a8f2a4321407c71f7e120cf55";
+    sha256 = "d729657f0083cf898cb4afbb270aa266966f16b19be6ffd30d5a62ae22316a9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "17e9d3302bbe0477177d6b2bb425b213e5de4d9af19baf2f730b34eca7315a52";
+    sha256 = "e0e8419092f2c060974ae1ac7b53077de2b473e33a6fa9bf0cb66b1dd1cb2f40";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.2-r2";
+  version = "0.5.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.2-2";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.8-1";
     name = "archive.tar.gz";
-    sha256 = "0b740616a3aa3f6b55a8f2ff5a614b6a1cd96dd6d35b52888457d04b648ac537";
+    sha256 = "b8968f21789b570c4e5348abe78774b86bc4237301f64d91c2de44bda2954db6";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cmake-modules eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rosbag-snapshot-msgs/default.nix
+++ b/distros/melodic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "3d5c6a3fafa000c6cd9619405354dbde5bf1440749bb730db9c32cad581e0994";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7dfcfda926b100b95b36509fd0e05e2988d23fcdde8f2c116802da67d96c4bc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-snapshot/default.nix
+++ b/distros/melodic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-snapshot";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "15bc7f1085ad63e259c0843d9d901ae9207707ebf5e4e7ac248bf6f6613d4ae6";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/melodic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1e6ebfa8f2773794f99a2379a42b9ca80ad6aea174b24626f6f5a32044f3c23a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "02ab2ca86f2b1ef188676a3c5d2133813f883b0f0fc43d90a27785e3200a7b20";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "051cb5fcc3c00598cf4c225e77bf6a71a14bda79bd90376c305e7a7921eb9dd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostest-node-interface-validation/default.nix
+++ b/distros/melodic/rostest-node-interface-validation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslint, rospy, rospy-message-converter, rosservice, rostest, rostopic, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-rostest-node-interface-validation";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tecnalia-advancedmanufacturing-robotics/rostest_node_interface_validation-release/archive/release/melodic/rostest_node_interface_validation/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "04d36f1346f96b88c4bcbece65fa1917697ffc129132adf4a307e8bd44dc18dc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest std-srvs ];
+  propagatedBuildInputs = [ rospy rospy-message-converter rosservice rostopic ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Additiional testing tools at node level'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rqt-bag-plugins/default.nix
+++ b/distros/melodic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag-plugins";
-  version = "0.4.14-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "767219002743eee60ba41a82a3a28696e931cc62d3984c1aae740191bc9eaf8f";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ca99407bcee6772429093e5a980a88a8c5b0f71ebd2166bd7ab0feb574e2084e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-bag/default.nix
+++ b/distros/melodic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag";
-  version = "0.4.14-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.4.14-1.tar.gz";
-    name = "0.4.14-1.tar.gz";
-    sha256 = "b146c934f19f079f1fa759457d9a244f86c7af2092d57b54972be4e3db572be0";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "576d8412c68894c8430619ed33113e43406d2b6e56ece10c2cf5c24b62cdea36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rsm-additions/default.nix
+++ b/distros/melodic/rsm-additions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, move-base-msgs, pluginlib, roscpp, rsm-core, rsm-msgs, sensor-msgs, std-msgs, std-srvs, tf, tf2, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rsm-additions";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/rsm_additions/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fec4c5529ec2dfc2fd2873f8f2dfbb2de3f947a4926839a3c59deeb380113337";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs move-base-msgs pluginlib roscpp rsm-core rsm-msgs sensor-msgs std-msgs std-srvs tf tf2 tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rsm_additions package includes plugins for the Robot
+		Statemachine and exemplary launch files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rsm-core/default.nix
+++ b/distros/melodic/rsm-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, pluginlib, roscpp, rsm-msgs, sensor-msgs, std-msgs, std-srvs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-rsm-core";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/rsm_core/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "73718531335c64edd3311b0982b207d96fe3d5527e5183f619d80a37acbae87b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs pluginlib roscpp rsm-msgs sensor-msgs std-msgs std-srvs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The statemachine package includes the Robot Statemachine's
+		main functionality'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rsm-msgs/default.nix
+++ b/distros/melodic/rsm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rsm-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/rsm_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "0ad923adfb26ca4ea60822201b7ceae4deabadb749701fd325228ffad1ca62af";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rsm_msgs package features messages and services for the Robot Statemachine'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rsm-rqt-plugins/default.nix
+++ b/distros/melodic/rsm-rqt-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, roscpp, rqt-gui, rqt-gui-cpp, rsm-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-rsm-rqt-plugins";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/rsm_rqt_plugins/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "10a50da0619295d4a0c946cd9ef634c09ec44c8ad3fb3298422d025989cd634c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules roscpp rqt-gui rqt-gui-cpp rsm-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rsm_rqt_plugins package includes the Robot
+		Statemachine GUI plugin for rqt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rsm-rviz-plugins/default.nix
+++ b/distros/melodic/rsm-rviz-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, interactive-markers, pluginlib, roscpp, rsm-msgs, rviz, std-msgs, std-srvs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rsm-rviz-plugins";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarcoStb1993/robot_statemachine-release/archive/release/melodic/rsm_rviz_plugins/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f5efbb578bac6c1465862cb6b29d8255f8307814a27bc0aa5fbc5202c5434124";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules interactive-markers pluginlib roscpp rsm-msgs rviz std-msgs std-srvs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rsm_rviz_plugins package includes the Robot
+		Statemachine GUI plugin for RViz and the waypoint visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rviz-mesh-plugin/default.nix
+++ b/distros/melodic/rviz-mesh-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mesh-msgs, qt5, roscpp, rviz, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rviz-mesh-plugin";
-  version = "1.0.0-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/rviz_mesh_plugin/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "1ac3536d778bcff8100d72b5038947172f31cc12c6e88026f9f2acf06f289ed0";
+    url = "https://github.com/uos-gbp/mesh-tools/archive/release/melodic/rviz_mesh_plugin/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "b033a57f17fdb501834a309610e3cfffc834892a78b9715f6e4127831afe2fe7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.14-r1";
+  version = "1.13.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.14-1.tar.gz";
-    name = "1.13.14-1.tar.gz";
-    sha256 = "ee23b05dc98e61c0d8501ead6667f24f4d8eaeb82029f36ae078800c07943d9a";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.15-1.tar.gz";
+    name = "1.13.15-1.tar.gz";
+    sha256 = "2231a3c4f10650e37f5650cc85a25590474a6d1a1e26e2fd00cd8303581f6c02";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "25bae0bd0d9f03e89d56568ff29947958086b2725a24b495e573ab681807c93d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "cf8ca560bc034dbe9d734a6743292f89cdd796674cdfcaf043730cc4bd54308d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sick-safetyscanners/default.nix
+++ b/distros/melodic/sick-safetyscanners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-safetyscanners";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/melodic/sick_safetyscanners/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "cc08c0d0b1c86ca621137dc3fe1621a49e59076c3fe28c0ca17a844304d26a76";
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/melodic/sick_safetyscanners/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "598d9960f83457e229e3110ae8897d7720e7b2112d0df14e46428d714182b3dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "948337659afd854e975a3d6919a558cbe59cfea2c9d07831e1ac10505ff97af0";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "185bcc24d6846c3433aaa8f0c2cb4e2a3b8975d1c761cec63ae3ecd4c44e51b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-bringup/default.nix
+++ b/distros/melodic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "8070e4fc87ea31059e71d41c0961b6ab39ef6feed24b667207c3a9d8a5e44d66";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/toposens-description/default.nix
+++ b/distros/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "9449bf971c63000bcf088ece79703def3d1cd7189b4c19e4b872e56556389000";
+    sha256 = "1bd77a491c96473f5a1bb563090149c58c421324891f14a3681fc3103e0e553e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-driver/default.nix
+++ b/distros/melodic/toposens-driver/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-msgs, turtlebot3-bringup }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "c85f8b7bb6cd4fbf18fbc15a9602d2e4098310a632d56e2be1a8e6de54dfaab1";
+    sha256 = "fa52fa15587860d0f954e2da53460251dd6f788bf7e696bf46f9ac8ed9f2b334";
   };
 
   buildType = "catkin";
-  checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy toposens-msgs turtlebot3-bringup ];
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-markers/default.nix
+++ b/distros/melodic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rospy, rostest, rviz, rviz-visual-tools, toposens-description, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "135dd96e3468ab3caf9e08a9e0cd8cc7cf93070c075aed26f1e8ec18b270de6b";
+    sha256 = "caa8dc40b5a17cd9f98149587ef3afeb0191599c4cf0aa5ef2bd5beaeb9cafa6";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rospy rviz rviz-visual-tools toposens-description toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-msgs/default.nix
+++ b/distros/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "77964b3ea4262c128f14a4f6ffb5e0fbb525f0e15bd73cb598471daa9b9640a4";
+    sha256 = "e74ec8411e4507b36e9cf326903e425c90f4b02e24541d39bb30980ad9b15730";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-pointcloud/default.nix
+++ b/distros/melodic/toposens-pointcloud/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, robot-state-publisher, roscpp, roslaunch, rospy, rostest, rviz, tf2, tf2-geometry-msgs, tf2-ros, toposens-description, toposens-driver, toposens-msgs, turtlebot3-teleop, visualization-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "f534b81233f4e2fd347254c66cfd16d52e028c2ef5a1fbf17f47560bd8c75461";
+    sha256 = "d720d6d42394732c5d894e904bed47a21b3b04cf5bd3faed434e661105e9bad0";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros robot-state-publisher roscpp rospy rviz tf2 tf2-geometry-msgs tf2-ros toposens-description toposens-driver toposens-msgs turtlebot3-teleop visualization-msgs xacro ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-sync/default.nix
+++ b/distros/melodic/toposens-sync/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rospy, rostest, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "34473cd0343a4ecfd449d11e7440e3bc0bbfcaadef3980429cf91b43db06e4eb";
+    sha256 = "449c7fbdc4adefc79797eb9a74f9c2a86daae76a9a5e365872bdc056adcbec65";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage roslaunch rostest ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens/default.nix
+++ b/distros/melodic/toposens/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "2.0.4-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.0.4-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.1.0-1";
     name = "archive.tar.gz";
-    sha256 = "6dc77e60003b588730aff6d6fd8e38d95ae946e85dcb066ff61ba60b4f4c7be0";
+    sha256 = "703e1844de02b4ebaa27df9a4f71822c1848d00cf9e3ae62e7f970a81867c50a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "ee60fd044e5265378d7b846a0c39974ffa21254b44d7c21cbe4570011d1c2277";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "eb0d0543d17ab8829cfd2ff3992a9f5c3279df3b5a6268b6942af8f5350f4c9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "42afb967c056f35bd33c25c847f427883313952f9fd69c43e537d0084f5b3548";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "41e4585775581dd18efdd41081e738bb13b6c2b30126370a8fa859a4b22035ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/autoware-can-msgs/default.nix
+++ b/distros/noetic/autoware-can-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-can-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_can_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f7b4868e4fb6ce3d591b53a3f9e744e9a1a3194ccba26b63dc4540ad5491f0b3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_can_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-config-msgs/default.nix
+++ b/distros/noetic/autoware-config-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-config-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_config_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "eafaea3c8e37f57ddb46a1f4b9cb3152ba49dec22a3cf4b13e538c70c2947ccf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_config_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-external-msgs/default.nix
+++ b/distros/noetic/autoware-external-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lgsvl-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-external-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_external_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "9e46e8c0fb4b274a632a42d058fe1b33b556a809f602ec8a9567c468c719b2a6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lgsvl-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package to contain an install external message dependencies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-lanelet2-msgs/default.nix
+++ b/distros/noetic/autoware-lanelet2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-lanelet2-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_lanelet2_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "fa2a058aa23ed50120b0e7ac33a75dfe637ea301578124929ab0126de9f61f43";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_lanelet2_msgs package. Contains messages for lanelet2 maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-map-msgs/default.nix
+++ b/distros/noetic/autoware-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "dfea163b4bd892c5a7cbd519885e309449e6a0f21fe088bd91ce9836b0b68247";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Includes messages to handle each class in Autoware Map Format'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-msgs/default.nix
+++ b/distros/noetic/autoware-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, jsk-recognition-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "f445a6713e8764e34e58f34fc1f8ad56637b3699546b7912baba2cd05c7b31ee";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs jsk-recognition-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/autoware-system-msgs/default.nix
+++ b/distros/noetic/autoware-system-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-autoware-system-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/autoware_system_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "7bc5e114a49f6224db2da7cba91ce2e05baf589858391e1366616066a8ded740";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosgraph-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The autoware_system_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/backward-ros/default.nix
+++ b/distros/noetic/backward-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, elfutils, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-backward-ros";
+  version = "0.1.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/backward_ros-release/archive/release/noetic/backward_ros/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "64789ad4703518a057483120d2df9ef2780f4f4436e1752311bd62e46368309c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ elfutils roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The backward_ros package is a ros wrapper of backward-cpp from https://github.com/bombela/backward-cpp'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/bagger/default.nix
+++ b/distros/noetic/bagger/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, rosbag, roscpp, roslint, rospy, rostest, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-bagger";
+  version = "0.1.3-r4";
+
+  src = fetchurl {
+    url = "https://github.com/squarerobot/bagger-release/archive/release/noetic/bagger/0.1.3-4.tar.gz";
+    name = "0.1.3-4.tar.gz";
+    sha256 = "acd129c677edeac531445ce4b48eb37e89e0f94e67ad2b45e7705a305a167ed3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  checkInputs = [ geometry-msgs nav-msgs ];
+  propagatedBuildInputs = [ message-runtime rosbag roscpp rospy rostest std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An application used to systematically record rosbags'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-device-driver/default.nix
+++ b/distros/noetic/bota-device-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-bota-device-driver";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_device_driver/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "b8ebc073955c3761a70674d21d4fbcd8010654e53b74d8d4d80f2b37f7cc1e94";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-node rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-bota-driver";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_driver/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "d3d8ccd3219c9fa2d054781dd7b84b055b08331ce6edd3fd1a0b4966865d93cf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of BOTA driver.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-node";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_node/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "026bfb7f50aa82b35f766444db2315bd1ff876d8e9dc48013941bd9ddbe87aeb";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-signal-handler bota-worker roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node wrapper with some convenience functions using *bota_worker*.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-signal-handler";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_signal_handler/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "489dec973794dc77d424e6ce8b4da17618963d57fa4019b0c591ddcfbbbf8277";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains a static signal handling helper class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-worker";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_worker/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "7ab383e91f34051013936e3ec6c4ab5882460f0d6758bf873f030ebfc4b986fe";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''High resolution version of the ROS worker.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/code-coverage/default.nix
+++ b/distros/noetic/code-coverage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lcov, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-code-coverage";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "8cd4d5c421532b7b8bb57563cd3cbbf6fd5edce3830da323f18b72d0a9bd9a1f";
+    url = "https://github.com/mikeferguson/code_coverage-gbp/archive/release/noetic/code_coverage/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "9b9a65c55bcf50a7a90c55a13d0376e59aa1d331a6a2ae75d1c452caa9cb03f0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "f104fe63de8cbe33ae3107df638bad78aafa98fc513457f20abe1c4fc784ba58";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "64c293612724ceff86271b8a6b440db5dfd2c1770e7ff6f12f625177aafd18d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dataspeed-pds-can/default.nix
+++ b/distros/noetic/dataspeed-pds-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-pds-msgs, message-filters, nodelet, roscpp, roslaunch, rostest }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-can";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_can/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "f22fd5414cd0fbb26bc91a39a4e2a593e2a5ae2b12a93447f5a4466b3ad823e1";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_can/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3013fe2ad968c981c9af9147401262a624d168dc18e75b8ae68e9ce9bb5608da";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS) via CAN'';
+    description = ''Interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS) via CAN'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/dataspeed-pds-msgs/default.nix
+++ b/distros/noetic/dataspeed-pds-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9b9b7b3eac15fa9bf444c45a829c7f417613124661b17e346485c5606412ee6d";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3fef22aba59316e7daf38726ded577eead137cd17cbcf800888b0095e0a6546b";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Messages for the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Messages for the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/dataspeed-pds-rqt/default.nix
+++ b/distros/noetic/dataspeed-pds-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-rqt";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_rqt/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "bc67fb5fe19b991e962442a5b325ad78985a126d938a292cd099cc8d69380d87";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_rqt/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "bbb99a9aa319880f7f8f23a2c835d61025249f938e9a7cd9d10e9272f3f2ac7a";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {
-    description = ''ROS rqt GUI for the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''ROS rqt GUI for the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/dataspeed-pds-scripts/default.nix
+++ b/distros/noetic/dataspeed-pds-scripts/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds-scripts";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_scripts/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "6cc2ce71d6e5d433c53c5bef9b841f43f125b135a468972a4daeda8d9929a596";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds_scripts/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "872aaddc11dad62f89dc85b08b4060bc082dd0a4e712f3d4d23be388adcff8ea";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Test scripts to interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Test scripts to interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/dataspeed-pds/default.nix
+++ b/distros/noetic/dataspeed-pds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dataspeed-pds-can, dataspeed-pds-lcm, dataspeed-pds-msgs, dataspeed-pds-scripts }:
 buildRosPackage {
   pname = "ros-noetic-dataspeed-pds";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "44c8a7c766f762858594df8de00e49d1a701c93c4899f3ecfdde3dcee05687a6";
+    url = "https://github.com/DataspeedInc-release/dataspeed_pds-release/archive/release/noetic/dataspeed_pds/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "93c905bc798c40a8342c4179e3648e58d8f267a2d684286a67fb142e85db2bc2";
   };
 
   buildType = "catkin";
@@ -18,7 +18,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Interface to the Dataspeed Inc. Power Distribution System (PDS)'';
+    description = ''Interface to the Dataspeed Inc. Intelligent Power Distribution System (iPDS)'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/ddynamic-reconfigure-python/default.nix
+++ b/distros/noetic/ddynamic-reconfigure-python/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-ddynamic-reconfigure-python";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/ddynamic_reconfigure_python-release/archive/release/noetic/ddynamic_reconfigure_python/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b99b19d692984bb83a34afb74dbe92b3d4e7bde5e89afd47cacbc57e3963df5a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ddynamic_reconfigure_python package contains
+    a class to instantiate dynamic reconfigure servers on the fly
+    registering variables'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, git, roscpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "3.5.3-r2";
+  version = "4.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/3.5.3-2.tar.gz";
-    name = "3.5.3-2.tar.gz";
-    sha256 = "8b6a74f4078a0314d0b2ecba099e6e078400eea037cc7cdc4ba9d5704ae205d4";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "5aa3df95d58c0cd6272a61c1cb04c43df264df6201c56d6263530d8f44eb2fff";
   };
 
   buildType = "cmake";
   buildInputs = [ doxygen git ];
-  propagatedBuildInputs = [ boost catkin dynamic-graph roscpp ];
+  propagatedBuildInputs = [ boost catkin dynamic-graph eigenpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.2.2-r1";
+  version = "4.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.2.2-1.tar.gz";
-    name = "4.2.2-1.tar.gz";
-    sha256 = "9044a56f1b493709619b6ce9bf8db8156fa5687d681dfa08b847c271ee8d0559";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.1-1.tar.gz";
+    name = "4.3.1-1.tar.gz";
+    sha256 = "57b4e2d7e07e5a59c662cfc96da23485e1ff945f9dabe1a65babc155d48c6707";
   };
 
   buildType = "cmake";

--- a/distros/noetic/exotica-aico-solver/default.nix
+++ b/distros/noetic/exotica-aico-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-aico-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "babad9a7bc81d4de08fe0863e4693fd2b43f1835fb8935c02fc4dd8a042a2d51";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Implementation of the Approximate Inference Control algorithm (AICO)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-cartpole-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a19d6c63cb7f91a8003f8bdae0f096f971c406bfe85c14c467922f32a71d9b6d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ exotica-python ];
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartpole dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-collision-scene-fcl-latest";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6a068dd35a2b865d83803b9743c2a10b8d4db856bff6bff828e98defda07573c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core fcl-catkin geometric-shapes ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Collision checking and distance computation using the latest version of the FCL library.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-core-task-maps/default.nix
+++ b/distros/noetic/exotica-core-task-maps/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-core-task-maps";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ac1b5a19508c57b345a794abaa701c48ae163511db3bf51bbaaaf7f1f23715a2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions ];
+  checkInputs = [ exotica-collision-scene-fcl-latest rosunit ];
+  propagatedBuildInputs = [ exotica-core exotica-python geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Common taskmaps provided with EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-core/default.nix
+++ b/distros/noetic/exotica-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-core";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "dbceb5d9bb097357508a127b29c19bb06d100aea401434317d7af68cf3b731cf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cppzmq eigen-conversions geometry-msgs kdl-parser moveit-core moveit-msgs moveit-ros-planning msgpack orocos-kdl pluginlib roscpp std-msgs tf tf-conversions tinyxml-2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Extensible Optimization Toolset (EXOTica) is a library for defining problems for robot motion planning.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ddp-solver/default.nix
+++ b/distros/noetic/exotica-ddp-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ddp-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "752cd837531b317dbea29065f8a1f2f4fbac7e294ada4f3a3e649c3f72f3d869";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various DDP Solvers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-double-integrator-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "14985f8c402c30ce483b4841f92783717767004bb13081420127b86f3d6d6c31";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Double integrator dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-dynamics-solvers/default.nix
+++ b/distros/noetic/exotica-dynamics-solvers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-dynamics-solvers";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "04f1a58969af8a3b73737000d720d20d36cd5e3c1e478fdb6c1c17112506333e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-cartpole-dynamics-solver exotica-double-integrator-dynamics-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-quadrotor-dynamics-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for all dynamics solvers bundled with core EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-examples/default.nix
+++ b/distros/noetic/exotica-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python3Packages, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-examples";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "a5be687d3f439d47fe2c1f25da58f45332f4ecd8c97ddcb5edb8116601c1b02c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ exotica-val-description rostest rosunit ];
+  propagatedBuildInputs = [ exotica-aico-solver exotica-cartpole-dynamics-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ddp-solver exotica-double-integrator-dynamics-solver exotica-ik-solver exotica-ilqg-solver exotica-ilqr-solver exotica-levenberg-marquardt-solver exotica-ompl-control-solver exotica-ompl-solver exotica-pendulum-dynamics-solver exotica-pinocchio-dynamics-solver exotica-python exotica-quadrotor-dynamics-solver exotica-scipy-solver exotica-time-indexed-rrt-connect-solver geometry-msgs interactive-markers python3Packages.pykdl robot-state-publisher rviz sensor-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package containing examples and system tests for EXOTica.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ik-solver/default.nix
+++ b/distros/noetic/exotica-ik-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ik-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "f4f57db036fda82b40aab770293214b7469dde20ccf07e00fe36d87631b018c2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Regularised and weighted pseudo-inverse unconstrained end-pose solver'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ilqg-solver/default.nix
+++ b/distros/noetic/exotica-ilqg-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ilqg-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ade567828ea1045ec1eb7e5e068563d8abfcb50e24101bef6cf6fc88e018890e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQG Solver (Todorov and Li, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ilqr-solver/default.nix
+++ b/distros/noetic/exotica-ilqr-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ilqr-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "5682e03d18233d0b722f4c92e1d658694408da476d12ea094bc0628c9ca2deef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ILQR Solver (Li and Todorov, 2004)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-levenberg-marquardt-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "d6ec17486e0ff0917b9a58441c5b6d02fbebaee63c29f1939b1a3bfdc5c04d93";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen exotica-core ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Levenberg-Marquardt solver for EXOTica'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/exotica-ompl-control-solver/default.nix
+++ b/distros/noetic/exotica-ompl-control-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ompl-control-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "4c962316ab3e0e3d4a676a58019d2e43c13a227b327d6fd47cfb09ec46ed3c28";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Kinodynamic Control Solvers from OMPL'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-ompl-solver/default.nix
+++ b/distros/noetic/exotica-ompl-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-ompl-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "78769d3f5e6521fa2985ac14177a57c344f7a5935c2732e3456c3c15c6ca5692";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core exotica-python ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Exotica solvers based on the Open Motion Planning Libary (OMPL)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-pendulum-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "1bd6b0c394c65b493db0b40dd99bae5e2c6e989ecef1a179886dc9079131cf85";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Pendulum dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-pinocchio-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "ee8b73f8c05508acd87e7e9e8d1f94b810e9661cd9a1483cd94a67239a83ff67";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Dynamics solver plug-in using Pinocchio for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-quadrotor-dynamics-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "455dc38180053f01302690816d9c5750f38eade007d65067411da03b6b7dccef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Quadrotor dynamics solver plug-in for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-scipy-solver/default.nix
+++ b/distros/noetic/exotica-scipy-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-scipy-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "5475439a6d874f0a093c9e84c4ee975fcc54ca25bb19eb9caca140822cdfc72d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core python3Packages.numpy python3Packages.scipy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''SciPy-based Python solvers for Exotica'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
+buildRosPackage {
+  pname = "ros-noetic-exotica-time-indexed-rrt-connect-solver";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "063cfddfaa00d3aeb807117810e5936dd4e9dc294d1d0ff5980b4eae489c8d07";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-core ompl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Time-Indexed RRT-Connect solver (Humanoids 2018)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/exotica/default.nix
+++ b/distros/noetic/exotica/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
+buildRosPackage {
+  pname = "ros-noetic-exotica";
+  version = "6.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.0.0-1.tar.gz";
+    name = "6.0.0-1.tar.gz";
+    sha256 = "6eba3dc9fbbbd6ed0f89385945fdc16c107684407e56d10be5a38b34b5d5d814";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ exotica-aico-solver exotica-collision-scene-fcl-latest exotica-core exotica-core-task-maps exotica-ik-solver exotica-levenberg-marquardt-solver exotica-ompl-solver exotica-python exotica-time-indexed-rrt-connect-solver ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Extensible Optimization Toolset (EXOTica) is a library for defining problems for robot motion planning. This package serves similar to a metapackage and contains dependencies onto all core-released exotica packages. It also builds the documentation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "109358fbe47d2113a169631ae42fad3f410d93c4a22f5e0143be153435d0ef0b";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "8127adc92c19930bb41d8e332f94febe5256a04402970b18f20f10e6c7155874";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "d304fd952659e934321b489879180dda5755dfff7e64b68ba7999b8e13db21a3";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "28181b950a206e9a148f5ca518685914dea85e236395da30472890925c973efb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -52,9 +52,27 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ autoware-can-msgs = self.callPackage ./autoware-can-msgs {};
+
+ autoware-config-msgs = self.callPackage ./autoware-config-msgs {};
+
+ autoware-external-msgs = self.callPackage ./autoware-external-msgs {};
+
+ autoware-lanelet2-msgs = self.callPackage ./autoware-lanelet2-msgs {};
+
+ autoware-map-msgs = self.callPackage ./autoware-map-msgs {};
+
+ autoware-msgs = self.callPackage ./autoware-msgs {};
+
+ autoware-system-msgs = self.callPackage ./autoware-system-msgs {};
+
  auv-msgs = self.callPackage ./auv-msgs {};
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
+
+ backward-ros = self.callPackage ./backward-ros {};
+
+ bagger = self.callPackage ./bagger {};
 
  baldor = self.callPackage ./baldor {};
 
@@ -73,6 +91,16 @@ self: super: {
  bondpy = self.callPackage ./bondpy {};
 
  boost-sml = self.callPackage ./boost-sml {};
+
+ bota-device-driver = self.callPackage ./bota-device-driver {};
+
+ bota-driver = self.callPackage ./bota-driver {};
+
+ bota-node = self.callPackage ./bota-node {};
+
+ bota-signal-handler = self.callPackage ./bota-signal-handler {};
+
+ bota-worker = self.callPackage ./bota-worker {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
 
@@ -364,6 +392,8 @@ self: super: {
 
  ddynamic-reconfigure = self.callPackage ./ddynamic-reconfigure {};
 
+ ddynamic-reconfigure-python = self.callPackage ./ddynamic-reconfigure-python {};
+
  delphi-esr-msgs = self.callPackage ./delphi-esr-msgs {};
 
  delphi-mrr-msgs = self.callPackage ./delphi-mrr-msgs {};
@@ -516,6 +546,48 @@ self: super: {
 
  executive-smach-visualization = self.callPackage ./executive-smach-visualization {};
 
+ exotica = self.callPackage ./exotica {};
+
+ exotica-aico-solver = self.callPackage ./exotica-aico-solver {};
+
+ exotica-cartpole-dynamics-solver = self.callPackage ./exotica-cartpole-dynamics-solver {};
+
+ exotica-collision-scene-fcl-latest = self.callPackage ./exotica-collision-scene-fcl-latest {};
+
+ exotica-core = self.callPackage ./exotica-core {};
+
+ exotica-core-task-maps = self.callPackage ./exotica-core-task-maps {};
+
+ exotica-ddp-solver = self.callPackage ./exotica-ddp-solver {};
+
+ exotica-double-integrator-dynamics-solver = self.callPackage ./exotica-double-integrator-dynamics-solver {};
+
+ exotica-dynamics-solvers = self.callPackage ./exotica-dynamics-solvers {};
+
+ exotica-examples = self.callPackage ./exotica-examples {};
+
+ exotica-ik-solver = self.callPackage ./exotica-ik-solver {};
+
+ exotica-ilqg-solver = self.callPackage ./exotica-ilqg-solver {};
+
+ exotica-ilqr-solver = self.callPackage ./exotica-ilqr-solver {};
+
+ exotica-levenberg-marquardt-solver = self.callPackage ./exotica-levenberg-marquardt-solver {};
+
+ exotica-ompl-control-solver = self.callPackage ./exotica-ompl-control-solver {};
+
+ exotica-ompl-solver = self.callPackage ./exotica-ompl-solver {};
+
+ exotica-pendulum-dynamics-solver = self.callPackage ./exotica-pendulum-dynamics-solver {};
+
+ exotica-pinocchio-dynamics-solver = self.callPackage ./exotica-pinocchio-dynamics-solver {};
+
+ exotica-quadrotor-dynamics-solver = self.callPackage ./exotica-quadrotor-dynamics-solver {};
+
+ exotica-scipy-solver = self.callPackage ./exotica-scipy-solver {};
+
+ exotica-time-indexed-rrt-connect-solver = self.callPackage ./exotica-time-indexed-rrt-connect-solver {};
+
  exotica-val-description = self.callPackage ./exotica-val-description {};
 
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
@@ -632,6 +704,8 @@ self: super: {
 
  graph-msgs = self.callPackage ./graph-msgs {};
 
+ grasping-msgs = self.callPackage ./grasping-msgs {};
+
  gripper-action-controller = self.callPackage ./gripper-action-controller {};
 
  handeye = self.callPackage ./handeye {};
@@ -651,6 +725,8 @@ self: super: {
  ifm3d = self.callPackage ./ifm3d {};
 
  image-common = self.callPackage ./image-common {};
+
+ image-exposure-msgs = self.callPackage ./image-exposure-msgs {};
 
  image-geometry = self.callPackage ./image-geometry {};
 
@@ -685,6 +761,12 @@ self: super: {
  imu-tools = self.callPackage ./imu-tools {};
 
  imu-transformer = self.callPackage ./imu-transformer {};
+
+ industrial-msgs = self.callPackage ./industrial-msgs {};
+
+ industrial-robot-status-controller = self.callPackage ./industrial-robot-status-controller {};
+
+ industrial-robot-status-interface = self.callPackage ./industrial-robot-status-interface {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
@@ -1110,6 +1192,10 @@ self: super: {
 
  nonpersistent-voxel-layer = self.callPackage ./nonpersistent-voxel-layer {};
 
+ novatel-oem7-driver = self.callPackage ./novatel-oem7-driver {};
+
+ novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
+
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -1220,6 +1306,12 @@ self: super: {
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
+ pointgrey-camera-description = self.callPackage ./pointgrey-camera-description {};
+
+ pointgrey-camera-driver = self.callPackage ./pointgrey-camera-driver {};
+
+ points-preprocessor = self.callPackage ./points-preprocessor {};
+
  polled-camera = self.callPackage ./polled-camera {};
 
  pose-base-controller = self.callPackage ./pose-base-controller {};
@@ -1312,6 +1404,10 @@ self: super: {
 
  robot = self.callPackage ./robot {};
 
+ robot-calibration = self.callPackage ./robot-calibration {};
+
+ robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-navigation = self.callPackage ./robot-navigation {};
@@ -1321,6 +1417,24 @@ self: super: {
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
+
+ rokubimini = self.callPackage ./rokubimini {};
+
+ rokubimini-bus-manager = self.callPackage ./rokubimini-bus-manager {};
+
+ rokubimini-description = self.callPackage ./rokubimini-description {};
+
+ rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
+
+ rokubimini-examples = self.callPackage ./rokubimini-examples {};
+
+ rokubimini-factory = self.callPackage ./rokubimini-factory {};
+
+ rokubimini-manager = self.callPackage ./rokubimini-manager {};
+
+ rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
+
+ rokubimini-serial = self.callPackage ./rokubimini-serial {};
 
  ros = self.callPackage ./ros {};
 
@@ -1698,6 +1812,8 @@ self: super: {
 
  stage-ros = self.callPackage ./stage-ros {};
 
+ statistics-msgs = self.callPackage ./statistics-msgs {};
+
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
@@ -1746,6 +1862,8 @@ self: super: {
 
  swri-yaml-util = self.callPackage ./swri-yaml-util {};
 
+ tablet-socket-msgs = self.callPackage ./tablet-socket-msgs {};
+
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
@@ -1789,6 +1907,22 @@ self: super: {
  tile-map = self.callPackage ./tile-map {};
 
  topic-tools = self.callPackage ./topic-tools {};
+
+ toposens = self.callPackage ./toposens {};
+
+ toposens-bringup = self.callPackage ./toposens-bringup {};
+
+ toposens-description = self.callPackage ./toposens-description {};
+
+ toposens-driver = self.callPackage ./toposens-driver {};
+
+ toposens-markers = self.callPackage ./toposens-markers {};
+
+ toposens-msgs = self.callPackage ./toposens-msgs {};
+
+ toposens-pointcloud = self.callPackage ./toposens-pointcloud {};
+
+ toposens-sync = self.callPackage ./toposens-sync {};
 
  track-odometry = self.callPackage ./track-odometry {};
 
@@ -1878,6 +2012,8 @@ self: super: {
 
  uuid-msgs = self.callPackage ./uuid-msgs {};
 
+ vector-map-msgs = self.callPackage ./vector-map-msgs {};
+
  velocity-controllers = self.callPackage ./velocity-controllers {};
 
  velodyne = self.callPackage ./velodyne {};
@@ -1921,6 +2057,8 @@ self: super: {
  warehouse-ros = self.callPackage ./warehouse-ros {};
 
  webots-ros = self.callPackage ./webots-ros {};
+
+ wfov-camera-msgs = self.callPackage ./wfov-camera-msgs {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/noetic/grasping-msgs/default.nix
+++ b/distros/noetic/grasping-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, moveit-msgs, sensor-msgs, shape-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-grasping-msgs";
+  version = "0.3.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mikeferguson/grasping_msgs-gbp/archive/release/noetic/grasping_msgs/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "87a1982676f3578bf4799db82e984990dec14eab6d9df3a98ab13b4d4a2d6c33";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib geometry-msgs message-runtime moveit-msgs sensor-msgs shape-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for describing objects and how to grasp them.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/image-exposure-msgs/default.nix
+++ b/distros/noetic/image-exposure-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, statistics-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-image-exposure-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/image_exposure_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "2b9a6a7f16a46e84d8daa950430e3b3cdbe23ab5399ab6dde4161e3509fb705a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime statistics-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-msgs/default.nix
+++ b/distros/noetic/industrial-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-msgs";
+  version = "0.7.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "c1cc02b17cffe63eacfb0ba825cde514478f3c405ced7b8e63c5756085b50554";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The industrial message package containes industrial specific messages 
+	definitions. This package is part of the ROS-Industrial program.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-controller/default.nix
+++ b/distros/noetic/industrial-robot-status-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, industrial-msgs, industrial-robot-status-interface, pluginlib, realtime-tools }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-controller";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "6f9dcec5e3bff7ae4470fc249277610e11b04451cdb06c053d663ffab0bf1bc0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ industrial-robot-status-interface ];
+  propagatedBuildInputs = [ controller-interface hardware-interface industrial-msgs pluginlib realtime-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller that reports robot status using the ROS-Industrial RobotStatus message.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/industrial-robot-status-interface/default.nix
+++ b/distros/noetic/industrial-robot-status-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-status-interface";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/gavanderhoorn/industrial_robot_status_controller-release/archive/release/noetic/industrial_robot_status_interface/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "c1b73b8150bcb01b2bee3263026aa99571d1dcbdd4237e30ec9bafbed2938bcf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hardware-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Exposes ROS-Industrial's RobotStatus info from hardware_interfaces for consumption by ros_control controllers.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ixblue-ins-driver/default.nix
+++ b/distros/noetic/ixblue-ins-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, ixblue-ins-msgs, ixblue-stdbin-decoder, libpcap, nav-msgs, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins-driver";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_driver/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "5115c57a766a1ebfcd9b8fe2c53c5a53f5a6de5165962233bc411de74e273bc2";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_driver/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "e01d4b7c09ead8bde1bf548923c5a2c39991dd8a04dfba6c152b541cb0cd12d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ixblue-ins-msgs/default.nix
+++ b/distros/noetic/ixblue-ins-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins-msgs";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_msgs/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "539788d59cfcc1e8262dbb1c49d18825b59fa4224bc260293830e7a59664a6ca";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins_msgs/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "7a178cbeec8c97cd1404323c1d1dad1b65074bd87ab0b521ea7760582d87f191";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ixblue-ins/default.nix
+++ b/distros/noetic/ixblue-ins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ixblue-ins-driver, ixblue-ins-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-ins";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "b3556595467ee028c39e2e1500bfce3fbb7a9d7e0804fefde04a79d812f0c812";
+    url = "https://github.com/ixblue/ixblue_ins_stdbin_driver-release/archive/release/noetic/ixblue_ins/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "c51da63e62ceef41233cce304af30cb19d8499fec4af310f3a0c64b29f398263";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ixblue-stdbin-decoder/default.nix
+++ b/distros/noetic/ixblue-stdbin-decoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, git, gtest }:
 buildRosPackage {
   pname = "ros-noetic-ixblue-stdbin-decoder";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/noetic/ixblue_stdbin_decoder/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "0257fe35424f1f72730026bfdade654e453e04236dc5ea6af2ac6c0560e362e3";
+    url = "https://github.com/ixblue/ixblue_stdbin_decoder-release/archive/release/noetic/ixblue_stdbin_decoder/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "9a2b8c3102a0a1dd9ad85cb3788c80c91dfb6ddbc702b30a8091bd487400d16b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "58349e0a94bc6db80cbc0b4d7f89b47e7cb68e56aa8f5cb5d1d09a80ae83a3b3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "a23ea0003c8eb18294e5c50175c979959975dec29deff70c8a8827749bc52498";
   };
 
   buildType = "catkin";

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "36666ab250bd37e34b9812d35f89206ebbfc54759e1624ada280b34231a377df";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "0b1c909da6aede4d99a414890b29e6290e5bcfcdc76f4471beb8f1269a166faf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-msgs/default.nix
+++ b/distros/noetic/map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nav-msgs, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-map-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "a4f536d85ba775adbb06217eff50d3ed057d4bd87ef42c38e4c0523dc5b79d74";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/map_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "e9ae695b8c3f745dc6c3878810a97546c4dd528000a0c8058d6f1f41983df432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "6c079d78958afa2729b1068249c50e451cf70a40254444b4d7946d9f4c8b1775";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "a0a6316503dd0bfffd115b619b9b38895749cec4344293f8ac6f51fa42a93957";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2020.10.11-r2";
+  version = "2020.11.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.10.11-2.tar.gz";
-    name = "2020.10.11-2.tar.gz";
-    sha256 = "ad8387ddda42bcdfd77d35d65f27ec5795d3990ed3014a6ab7f39a511a751d3f";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2020.11.11-1.tar.gz";
+    name = "2020.11.11-1.tar.gz";
+    sha256 = "878f4ff6fe57cd052081ae241d38032157630f985e939365f06a32c564bde56d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "8e28909f31fa9dfae3e6ea7f0cb961d6fb5cfa9bc4604a8cdad5f0f0aaa16b3b";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "3880a7af536340f0458026793baa466a9fa193db80bbb854e7266d5b2040e2d0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "4e2bea6d3309a4294fd1a651af3efe20d1b0f5cb136d098fe4f424ff2205cb58";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "919987160b2f1ec66d982a1896fcc57e4b048d2e6d0d74d63f40d62494dea966";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "17dfad7b061b7da7f36d3ca747e09e110f79954fcb82016359ac4f998bc5cc91";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e5a6d4ddf8ba860c150104167ee3523f137dd65f1bf9611d41b1151f32952bb0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-abstract-core/default.nix
+++ b/distros/noetic/mbf-abstract-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mbf-abstract-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "b53606d12bd6f5e4c761882d24185902d80d891225b8c2b7a9927a4ff99e8b45";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "9e116b9e7cc2132960124634b4be1ba64dd9798b4f1349fd76ffae62f705a330";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-abstract-nav/default.nix
+++ b/distros/noetic/mbf-abstract-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-msgs, mbf-utility, nav-msgs, roscpp, std-msgs, std-srvs, tf, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-mbf-abstract-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "355985f9c150b0ac8022a6243e6757e862540141001cce4c10ac0612b7905652";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_abstract_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "aa56023690a79abd5b9dcce1beef94d4d323d056b2e40961ef40b16ef5963a13";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-costmap-core/default.nix
+++ b/distros/noetic/mbf-costmap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, geometry-msgs, mbf-abstract-core, mbf-utility, nav-core, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mbf-costmap-core";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_core/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "00cdd0d83ef0d1729d7de90f2b7c99b8f479a33536ac3e9e67968672110c5149";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_core/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "a98cc5aecc20414e20fd8a75b865376271e94d982f3e13d112364de73c6283ea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-costmap-nav/default.nix
+++ b/distros/noetic/mbf-costmap-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, mbf-abstract-nav, mbf-costmap-core, mbf-msgs, mbf-utility, move-base, move-base-msgs, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-mbf-costmap-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "cd3b22be4bb0029ff9fb7bd83e910c3736d256784fc3f192716076e03bf94a10";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_costmap_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "45b8c65cefeb8e584aa5653699fb2a51aca852581beb3ef28cdfcb6756dd3382";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-msgs/default.nix
+++ b/distros/noetic/mbf-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, genmsg, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mbf-msgs";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_msgs/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "b619e01a59ab9a269f0f3bd220b616ec4af4a200dc0ed36b2a59955822766942";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_msgs/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "2bc7138f1a804d6087793eefbf0c4da55880bb2e19f7958f531afb718e54a41a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-simple-nav/default.nix
+++ b/distros/noetic/mbf-simple-nav/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, mbf-abstract-core, mbf-abstract-nav, mbf-msgs, nav-msgs, pluginlib, roscpp, std-msgs, std-srvs, tf, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mbf-simple-nav";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_simple_nav/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "70c38eb038a9a84f0aa2f22dfabc0157f820155385c74ffd4f2e219dca57a6fc";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_simple_nav/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "cafb91074da66effe08ab3f6c5e82851f9846953217c3fa29614e1951cd2d0bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mbf-utility/default.nix
+++ b/distros/noetic/mbf-utility/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-mbf-utility";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_utility/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "b5ce41cbc7a1cbfec9f797e8b5da24f640be3d4decb9eadf2b0d5f57aa447652";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/mbf_utility/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e610060ea5b82ad5939375bb1b2d026c41c53a69317bc1b8d2a19461a4359967";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-base-flex/default.nix
+++ b/distros/noetic/move-base-flex/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2020 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav }:
+{ lib, buildRosPackage, fetchurl, catkin, mbf-abstract-core, mbf-abstract-nav, mbf-costmap-core, mbf-costmap-nav, mbf-msgs, mbf-simple-nav, mbf-utility }:
 buildRosPackage {
   pname = "ros-noetic-move-base-flex";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/move_base_flex/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "81a8e991123c9157df111b97b276dcbde653c927bfc622b2da7c58c5d24d549c";
+    url = "https://github.com/uos-gbp/move_base_flex-release/archive/release/noetic/move_base_flex/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "c15f04dcb7db97c16cc3a3032d2c1ba504dfa3a36b59090f6bacd4762a30d3dc";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav ];
+  propagatedBuildInputs = [ mbf-abstract-core mbf-abstract-nav mbf-costmap-core mbf-costmap-nav mbf-msgs mbf-simple-nav mbf-utility ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/move-base-msgs/default.nix
+++ b/distros/noetic/move-base-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-move-base-msgs";
-  version = "1.14.0-r1";
+  version = "1.14.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.0-1.tar.gz";
-    name = "1.14.0-1.tar.gz";
-    sha256 = "f7778f0c15c1e93642f7f3b52abb03a9072bece78530660576a93bc2a354671c";
+    url = "https://github.com/ros-gbp/navigation_msgs-release/archive/release/noetic/move_base_msgs/1.14.1-1.tar.gz";
+    name = "1.14.1-1.tar.gz";
+    sha256 = "a3cfcbeed9a83959c3a7b12abf8737062bee94c627d1a961be4ff589a4c4ad7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "13f9abec005c76e90f0d4c57279018cf6b21bd35b11b08e36d5bab0aece992d8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "a0486c8fd5ac58192ba6deb7c926a2c3b8721b1d6e6c2df76245b92a92aa501c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "56559aa3d9cfb85454754930cda46d892fe2dcfedec1c06d856affc6a06da3cf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "4be49dd19f2d8bc340b896b8646cd97b76a2e2365f4012f509675febf1a1687c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "36d8bfe6eecf2ebb6026fc014f5701bc55742ea6bbbf3e9b8584f5c0b8eb9fc4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "e7796c0286bd6fdc768a7dcd3e7b056991249183d1e6d6c8efbe8ff372957146";
   };
 
   buildType = "catkin";

--- a/distros/noetic/novatel-oem7-driver/default.nix
+++ b/distros/noetic/novatel-oem7-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gps-common, nodelet, novatel-oem7-msgs, roscpp, rostest, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-driver";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "31177a28c690bbe9df9b89d554af623b43cbcd195a290336083e307396754378";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ boost gps-common nodelet novatel-oem7-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''NovAtel Oem7 ROS Driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/novatel-oem7-msgs/default.nix
+++ b/distros/noetic/novatel-oem7-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-novatel-oem7-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/novatel-gbp/novatel_oem7_driver-release/archive/release/noetic/novatel_oem7_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "99cd8fe9aee43c2f2252b1542adec52cecbc9d03bfbe10b8703679bc23cb04f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for NovAtel Oem7 family of receivers.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "956c819ae1ba1385f29358b15ef681e7d53b7a896e996cee390ecb47a0220688";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "740eb27466d535b6e1646154faddf155297d5b9f225db5e0682b07604f8438f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "37dc77b976c4c79ebf8ad2758741b98e8923adc0ec8541691a17b67ee071178e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "57467b847adcd594946bbe4e33ff39e5a7be6037152aba34f12b26031b15d2ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pointgrey-camera-description/default.nix
+++ b/distros/noetic/pointgrey-camera-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pointgrey-camera-description";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_description/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "0d0bd0da10b7a6f888abbac3b5f79360df4b6dac1949ace934a684f760ff1e0b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-state-publisher urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF descriptions for Point Grey cameras'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pointgrey-camera-driver/default.nix
+++ b/distros/noetic/pointgrey-camera-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, curl, diagnostic-updater, dpkg, dynamic-reconfigure, image-exposure-msgs, image-proc, image-transport, libraw1394, libusb1, nodelet, roscpp, roslaunch, roslint, sensor-msgs, stereo-image-proc, wfov-camera-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pointgrey-camera-driver";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/pointgrey_camera_driver/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "70339f114659294dcdcb58bd3e8db2a80eac8a1f537dc84693a94e54a672ae27";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ curl dpkg ];
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ camera-info-manager diagnostic-updater dynamic-reconfigure image-exposure-msgs image-proc image-transport libraw1394 libusb1 nodelet roscpp sensor-msgs stereo-image-proc wfov-camera-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Point Grey camera driver based on libflycapture2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/points-preprocessor/default.nix
+++ b/distros/noetic/points-preprocessor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pointcloud }:
+buildRosPackage {
+  pname = "ros-noetic-points-preprocessor";
+  version = "1.14.9-r2";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/core_perception-release/archive/release/noetic/points_preprocessor/1.14.9-2.tar.gz";
+    name = "1.14.9-2.tar.gz";
+    sha256 = "94638e27cf0a363e87e96b3212b926c00a5ea37dfd470f41330e243879c299d1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ autoware-config-msgs cv-bridge gtest libyamlcpp message-filters pcl-conversions pcl-ros qt5.qtbase roscpp roslint rostest sensor-msgs std-msgs tf tf2 tf2-eigen tf2-ros velodyne-pointcloud ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The points_preprocessor package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/robot-calibration-msgs/default.nix
+++ b/distros/noetic/robot-calibration-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration-msgs";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration_msgs/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "90dcef12df3501596deef0b54aecae6da568f24a0702d533a16f3503dace8215";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for calibrating a robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/robot-calibration/default.nix
+++ b/distros/noetic/robot-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, camera-calibration-parsers, catkin, ceres-solver, code-coverage, control-msgs, cv-bridge, geometry-msgs, gflags, kdl-parser, moveit-msgs, nav-msgs, orocos-kdl, pluginlib, protobuf, robot-calibration-msgs, rosbag, roscpp, sensor-msgs, std-msgs, suitesparse, tf, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-calibration";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/robot_calibration-release/archive/release/noetic/robot_calibration/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "f90812efe92713874c112e6a8dc83efde3ce72915f102dfcd4f1a8db8e057883";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage ];
+  propagatedBuildInputs = [ actionlib camera-calibration-parsers ceres-solver control-msgs cv-bridge geometry-msgs gflags kdl-parser moveit-msgs nav-msgs orocos-kdl pluginlib protobuf robot-calibration-msgs rosbag roscpp sensor-msgs std-msgs suitesparse tf tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Calibrate a Robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-bus-manager";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_bus_manager/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "46ddeb924599940f63dd3d27c55d0db4e9280d896a298913e9a52be863ff22fd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-description";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_description/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "4ee26763d78c841b0620a8674829e0eb065fa3a262a409b3207f3863a40285cf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ sensor-msgs std-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rokubimini_description package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-ethercat";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_ethercat/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "019b97869a35db3db0b81b43fa8b80e82d747546e161f7598ca6d0cd1d4e2447";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Ethercat implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-examples/default.nix
+++ b/distros/noetic/rokubimini-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-examples";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_examples/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "c6d557a91b23578f71da48dc93e20b2795a0f4d25fb058e01e765f1204bc3934";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-factory/default.nix
+++ b/distros/noetic/rokubimini-factory/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-factory";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_factory/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "2d3a99e4b97a4d476873d6c2f44e312e67ada31d73fe0ea785cf5fe0bd9ec02f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libyamlcpp rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-serial ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-manager/default.nix
+++ b/distros/noetic/rokubimini-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-manager";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_manager/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "97643ff3334cd6e9f911243ed9ce94693152442a70647a46c87e11c6f30feebb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ bota-signal-handler bota-worker libyamlcpp rokubimini rokubimini-bus-manager rokubimini-factory ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-msgs";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_msgs/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "399e5a2b33f13a4999c82fea8944f48c68da813c97a38b60beb0089ecb64aa77";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message and service definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini-serial";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_serial/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "ce035926d9171d380ec0c5aefc94d6d731edaadafc3b4c8b4eb101e0333f56f9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rokubimini Serial implementation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rokubimini";
+  version = "0.5.8-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini/0.5.8-1";
+    name = "archive.tar.gz";
+    sha256 = "e94405dcd9f7e838749a53fccf9f7227601ec5ddb67cef69fb14d0e5e768f093";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''C++ library deriving the abstract communication interface classes in the rokubimini library for EtherCAT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rosbag-snapshot-msgs/default.nix
+++ b/distros/noetic/rosbag-snapshot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "1a6edd6ee7603c84ae671597872637e9496dbfd5636c6ebc0fb13883cf59a9a8";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f43930793890f754f95889a127475ee48672b05660aaaf28cf2ed6d962288fad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-snapshot/default.nix
+++ b/distros/noetic/rosbag-snapshot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbag, rosbag-snapshot-msgs, roscpp, rosgraph-msgs, roslint, rospy, rostest, rostopic, std-msgs, std-srvs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-snapshot";
-  version = "1.0.1-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5cc66d1435efb3483a207ddb125ed0a07b8903f719ca415c557ffc0caa136e8e";
+    url = "https://github.com/ros-gbp/rosbag_snapshot-release/archive/release/noetic/rosbag_snapshot/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "aeeacd6ab144acbc737b6f5cb8d6199f7d822dcd0887f176b3766f495952e060";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.4-r1";
+  version = "0.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "4f25539887d9b7f6ae1b0c5fdf836d08fc9a4f741b9a4687f374ff9560494852";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.5-1.tar.gz";
+    name = "0.5.5-1.tar.gz";
+    sha256 = "e9be4a0711b9268d8c7f3c875d2fbb1d787aaa43f7907e08e4204dcbb9a178ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag-plugins/default.nix
+++ b/distros/noetic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag-plugins";
-  version = "0.4.15-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.4.15-1.tar.gz";
-    name = "0.4.15-1.tar.gz";
-    sha256 = "c758ecb338b386cb2deae24a077a07a02b10b03397e4b53cb13d0d0f7dad9f8f";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "0a79f66d0f2f1eea4e5aa1f8ce9070d06ac7e3b3ce90cf683da9d77a7d1596c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag/default.nix
+++ b/distros/noetic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag";
-  version = "0.4.15-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.4.15-1.tar.gz";
-    name = "0.4.15-1.tar.gz";
-    sha256 = "c3739f47ee6d48b1b3d4491684761944b76137adcb410d586f07b8790b76ae29";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "6d6231e94ceedf1940d5b0a80d302b420f2536e5c243bfd1660a41bb39e804bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.3-r1";
+  version = "1.14.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.3-1.tar.gz";
-    name = "1.14.3-1.tar.gz";
-    sha256 = "5375cdc1804c5a8cd42608596089f24b8addc13123c506fa4422aa0d7af4f2fe";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.4-1.tar.gz";
+    name = "1.14.4-1.tar.gz";
+    sha256 = "17654e17b751ce995990ed5b61c5b296622512d4c30571b69f33238b37ffb79b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "8e9d3549062494025eb62b1439782a00e42efdb9f776bd11500804906362ba25";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "33de19b4ed01d3442ec9842ae36c5244640728f19a52b5c30e8f4fba3d2b529a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-safetyscanners/default.nix
+++ b/distros/noetic/sick-safetyscanners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-safetyscanners";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/noetic/sick_safetyscanners/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "bcced4534d2fac16d0c7c1efc99cc1164c61f5c23bb4af1e68b0fd7abc5d40fc";
+    url = "https://github.com/SICKAG/sick_safetyscanners-release/archive/release/noetic/sick_safetyscanners/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a43f89f24ecd4eb9a0ac26120b642fe217effda5c4762e427f206aa82830fbe1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/statistics-msgs/default.nix
+++ b/distros/noetic/statistics-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-statistics-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/statistics_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "5eb0ddd6586f00d4ce5baf52af1eea155449e3bbbb1ddc668ccfc402a57d95c0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/tablet-socket-msgs/default.nix
+++ b/distros/noetic/tablet-socket-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-tablet-socket-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/tablet_socket_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "6bf111b0e4f1332a69414b38dbed9f61247e048b4018e882997ad99a93fd90f8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tablet_socket_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.4.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ab2bfdad011b838f229de030213948d9e425ba6e0dd9add7c0a21f5c14694e93";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "a542fcd8c8a51fcac9c2b32e11c1ff630b48647c9167f0a6ce1e0251897ecdc1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-bringup/default.nix
+++ b/distros/noetic/toposens-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-bringup";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_bringup/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "efe7df738acf96ae0db6743081dde793ed4b0f59b0d0ee777bf7d1f170fe5a3e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files for bringup and demos of toposens package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-description/default.nix
+++ b/distros/noetic/toposens-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-description";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_description/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "7382b0380ebc322f9048da8cafae81500b3f38dafd6cb077ce45697c8c18e9ad";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rviz urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''3D models of the sensor for visualization.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-driver/default.nix
+++ b/distros/noetic/toposens-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-driver";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_driver/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "61a68366695b41b35f2db96c2044ed7463011b4b6eebe86c49072ca911482729";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS device driver for communication with TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-markers/default.nix
+++ b/distros/noetic/toposens-markers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-markers";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_markers/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "b13697c65debd53352283e9cdf9ac40360388023bc97bd7aaa5e7d96b78ffa4a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Rviz integration for TS sensor data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-msgs/default.nix
+++ b/distros/noetic/toposens-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_msgs/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "b3ef9b6944cc3ca9049c41def4e8ca50ab6d71f184d88c15b352e515cb33c661";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-generation message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS message definitions for TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-pointcloud/default.nix
+++ b/distros/noetic/toposens-pointcloud/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-pointcloud";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_pointcloud/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "91acf806538ab42f694b5a05849e0c67cd90a58c3750edc57db77e48c2fcdfb6";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pcl-ros roscpp tf2 tf2-geometry-msgs toposens-driver toposens-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''PCL integration for TS sensors mounted on Turtlebot3.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens-sync/default.nix
+++ b/distros/noetic/toposens-sync/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-toposens-sync";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_sync/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "c7fba8d2196e90029ac42cda4287f6dedc29b2cb562b3c1c18734ffc4a46e0e1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage roslaunch rostest ];
+  propagatedBuildInputs = [ message-runtime roscpp toposens-driver toposens-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Operational sync of multiple TS sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/toposens/default.nix
+++ b/distros/noetic/toposens/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
+buildRosPackage {
+  pname = "ros-noetic-toposens";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens/2.1.0-1";
+    name = "archive.tar.gz";
+    sha256 = "351b1c1ea2c15c083ca0387ef8096cfd19a6e62f6d211dc59dc9531e1fa71bc1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ toposens-bringup toposens-description toposens-driver toposens-markers toposens-msgs toposens-pointcloud toposens-sync ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS support for Toposens 3D Ultrasound sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "fdeebde27300c71c5effd06b7b760c5c76dbe7a46ee608fecbbe0f59ed5e4323";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "fa3723d0a72c122369cd337c9ebff688e0fe4b499c0e0abcce68818f21f3d951";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.3-r1";
+  version = "0.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.3-1.tar.gz";
-    name = "0.10.3-1.tar.gz";
-    sha256 = "bd8cdd71c7a4adcab31b1b7787375f354dda3db7ceb5fcd2ce0cf03bfd6339d5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.4-1.tar.gz";
+    name = "0.10.4-1.tar.gz";
+    sha256 = "0d0b1d70fe0934da44452d61d970a9f9370e1f68856df590b1ae4ac4197a55f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vector-map-msgs/default.nix
+++ b/distros/noetic/vector-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-vector-map-msgs";
+  version = "1.14.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/autoware-ai/messages-release/archive/release/noetic/vector_map_msgs/1.14.0-1.tar.gz";
+    name = "1.14.0-1.tar.gz";
+    sha256 = "4132fc88a828774dc43bac8d108aed130622159af96ab717a8a0c8464929a65f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The vector_map_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/velodyne-driver/default.nix
+++ b/distros/noetic/velodyne-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libpcap, nodelet, roscpp, roslaunch, roslint, rostest, tf, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-driver";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "a81f0c6824c1ac06ee5d2f5abd7cf48d2d5661a93dc5e08381df8eff9c220c59";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_driver/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "d0ac953f3a48c3e13e60a94fb9ed768ea22699004bc7c62a638785dc37f1ffea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-laserscan/default.nix
+++ b/distros/noetic/velodyne-laserscan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, nodelet, roscpp, roslaunch, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-laserscan";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "b41a82000caa5ffb71abef4e56447be313859394d948d68ce6d22691c5d7f521";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_laserscan/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "bbe1d9264cf193a2b2610fa19280c3a7a57f0de6c3d4c1a037ba713127e63438";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-msgs/default.nix
+++ b/distros/noetic/velodyne-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-msgs";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "563078f455430be8e3aad7225c51d74994d12c72b259d6f7c79b585378b269ea";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_msgs/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "fb3b32e45e68234f8e01121aeee2e8d33966379c3a5ce4c2365e3751ee284e2f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pcl/default.nix
+++ b/distros/noetic/velodyne-pcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, roslint }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pcl";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "4e9f1613629cc23ce3c56ffda7b0cfeb1abe11ff1994cb505fc4b31ec7d07f23";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pcl/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "08d0a84826d952dc1b0ae6cec5909fcb70a291dcd96f817cf54a34e24024751e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-pointcloud/default.nix
+++ b/distros/noetic/velodyne-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, diagnostic-updater, dynamic-reconfigure, eigen, libyamlcpp, nodelet, roscpp, roslaunch, roslib, roslint, rostest, rosunit, sensor-msgs, tf2-ros, velodyne-driver, velodyne-laserscan, velodyne-msgs }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-pointcloud";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "39b31cb1d871a82d5a7a1c24ce6119588bbd310b3dec7a49e91f2e7827f5a9b4";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne_pointcloud/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "49cf0b37a42143d5cbbc93086d4a478372201ef6b758891a06807abba7e16c29";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne/default.nix
+++ b/distros/noetic/velodyne/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-driver, velodyne-laserscan, velodyne-msgs, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-noetic-velodyne";
-  version = "1.6.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.0-1.tar.gz";
-    name = "1.6.0-1.tar.gz";
-    sha256 = "c8f5e8a30661b80796005171875f1db08536c6e6562680c419ea7b23a18920c0";
+    url = "https://github.com/ros-drivers-gbp/velodyne-release/archive/release/noetic/velodyne/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "20968c2bc112c14694268e3b421517184a68bec969904cb167c7c14ab11b415a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/wfov-camera-msgs/default.nix
+++ b/distros/noetic/wfov-camera-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2020 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-wfov-camera-msgs";
+  version = "0.15.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/pointgrey_camera_driver-release/archive/release/noetic/wfov_camera_msgs/0.15.0-1.tar.gz";
+    name = "0.15.0-1.tar.gz";
+    sha256 = "fa2494db9b9b17f019705378aae3e21916120d81e7b0b6ed58382186e34267fb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages related to the Point Grey camera driver.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'eloquent', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 1f2193c9440f65c3a75c96ae4a1138a9802c9667.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --skip cross_compile --all
```

Changes:
========
Dashing Changes:
----------------
* *aws-robomaker-simulation-ros-pkgs 1.2.1-r1*
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cyclonedds 0.5.1-r1 --> 0.7.0-r1*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*
* *robomaker-simulation-msgs 1.2.1-r1*
* *smclib 2.0.0-r1*
* *test-bond 2.0.0-r1*
* *xacro 2.0.3-r1 --> 2.0.4-r1*

Eloquent Changes:
-----------------
* *cyclonedds 0.5.1-r2 --> 0.7.0-r3*
* *cyclonedds-cmake-module 0.5.1-r1 --> 0.7.0-r1*
* *mavlink 2020.10.11-r1 --> 2020.11.11-r1*
* *rmw-cyclonedds-cpp 0.5.1-r1 --> 0.7.0-r1*
* *xacro 2.0.3-r1 --> 2.0.4-r1*

Foxy Changes:
-------------
* *bond 2.0.0-r1*
* *bond-core 2.0.0-r1*
* *bondcpp 2.0.0-r1*
* *cartographer-ros 1.0.9001-r1 --> 1.0.9002-r1*
* *cartographer-ros-msgs 1.0.9001-r1 --> 1.0.9002-r1*
* *costmap-queue 0.4.3-r1 --> 0.4.5-r1*
* *dsr-description2 0.1.1-r4*
* *dsr-msgs2 0.1.1-r4*
* *dwb-core 0.4.3-r1 --> 0.4.5-r1*
* *dwb-critics 0.4.3-r1 --> 0.4.5-r1*
* *dwb-msgs 0.4.3-r1 --> 0.4.5-r1*
* *dwb-plugins 0.4.3-r1 --> 0.4.5-r1*
* *examples-tf2-py 0.13.6-r1 --> 0.13.7-r1*
* *fastrtps 2.0.1-r1 --> 2.0.2-r1*
* *geometry2 0.13.6-r1 --> 0.13.7-r1*
* *marti-can-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-common-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-dbw-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-nav-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-perception-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-sensor-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-status-msgs 1.1.0-r1 --> 1.2.0-r1*
* *marti-visualization-msgs 1.1.0-r1 --> 1.2.0-r1*
* *mavlink 2020.10.11-r1 --> 2020.11.11-r1*
* *nav-2d-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav-2d-utils 0.4.3-r1 --> 0.4.5-r1*
* *nav2-amcl 0.4.3-r1 --> 0.4.5-r1*
* *nav2-behavior-tree 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bringup 0.4.3-r1 --> 0.4.5-r1*
* *nav2-bt-navigator 0.4.3-r1 --> 0.4.5-r1*
* *nav2-common 0.4.3-r1 --> 0.4.5-r1*
* *nav2-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-core 0.4.3-r1 --> 0.4.5-r1*
* *nav2-costmap-2d 0.4.3-r1 --> 0.4.5-r1*
* *nav2-dwb-controller 0.4.3-r1 --> 0.4.5-r1*
* *nav2-gazebo-spawner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-lifecycle-manager 0.4.3-r1 --> 0.4.5-r1*
* *nav2-map-server 0.4.3-r1 --> 0.4.5-r1*
* *nav2-msgs 0.4.3-r1 --> 0.4.5-r1*
* *nav2-navfn-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-planner 0.4.3-r1 --> 0.4.5-r1*
* *nav2-recoveries 0.4.3-r1 --> 0.4.5-r1*
* *nav2-rviz-plugins 0.4.3-r1 --> 0.4.5-r1*
* *nav2-system-tests 0.4.3-r1 --> 0.4.5-r1*
* *nav2-util 0.4.3-r1 --> 0.4.5-r1*
* *nav2-voxel-grid 0.4.3-r1 --> 0.4.5-r1*
* *nav2-waypoint-follower 0.4.3-r1 --> 0.4.5-r1*
* *navigation2 0.4.3-r1 --> 0.4.5-r1*
* *osqp-vendor 0.0.1-r3 --> 0.0.2-r1*
* *rcl 1.1.8-r1 --> 1.1.9-r1*
* *rcl-action 1.1.8-r1 --> 1.1.9-r1*
* *rcl-lifecycle 1.1.8-r1 --> 1.1.9-r1*
* *rcl-yaml-param-parser 1.1.8-r1 --> 1.1.9-r1*
* *rmw-dds-common 1.0.1-r1 --> 1.0.2-r1*
* *rmw-fastrtps-cpp 1.2.2-r1 --> 1.2.3-r1*
* *rmw-fastrtps-dynamic-cpp 1.2.2-r1 --> 1.2.3-r1*
* *rmw-fastrtps-shared-cpp 1.2.2-r1 --> 1.2.3-r1*
* *smac-planner 0.4.5-r1*
* *smclib 2.0.0-r1*
* *sros2 0.9.3-r1 --> 0.9.4-r1*
* *sros2-cmake 0.9.3-r1 --> 0.9.4-r1*
* *teleop-twist-joy 2.3.0-r1 --> 2.4.0-r1*
* *test-bond 2.0.0-r1*
* *tf2 0.13.6-r1 --> 0.13.7-r1*
* *tf2-bullet 0.13.6-r1 --> 0.13.7-r1*
* *tf2-eigen 0.13.6-r1 --> 0.13.7-r1*
* *tf2-geometry-msgs 0.13.6-r1 --> 0.13.7-r1*
* *tf2-kdl 0.13.6-r1 --> 0.13.7-r1*
* *tf2-msgs 0.13.6-r1 --> 0.13.7-r1*
* *tf2-py 0.13.6-r1 --> 0.13.7-r1*
* *tf2-ros 0.13.6-r1 --> 0.13.7-r1*
* *tf2-sensor-msgs 0.13.6-r1 --> 0.13.7-r1*
* *tf2-tools 0.13.6-r1 --> 0.13.7-r1*
* *v4l2-camera 0.3.0-r1 --> 0.3.1-r1*
* *xacro 2.0.3-r1 --> 2.0.4-r1*

Kinetic Changes:
----------------
* *aws-robomaker-simulation-ros-pkgs 1.1.1-r1*
* *bota-device-driver 0.5.8-r1*
* *bota-driver 0.5.8-r1*
* *bota-node 0.5.8-r1*
* *bota-signal-handler 0.5.8-r1*
* *bota-worker 0.5.8-r1*
* *costmap-cspace 0.10.3-r1 --> 0.10.4-r1*
* *exotica 5.1.3-r1 --> 6.0.1-r1*
* *exotica-aico-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-cartpole-dynamics-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-collision-scene-fcl-latest 5.1.3-r1 --> 6.0.1-r1*
* *exotica-core 5.1.3-r1 --> 6.0.1-r1*
* *exotica-core-task-maps 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ddp-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-double-integrator-dynamics-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-dynamics-solvers 5.1.3-r1 --> 6.0.1-r1*
* *exotica-examples 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ik-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ilqg-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ilqr-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-levenberg-marquardt-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ompl-control-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-ompl-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-pendulum-dynamics-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-pinocchio-dynamics-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-quadrotor-dynamics-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-scipy-solver 5.1.3-r1 --> 6.0.1-r1*
* *exotica-time-indexed-rrt-connect-solver 5.1.3-r1 --> 6.0.1-r1*
* *flexbe-behavior-engine 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-core 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-input 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-mirror 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-msgs 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-onboard 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-states 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-testing 1.2.5-r1 --> 1.3.0-r1*
* *flexbe-widget 1.2.5-r1 --> 1.3.0-r1*
* *ixblue-ins 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-driver 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-msgs 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-stdbin-decoder 0.1.3-r1 --> 0.2.0-r1*
* *joystick-interrupt 0.10.3-r1 --> 0.10.4-r1*
* *libmavconn 1.4.0-r1 --> 1.5.0-r1*
* *librealsense2 2.39.0-r1 --> 2.40.0-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *map-organizer 0.10.3-r1 --> 0.10.4-r1*
* *marti-can-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-common-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-dbw-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-nav-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-perception-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-sensor-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-status-msgs 0.9.0-r1 --> 0.10.0-r1*
* *marti-visualization-msgs 0.9.0-r1 --> 0.10.0-r1*
* *mavlink 2020.10.11-r1 --> 2020.11.11-r1*
* *mavros 1.4.0-r1 --> 1.5.0-r1*
* *mavros-extras 1.4.0-r1 --> 1.5.0-r1*
* *mavros-msgs 1.4.0-r1 --> 1.5.0-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *message-filters 1.12.16-r1 --> 1.12.17-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *neonavigation 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-common 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-launch 0.10.3-r1 --> 0.10.4-r1*
* *obj-to-pointcloud 0.10.3-r1 --> 0.10.4-r1*
* *planner-cspace 0.10.3-r1 --> 0.10.4-r1*
* *rc-hand-eye-calibration-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-pick-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-roi-manager-gui 3.0.4-r1 --> 3.0.5-r1*
* *rc-silhouettematch-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-tagdetect-client 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-description 3.0.4-r1 --> 3.0.5-r1*
* *rc-visard-driver 3.0.4-r1 --> 3.0.5-r1*
* *realsense2-camera 2.2.18-r1 --> 2.2.20-r1*
* *realsense2-description 2.2.18-r1 --> 2.2.20-r1*
* *robomaker-simulation-msgs 1.1.1-r1*
* *rokubimini 0.5.8-r1*
* *rokubimini-bus-manager 0.5.8-r1*
* *rokubimini-description 0.5.8-r1*
* *rokubimini-ethercat 0.5.8-r1*
* *rokubimini-examples 0.5.8-r1*
* *rokubimini-factory 0.5.8-r1*
* *rokubimini-manager 0.5.8-r1*
* *rokubimini-msgs 0.5.8-r1*
* *rokubimini-serial 0.5.8-r1*
* *ros-comm 1.12.16-r1 --> 1.12.17-r1*
* *ros-introspection 1.0.3-r1 --> 1.1.0-r1*
* *rosbag 1.12.16-r1 --> 1.12.17-r1*
* *rosbag-snapshot 1.0.2-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.2-r1 --> 1.0.3-r1*
* *rosbag-storage 1.12.16-r1 --> 1.12.17-r1*
* *roscompile 1.0.3-r1 --> 1.1.0-r1*
* *rosconsole 1.12.16-r1 --> 1.12.17-r1*
* *roscpp 1.12.16-r1 --> 1.12.17-r1*
* *rosgraph 1.12.16-r1 --> 1.12.17-r1*
* *roslaunch 1.12.16-r1 --> 1.12.17-r1*
* *roslz4 1.12.16-r1 --> 1.12.17-r1*
* *rosmaster 1.12.16-r1 --> 1.12.17-r1*
* *rosmsg 1.12.16-r1 --> 1.12.17-r1*
* *rosnode 1.12.16-r1 --> 1.12.17-r1*
* *rosout 1.12.16-r1 --> 1.12.17-r1*
* *rosparam 1.12.16-r1 --> 1.12.17-r1*
* *rospy 1.12.16-r1 --> 1.12.17-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *rosservice 1.12.16-r1 --> 1.12.17-r1*
* *rostest 1.12.16-r1 --> 1.12.17-r1*
* *rostopic 1.12.16-r1 --> 1.12.17-r1*
* *roswtf 1.12.16-r1 --> 1.12.17-r1*
* *rqt-bag 0.4.14-r1 --> 0.5.0-r1*
* *rqt-bag-plugins 0.4.14-r1 --> 0.5.0-r1*
* *safety-limiter 0.10.3-r1 --> 0.10.4-r1*
* *seed-smartactuator-sdk 0.0.4-r1 --> 0.0.5-r1*
* *sick-safetyscanners 1.0.6-r1 --> 1.0.7-r1*
* *test-mavros 1.4.0-r1 --> 1.5.0-r1*
* *topic-tools 1.12.16-r1 --> 1.12.17-r1*
* *toposens 2.0.4-r1 --> 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.0.4-r1 --> 2.1.0-r1*
* *toposens-driver 2.0.4-r1 --> 2.1.0-r1*
* *toposens-markers 2.0.4-r1 --> 2.1.0-r1*
* *toposens-msgs 2.0.4-r1 --> 2.1.0-r1*
* *toposens-pointcloud 2.0.4-r1 --> 2.1.0-r1*
* *toposens-sync 2.0.4-r1 --> 2.1.0-r1*
* *track-odometry 0.10.3-r1 --> 0.10.4-r1*
* *trajectory-tracker 0.10.3-r1 --> 0.10.4-r1*
* *urg-node 0.1.14-r1 --> 0.1.15-r1*
* *volta-base 1.0.0-r1*
* *volta-control 1.0.0-r1*
* *volta-description 1.0.0-r1*
* *volta-localization 1.0.0-r1*
* *volta-msgs 1.0.0-r1*
* *volta-navigation 1.0.0-r1*
* *volta-rules 1.0.0-r1*
* *volta-teleoperator 1.0.0-r1*
* *xmlrpcpp 1.12.16-r1 --> 1.12.17-r1*

Melodic Changes:
----------------
* *aws-robomaker-simulation-ros-pkgs 1.1.1-r2*
* *bota-device-driver 0.5.2-r2 --> 0.5.8-r1*
* *bota-driver 0.5.2-r2 --> 0.5.8-r1*
* *bota-node 0.5.2-r2 --> 0.5.8-r1*
* *bota-signal-handler 0.5.2-r2 --> 0.5.8-r1*
* *bota-worker 0.5.2-r2 --> 0.5.8-r1*
* *costmap-cspace 0.10.3-r1 --> 0.10.4-r1*
* *dataspeed-pds 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-can 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-msgs 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-rqt 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-scripts 1.0.5-r1 --> 1.0.6-r1*
* *dingo-control 0.1.4-r1 --> 0.1.5-r1*
* *dingo-description 0.1.4-r1 --> 0.1.5-r1*
* *dingo-msgs 0.1.4-r1 --> 0.1.5-r1*
* *dingo-navigation 0.1.4-r1 --> 0.1.5-r1*
* *dynamic-graph 4.2.2-r1 --> 4.3.1-r1*
* *dynamic-graph-python 3.5.3-r2 --> 4.0.1-r1*
* *eiquadprog 1.2.2-r1 --> 1.2.2-r2*
* *exotica 5.1.3-r3 --> 6.0.0-r1*
* *exotica-aico-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-cartpole-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-collision-scene-fcl-latest 5.1.3-r3 --> 6.0.0-r1*
* *exotica-core 5.1.3-r3 --> 6.0.0-r1*
* *exotica-core-task-maps 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ddp-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-double-integrator-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-dynamics-solvers 5.1.3-r3 --> 6.0.0-r1*
* *exotica-examples 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ik-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ilqg-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ilqr-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-levenberg-marquardt-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ompl-control-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-ompl-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-pendulum-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-pinocchio-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-quadrotor-dynamics-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-scipy-solver 5.1.3-r3 --> 6.0.0-r1*
* *exotica-time-indexed-rrt-connect-solver 5.1.3-r3 --> 6.0.0-r1*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *hdf5-map-io 1.0.0-r2 --> 1.0.1-r1*
* *ixblue-ins 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-driver 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-msgs 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-stdbin-decoder 0.1.3-r1 --> 0.2.0-r1*
* *jackal-gazebo 0.3.0-r2 --> 0.4.0-r1*
* *jackal-simulator 0.3.0-r2 --> 0.4.0-r1*
* *joystick-interrupt 0.10.3-r1 --> 0.10.4-r1*
* *label-manager 1.0.0-r2 --> 1.0.1-r1*
* *libmavconn 1.4.0-r1 --> 1.5.0-r1*
* *map-msgs 1.13.0 --> 1.14.1-r1*
* *map-organizer 0.10.3-r1 --> 0.10.4-r1*
* *mavlink 2020.10.11-r1 --> 2020.11.11-r1*
* *mavros 1.4.0-r1 --> 1.5.0-r1*
* *mavros-extras 1.4.0-r1 --> 1.5.0-r1*
* *mavros-msgs 1.4.0-r1 --> 1.5.0-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *mesh-msgs 1.0.0-r2 --> 1.0.1-r1*
* *mesh-msgs-conversions 1.0.1-r1*
* *mesh-msgs-hdf5 1.0.0-r2 --> 1.0.1-r1*
* *mesh-msgs-transform 1.0.0-r2 --> 1.0.1-r1*
* *mesh-tools 1.0.0-r2 --> 1.0.1-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.13.0 --> 1.14.1-r1*
* *neonavigation 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-common 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-launch 0.10.3-r1 --> 0.10.4-r1*
* *obj-to-pointcloud 0.10.3-r1 --> 0.10.4-r1*
* *open-karto 1.2.2-r1 --> 1.2.3-r1*
* *pal-carbon-collector 1.4.1-r1*
* *pal-statistics 1.4.1-r1*
* *pal-statistics-msgs 1.4.1-r1*
* *planner-cspace 0.10.3-r1 --> 0.10.4-r1*
* *psen-scan-v2 0.1.0-r1 --> 0.1.1-r1*
* *robomaker-simulation-msgs 1.1.1-r2*
* *robot-calibration 0.6.3-r1 --> 0.6.4-r1*
* *robot-calibration-msgs 0.6.3-r1 --> 0.6.4-r1*
* *robot-statemachine 1.2.0-r1*
* *robotont-description 0.0.7-r1*
* *rokubimini 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-bus-manager 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-description 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-ethercat 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-examples 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-factory 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-manager 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-msgs 0.5.2-r2 --> 0.5.8-r1*
* *rokubimini-serial 0.5.2-r2 --> 0.5.8-r1*
* *rosbag-snapshot 1.0.1-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.1-r1 --> 1.0.3-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *rostest-node-interface-validation 0.2.0-r1*
* *rqt-bag 0.4.14-r1 --> 0.5.0-r1*
* *rqt-bag-plugins 0.4.14-r1 --> 0.5.0-r1*
* *rsm-additions 1.2.0-r1*
* *rsm-core 1.2.0-r1*
* *rsm-msgs 1.2.0-r1*
* *rsm-rqt-plugins 1.2.0-r1*
* *rsm-rviz-plugins 1.2.0-r1*
* *rviz 1.13.14-r1 --> 1.13.15-r1*
* *rviz-mesh-plugin 1.0.0-r2 --> 1.0.1-r1*
* *safety-limiter 0.10.3-r1 --> 0.10.4-r1*
* *sick-safetyscanners 1.0.6-r1 --> 1.0.7-r1*
* *test-mavros 1.4.0-r1 --> 1.5.0-r1*
* *toposens 2.0.4-r1 --> 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.0.4-r1 --> 2.1.0-r1*
* *toposens-driver 2.0.4-r1 --> 2.1.0-r1*
* *toposens-markers 2.0.4-r1 --> 2.1.0-r1*
* *toposens-msgs 2.0.4-r1 --> 2.1.0-r1*
* *toposens-pointcloud 2.0.4-r1 --> 2.1.0-r1*
* *toposens-sync 2.0.4-r1 --> 2.1.0-r1*
* *track-odometry 0.10.3-r1 --> 0.10.4-r1*
* *trajectory-tracker 0.10.3-r1 --> 0.10.4-r1*

Noetic Changes:
---------------
* *autoware-can-msgs 1.14.0-r1*
* *autoware-config-msgs 1.14.0-r1*
* *autoware-external-msgs 1.14.0-r1*
* *autoware-lanelet2-msgs 1.14.0-r1*
* *autoware-map-msgs 1.14.0-r1*
* *autoware-msgs 1.14.0-r1*
* *autoware-system-msgs 1.14.0-r1*
* *backward-ros 0.1.7-r1*
* *bagger 0.1.3-r4*
* *bota-device-driver 0.5.8-r1*
* *bota-driver 0.5.8-r1*
* *bota-node 0.5.8-r1*
* *bota-signal-handler 0.5.8-r1*
* *bota-worker 0.5.8-r1*
* *code-coverage 0.4.3-r1 --> 0.4.4-r1*
* *costmap-cspace 0.10.3-r1 --> 0.10.4-r1*
* *dataspeed-pds 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-can 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-msgs 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-rqt 1.0.5-r1 --> 1.0.6-r1*
* *dataspeed-pds-scripts 1.0.5-r1 --> 1.0.6-r1*
* *ddynamic-reconfigure-python 0.0.1-r1*
* *dynamic-graph 4.2.2-r1 --> 4.3.1-r1*
* *dynamic-graph-python 3.5.3-r2 --> 4.0.1-r1*
* *exotica 6.0.0-r1*
* *exotica-aico-solver 6.0.0-r1*
* *exotica-cartpole-dynamics-solver 6.0.0-r1*
* *exotica-collision-scene-fcl-latest 6.0.0-r1*
* *exotica-core 6.0.0-r1*
* *exotica-core-task-maps 6.0.0-r1*
* *exotica-ddp-solver 6.0.0-r1*
* *exotica-double-integrator-dynamics-solver 6.0.0-r1*
* *exotica-dynamics-solvers 6.0.0-r1*
* *exotica-examples 6.0.0-r1*
* *exotica-ik-solver 6.0.0-r1*
* *exotica-ilqg-solver 6.0.0-r1*
* *exotica-ilqr-solver 6.0.0-r1*
* *exotica-levenberg-marquardt-solver 6.0.0-r1*
* *exotica-ompl-control-solver 6.0.0-r1*
* *exotica-ompl-solver 6.0.0-r1*
* *exotica-pendulum-dynamics-solver 6.0.0-r1*
* *exotica-pinocchio-dynamics-solver 6.0.0-r1*
* *exotica-quadrotor-dynamics-solver 6.0.0-r1*
* *exotica-scipy-solver 6.0.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.0.0-r1*
* *fadecandy-driver 0.1.2-r1 --> 0.1.3-r1*
* *fadecandy-msgs 0.1.2-r1 --> 0.1.3-r1*
* *grasping-msgs 0.3.1-r1*
* *image-exposure-msgs 0.15.0-r1*
* *industrial-msgs 0.7.1-r1*
* *industrial-robot-status-controller 0.1.2-r1*
* *industrial-robot-status-interface 0.1.2-r1*
* *ixblue-ins 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-driver 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-ins-msgs 0.1.4-r1 --> 0.1.5-r1*
* *ixblue-stdbin-decoder 0.1.3-r1 --> 0.2.0-r1*
* *joystick-interrupt 0.10.3-r1 --> 0.10.4-r1*
* *libmavconn 1.4.0-r1 --> 1.5.0-r1*
* *map-msgs 1.14.0-r1 --> 1.14.1-r1*
* *map-organizer 0.10.3-r1 --> 0.10.4-r1*
* *mavlink 2020.10.11-r2 --> 2020.11.11-r1*
* *mavros 1.4.0-r1 --> 1.5.0-r1*
* *mavros-extras 1.4.0-r1 --> 1.5.0-r1*
* *mavros-msgs 1.4.0-r1 --> 1.5.0-r1*
* *mbf-abstract-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-abstract-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-core 0.3.2-r1 --> 0.3.3-r1*
* *mbf-costmap-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-msgs 0.3.2-r1 --> 0.3.3-r1*
* *mbf-simple-nav 0.3.2-r1 --> 0.3.3-r1*
* *mbf-utility 0.3.2-r1 --> 0.3.3-r1*
* *move-base-flex 0.3.2-r1 --> 0.3.3-r1*
* *move-base-msgs 1.14.0-r1 --> 1.14.1-r1*
* *neonavigation 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-common 0.10.3-r1 --> 0.10.4-r1*
* *neonavigation-launch 0.10.3-r1 --> 0.10.4-r1*
* *novatel-oem7-driver 1.1.0-r1*
* *novatel-oem7-msgs 1.1.0-r1*
* *obj-to-pointcloud 0.10.3-r1 --> 0.10.4-r1*
* *planner-cspace 0.10.3-r1 --> 0.10.4-r1*
* *pointgrey-camera-description 0.15.0-r1*
* *pointgrey-camera-driver 0.15.0-r1*
* *points-preprocessor 1.14.9-r2*
* *robot-calibration 0.6.4-r1*
* *robot-calibration-msgs 0.6.4-r1*
* *rokubimini 0.5.8-r1*
* *rokubimini-bus-manager 0.5.8-r1*
* *rokubimini-description 0.5.8-r1*
* *rokubimini-ethercat 0.5.8-r1*
* *rokubimini-examples 0.5.8-r1*
* *rokubimini-factory 0.5.8-r1*
* *rokubimini-manager 0.5.8-r1*
* *rokubimini-msgs 0.5.8-r1*
* *rokubimini-serial 0.5.8-r1*
* *rosbag-snapshot 1.0.1-r1 --> 1.0.3-r1*
* *rosbag-snapshot-msgs 1.0.1-r1 --> 1.0.3-r1*
* *rospy-message-converter 0.5.4-r1 --> 0.5.5-r1*
* *rqt-bag 0.4.15-r1 --> 0.5.0-r1*
* *rqt-bag-plugins 0.4.15-r1 --> 0.5.0-r1*
* *rviz 1.14.3-r1 --> 1.14.4-r1*
* *safety-limiter 0.10.3-r1 --> 0.10.4-r1*
* *sick-safetyscanners 1.0.6-r1 --> 1.0.7-r1*
* *statistics-msgs 0.15.0-r1*
* *tablet-socket-msgs 1.14.0-r1*
* *test-mavros 1.4.0-r1 --> 1.5.0-r1*
* *toposens 2.1.0-r1*
* *toposens-bringup 2.1.0-r1*
* *toposens-description 2.1.0-r1*
* *toposens-driver 2.1.0-r1*
* *toposens-markers 2.1.0-r1*
* *toposens-msgs 2.1.0-r1*
* *toposens-pointcloud 2.1.0-r1*
* *toposens-sync 2.1.0-r1*
* *track-odometry 0.10.3-r1 --> 0.10.4-r1*
* *trajectory-tracker 0.10.3-r1 --> 0.10.4-r1*
* *vector-map-msgs 1.14.0-r1*
* *velodyne 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-driver 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-laserscan 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-msgs 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-pcl 1.6.0-r1 --> 1.6.1-r1*
* *velodyne-pointcloud 1.6.0-r1 --> 1.6.1-r1*
* *wfov-camera-msgs 0.15.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] controller_manager
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.6
 * [ ] hardware_interface
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-whichcraft
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-h5py
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-mechanize
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

