### PR TITLE
Call wrapQtApp on rviz executable

### DIFF
--- a/distros/distro-overlay.nix
+++ b/distros/distro-overlay.nix
@@ -255,6 +255,9 @@ let
       nativeBuildInputs ? [], ...
     }: {
       nativeBuildInputs = nativeBuildInputs ++ [ self.qt5.wrapQtAppsHook ];
+      postFixup = ''
+        wrapQtApp "$out/lib/rviz/rviz"
+      '';
     });
 
     rviz-ogre-vendor = rosSuper.rviz-ogre-vendor.overrideAttrs ({


### PR DESCRIPTION
Hi @lopsided98 

Thanks for the great work on this overlay!

This fix is similar to the one introduced in https://github.com/lopsided98/nix-ros-overlay/commit/c0ebfc2faa28d8b80e8617dddc41c2a41db9ab16 but for RViZ