### PR TITLE
rosdistro sync, Fri Jan 29 13:16:21 2021

### DIFF
--- a/distros/dashing/cartographer-ros-msgs/default.nix
+++ b/distros/dashing/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-cartographer-ros-msgs";
-  version = "1.0.9000-r1";
+  version = "1.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/dashing/cartographer_ros_msgs/1.0.9000-1.tar.gz";
-    name = "1.0.9000-1.tar.gz";
-    sha256 = "156d2fb8639bc2045309ac183bf2a03898fd0f955afc95aeba7369ae924e0fbb";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/dashing/cartographer_ros_msgs/1.0.9003-1.tar.gz";
+    name = "1.0.9003-1.tar.gz";
+    sha256 = "e13398ca404d358c0a4c0326a4bc37aa9d844698f105ae095f7cf065b3720d92";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/cartographer-ros/default.nix
+++ b/distros/dashing/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-cartographer-ros";
-  version = "1.0.9000-r1";
+  version = "1.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/dashing/cartographer_ros/1.0.9000-1.tar.gz";
-    name = "1.0.9000-1.tar.gz";
-    sha256 = "bd296ee946e767b374ebd4488c1d06e4e6cca7ac37de7ef883e754b156a2e84e";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/dashing/cartographer_ros/1.0.9003-1.tar.gz";
+    name = "1.0.9003-1.tar.gz";
+    sha256 = "361be20513b88a4aa2f2aa262a7cb64e029e035e2301305d374cb7abaede4fb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/laser-proc/default.nix
+++ b/distros/dashing/laser-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-laser-proc";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_proc-release/archive/release/dashing/laser_proc/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f3702c1645541e03da789f04d4a3b81f87f00215ec946a642f8d3e2eb2e6b00a";
+    url = "https://github.com/ros2-gbp/laser_proc-release/archive/release/dashing/laser_proc/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6b6d1a325d8bc7920389e386327fec57d8f8a3423e7870aa41773b7cc48a75e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-ros/default.nix
+++ b/distros/foxy/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-ros";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "36c0112e464925fad61e855f13518209376135d898456dc0b4c1516e0e8f6fe6";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "9fc0c46e7be8f40ddf5938ed7cf3657b8f591111b9134ece9d1a703a2666961f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-index-cpp/default.nix
+++ b/distros/foxy/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-ament-index-cpp";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_cpp/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "2599a4693285fe34beb3026dada280d06da38b968ae87848c2f428e7cf042997";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_cpp/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5df0a4d5b914c42e92419ca120ea2647622d1b614069d639411fdbbb96ffbd65";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-index-python/default.nix
+++ b/distros/foxy/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-index-python";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_python/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "e10be3bd22652636b47c97f29f741952a024ba3d0c23d73c6c0a80b9e2b11643";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_python/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "75164565cdd37e714af887bcf276df352427e0db3a89a51e78f950f2b5a383fe";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/behaviortree-cpp-v3/default.nix
+++ b/distros/foxy/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, cppzmq, ncurses, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-behaviortree-cpp-v3";
-  version = "3.5.3-r1";
+  version = "3.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/foxy/behaviortree_cpp_v3/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "0ee1e9ea2e67b8a769d45cad54798d4f6fae0fbb6dba49dd273993263dcd18c8";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/foxy/behaviortree_cpp_v3/3.5.5-1.tar.gz";
+    name = "3.5.5-1.tar.gz";
+    sha256 = "3a37b7f1875fc93110b774825a16a9614ea6e7a9d827bbbf91fdf17857d7e43b";
   };
 
   buildType = "catkin";

--- a/distros/foxy/cartographer-ros-msgs/default.nix
+++ b/distros/foxy/cartographer-ros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros-msgs";
-  version = "1.0.9002-r1";
+  version = "1.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9002-1.tar.gz";
-    name = "1.0.9002-1.tar.gz";
-    sha256 = "33e58b9796bdb026afb0acb4a2cbaded6604e729a46ce3eae1a41a953058beab";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros_msgs/1.0.9003-1.tar.gz";
+    name = "1.0.9003-1.tar.gz";
+    sha256 = "69a4899d3415f634ba49083b94ae568bac2b87daea5613e2ae8a3aece5dd9761";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cartographer-ros/default.nix
+++ b/distros/foxy/cartographer-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cartographer, cartographer-ros-msgs, eigen, libyamlcpp, lua5, nav-msgs, pcl, pcl-conversions, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-msgs, tf2-ros, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-cartographer-ros";
-  version = "1.0.9002-r1";
+  version = "1.0.9003-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9002-1.tar.gz";
-    name = "1.0.9002-1.tar.gz";
-    sha256 = "cb23d500a2659e1661b8d0c6f7f1a3e2c5d2434416f34ae68068bf31169fa708";
+    url = "https://github.com/ros2-gbp/cartographer_ros-release/archive/release/foxy/cartographer_ros/1.0.9003-1.tar.gz";
+    name = "1.0.9003-1.tar.gz";
+    sha256 = "5df4a0442de6bba62724fd2b1bcf9e0d11fd98c448240af3b9b52c1dffce932a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/control-msgs/default.nix
+++ b/distros/foxy/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-control-msgs";
-  version = "2.4.1-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/control_msgs-release/archive/release/foxy/control_msgs/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "e9b01671cf82c2e6367c14055fcd3c531b4924782384faf7092e0b32690942df";
+    url = "https://github.com/ros-gbp/control_msgs-release/archive/release/foxy/control_msgs/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "ab7f17a39e21c928f7e22268de920281d2115c5b64e50e88cea92dd2390acac8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-aggregator/default.nix
+++ b/distros/foxy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-aggregator";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "cafee26d9cc58ab71f5b2e30837658870ffaaf87a86f6e4c833b34cf098f52d7";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "6c492b0fc6be6791546eaf9a84278867db28ffebc189bdce6bef28c0880e6cbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-updater/default.nix
+++ b/distros/foxy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-updater";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "a0f5fb17c0d5183e175cdc4116c608736c1bc8b595ffa66f60741b336ea04f8d";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "7c949bd3da3e4ae19176f42a448dee2a28453c0f10a5ac56e7783db72307e531";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/domain-coordinator/default.nix
+++ b/distros/foxy/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-domain-coordinator";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "efeccebd28642b468e619386391c2fec3a9c30b2a531402310ef26d38010f715";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "af7d7476efae55600ff613e1899a5ec47687ab7922e5bf0a7182bb0df3834344";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/laser-proc/default.nix
+++ b/distros/foxy/laser-proc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-laser-proc";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/laser_proc-release/archive/release/foxy/laser_proc/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c04e3e3edaa464a64d316b602bae4355333def02679918cdc2171d11c5adfee9";
+    url = "https://github.com/ros2-gbp/laser_proc-release/archive/release/foxy/laser_proc/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "03c68a7d9b9cef1c049da4b6314cd86514f4f571e3ca02f004aaf92eb97514d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/libyaml-vendor/default.nix
+++ b/distros/foxy/libyaml-vendor/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-libyaml-vendor";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/foxy/libyaml_vendor/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "2d9d6e4a32ac17bf0617218b0caecf892a837cfb23835a55a072e13363e48bf0";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/foxy/libyaml_vendor/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f16180e3aded15087e9e41e9f7acb34062ab01439f0e3f7b298a4cd5e4559040";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture rcpputils ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/map-transformer/default.nix
+++ b/distros/foxy/map-transformer/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, opencv3, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-map-transformer";
-  version = "1.0.0-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/map_transformer-release/archive/release/foxy/map_transformer/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "eddb4d0a104dc199e614fd490355515e26c6575152ad5b1ed6b55834693c7be4";
+    url = "https://github.com/ros-gbp/map_transformer-release/archive/release/foxy/map_transformer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d9f8ccf5a5879fa8965b65fa6f65b1d33503deb694b910eba3cd5ded46bff5ad";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ opencv3 yaml-cpp-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/foxy/orocos-kdl/default.nix
+++ b/distros/foxy/orocos-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, cppunit, eigen, eigen3-cmake-module, pkg-config }:
 buildRosPackage {
   pname = "ros-foxy-orocos-kdl";
-  version = "3.3.1-r1";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/foxy/orocos_kdl/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "a76f67c07a0e87df041957dcd9bdf0c27f665038f597e0dd0b62ea3df8b575e4";
+    url = "https://github.com/ros2-gbp/orocos_kinematics_dynamics-release/archive/release/foxy/orocos_kdl/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "98db0b3f2f98694048993f760461db36c01c9ee1cb2cf413ab061dd3882aa5cd";
   };
 
   buildType = "cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.0.2-r1";
+  version = "1.0.3-r8";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "afd698702b2f279c5c1c62b6f65b225532cb6d8f759c73254ca46a30888ed73e";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.0.3-8.tar.gz";
+    name = "1.0.3-8.tar.gz";
+    sha256 = "bf860ca65e4ce4cb97bbdca03555d075c480f857554e9204195c7ad29a364a7e";
   };
 
   buildType = "catkin";

--- a/distros/foxy/robot-state-publisher/default.nix
+++ b/distros/foxy/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-foxy-robot-state-publisher";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "9ddc81f216689e36e8b5cb0814fdd05b9e6fa5f67e4422a02dd8ef64f065f544";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "59f69893fc4e810209db9c569c6d0826a230428a936690303884c03d61f7aba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/self-test/default.nix
+++ b/distros/foxy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-self-test";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "5969afe2ed15294b1018683d0594b1d323e8276295a11ca0517d513c11b07b71";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "800861e2dafa8762833a4cb1fa1cb56b3045c458e30182528b6cf1f5179baca8";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/cob-command-gui/default.nix
+++ b/distros/kinetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, pythonPackages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-cob-command-gui";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_command_gui/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "453c7ef2e80d2c49cbb54cf6341ee3cd31d69b74d21db469e6dc0b4d566e50d3";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_command_gui/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "a36fa7061c30fe0860bdb53743db533748dc07f1529b6c3dad74a005e5a565d4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-command-tools/default.nix
+++ b/distros/kinetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-kinetic-cob-command-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_command_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "2c1e58a39a59f75e108b8fdc3f2cc66eb78403b01c1be43355698504b30b1fc6";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_command_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "28478871c5aa1cc1764c613889b6bb793086c7ebeb17d0486ef62177c65d41fc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-dashboard/default.nix
+++ b/distros/kinetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-kinetic-cob-dashboard";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_dashboard/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "bb71e8daa0ab499a91ba61e4cc6be8579003cfa6b5f6e97d2138181e0b535706";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_dashboard/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "3a5f12795d29c4c1023dccf5cb905bdc4e2a76ea4c209b19f6bb68139d5dba2a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-helper-tools/default.nix
+++ b/distros/kinetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-cob-helper-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_helper_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "8c549a8ad775ab7bb889ffc565adbfd3b72e681680b573e7da0eae8ec3fb35b5";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_helper_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "afd5ec55f8b271472a2fcd18f0fd55684d3f62cf984536ea79cc7c03d7aa13d0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-interactive-teleop/default.nix
+++ b/distros/kinetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-cob-interactive-teleop";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_interactive_teleop/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "8661c830a22d7a94e6605e040e305531166c75ea3262af547970f826a8e2b87f";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_interactive_teleop/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "d7645c860bf43f86914489eb700f5e78f25648ef320330d021a07a19a9722a1a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-monitoring/default.nix
+++ b/distros/kinetic/cob-monitoring/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, pythonPackages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-cob-monitoring";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_monitoring/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "744ecaaad6db561f3d676b4d233ade76727995fb1695e89c23b9503c90e19df9";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_monitoring/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "a67838208e55816345a4967af611f9cdc896dea707b1ebf01d8e8022d28d2b99";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-script-server/default.nix
+++ b/distros/kinetic/cob-script-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, pythonPackages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
 buildRosPackage {
   pname = "ros-kinetic-cob-script-server";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_script_server/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "e4ad0de4f69a0e5ec9399a542b6ca2f41d7ca7a2dc400449fcd8cd750fa5a22f";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_script_server/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "c6ea28d2b8c964fc9f02fd88785419f2d49c205aa16911a576f478180196dc52";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/cob-teleop/default.nix
+++ b/distros/kinetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-cob-teleop";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_teleop/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "eed7534c066e583d76ac6118202b97fec528be4fa816ed59565587d0703d822d";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/cob_teleop/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "c2d09bdcca50d556184d009a74a8c2f9fe4b5eb9f581a12040c9878eeb3e1603";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "56430cadd5008732c2f0027f511a16293d37ebd93a01ec33037922ec55a352f2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "e669d8f230926351052d2cc2f200c74a5935e9aeca93b297ddfc9133771a6aa9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -1920,6 +1920,8 @@ self: super: {
 
  khi-robot-msgs = self.callPackage ./khi-robot-msgs {};
 
+ khi-robot-test = self.callPackage ./khi-robot-test {};
+
  khi-rs007l-moveit-config = self.callPackage ./khi-rs007l-moveit-config {};
 
  khi-rs007n-moveit-config = self.callPackage ./khi-rs007n-moveit-config {};
@@ -4621,6 +4623,8 @@ self: super: {
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teb-local-planner-tutorials = self.callPackage ./teb-local-planner-tutorials {};
+
+ teleop-legged-robots = self.callPackage ./teleop-legged-robots {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 

--- a/distros/kinetic/generic-throttle/default.nix
+++ b/distros/kinetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, pythonPackages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-kinetic-generic-throttle";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/generic_throttle/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "4ba99ef99bcdd5560fe017b87922e92caaca5c3da88c664282e0bc0cdbf63c91";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/generic_throttle/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "fbdb7e283cd0ed8346407bd9f632d6f81f866fa4596ca877c5f4ef2f95ed8e2b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "297cfe737428b92bb7e363682569c29b185e2b04a42119635c9cb402136bd1f8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "7b455bcdfe44f6abd5a877a65b3e8ac0fce914142635762e4ad9eb0e00939014";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-duaro-description/default.nix
+++ b/distros/kinetic/khi-duaro-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-kinetic-khi-duaro-description";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_description/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "9b46740c8c77cbf61497aaea1a8b804d1208896be9c99cc1890768e2b49ad146";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_description/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "297c05a6cfc1a11833e80668ae4bc7a9c99069032717d02b8d8d1caa0e6bac5b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-duaro-gazebo/default.nix
+++ b/distros/kinetic/khi-duaro-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros-control }:
 buildRosPackage {
   pname = "ros-kinetic-khi-duaro-gazebo";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_gazebo/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3c620509b6f309b8d95b095318db45c3d2148a8289aaffb3394e93b7b9ce8425";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_gazebo/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "3cda275a6cfaf6aac829106bac441f5958cc7a1d717116abbd561132b76ff005";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-duaro-ikfast-plugin/default.nix
+++ b/distros/kinetic/khi-duaro-ikfast-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
 buildRosPackage {
   pname = "ros-kinetic-khi-duaro-ikfast-plugin";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_ikfast_plugin/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "63c2ac58d289bacc188c69629427ed5bfee694f77e4b68e3b472d7d10feb7242";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_ikfast_plugin/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "dfed859c60e4ef6dc8eb3bafbdb084e3b4fd54ec3e3597ce02ba726c142afbe7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-duaro-moveit-config/default.nix
+++ b/distros/kinetic/khi-duaro-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-duaro-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-khi-duaro-moveit-config";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_moveit_config/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "49163da73b919add96090f4f1f290dbd8b941a335ea169937312b75863ec3bbe";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_duaro_moveit_config/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "c2ce8eae0c51aca86511817807363afc251afac49c4392a651a1140b07e0af57";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-robot-bringup/default.nix
+++ b/distros/kinetic/khi-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, joint-state-controller, joint-trajectory-controller, khi-duaro-description, khi-duaro-moveit-config, khi-robot-control, position-controllers, robot-state-publisher, roslaunch, rostest, tf }:
 buildRosPackage {
   pname = "ros-kinetic-khi-robot-bringup";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_bringup/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "be1db76ee75dd250d42a6db1aa2dec4513ecdab9e23ea5c9e0c27bfcee963177";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_bringup/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "8806146bfd3bc17230c3dd1f3120ef6e4b3bd9a769480d7dc68f9260fcb845c4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-robot-control/default.nix
+++ b/distros/kinetic/khi-robot-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-updater, hardware-interface, joint-limits-interface, joint-state-controller, joint-trajectory-controller, khi-robot-msgs, position-controllers, realtime-tools, rostest, trajectory-msgs, transmission-interface }:
 buildRosPackage {
   pname = "ros-kinetic-khi-robot-control";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_control/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "97c62532a93adcc6c37496e3a77b659ff44c346680f2c870feb296c3b9ae0930";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_control/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "176edce4b0c1eb25c4847f3b44ef815267f7897aa13cc4fe1499550a15e6c693";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-robot-msgs/default.nix
+++ b/distros/kinetic/khi-robot-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-khi-robot-msgs";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_msgs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "71ab525f8ea629ca0a3cce453e6bee8fe65ed196b1af39b4dd4df9f4d36e6c10";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_msgs/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "31625b405eae7257531733a03bd5c7f974ffdb1d59219163ac4f8d60a8df24a7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-robot-test/default.nix
+++ b/distros/kinetic/khi-robot-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs080n-moveit-config, moveit-commander, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-kinetic-khi-robot-test";
+  version = "1.2.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot_test/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "39f9f4a055e622b4c6a097541578c10ddfbc284254d4f045fd779f247833a8b1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ khi-duaro-moveit-config khi-robot-bringup khi-robot-control khi-robot-msgs khi-rs007l-moveit-config khi-rs007n-moveit-config khi-rs080n-moveit-config moveit-commander rostest ];
+  propagatedBuildInputs = [ khi-robot-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Test package for khi_robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/khi-robot/default.nix
+++ b/distros/kinetic/khi-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, khi-duaro-description, khi-duaro-gazebo, khi-duaro-ikfast-plugin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs-description, khi-rs-gazebo, khi-rs-ikfast-plugin, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs080n-moveit-config }:
 buildRosPackage {
   pname = "ros-kinetic-khi-robot";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "e44b715ba4d86e915967708a6d4a4d993a2ffdfe3bf2cc9e950096a2459c2f2b";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_robot/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "d6397e3b7383f1c0126daef61a9f70b2bfe9db74157a3de149d26dca420a950e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs-description/default.nix
+++ b/distros/kinetic/khi-rs-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs-description";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_description/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "67217515755eb1c89dac53f8eaa6a122d6641ab5f7f9270b8b9b0cc7f1bfe4e7";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_description/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "b20c4b2926a4cb48190f097bab1a22f8bc661722f0aa3a02e83173871e0ac490";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs-gazebo/default.nix
+++ b/distros/kinetic/khi-rs-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-ros-control }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs-gazebo";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_gazebo/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "20ac49b5b30593e669743da9e1520e57cf71154bcd6895413bf5c0072eb937bb";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_gazebo/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "ef000ad5cbe4b620a5ba833b0d1755b83561a028ff1bfa35b74909ddcc806f85";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs-ikfast-plugin/default.nix
+++ b/distros/kinetic/khi-rs-ikfast-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs-ikfast-plugin";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_ikfast_plugin/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "f38eeb5fe9d9ed489432cdab4465fd90105bf0855dca96de55bfda398c3a2004";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs_ikfast_plugin/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "ffa165109ab04e7363003d51e0b97e6dccd89c9adb92018c4487e6bdd7fe3f8e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs007l-moveit-config/default.nix
+++ b/distros/kinetic/khi-rs007l-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs007l-moveit-config";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs007l_moveit_config/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "122afb77de453544e1705a0ffeb607bbcae6c3b0055fa6c0cfe9cc2c3fcbef11";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs007l_moveit_config/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "53b65a86709f1bb28f16459810f4f45cc14aa006feebd8d0407c8a6d289a2ea4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs007n-moveit-config/default.nix
+++ b/distros/kinetic/khi-rs007n-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs007n-moveit-config";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs007n_moveit_config/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3e6de855e5f31817ccd1cd379ebab47fb9ebda7af634e98dbeed11697c9d7650";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs007n_moveit_config/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "46a4ba259ae9e226a0870019c0f41341d948a6ef297481d8770dc5c20b5d1c7c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/khi-rs080n-moveit-config/default.nix
+++ b/distros/kinetic/khi-rs080n-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-khi-rs080n-moveit-config";
-  version = "1.1.2-r1";
+  version = "1.2.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs080n_moveit_config/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "145aa2cbc7db77e95f6e51caae3ba2f8ab47e9ae62c33069c1389ad46c344035";
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/kinetic/khi_rs080n_moveit_config/1.2.0-5.tar.gz";
+    name = "1.2.0-5.tar.gz";
+    sha256 = "b265cfb6de896a179a8d610d85d51857b29d47079f1d3408fa7b2ac5f74fe242";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "f5c3e928d34480af75589849919d4c804e4bf7f38dbeb52584dd40f3cf779119";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "f4453f4db70b7038763a826b074faaa74f34792f9902f1bc7d50e71cd91c3b07";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "93d873abe9102ac166883edae0aaa6025797493ce86fe5e9175099be26b4debe";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "6f3f0b710ebeccbd0488d996a7f3d604a7e2f2af1a0443a96b2b9bcdbc0600fe";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "c246a558f9f62e1134729542b25eab690df5d7080f780c11750c7266dd1c5881";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "a9e368bef1ec8ab2ff1c3e54c03b0c6a25df86ba2df157354cda68c7d0de3dd9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "3b1be32c7d7b1dce7a3c884a9b74aef98fadf687cdae9b788289dd56e7ee383b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "ec4310978a8c5dd312a86f5a1a79e508cebf916ce7bf6b23d6d20181271fb4c1";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "1488e64a2e610b1d1c5f6a04b1e6c8b02216afeabb952d5749659bafda8d88f5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "81525e2aa6010feea93e5c6d8cf31879c62d639a15146ed35ecd698e9fb74cb6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "9856b4d1877fc5d958809b2d724accb3ce8680c5e4887c0b052e32aa154828e4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "d6b5544920d9c1b30d3c3839db31ca2088ad5fe2b5b81c47f00a0039853f6639";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rc-genicam-driver/default.nix
+++ b/distros/kinetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-rc-genicam-driver";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/kinetic/rc_genicam_driver/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "aecdb2ab526647e28dc9d7115ba61291e9ab4a9b44ee5e7987b1f99c8d9dd4c7";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/kinetic/rc_genicam_driver/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "6a2dcea6fa7bd6c13e35cbcc474017493da5a52f5a10b8c4c1fa160255d67843";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "08382f9d00c3d8297346c2922c1013279936775604e59fe82aa3fad02754deaf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "12e1735d6906f96b694c32c509532b57768fc4765d94f8a6557294080a3484a8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/scenario-test-tools/default.nix
+++ b/distros/kinetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, pythonPackages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-scenario-test-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/scenario_test_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "9db274be12ac667113827522557d817b42095a244db0b3e99e5d4fa47bd33629";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/scenario_test_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "ee32a9771a99ff9f0a0b40d0dcb79c719db9abe7b001b17e060495ffddfe52bc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/service-tools/default.nix
+++ b/distros/kinetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-kinetic-service-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/service_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "3fd9399005b49d708fe478087fd0c36fe01f20fcca079b4baf99aba0d698556b";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/kinetic/service_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "28bd9d5a43028da7fb69cf941f4a9b45fb62175d726717907f63493a432d0a1e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/teleop-legged-robots/default.nix
+++ b/distros/kinetic/teleop-legged-robots/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-kinetic-teleop-legged-robots";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SoftServeSAG/teleop_legged_robots-release/archive/release/kinetic/teleop_legged_robots/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d0bf702437a144dc8c8143c17dd35d5851d26453766ee047909867acbbb7817a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic keyboard teleop for legged robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "d3cbcb6be1a80f3c7b04efcb4d6227676cbc1ab57be96b117131a02eedff03cd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "b33e5406abfe8a30be7211f2138d4086f6651076dfebd0665ee2ce57c64ed739";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "ecee055ac44ed2a5010a62dd947f8308377a2473385160ee85101efdb9be8a14";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "fce3aa3ba1635826125f1e999a03a75caabf2cf00a8e27b71e2150bff745a1a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/behaviortree-cpp-v3/default.nix
+++ b/distros/melodic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-melodic-behaviortree-cpp-v3";
-  version = "3.5.3-r1";
+  version = "3.5.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "6fde0c7f8294c20c5b62ac75cf0e5749c07a12b59373c4be3ea0ed3643cf7bbe";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp_v3-release/archive/release/melodic/behaviortree_cpp_v3/3.5.5-2.tar.gz";
+    name = "3.5.5-2.tar.gz";
+    sha256 = "f7db85511cdd46bfa3feaf418bc0b9a9285c514580aeeeb23d8f8fa55324b9bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "a6f7e003a82d71cf1970ebdeb956b32bcf6180b83b9fb686acede17c5b802736";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "bd30c6512a006d5a47ba9874610b5c95989904e5815834848d402d668688f6b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1598,6 +1598,36 @@ self: super: {
 
  key-teleop = self.callPackage ./key-teleop {};
 
+ khi-duaro-description = self.callPackage ./khi-duaro-description {};
+
+ khi-duaro-gazebo = self.callPackage ./khi-duaro-gazebo {};
+
+ khi-duaro-ikfast-plugin = self.callPackage ./khi-duaro-ikfast-plugin {};
+
+ khi-duaro-moveit-config = self.callPackage ./khi-duaro-moveit-config {};
+
+ khi-robot = self.callPackage ./khi-robot {};
+
+ khi-robot-bringup = self.callPackage ./khi-robot-bringup {};
+
+ khi-robot-control = self.callPackage ./khi-robot-control {};
+
+ khi-robot-msgs = self.callPackage ./khi-robot-msgs {};
+
+ khi-robot-test = self.callPackage ./khi-robot-test {};
+
+ khi-rs007l-moveit-config = self.callPackage ./khi-rs007l-moveit-config {};
+
+ khi-rs007n-moveit-config = self.callPackage ./khi-rs007n-moveit-config {};
+
+ khi-rs080n-moveit-config = self.callPackage ./khi-rs080n-moveit-config {};
+
+ khi-rs-description = self.callPackage ./khi-rs-description {};
+
+ khi-rs-gazebo = self.callPackage ./khi-rs-gazebo {};
+
+ khi-rs-ikfast-plugin = self.callPackage ./khi-rs-ikfast-plugin {};
+
  kinesis-manager = self.callPackage ./kinesis-manager {};
 
  kinesis-video-msgs = self.callPackage ./kinesis-video-msgs {};
@@ -3484,6 +3514,8 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ rx-service-tools = self.callPackage ./rx-service-tools {};
+
  rxcpp-vendor = self.callPackage ./rxcpp-vendor {};
 
  rxros = self.callPackage ./rxros {};
@@ -3715,6 +3747,8 @@ self: super: {
  teb-local-planner = self.callPackage ./teb-local-planner {};
 
  teb-local-planner-tutorials = self.callPackage ./teb-local-planner-tutorials {};
+
+ teleop-legged-robots = self.callPackage ./teleop-legged-robots {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 

--- a/distros/melodic/interactive-marker-twist-server/default.nix
+++ b/distros/melodic/interactive-marker-twist-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, roslaunch, roslint, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, roslaunch, roslint, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-interactive-marker-twist-server";
-  version = "1.2.0";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/melodic/interactive_marker_twist_server/1.2.0-0.tar.gz";
-    name = "1.2.0-0.tar.gz";
-    sha256 = "8597a128559ea347e15b06e235bb1124605e0060f42b3ceebe52769a75563946";
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/melodic/interactive_marker_twist_server/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "8a2184a3dd5aef7a00c0212cb5b0b86c2ccc787b29b7c06cb2ded6c930542078";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch roslint ];
-  propagatedBuildInputs = [ interactive-markers roscpp visualization-msgs ];
+  propagatedBuildInputs = [ interactive-markers roscpp tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "a8ba202c2ef023552bbbd220ba9f11fb018fd77ffaf61ec3a976b2beb73d9757";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "fee9fb49912bc031a3013085b813c66cc56bf1ce4e4877951918b881c7e607a4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/khi-duaro-description/default.nix
+++ b/distros/melodic/khi-duaro-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch }:
+buildRosPackage {
+  pname = "ros-melodic-khi-duaro-description";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_duaro_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a4666e742360013543b7fd11c8b01367f8abe03a01430fd247126b1222d8ff52";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_description package'';
+    license = with lib.licenses; [ bsdOriginal "KHI CAD license (mesh data, see readme)" ];
+  };
+}

--- a/distros/melodic/khi-duaro-gazebo/default.nix
+++ b/distros/melodic/khi-duaro-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros-control }:
+buildRosPackage {
+  pname = "ros-melodic-khi-duaro-gazebo";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_duaro_gazebo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "c72abe21a0c26ae8f45f33e712adc52cf35d9ebf41bcf7a1b2605d586b48773a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gazebo-ros-control ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_gazebo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-duaro-ikfast-plugin/default.nix
+++ b/distros/melodic/khi-duaro-ikfast-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
+buildRosPackage {
+  pname = "ros-melodic-khi-duaro-ikfast-plugin";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_duaro_ikfast_plugin/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "3eda3984c7adabaa70f7d83c4d63a58e147049ef64d09d61569e99d143e13d2e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ liblapack moveit-core pluginlib roscpp tf-conversions ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_duaro_ikfast_plugin package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-duaro-moveit-config/default.nix
+++ b/distros/melodic/khi-duaro-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-duaro-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-khi-duaro-moveit-config";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_duaro_moveit_config/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bbb02ab96961608832b53b3e37256e58849d8e66262b7adece3d6feb9f4cb9ea";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-duaro-description moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-simple-controller-manager robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_duaro with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-robot-bringup/default.nix
+++ b/distros/melodic/khi-robot-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, joint-state-controller, joint-trajectory-controller, khi-duaro-description, khi-duaro-moveit-config, khi-robot-control, position-controllers, robot-state-publisher, roslaunch, rostest, tf }:
+buildRosPackage {
+  pname = "ros-melodic-khi-robot-bringup";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_robot_bringup/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "6133099b2e9517127d48a9235e08db0ca88c5a89070257b2d08656a27a168089";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ controller-manager joint-state-controller joint-trajectory-controller khi-duaro-description khi-duaro-moveit-config khi-robot-control position-controllers robot-state-publisher tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package contains bringup scripts/config/tools for KHI Robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-robot-control/default.nix
+++ b/distros/melodic/khi-robot-control/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-updater, hardware-interface, joint-limits-interface, joint-state-controller, joint-trajectory-controller, khi-robot-msgs, position-controllers, realtime-tools, rostest, trajectory-msgs, transmission-interface }:
+buildRosPackage {
+  pname = "ros-melodic-khi-robot-control";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_robot_control/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5b41dc0be0d2c297e2df384f877f5db6388398fef8e557eddcd2433e2216c68b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ realtime-tools ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ controller-manager diagnostic-updater hardware-interface joint-limits-interface joint-state-controller joint-trajectory-controller khi-robot-msgs position-controllers trajectory-msgs transmission-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS KHI robot controller package based on ros_control'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-robot-msgs/default.nix
+++ b/distros/melodic/khi-robot-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-khi-robot-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_robot_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "63a2b5f4a4a75efd865b78c631ea2fb778ebe0fdf6a3a31d3c64849e64b583db";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains KHI ROS robot msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-robot-test/default.nix
+++ b/distros/melodic/khi-robot-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs080n-moveit-config, moveit-commander, rospy, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-khi-robot-test";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_robot_test/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e04b6b83430e5d53a7700c7c4a2ca88c8f52129691fdf804606c2bf5b69f7dab";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ khi-duaro-moveit-config khi-robot-bringup khi-robot-control khi-robot-msgs khi-rs007l-moveit-config khi-rs007n-moveit-config khi-rs080n-moveit-config moveit-commander rostest ];
+  propagatedBuildInputs = [ khi-robot-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Test package for khi_robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-robot/default.nix
+++ b/distros/melodic/khi-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, khi-duaro-description, khi-duaro-gazebo, khi-duaro-ikfast-plugin, khi-duaro-moveit-config, khi-robot-bringup, khi-robot-control, khi-robot-msgs, khi-rs-description, khi-rs-gazebo, khi-rs-ikfast-plugin, khi-rs007l-moveit-config, khi-rs007n-moveit-config, khi-rs080n-moveit-config }:
+buildRosPackage {
+  pname = "ros-melodic-khi-robot";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_robot/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b655c268651024301efbbf3b19403eec907af1d075347063715aa1e1a21d5d65";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ khi-duaro-description khi-duaro-gazebo khi-duaro-ikfast-plugin khi-duaro-moveit-config khi-robot-bringup khi-robot-control khi-robot-msgs khi-rs-description khi-rs-gazebo khi-rs-ikfast-plugin khi-rs007l-moveit-config khi-rs007n-moveit-config khi-rs080n-moveit-config ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package for khi_robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-rs-description/default.nix
+++ b/distros/melodic/khi-rs-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs-description";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4a43ed20e06a9b3a7a8cd7a0a536b08906e8b92bb1eb072cbf6c16515d98b40f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_description package'';
+    license = with lib.licenses; [ bsdOriginal "KHI CAD license (mesh data, see readme)" ];
+  };
+}

--- a/distros/melodic/khi-rs-gazebo/default.nix
+++ b/distros/melodic/khi-rs-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros, gazebo-ros-control }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs-gazebo";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs_gazebo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "5f8d1aca50da477a7b8f95fbc542d51f37acf6c9bd6df5e090e1f994554cd00a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros gazebo-ros-control ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_gazebo package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-rs-ikfast-plugin/default.nix
+++ b/distros/melodic/khi-rs-ikfast-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, liblapack, moveit-core, pluginlib, roscpp, tf-conversions }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs-ikfast-plugin";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs_ikfast_plugin/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d9f697807d99df9fb28ee0e5dacf746d59998eb9e36895e167c80fb571194b2f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ liblapack moveit-core pluginlib roscpp tf-conversions ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The khi_rs_ikfast_plugin package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-rs007l-moveit-config/default.nix
+++ b/distros/melodic/khi-rs007l-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs007l-moveit-config";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs007l_moveit_config/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "564e6223536c64aa0963d043a6a5ff3f8d819053acbdc2dec330a97da22e7a68";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs007l with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-rs007n-moveit-config/default.nix
+++ b/distros/melodic/khi-rs007n-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs007n-moveit-config";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs007n_moveit_config/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "8dcf45cb635bcb6fdb87094daf598e94ecc5a9748067c6550b9c139b5d72400f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs007n with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/khi-rs080n-moveit-config/default.nix
+++ b/distros/melodic/khi-rs080n-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, khi-rs-description, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, robot-state-publisher, roslaunch, rostest, rviz, tf, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-khi-rs080n-moveit-config";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Kawasaki-Robotics/khi_robot-release/archive/release/melodic/khi_rs080n_moveit_config/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "6719e7ec11326619aeba4b3289f06be44a33e87baec9fb28c7a6fe271d17a37e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ joint-state-publisher khi-rs-description moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization robot-state-publisher rviz tf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the khi_rs080n with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "d13a701c60594a47b5796916150d6f2b7bd259b14d2d94f263cfb55b513c59fd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "7a74619c8e44a2f719525ca845788a50112f850279895b99740073a549f9769d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "80cb35eb432ede2c58e513b5e70836a094a26c3f36397a82628cd14c946d7750";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "685e41caef0c36db53023cc2ed1d2717083e469d45f8fff8fa87854936c30766";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "a79abfbe925b1d6aaf3d3020ed48a70d3c2583a6b1d9b8d28b152d0e4060b6c7";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "d7c49f35a6bbbcb2094c65811a75614b1bfb8dc42737c0a6bc672bed4091dad5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "3a8002334ad27aaa153d577ee37b8ae21e45cb6b8d880b887cb037484ef00a16";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "69ebc422dbb64b26e3891687f86b0eb51160f314656a36eb9584b6df6093c2df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "bb07cdbb02455fe91a9ffb387cce01efcc2b23fc3782b32aea935bddd904242d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "1c36cd250a0e782d58fa6cc7d6e459495225bc56a3b2bfc053e19888c26ee45c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "acbe98203f361d1d0173c8d5a5dbc77039fcb620006694064487b718989953cc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "7a6061d6f8f2b747af64a0de6ecd3094f9f1f31357c27070bd0eed8a21016a45";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-genicam-driver/default.nix
+++ b/distros/melodic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-driver";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "64cbf993f6a22b2517029d7e564008fd3b0c2b56189033245dbd206c0eb00c18";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "d4a54226f8593bd1ec396cba39209d0208fed05fd076a3c9ad6476224ff0c9f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rx-service-tools/default.nix
+++ b/distros/melodic/rx-service-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python, pythonPackages, roslib, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-rx-service-tools";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rx_service_tools-release/archive/release/melodic/rx_service_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "68d0c57e7a8de53a6bfd718d6bbfef0871720a3b62113eda08506b6c7db6539b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python pythonPackages.pyyaml pythonPackages.wxPython roslib rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Graphical tools to interact with ROS services.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "95400b5482c4d007c48f37598b378f4ff05bc19a2a8f368bdb7e02a6ee3af91c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "3af3621e8db901908e86fffa32e609d4cb37ee2eca8d9567d7e7b513fc832afa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/teleop-legged-robots/default.nix
+++ b/distros/melodic/teleop-legged-robots/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-teleop-legged-robots";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SoftServeSAG/teleop_legged_robots-release/archive/release/melodic/teleop_legged_robots/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d0d4bd1d18469d4fc4b1f0c09d132aef28ba7d17e164040cd567d1c68381b686";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic keyboard teleop for legged robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "d9327be84440114b04245f5ccb1bab9dcdf22c378d4fc714f83f206091cb7775";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "798fef16feaf9fc0bed81c616b2c7707bd966c322f444d8939f7f862bc245f8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "5910c70801eb9912e5ae7bad2386597e48ae57f326fb6a0a37d172df68c85843";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "b126b52feb66eaca496393037fa4621d7655945a6ad48fd9408ee778d6a83500";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ueye-cam/default.nix
+++ b/distros/melodic/ueye-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, camera-info-manager, catkin, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ueye-cam";
-  version = "1.0.18-r1";
+  version = "1.0.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/anqixu/ueye_cam-release/archive/release/melodic/ueye_cam/1.0.18-1.tar.gz";
-    name = "1.0.18-1.tar.gz";
-    sha256 = "8286de2a4b958373e0b8fd3de53fb05632eb33a882a37388143139a306406e39";
+    url = "https://github.com/anqixu/ueye_cam-release/archive/release/melodic/ueye_cam/1.0.17-1.tar.gz";
+    name = "1.0.17-1.tar.gz";
+    sha256 = "03d172816684251094ab052bb7b8d6c9be51d752e47f5bea0153f24ccc2932f2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/webots-ros/default.nix
+++ b/distros/melodic/webots-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-webots-ros";
-  version = "2.1.1-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "379d2d916adfb7764363ed8edb185346e8a72187e7c406a82a766ed906fafed6";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "6f9ac67502359b0a49f239fbf9273de27ea8f845920d92992450b73984709ecb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/async-comm/default.nix
+++ b/distros/noetic/async-comm/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost }:
+buildRosPackage {
+  pname = "ros-noetic-async-comm";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/dpkoch/async_comm-release/archive/release/noetic/async_comm/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3d1a92c6a273016b8d5b6f7b220ca0947483abd605324c72b7ae3cf152212f03";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost ];
+
+  meta = {
+    description = ''A C++ library for asynchronous serial communication'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/behaviortree-cpp-v3/default.nix
+++ b/distros/noetic/behaviortree-cpp-v3/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cppzmq, ncurses, roslib }:
 buildRosPackage {
   pname = "ros-noetic-behaviortree-cpp-v3";
-  version = "3.5.3-r1";
+  version = "3.5.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/noetic/behaviortree_cpp_v3/3.5.3-1.tar.gz";
-    name = "3.5.3-1.tar.gz";
-    sha256 = "be572da316779c43e60a73249a34a5211238ff0520b28ce7d42080abba68e7a8";
+    url = "https://github.com/BehaviorTree/behaviortree_cpp-release/archive/release/noetic/behaviortree_cpp_v3/3.5.5-2.tar.gz";
+    name = "3.5.5-2.tar.gz";
+    sha256 = "b8eff999777fb417e1b9bf37d7b4de5892181cf4a13a0c75d90bbf06ee2953d5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-gui/default.nix
+++ b/distros/noetic/cob-command-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, python3Packages, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-gui";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "2f0bc40f83c53ce7132b508b84d799156e64742e3a200dc1b2af9ecb30424f68";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_gui/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "5f2c2ba3c291a72de4b8f837c74b64630ef8d851a6b62e5c315e4f4c1dc750ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-command-tools/default.nix
+++ b/distros/noetic/cob-command-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-command-gui, cob-dashboard, cob-helper-tools, cob-interactive-teleop, cob-monitoring, cob-script-server, cob-teleop }:
 buildRosPackage {
   pname = "ros-noetic-cob-command-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "618db6afd13a7ca9c7f1817bbf4f1e2f1d015853c2e50f5ae255c9146cc85ba6";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_command_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "5453e5c03029782eb334219a7c06e8403f29f3d3ddb16e71a12d1ef174c47996";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-dashboard/default.nix
+++ b/distros/noetic/cob-dashboard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-robot-dashboard }:
 buildRosPackage {
   pname = "ros-noetic-cob-dashboard";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "79b81a3a383261a367f0b05bb4f5c2cc97dc66eaa5ca236231bb3ae9b5893f3a";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_dashboard/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "df4f9e4b2f480d51035c9bd1a388858f59590fd55e169c4afab42333ea1eb1ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-helper-tools/default.nix
+++ b/distros/noetic/cob-helper-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cob-msgs, cob-script-server, diagnostic-msgs, dynamic-reconfigure, message-generation, message-runtime, rospy, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-helper-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "869c9bc3914988f310245a037577e5170b10ab65ec899e3f6a4b0e00680c49f5";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_helper_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "4a9b61f5b9c8b339e0fc1972d95af80ddfc6bcf17e92ca02e20fdcd7db13f052";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-interactive-teleop/default.nix
+++ b/distros/noetic/cob-interactive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, roscpp, rviz, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cob-interactive-teleop";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "5ee18d8a427589977c500d53cb0fa1341a3974a46a5311007b0c4d7942827f51";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_interactive_teleop/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "47359a2104aa5391c34e0bb4e2c34c3c0a72557087c10374e1a3d065c1092ad0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cob-monitoring/default.nix
+++ b/distros/noetic/cob-monitoring/default.nix
@@ -5,16 +5,16 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-light, cob-msgs, cob-script-server, diagnostic-msgs, diagnostic-updater, ifstat-legacy, ipmitool, ntp, python3Packages, roscpp, rospy, rostopic, sensor-msgs, std-msgs, sysstat, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-cob-monitoring";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "d29ac5a0929b85095479874c7486af3529426c0c7018341bab5ab89412502064";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_monitoring/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "9f60443cdd2d771e1bf4b60708e4eb7cf3184b8861c504057d61f290ec9db8b4";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ actionlib cob-light cob-msgs cob-script-server diagnostic-msgs diagnostic-updater ifstat-legacy ipmitool ntp python3Packages.mechanize python3Packages.paramiko python3Packages.psutil python3Packages.requests roscpp rospy rostopic sensor-msgs std-msgs sysstat topic-tools ];
+  propagatedBuildInputs = [ actionlib cob-light cob-msgs cob-script-server diagnostic-msgs diagnostic-updater ifstat-legacy ipmitool ntp python3Packages.paramiko python3Packages.psutil python3Packages.requests roscpp rospy rostopic sensor-msgs std-msgs sysstat topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/cob-teleop/default.nix
+++ b/distros/noetic/cob-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-actions, cob-light, cob-script-server, cob-sound, geometry-msgs, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-cob-teleop";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "f871229b61ce24cda49a106e4609e11bae7d6d6662fa5ac31cea0cdfd0b14a63";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_teleop/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "127deba9653b821a9b85eb60286f5f80ee3d61add8025e04487aa54627c422f1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "32900078241479f59d94c7f0dca285d899053ad305f47d46a41e2816cbd8e0f0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "db9b9473071f9dfcfbb93baf8b08f9eae30baeaa8f2155dae8923bf94cd86627";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamic-edt-3d/default.nix
+++ b/distros/noetic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-edt-3d";
-  version = "1.9.5-r4";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.5-4.tar.gz";
-    name = "1.9.5-4.tar.gz";
-    sha256 = "5e706bb118b62000c10af3217f63782f854ea0606ff175332df13da519b0d3c4";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "63235da0946f9e97a0126a7e1c21a0a431e330f44845cc3d7523413503ede4ca";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.5.0-r1";
+  version = "2.6.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "0413b69d033d9a26b7088475df82662fe6bfb57cb80be44607847b5ef80279cb";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.1-3.tar.gz";
+    name = "2.6.1-3.tar.gz";
+    sha256 = "559617490d0ea8a7b974ba1069d9e375e1ca2ae587ffead2a4df1d0a4d6b049e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/fkie-master-discovery/default.nix
+++ b/distros/noetic/fkie-master-discovery/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avahi, catkin, fkie-multimaster-msgs, rosgraph, roslib, rospy, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-discovery";
-  version = "1.2.6-r2";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.2.6-2.tar.gz";
-    name = "1.2.6-2.tar.gz";
-    sha256 = "c8b7b18e1bab1e5e32a6e14ba90847c07860981e7c54191a529cfd29e0414727";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_discovery/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "203483ec58feb471f5a9561b0cd1dd8d3baf7f3d123a8a026455bef1053e9991";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-master-sync/default.nix
+++ b/distros/noetic/fkie-master-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-multimaster-msgs, rosgraph, roslib, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fkie-master-sync";
-  version = "1.2.6-r2";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.2.6-2.tar.gz";
-    name = "1.2.6-2.tar.gz";
-    sha256 = "03889c2c4d499116a429d4cdad1701b7900fab9a5cbc1e15f83e2dbefc029201";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_master_sync/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "aa23531aee7d5e6d922d20f985399670edb3982d07746e731edb87ae10ead213";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-multimaster/default.nix
+++ b/distros/noetic/fkie-multimaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fkie-master-discovery, fkie-master-sync, fkie-multimaster-msgs, fkie-node-manager, fkie-node-manager-daemon }:
 buildRosPackage {
   pname = "ros-noetic-fkie-multimaster";
-  version = "1.2.6-r2";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.2.6-2.tar.gz";
-    name = "1.2.6-2.tar.gz";
-    sha256 = "6fc1c813f18cb18eb4dfb89aedba04838a109fd4caee56c3db9474d2245e1a79";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "40bde8a434e6a4f82a0bae231bd7c2308db56856ebf8900fad43b4bfdf138780";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fkie-node-manager-daemon/default.nix
+++ b/distros/noetic/fkie-node-manager-daemon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, fkie-master-discovery, fkie-multimaster-msgs, python3Packages, roslaunch, rospy, rostest, screen }:
 buildRosPackage {
   pname = "ros-noetic-fkie-node-manager-daemon";
-  version = "1.2.6-r2";
+  version = "1.2.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.2.6-2.tar.gz";
-    name = "1.2.6-2.tar.gz";
-    sha256 = "f421e8f9d9370bcda8b848ab319023232df41d278a003384e086e34007491fa3";
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_node_manager_daemon/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "3fa68a0bf213d497d7b682978a9be23f70068066cf05c397eaa1b940994d63fc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -44,6 +44,8 @@ self: super: {
 
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
 
+ async-comm = self.callPackage ./async-comm {};
+
  audibot = self.callPackage ./audibot {};
 
  audibot-description = self.callPackage ./audibot-description {};
@@ -1118,6 +1120,8 @@ self: super: {
 
  libsiftfast = self.callPackage ./libsiftfast {};
 
+ lms1xx = self.callPackage ./lms1xx {};
+
  locomotor = self.callPackage ./locomotor {};
 
  locomotor-msgs = self.callPackage ./locomotor-msgs {};
@@ -1392,6 +1396,8 @@ self: super: {
 
  nerian-stereo = self.callPackage ./nerian-stereo {};
 
+ nmea-comms = self.callPackage ./nmea-comms {};
+
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nmea-navsat-driver = self.callPackage ./nmea-navsat-driver {};
@@ -1619,6 +1625,8 @@ self: super: {
  rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
 
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
+
+ rc-genicam-camera = self.callPackage ./rc-genicam-camera {};
 
  rc-genicam-driver = self.callPackage ./rc-genicam-driver {};
 
@@ -1984,6 +1992,8 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ rx-service-tools = self.callPackage ./rx-service-tools {};
+
  safety-limiter = self.callPackage ./safety-limiter {};
 
  safety-limiter-msgs = self.callPackage ./safety-limiter-msgs {};
@@ -2141,6 +2151,8 @@ self: super: {
  taskflow = self.callPackage ./taskflow {};
 
  teb-local-planner = self.callPackage ./teb-local-planner {};
+
+ teleop-legged-robots = self.callPackage ./teleop-legged-robots {};
 
  teleop-tools = self.callPackage ./teleop-tools {};
 

--- a/distros/noetic/generic-throttle/default.nix
+++ b/distros/noetic/generic-throttle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, python3Packages, rospy, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-generic-throttle";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "1d95fee9bb0ab013827b8a32f4cd78fa469c8d70aaae01f061bd328dc3d104e6";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/generic_throttle/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "bdc324b5c5b70f4b9fcdc73123c0a54847b5c4ec2097a7d33480e05617cd9840";
   };
 
   buildType = "catkin";

--- a/distros/noetic/interactive-marker-twist-server/default.nix
+++ b/distros/noetic/interactive-marker-twist-server/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, roslaunch, roslint, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, interactive-markers, roscpp, roslaunch, roslint, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-interactive-marker-twist-server";
-  version = "1.2.0-r2";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/noetic/interactive_marker_twist_server/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "95ce1531e7067a10fec566d21738937772b436ac55729e2bfa04acac98c5479d";
+    url = "https://github.com/ros-gbp/interactive_marker_twist_server-release/archive/release/noetic/interactive_marker_twist_server/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "05328da91e51ebac3008361970d1863c329a67f257350848acf24806dd3e6673";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch roslint ];
-  propagatedBuildInputs = [ interactive-markers roscpp visualization-msgs ];
+  propagatedBuildInputs = [ interactive-markers roscpp tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "b5907bb096dbaf4249a71cf3b01586e139c36099a5c96154f5ebe57fea223c21";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "ef430550fdcad1b38f8c0224121ac1d8d453e855036fb93efcbbd7f341579617";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lms1xx/default.nix
+++ b/distros/noetic/lms1xx/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosconsole-bridge, roscpp, roscpp-serialization, roslaunch, roslint, rosunit, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-lms1xx";
+  version = "0.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/lms1xx-release/archive/release/noetic/lms1xx/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "542f79a2e70c555941a560b801052355adfc58fb791078a6da4d28d7e01a6ffe";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint rosunit ];
+  propagatedBuildInputs = [ rosconsole-bridge roscpp roscpp-serialization sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The lms1xx package contains a basic ROS driver for the SICK LMS1xx line of LIDARs.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "244dde72b9be13c12e356e3e5cf3171999102e02647157853bc597521f8bae92";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "e70688b82f7ff63a48a4a8caa476a043b7c28496b75e2c7d159238a225f6bed3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "f60f3cd11058ad3ba8e11979aa0a7c3e863eb3362013a13c63a9151e9be1711d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "acdea97e27cecfba83a32f922aef0ae7d7c51c966ff05ab46620643d6af753d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "38c6a3db95b36d0441ca5322a9d076dab8081078f007489c84715189a4867b84";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "cfcaf119a9f7506f57c8d504a10efb9240d184de5f475eab7304d9b61e07f20c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "b6582b8c94d4e8bb202aba4277850a4f58479aca8c4284d517915c5dc4883309";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "7be823daceb21053b6e100e62b3cd9f024086961fb3f6de479b7618171c9d514";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nmea-comms/default.nix
+++ b/distros/noetic/nmea-comms/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nmea-msgs, roscpp, roslaunch, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-nmea-comms";
+  version = "1.2.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/nmea_comms-release/archive/release/noetic/nmea_comms/1.2.0-3.tar.gz";
+    name = "1.2.0-3.tar.gz";
+    sha256 = "043ce2fedd2173e5d9fa7004aff8911555efeccb0a04150e737e149a6cdb7241";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch roslint rostest ];
+  propagatedBuildInputs = [ nmea-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The nmea_comms package provides helper nodes for transmitting and receiving
+    the NMEA sentences.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/nodelet-core/default.nix
+++ b/distros/noetic/nodelet-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, nodelet-topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-core";
-  version = "1.10.0-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "ea941ba1a04a52d01c3754aed9114f961678a5052e8e12b94a9515545eda7862";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "8e6b9ffcfb0abe296423f61201306683174fba537fce06e84d4a28218bec3f23";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet-topic-tools/default.nix
+++ b/distros/noetic/nodelet-topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, message-filters, nodelet, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-topic-tools";
-  version = "1.10.0-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "5a1402a884716ee3b11372305594933cd318d53a85083581f62dcddf498a2b3f";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "425324f1b12a552edc960f8a003f4ca8a986e56cf36e0848b489fb7327412838";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet/default.nix
+++ b/distros/noetic/nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, utillinux }:
 buildRosPackage {
   pname = "ros-noetic-nodelet";
-  version = "1.10.0-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.10.0-1.tar.gz";
-    name = "1.10.0-1.tar.gz";
-    sha256 = "d8ec0a7a8c2643af8e6ae6696410891bdc0d9826d0f430eff1ebd0a0222982e1";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "e5fc828f77cb9bc673340bae8e29fde4d16be54ceec4ef23153e29bc9aa0c00b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nonpersistent-voxel-layer/default.nix
+++ b/distros/noetic/nonpersistent-voxel-layer/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, message-filters, message-generation, message-runtime, nav-msgs, pcl-conversions, pcl-ros, pluginlib, rosconsole, roscpp, sensor-msgs, std-msgs, tf, visualization-msgs, voxel-grid }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, geometry-msgs, laser-geometry, map-msgs, message-filters, message-generation, message-runtime, nav-msgs, pluginlib, rosconsole, roscpp, sensor-msgs, std-msgs, tf, visualization-msgs, voxel-grid }:
 buildRosPackage {
   pname = "ros-noetic-nonpersistent-voxel-layer";
-  version = "1.2.3-r2";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/noetic/nonpersistent_voxel_layer/1.2.3-2.tar.gz";
-    name = "1.2.3-2.tar.gz";
-    sha256 = "1fb02c102340c981395ffb126313d7ebf1045b583153884c6d80991b30da82ad";
+    url = "https://github.com/SteveMacenski/nonpersistent_voxel_layer-release/archive/release/noetic/nonpersistent_voxel_layer/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "873ea35875641ee32e4bfd53dd41ff0425e742cc6dcb75309e9094caa8b37c37";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation ];
-  propagatedBuildInputs = [ costmap-2d dynamic-reconfigure geometry-msgs laser-geometry map-msgs message-filters message-runtime nav-msgs pcl-conversions pcl-ros pluginlib rosconsole roscpp sensor-msgs std-msgs tf visualization-msgs voxel-grid ];
+  propagatedBuildInputs = [ costmap-2d dynamic-reconfigure geometry-msgs laser-geometry map-msgs message-filters message-runtime nav-msgs pluginlib rosconsole roscpp sensor-msgs std-msgs tf visualization-msgs voxel-grid ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "b205af253fdd0bec85dfa31a45aae9bcdd535b450236855c0ced5d703de38ff6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "e1a2b5a4b07e4787ccee12cd3d7511b690de1064cf19f7e7750dd18381a3ac5f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/octomap/default.nix
+++ b/distros/noetic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-octomap";
-  version = "1.9.5-r4";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.5-4.tar.gz";
-    name = "1.9.5-4.tar.gz";
-    sha256 = "2648c3ba5f31d3b93f6377d3b12bb4ed3f3212faae1422a73f6a222fb3e0a012";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "c77e3e57696d76a69bd4c6fa731b14dcce92eb63c7db6675d8b841ca816714fc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/octovis/default.nix
+++ b/distros/noetic/octovis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-noetic-octovis";
-  version = "1.9.5-r4";
+  version = "1.9.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.5-4.tar.gz";
-    name = "1.9.5-4.tar.gz";
-    sha256 = "384b1a1df103c9729ca33a0e992aa513443778228cfd51736617db53f96c3aa5";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-1.tar.gz";
+    name = "1.9.6-1.tar.gz";
+    sha256 = "feb098684affecd77636c6992084628036bf9101a41a42438723bb855b77401a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.5.0-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "e5166246bd99af2348f277870f44fc81c6ffa9662aa41a3c40544227e9b2f35a";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "8445464c30a254293a4f35edae134d3b0293fdc32403b85cc839d5abef6af5d8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "db3b341cb6cb769c39ca71a150e6a5865d392700016b531ec20e05c41c5acd1a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "139884dab4de402e96b1880b239d9fcfdddc1b8e0820db9dd603509784c11bab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-camera/default.nix
+++ b/distros/noetic/rc-genicam-camera/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, rc-genicam-api, roscpp, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-rc-genicam-camera";
+  version = "1.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_genicam_camera-release/archive/release/noetic/rc_genicam_camera/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7ef9fba712de3ab5ccbf2c19b2df06a765e072f0de847a4fb17d95624da6b97d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure image-transport message-runtime nodelet rc-genicam-api roscpp sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rc_genicam_camera provides images from a GenICam compatible camera.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1bdec963b6e19e0bba4b4158efac2142f30d7b8bbb9e7e8c58bf0c6443f27614";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "b46a0b005ba84b31997044db978324f30a0fb5db0706c2640b18a511ae271768";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rx-service-tools/default.nix
+++ b/distros/noetic/rx-service-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, pythonPackages, roslib, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-rx-service-tools";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rx_service_tools-release/archive/release/noetic/rx_service_tools/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "4bab469592a818690220bfbcee55ee63d3f48b4376bc5bdd088e3d958a9dd61a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.pyyaml pythonPackages.wxPython roslib rospy ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Graphical tools to interact with ROS services.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "9ee529f55af99bfa2a50d2b47e7a5d87b3225aaa910a557ebcd1993fc8f1bf52";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "f9b88eaaa62c18e46dfd9d3f905a2059b363d5b46360736ca6aff435067810a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scenario-test-tools/default.nix
+++ b/distros/noetic/scenario-test-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cob-sound, cob-srvs, control-msgs, geometry-msgs, move-base-msgs, python3Packages, rospy, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-scenario-test-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "d24c2484f3cfb2665bcac332665b9a4dcbb16dea12c6f689d415b4ffeab97108";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/scenario_test_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "b5e3c5e1a96e6ac265b6783d281ad8cd092d1f7913c6f5e39ff744bf0f8c129d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/service-tools/default.nix
+++ b/distros/noetic/service-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rosservice }:
 buildRosPackage {
   pname = "ros-noetic-service-tools";
-  version = "0.6.19-r1";
+  version = "0.6.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.19-1.tar.gz";
-    name = "0.6.19-1.tar.gz";
-    sha256 = "bd1a37bb2fb3d929a6dd2646503df36763fe5b4ec34b22f5ae8100caa0e5a75b";
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/service_tools/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "9411074ab73dcc7d46a93570aae481a5398bb1efa701fd7532eef115392b4687";
   };
 
   buildType = "catkin";

--- a/distros/noetic/teleop-legged-robots/default.nix
+++ b/distros/noetic/teleop-legged-robots/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-teleop-legged-robots";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SoftServeSAG/teleop_legged_robots-release/archive/release/noetic/teleop_legged_robots/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5bd9db60ca32e7370d7fcb2e7d12569d3aa9a2c85cd378c3e4130d21cfbfcb1f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic keyboard teleop for legged robots.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "8d531c45a31498ba6608f4159b335136246053eacd2f073c7b2d9f42430686b2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "123d6a743318aca5535b8e4b814075cd9e8425ac1c63e03af484e0486b9880cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "d23d16f6584eb19a87e107a5e6054394eb373a101f84e03b0af0f855b334ddc9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "5845c470dc1108b1bed93c1374f46114f46fe389b8c0839c6973c0d0c7dc7c80";
   };
 
   buildType = "catkin";

--- a/distros/noetic/webots-ros/default.nix
+++ b/distros/noetic/webots-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-webots-ros";
-  version = "2.1.1-r1";
+  version = "4.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "b723baa673d59cbea883c50c51c703823ade1c64078a35b5be961934c27050c4";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "a1dfb1b3ef8ccd39b81de369dd2e40341463bdb1911d113008e7ccd021ec648e";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit c894915970a70880eed5325a524ff571fe66ae17.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *cartographer-ros 1.0.9000-r1 --> 1.0.9003-r1*
* *cartographer-ros-msgs 1.0.9000-r1 --> 1.0.9003-r1*
* *laser-proc 1.0.1-r1 --> 1.0.2-r1*

Foxy Changes:
-------------
* *ament-cmake-ros 0.9.0-r1 --> 0.9.1-r1*
* *ament-index-cpp 1.0.1-r1 --> 1.0.2-r1*
* *ament-index-python 1.0.1-r1 --> 1.0.2-r1*
* *behaviortree-cpp-v3 3.5.3-r1 --> 3.5.5-r1*
* *cartographer-ros 1.0.9002-r1 --> 1.0.9003-r1*
* *cartographer-ros-msgs 1.0.9002-r1 --> 1.0.9003-r1*
* *control-msgs 2.4.1-r1 --> 2.5.0-r1*
* *diagnostic-aggregator 2.0.5-r1 --> 2.0.6-r1*
* *diagnostic-updater 2.0.5-r1 --> 2.0.6-r1*
* *domain-coordinator 0.9.0-r1 --> 0.9.1-r1*
* *laser-proc 1.0.1-r1 --> 1.0.2-r1*
* *libyaml-vendor 1.0.2-r1 --> 1.0.3-r1*
* *map-transformer 1.0.0-r1 --> 1.0.3-r1*
* *orocos-kdl 3.3.1-r1 --> 3.3.2-r1*
* *plotjuggler-ros 1.0.2-r1 --> 1.0.3-r8*
* *robot-state-publisher 2.4.1-r1 --> 2.4.2-r1*
* *self-test 2.0.5-r1 --> 2.0.6-r1*

Kinetic Changes:
----------------
* *cob-command-gui 0.6.19-r1 --> 0.6.20-r1*
* *cob-command-tools 0.6.19-r1 --> 0.6.20-r1*
* *cob-dashboard 0.6.19-r1 --> 0.6.20-r1*
* *cob-helper-tools 0.6.19-r1 --> 0.6.20-r1*
* *cob-interactive-teleop 0.6.19-r1 --> 0.6.20-r1*
* *cob-monitoring 0.6.19-r1 --> 0.6.20-r1*
* *cob-script-server 0.6.19-r1 --> 0.6.20-r1*
* *cob-teleop 0.6.19-r1 --> 0.6.20-r1*
* *costmap-cspace 0.10.5-r1 --> 0.10.6-r1*
* *generic-throttle 0.6.19-r1 --> 0.6.20-r1*
* *joystick-interrupt 0.10.5-r1 --> 0.10.6-r1*
* *khi-duaro-description 1.1.2-r1 --> 1.2.0-r5*
* *khi-duaro-gazebo 1.1.2-r1 --> 1.2.0-r5*
* *khi-duaro-ikfast-plugin 1.1.2-r1 --> 1.2.0-r5*
* *khi-duaro-moveit-config 1.1.2-r1 --> 1.2.0-r5*
* *khi-robot 1.1.2-r1 --> 1.2.0-r5*
* *khi-robot-bringup 1.1.2-r1 --> 1.2.0-r5*
* *khi-robot-control 1.1.2-r1 --> 1.2.0-r5*
* *khi-robot-msgs 1.1.2-r1 --> 1.2.0-r5*
* *khi-robot-test 1.2.0-r5*
* *khi-rs-description 1.1.2-r1 --> 1.2.0-r5*
* *khi-rs-gazebo 1.1.2-r1 --> 1.2.0-r5*
* *khi-rs-ikfast-plugin 1.1.2-r1 --> 1.2.0-r5*
* *khi-rs007l-moveit-config 1.1.2-r1 --> 1.2.0-r5*
* *khi-rs007n-moveit-config 1.1.2-r1 --> 1.2.0-r5*
* *khi-rs080n-moveit-config 1.1.2-r1 --> 1.2.0-r5*
* *map-organizer 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-common 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-launch 0.10.5-r1 --> 0.10.6-r1*
* *obj-to-pointcloud 0.10.5-r1 --> 0.10.6-r1*
* *planner-cspace 0.10.5-r1 --> 0.10.6-r1*
* *rc-genicam-driver 0.4.0-r1 --> 0.5.0-r1*
* *safety-limiter 0.10.5-r1 --> 0.10.6-r1*
* *scenario-test-tools 0.6.19-r1 --> 0.6.20-r1*
* *service-tools 0.6.19-r1 --> 0.6.20-r1*
* *teleop-legged-robots 1.1.0-r1*
* *track-odometry 0.10.5-r1 --> 0.10.6-r1*
* *trajectory-tracker 0.10.5-r1 --> 0.10.6-r1*

Melodic Changes:
----------------
* *behaviortree-cpp-v3 3.5.3-r1 --> 3.5.5-r2*
* *costmap-cspace 0.10.5-r1 --> 0.10.6-r1*
* *interactive-marker-twist-server 1.2.0 --> 1.2.1-r1*
* *joystick-interrupt 0.10.5-r1 --> 0.10.6-r1*
* *khi-duaro-description 1.2.0-r1*
* *khi-duaro-gazebo 1.2.0-r1*
* *khi-duaro-ikfast-plugin 1.2.0-r1*
* *khi-duaro-moveit-config 1.2.0-r1*
* *khi-robot 1.2.0-r1*
* *khi-robot-bringup 1.2.0-r1*
* *khi-robot-control 1.2.0-r1*
* *khi-robot-msgs 1.2.0-r1*
* *khi-robot-test 1.2.0-r1*
* *khi-rs-description 1.2.0-r1*
* *khi-rs-gazebo 1.2.0-r1*
* *khi-rs-ikfast-plugin 1.2.0-r1*
* *khi-rs007l-moveit-config 1.2.0-r1*
* *khi-rs007n-moveit-config 1.2.0-r1*
* *khi-rs080n-moveit-config 1.2.0-r1*
* *map-organizer 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-common 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-launch 0.10.5-r1 --> 0.10.6-r1*
* *obj-to-pointcloud 0.10.5-r1 --> 0.10.6-r1*
* *planner-cspace 0.10.5-r1 --> 0.10.6-r1*
* *rc-genicam-driver 0.4.0-r1 --> 0.5.0-r1*
* *rx-service-tools 1.0.1-r1*
* *safety-limiter 0.10.5-r1 --> 0.10.6-r1*
* *teleop-legged-robots 1.1.0-r1*
* *track-odometry 0.10.5-r1 --> 0.10.6-r1*
* *trajectory-tracker 0.10.5-r1 --> 0.10.6-r1*
* *ueye-cam 1.0.18-r1 --> 1.0.17-r1*
* *webots-ros 2.1.1-r1 --> 4.0.0-r1*

Noetic Changes:
---------------
* *async-comm 0.2.1-r1*
* *behaviortree-cpp-v3 3.5.3-r1 --> 3.5.5-r2*
* *cob-command-gui 0.6.19-r1 --> 0.6.20-r1*
* *cob-command-tools 0.6.19-r1 --> 0.6.20-r1*
* *cob-dashboard 0.6.19-r1 --> 0.6.20-r1*
* *cob-helper-tools 0.6.19-r1 --> 0.6.20-r1*
* *cob-interactive-teleop 0.6.19-r1 --> 0.6.20-r1*
* *cob-monitoring 0.6.19-r1 --> 0.6.20-r1*
* *cob-teleop 0.6.19-r1 --> 0.6.20-r1*
* *costmap-cspace 0.10.5-r1 --> 0.10.6-r1*
* *dynamic-edt-3d 1.9.5-r4 --> 1.9.6-r1*
* *eigenpy 2.5.0-r1 --> 2.6.1-r3*
* *fkie-master-discovery 1.2.6-r2 --> 1.2.7-r1*
* *fkie-master-sync 1.2.6-r2 --> 1.2.7-r1*
* *fkie-multimaster 1.2.6-r2 --> 1.2.7-r1*
* *fkie-node-manager-daemon 1.2.6-r2 --> 1.2.7-r1*
* *generic-throttle 0.6.19-r1 --> 0.6.20-r1*
* *interactive-marker-twist-server 1.2.0-r2 --> 1.2.1-r1*
* *joystick-interrupt 0.10.5-r1 --> 0.10.6-r1*
* *lms1xx 0.3.0-r2*
* *map-organizer 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-common 0.10.5-r1 --> 0.10.6-r1*
* *neonavigation-launch 0.10.5-r1 --> 0.10.6-r1*
* *nmea-comms 1.2.0-r3*
* *nodelet 1.10.0-r1 --> 1.10.1-r1*
* *nodelet-core 1.10.0-r1 --> 1.10.1-r1*
* *nodelet-topic-tools 1.10.0-r1 --> 1.10.1-r1*
* *nonpersistent-voxel-layer 1.2.3-r2 --> 1.3.0-r2*
* *obj-to-pointcloud 0.10.5-r1 --> 0.10.6-r1*
* *octomap 1.9.5-r4 --> 1.9.6-r1*
* *octovis 1.9.5-r4 --> 1.9.6-r1*
* *pinocchio 2.5.0-r1 --> 2.5.6-r1*
* *planner-cspace 0.10.5-r1 --> 0.10.6-r1*
* *rc-genicam-camera 1.2.3-r1*
* *rc-genicam-driver 0.4.0-r1 --> 0.5.0-r1*
* *rx-service-tools 1.0.2-r1*
* *safety-limiter 0.10.5-r1 --> 0.10.6-r1*
* *scenario-test-tools 0.6.19-r1 --> 0.6.20-r1*
* *service-tools 0.6.19-r1 --> 0.6.20-r1*
* *teleop-legged-robots 1.1.0-r1*
* *track-odometry 0.10.5-r1 --> 0.10.6-r1*
* *trajectory-tracker 0.10.5-r1 --> 0.10.6-r1*
* *webots-ros 2.1.1-r1 --> 4.0.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] cmake_common_scripts
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] fmt
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-msgpack
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pymongo
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

