### PR TITLE
rosdistro sync, Fri Feb 12 13:24:24 2021

### DIFF
--- a/distros/dashing/rqt-gui-cpp/default.nix
+++ b/distros/dashing/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-dashing-rqt-gui-cpp";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui_cpp/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "74a2928add4281a74a24cda26fa36468a8aeb70348e82de6979b95a57b28bd0e";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7e7068945e1a32aed9db363c1fc84a491a19290430acfb522cc2a28f73471570";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rqt-gui-py/default.nix
+++ b/distros/dashing/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-dashing-rqt-gui-py";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui_py/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8f09fbdd8160972ac056a782961dd44fe027365fe36879c33ce9dfae16de1d0c";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b52b62ec555e07b26038d54870e663bab32caff255a398fd5469946e1349e69c";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/rqt-gui/default.nix
+++ b/distros/dashing/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-dashing-rqt-gui";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "e7efeebc99ec302d1e1a3de86ca474a3434143ba1c5e885c0edec9e3f68611fb";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_gui/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "13d6aa26f6b1b2ba4428ad8adf917f1555914ac0fd5b9fcd2a389d57dce1216e";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/rqt-py-common/default.nix
+++ b/distros/dashing/rqt-py-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-dashing-rqt-py-common";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_py_common/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "def9938b7298af79e2e3f9453823327db15138bec526c6495abf5f10839dad0b";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt_py_common/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "ffde541a2947f0114546d428fe8c05ca211a71594434f00c99d7b511a176d502";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-pytest python-cmake-module ];
-  propagatedBuildInputs = [ python-qt-binding qt-gui qt5.qtbase rclpy rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-pytest python-cmake-module rosidl-default-generators rosidl-default-runtime ];
+  propagatedBuildInputs = [ python-qt-binding qt-gui qt5.qtbase rclpy ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_py_common provides common functionality for rqt plugins written in Python.

--- a/distros/dashing/rqt/default.nix
+++ b/distros/dashing/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-dashing-rqt";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "4a204657cf0c03ab72115438d77a145146ef0676d5e4473eafa0d32f36d58969";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/dashing/rqt/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b872ba2d7509ba65d202436d38467773207d619875980194d79de3d5a43356e0";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/bno055/default.nix
+++ b/distros/foxy/bno055/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-bno055";
+  version = "0.1.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/flynneva/bno055-release/archive/release/foxy/bno055/0.1.1-3.tar.gz";
+    name = "0.1.1-3.tar.gz";
+    sha256 = "858f1d3f3932d7bb4f17ab52a46b6305fe6b2776baf39fec109808de52262d01";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.pyserial rclpy std-msgs ];
+
+  meta = {
+    description = ''Bosch BNO055 IMU driver for ROS2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "645427e320558727ad744eb6a5545f68be410244833dc9007ec17d453098ff40";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "156744121274b37e535b5a60a4ebffc6c116793f90514ae4992d8c27e329602a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "a0e669d34f1aa9bf2813e7987f1de022e968c93e697ebf55e99d79a1723c91ff";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "34050b6ee19dbbd64e9800341af5258f37bad0650fb5546a8eefd3e63114137f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, rclcpp, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "e57ce131218a3d95df32205f418c4e7d8c49381cff62647c432d41723407dc81";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "8f53aca102ba02f3b72b8831474e2c4e34ab2d9fd05ac63b3767ca75458c7656";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "a678c435a2e89ebbbff160b0da8d1be59c4c8d8fd2fc639c2a6f8f9eefcc24af";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d2b3f3ca141acf6b5c758e1f1b42bc8b4a74296852ddfe830f9b6f22df381065";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, test-robot-hardware }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "1da6c9b4165bb2ab9211b29c09ae9c36c288a96e22b51d2a93a3575c8f96fa18";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d6d2c02da2803afda3d0193d84c8e1dceb3fe275d8e98afe1fa1ffa14b236b8a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager test-robot-hardware ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "c1f50792e78b5a921654b71ee275b6300229f80491bbf1ab33557853316def66";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "0995f3fb3aaa6e01080b53000f9213d5be9c98fd098ab4344ffb0b726a7bed96";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ controller-interface hardware-interface rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/gazebo-ros2-control-demos/default.nix
+++ b/distros/foxy/gazebo-ros2-control-demos/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, std-msgs, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-gazebo-ros2-control-demos";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "0aa94bfccea3be2f45b9b8a26f1dc128b8986ef9ebab7ebdbe321b5ce64438c3";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rclcpp-action ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python control-msgs gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher std-msgs velocity-controllers xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gazebo_ros2_control_demos'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/gazebo-ros2-control/default.nix
+++ b/distros/foxy/gazebo-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
+buildRosPackage {
+  pname = "ros-foxy-gazebo-ros2-control";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "3df932b76645e5c35d33a915baa5f445f85aa8108245a544da89377f2312c9ca";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ angles controller-manager gazebo-dev gazebo-ros hardware-interface pluginlib rclcpp std-msgs urdf yaml-cpp-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''gazebo_ros2_control'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -148,6 +148,8 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bno055 = self.callPackage ./bno055 {};
+
  bond = self.callPackage ./bond {};
 
  bond-core = self.callPackage ./bond-core {};
@@ -344,6 +346,8 @@ self: super: {
 
  ecl-utilities = self.callPackage ./ecl-utilities {};
 
+ effort-controllers = self.callPackage ./effort-controllers {};
+
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
@@ -418,6 +422,10 @@ self: super: {
 
  gazebo-ros = self.callPackage ./gazebo-ros {};
 
+ gazebo-ros2-control = self.callPackage ./gazebo-ros2-control {};
+
+ gazebo-ros2-control-demos = self.callPackage ./gazebo-ros2-control-demos {};
+
  gazebo-ros-pkgs = self.callPackage ./gazebo-ros-pkgs {};
 
  geodesy = self.callPackage ./geodesy {};
@@ -485,6 +493,8 @@ self: super: {
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
  joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
+ joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
 
  joy = self.callPackage ./joy {};
 

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "ebfbcea1955f6157944412e5c7f30f27539700b34c2058e1d36b9d9ca8b01f21";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "b501141645cca3aa1a875ed09586c75aecd81c1f65e741f85589ade72c219a9d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "1716dc0263b74d1e1c76b88f4840e4b6c5f24ac295d056dace79ffcc9cefa719";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "c104aed4df9e821871a8ba13a530b27acce3d6e3e086142604f1ac570747ca77";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager rclcpp ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager rclcpp ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, test-robot-hardware, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "832513914516b39924aaade2c13092d85dcc4122d2e22779492afdfdda9574f2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "f82abd362220bafdc1ddb1d08c10e0193a7989b5c14a535062fb9d96aae5b397";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager test-robot-hardware ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ angles control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle rcutils realtime-tools trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "d0fe8a7ba8f795dff75ba9b6d89e20fbc6b6e5000735426f583203e283009c60";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "b3b5422f74c918c62806445e94b3e78086ee95305eb1e96a258264295c366421";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "6941f7128b9564cbe333a9e1995c6ca0d06c7b0b0e97d165328aad1d21459b8a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "095e4b47a5e4964e6de046fac70e86b2ab2c0524fd270d6c679e1515c0dc30dd";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "974ac3bdf210ffd2e22b2272fbd4931b5e7c3c587453671f603020f181f56c2e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "9f1305546222300cf7f0ec3bc6689b43272274c5f91ff2752933edae2f765276";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, forward-command-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "0ff0eb27c39e2521778537db5ccb0030bec933f06da50b4adc6a3304de3f8ad4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "5890b99f3d442576cb8960a82f2ca6078480df0a192dd97c7126b98a1545327b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "323b6fbda8991264ddfa7b2273bc3e70cda42aa12aaee27484b0c5d90a30996f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "fc30166757a5aa5e5cf76963e759bd910815594f045ede6a9f5b8212d161695e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-gui-cpp/default.nix
+++ b/distros/foxy/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-cpp";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "a1fdef3ea59c90b09152ed4603943a05ad7aaaf2dcea62f57cbf87a6e56fdbac";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "3b1d267733147a33e3a689144f64d42c4482449b544fabaec96702466e8885e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-gui-py/default.nix
+++ b/distros/foxy/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-py";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "bdcecfac5b6138b586b0e474ebd9c570873b413c03ec3698e67a33bc99616329";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "7f8b0c9f6678b5f9f7f20bca1a8e1763fef35394981baeb1a98d8c9f760a8da2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-gui/default.nix
+++ b/distros/foxy/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "9bcb777da708d1a4f35ae03a37745c9012d9d2b2ccb95996a928fa611d3404fd";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "143c2a4dbda33155814440abbc40a7cdd12bcee169ead22a56bfe9e085d52f11";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-py-common/default.nix
+++ b/distros/foxy/rqt-py-common/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rqt-py-common";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "8865519826e3e9d61d7c12a03a4d190d21a2c35e904f83b210643ad164af6cd0";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "134b115263c4f4559512c8c09db423d59276ae89bb32e08c1305b4f68729907b";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-pytest python-cmake-module ];
-  propagatedBuildInputs = [ python-qt-binding qt-gui qt5.qtbase rclpy rosidl-default-runtime ];
-  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+  checkInputs = [ ament-cmake-pytest python-cmake-module rosidl-default-generators rosidl-default-runtime ];
+  propagatedBuildInputs = [ python-qt-binding qt-gui qt5.qtbase rclpy ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_py_common provides common functionality for rqt plugins written in Python.

--- a/distros/foxy/rqt/default.nix
+++ b/distros/foxy/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "5b81137a6880dda6bf9b3c082a93a6f0be0d7cda4d1fa55e3d33ea62920cfe65";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2b6a2e58eb6e48209b2703a6f1c35c6a8ad109935a9bf6bba980cdcfbf88682f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "7a444b9341480d6b69efc16c0bd5246a0752e37d61aa26b8581d07c7472346ba";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "6c43b307ed5fede0bcecfe6f03c9c11076fcae39db4d76fcd630ec12b48ec75e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "1fde6edca444bfaf170b9b84a010bbb6901ca736d007bd78997cbaa51be2ca45";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "afaf2efa81937138d3622c4ad54998986514bba8ba47bfe95efeb057c2f9a713";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/kinetic/bota-device-driver/default.nix
+++ b/distros/kinetic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-kinetic-bota-device-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_device_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_device_driver/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "c15cc8c2917e484145cac8b3b9aec9c25780cb589a4729202495615a91ef62e5";
+    sha256 = "9ecc8518da0b3a7189c9f7922b264ba9b1bf6d9d0641b9e31121b729f22752e4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/bota-driver/default.nix
+++ b/distros/kinetic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-kinetic-bota-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_driver/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "e3e34c342e91618835aa8f7d4645cd10dd4f7c8d11a002ee0c342b19a6850354";
+    sha256 = "141167729bd2e15726272eb3c8b40059d8ebb4b4279e25224f1f07a922492f41";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/bota-node/default.nix
+++ b/distros/kinetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-bota-node";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_node/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_node/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "b15f4142e13f5fd815adf8ce74560fee2e9ebde8d3b30ba1c3e6598dd9c6e0dd";
+    sha256 = "c6f023bf456ec0323c007b7672e63017b82699bfbbaaee7f4499ceb0738d8cb3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/bota-signal-handler/default.nix
+++ b/distros/kinetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-bota-signal-handler";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_signal_handler/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_signal_handler/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "2898209f5099d79ea1f3022945673387409adf20b389cfe441a2f9333cac1c46";
+    sha256 = "aea00ff9bc40bb6ad6fa8b100632f03694bb6932dcc550ecd692d036e2423490";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/bota-worker/default.nix
+++ b/distros/kinetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-bota-worker";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_worker/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/bota_worker/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "b801775322a6da4a59d61eaf814c5fa4ae3f9fa3ef6e442b382d754d459d300a";
+    sha256 = "3d68181881ffc2cf6e1147c7f837ae10034768a4681f240b740441ca3668a25f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/laser-geometry/default.nix
+++ b/distros/kinetic/laser-geometry/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, pythonPackages, roscpp, rosunit, sensor-msgs, tf, tf2 }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, pythonPackages, roscpp, rosunit, sensor-msgs, tf, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-laser-geometry";
-  version = "1.6.5-r1";
+  version = "1.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/kinetic/laser_geometry/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "235a29117a388473f644ea173ce84051ad11c2ccfa0ba944654446c65fb41322";
+    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/kinetic/laser_geometry/1.6.7-1.tar.gz";
+    name = "1.6.7-1.tar.gz";
+    sha256 = "f279119bb104347e688f05bca0ef6939d5b2fa53edca311919c4c2ed14fa763d";
   };
 
   buildType = "catkin";
+  buildInputs = [ tf2-geometry-msgs ];
   checkInputs = [ rosunit ];
   propagatedBuildInputs = [ angles boost eigen pythonPackages.numpy roscpp sensor-msgs tf tf2 ];
   nativeBuildInputs = [ catkin ];

--- a/distros/kinetic/mir-actions/default.nix
+++ b/distros/kinetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-actions";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_actions/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "61129c9169ec5cb1cc15c3a430256a777fad035deb6b33a25a0979ccf29cb4e9";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_actions/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "22222394f36cf7a5428a03aab69bd72cb5d939f1f7ff2d79ceecefa4cddfe350";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-description/default.nix
+++ b/distros/kinetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-mir-description";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_description/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "88eaf791d81098f0460526e75ce8d37d702c1a1d07346f2f8795cb5d8c5e41c3";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_description/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "655cb40127618272023eaeaad270f5a16b40c0b0b081f4c85fa98c8101465fc6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-driver/default.nix
+++ b/distros/kinetic/mir-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, mir-actions, mir-description, mir-msgs, move-base-msgs, nav-msgs, pythonPackages, robot-state-publisher, rosgraph-msgs, roslaunch, rospy, rospy-message-converter, sensor-msgs, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-driver";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_driver/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "3c6336e0b0347d16b88e5982e9fefb7fffd88cc82056077a6d37388884ff5aed";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_driver/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "32363c178a1ae6ca86da6f414c2bd5497a8128a82d7ad7fb298d94bbe96d7953";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-dwb-critics/default.nix
+++ b/distros/kinetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, pythonPackages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mir-dwb-critics";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_dwb_critics/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c0d1b885bbb8ab09bed1a4620da36d582471f8789c230480b8a6dad5188c40b4";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_dwb_critics/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "ee3bdf648805ee71c40b7e918ca9a039962490bfa41973800c65e5ff99892194";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-gazebo/default.nix
+++ b/distros/kinetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-mir-gazebo";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_gazebo/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "92022d8147ef37ade24946255f05a627c1bf7129193ef694bd47d8cf9cda0d60";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_gazebo/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "a2b89bd005d1d5ac797b4ee8a77cf326e8812f31d6baac58fa1358718708287f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-msgs/default.nix
+++ b/distros/kinetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-kinetic-mir-msgs";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "2fa5fc4b7943d29ff754d8f38422c491b478bc0b3320c2a8784f829598dd56cd";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_msgs/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "c76ef153a3259c94bbcdb8791b642eb5432806f4bb75ced0e5396336d448b76d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-navigation/default.nix
+++ b/distros/kinetic/mir-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, pythonPackages, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-kinetic-mir-navigation";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_navigation/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "940f7942f74f1cef7c82bdc5d27b46a6b7b890eaf8b83356e68b35310dc301a0";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_navigation/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "239e6837155dcf4411ae014163fcd8bae4c7adbc33df017d3cb9ce3883464bbc";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mir-robot/default.nix
+++ b/distros/kinetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-kinetic-mir-robot";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_robot/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "72ccdda4a8658a16167e418835a087aadf6ed2c99402ca1099affd77f62dac36";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/mir_robot/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "a4267e7aa19d37d700ef9328deaf977581df0cac9ef5a261d3721ea6200d484d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-bus-manager/default.nix
+++ b/distros/kinetic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-bus-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_bus_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_bus_manager/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "ec288b09feefd1aef51b6647ba5096eae65dbd331fdf9811f20f8865039f517c";
+    sha256 = "ee34d7ebb89a5b35eb8bb4cea4bf9706953c99ca5ab63991dd3bf9868931993e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-description/default.nix
+++ b/distros/kinetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-description";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_description/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_description/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "a47b63478f05867ce85495259bfc8cdc58de3fac4c4951e013fd7a399f1525a2";
+    sha256 = "c7cd1011dc85df56c4d7ae77f089c973a80d2a6b76b7e31033f19daacb16b8c0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-ethercat/default.nix
+++ b/distros/kinetic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-ethercat";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_ethercat/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_ethercat/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "fe69110b5525013f48e077e460356d8da09e90032142ffcc3149a831869f5d0f";
+    sha256 = "b0104749311c7ea349cbec6451564a12085a8f5c8c08868a8c0b4ed56676b112";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-examples/default.nix
+++ b/distros/kinetic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-examples";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_examples/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_examples/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "cc0b75c56ef8a2881f43442e6eba4b9339b9e3bd30c9afd5113be19b320e9e85";
+    sha256 = "e9a9314bd94b0cdbf843e3004945d75616eb0e71966b8f3a42ac07eac1e6e346";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-factory/default.nix
+++ b/distros/kinetic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-factory";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_factory/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_factory/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "1a5b09c9df32e5252e240836a140ece0f58247557a59f1fad1905eedd4317bb6";
+    sha256 = "4255ccb8e14d866dfb1fe6d469d47f8c87dcafd433c426a256eab68050cbfc97";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-manager/default.nix
+++ b/distros/kinetic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_manager/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "634f287ac2962b4f1efcdd498361e414dba213356c21625826ca7c02853eabee";
+    sha256 = "2124efd250bfb13718ecd1963817cd0c8b3a9e79d8181005167241441f96f1ff";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-msgs/default.nix
+++ b/distros/kinetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-msgs";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_msgs/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_msgs/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "3d46f9b7af38013a92652422d43c399609c2c13f12209cd2d785bd3f0fde4bce";
+    sha256 = "546f12f79cb996f8748bf3c47f1b4539aa17a76a74f6508a4ffd7517d5b4fe82";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rokubimini-serial/default.nix
+++ b/distros/kinetic/rokubimini-serial/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+{ lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini-serial";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_serial/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini_serial/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "1f6a3d14fdd9ee509891b6d92356904e57afd195805150adc92e307eb4b77e85";
+    sha256 = "5747d3913a3a955141be347048f372e897287a505d0dead39d9383c815bebab4";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  propagatedBuildInputs = [ avrdude rokubimini rokubimini-bus-manager rokubimini-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rokubimini/default.nix
+++ b/distros/kinetic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, roslib, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rokubimini";
-  version = "0.5.8-r1";
+  version = "0.5.9-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/kinetic/rokubimini/0.5.9-2";
     name = "archive.tar.gz";
-    sha256 = "1ce3c4930dd5cb63b8ac6d414ecc953e2ef85e8615a93fc26effdde1101c2442";
+    sha256 = "1b7729bcc6342c347eaced54735a9334a3423e43b668556091266c523242af86";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp roslib sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/sdc21x0/default.nix
+++ b/distros/kinetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sdc21x0";
-  version = "1.0.6-r1";
+  version = "1.0.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/sdc21x0/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "dd101ef9cfa4334695bb16dd98b092d0feeade99931a5988244a785ee210fe92";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/kinetic/sdc21x0/1.0.7-2.tar.gz";
+    name = "1.0.7-2.tar.gz";
+    sha256 = "9ee826655363459976cae79619e84c1640456aac3799dacafb9c231819098c50";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-bringup/default.nix
+++ b/distros/kinetic/toposens-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-gui, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-bringup";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_bringup/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_bringup/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "0796fb4f42ece88a3dd0647c73251f088ab912687969f2fef13d742968dda5ed";
+    sha256 = "ccfb1521767d3a5db2d2e90167eac953f5b4a359015341f6cbd85a69808b6687";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-gui rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-description/default.nix
+++ b/distros/kinetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-description";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_description/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "18c474f5a04f5799e0930a112e711b6822249be9833f5b0895009d060cb995b4";
+    sha256 = "2a4ff853759c0c67905143d3217c6e7e3e266790f636e303bcc4c04a32ed27b2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-driver/default.nix
+++ b/distros/kinetic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-driver";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_driver/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "1d82ae38c455f2eaff688162d46b1a4d4383672a05f09cc2548a7460f0dc9fce";
+    sha256 = "6999c7108e6b41058f7f042a99f1493a317a9cbaee523d2e0ef00cfe80362909";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-markers/default.nix
+++ b/distros/kinetic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-markers";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_markers/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "b0655bf1c10911a7b7ac3bd6ba1e1559f7808292cbd1568ecb2e1dc1547e4caf";
+    sha256 = "519220ef0f8568492cc1c1679a057d804bab9f3c37ae917f162b12ec58cc9412";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-description toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/toposens-msgs/default.nix
+++ b/distros/kinetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-msgs";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_msgs/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "f434bf7d89141928b4a5063633c2f32615de33034e551cda52289eabf2369b3c";
+    sha256 = "6251929ba739015ae4a29adb9d99d009cfc64bee7e7e2b97b6557cf117157728";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-pointcloud/default.nix
+++ b/distros/kinetic/toposens-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-pointcloud";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_pointcloud/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "b0467c8c14ce9278ed79b00804421cb3bf034eaa25f32791595bc63aee3318f9";
+    sha256 = "e126e8e5b62eeffadfb02bb69b42391230819dc14a5bd843a297850c287bb08e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens-sync/default.nix
+++ b/distros/kinetic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-toposens-sync";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens_sync/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "2619948aadb9b247b11906ff2547a223f4899355ab9be1da97a3863a3c790b84";
+    sha256 = "7934d3df0f7a6f32b6998fc8ff2764fe9bd35e3e7be52f2b2e5beb60fa319202";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/toposens/default.nix
+++ b/distros/kinetic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-kinetic-toposens";
-  version = "2.1.1-r1";
+  version = "2.2.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.1.1-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/kinetic/toposens/2.2.0-3";
     name = "archive.tar.gz";
-    sha256 = "acfd12fd165d6989c42d374b2bf87f7073f660535982e061eb397c16b7bd905e";
+    sha256 = "4d7bc94dd963ddfda5c36b6b1098ba86811dd8bb4cbca464d4b39748308778e5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ueye-cam/default.nix
+++ b/distros/kinetic/ueye-cam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, camera-info-manager, catkin, dynamic-reconfigure, image-transport, nodelet, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-ueye-cam";
-  version = "1.0.18-r1";
+  version = "1.0.16";
 
   src = fetchurl {
-    url = "https://github.com/anqixu/ueye_cam-release/archive/release/kinetic/ueye_cam/1.0.18-1.tar.gz";
-    name = "1.0.18-1.tar.gz";
-    sha256 = "c53010bc085888f9f8cc88c69c91ec25c828a3de8aa65d867253c1a4d0c3447c";
+    url = "https://github.com/anqixu/ueye_cam-release/archive/release/kinetic/ueye_cam/1.0.16-0.tar.gz";
+    name = "1.0.16-0.tar.gz";
+    sha256 = "b58bc503b7feca34d7d68fe1af42d122635fbef9f5a6263d1d38269f09b18acc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-device-driver/default.nix
+++ b/distros/melodic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-bota-device-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_device_driver/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "16055aea61b57d38557728e0012c23bc6aa0769522edbfa9abe3a92b1b486446";
+    sha256 = "710802b5ee066fd70bb3beb501bd051eaadfa2008d805b49a44064c26f6c3436";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_driver/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "8daee59cf0a68ccb10b21a4d4078e2af2447b64415eda86f7a91c28d79545ff5";
+    sha256 = "51df155e54278bba392e2b45abba2a7610386c302d6f963f5cc2f40dbc38e3c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_node/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "4e7cb8094782f0970d5429c14eb3f0079a0e3bcf4d4ec7dc0a287cd72a9ec430";
+    sha256 = "ea306dcf098dda086cf3646c8dd0543134cf5436f7a98639dc2496901ef6a9e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_signal_handler/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "1fd27aa27200b4257cc3daeeb613b97f8570b6f802284ca53d95b88c5439b7d3";
+    sha256 = "09894978b53475dcf15776d63afeba1e2cfb7bfbb42abe5dca536d030e2e9882";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/bota_worker/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "6c14dcaaf0f153867ebd920ffeb6d2ff41d5872666f1a4b32e5adaf3fcf77885";
+    sha256 = "b8e150e697a37f01f28417e984de8743082cf86234335674ef7aa91fe16522a3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-geometry/default.nix
+++ b/distros/melodic/laser-geometry/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, pythonPackages, roscpp, rosunit, sensor-msgs, tf, tf2 }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, pythonPackages, roscpp, rosunit, sensor-msgs, tf, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-laser-geometry";
-  version = "1.6.5-r1";
+  version = "1.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/melodic/laser_geometry/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "e1064427a3ab09ecaf250925472343410cb1b9e3fdb2cf7b07e9e953ad4616c5";
+    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/melodic/laser_geometry/1.6.7-1.tar.gz";
+    name = "1.6.7-1.tar.gz";
+    sha256 = "7c832a9a8bcb0caa67a9494b1a8945da5427b8dae18eecd6e4c5f08e0e6f09cc";
   };
 
   buildType = "catkin";
+  buildInputs = [ tf2-geometry-msgs ];
   checkInputs = [ rosunit ];
   propagatedBuildInputs = [ angles boost eigen pythonPackages.numpy roscpp sensor-msgs tf tf2 ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/mir-actions/default.nix
+++ b/distros/melodic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-actions";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "fa20842a20e9a995f594542b29d28480509c54cc3fab55ac35af33f760a5f3d3";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "c7b78c26c1442b17a04340c451da9a25674c5ddee70f9b054278b33987a0ecb5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-description/default.nix
+++ b/distros/melodic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-mir-description";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "de8f921a0c11964cab9a97f4fd7b67c8c00653bcef6747fc72c4003b070b4d42";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "0564f2d3ca0839e459e590680073f6556f78b49e3d0ed332b4dc039245e1792d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-driver/default.nix
+++ b/distros/melodic/mir-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, mir-actions, mir-description, mir-msgs, move-base-msgs, nav-msgs, pythonPackages, robot-state-publisher, rosgraph-msgs, roslaunch, rospy, rospy-message-converter, sensor-msgs, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-driver";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "d34171ab681d16b7db4799f2d08d621f8893191afab374db82363c124a891b26";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "e48f9194f54f10fcf7ef9d70a7437eae8c50129791d75bc9d77f42084a67726b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-dwb-critics/default.nix
+++ b/distros/melodic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, pythonPackages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-dwb-critics";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c2c152df0d3f32d0065f6c76e96512f93c0f5a3486f4e2f7fcca8e5b1e22aefd";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "29ab1e9fb86bf41a017fe5cff782c004e7a8187e34daca0921742e98f3d5fe40";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-gazebo/default.nix
+++ b/distros/melodic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-mir-gazebo";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "17443bcd02a0babf924cadbde02620d600bd5ba358fde405ef785f1bbd6dd5e3";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2a5455e17a833ca1c4498603c05b4d6de72c65933b74273c9b70daf338a648cc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-msgs/default.nix
+++ b/distros/melodic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-mir-msgs";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "1532b2bf7d1b6916ce1107a163d96d236620ad7a03afaa94d9d00ea70ac288d3";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "77c03361f0e213f65f6d710ea373b2af6d83f37a5afd0ad38564a75de43215bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-navigation/default.nix
+++ b/distros/melodic/mir-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, pythonPackages, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-melodic-mir-navigation";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "bd00e4c302ce0af23aeb7bf80f848f4fb76f3dee50aa8f24614b2acb0abe373d";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "17970fa4703c743d5b53c81cd2337a3ea27910777f273ec41e16e5b1a1f1e08c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-robot/default.nix
+++ b/distros/melodic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-melodic-mir-robot";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c02c1d9bb7153457c8d218d61c13f76491285055f0a8837ae528f726739c4f0d";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "121e765ef12b127dc5cfb80ad47583c123c9f5b993551cab1dcb248d617ef57c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-genicam-camera/default.nix
+++ b/distros/melodic/rc-genicam-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, rc-genicam-api, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-camera";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_camera-release/archive/release/melodic/rc_genicam_camera/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "2c4dd28cccedcc4677db9f914930fcb901237d03b7d0739475eb5e1a90f9bab4";
+    url = "https://github.com/roboception-gbp/rc_genicam_camera-release/archive/release/melodic/rc_genicam_camera/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9918f3dfd9322a017ac49220611b830db09e7a7d1f1b0f5c0de23feb56fe25bb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_bus_manager/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "dfaae0604c6789f77d4d12edd3dc101e0c0aecf2aaeed2054333982348622b84";
+    sha256 = "02590ba5fd6fbf943697ee8253a3255cfb4224ca323d9f45eefb7c7326283447";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_description/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "9e55902a11a52812580ebd57ddf6e19280e32ae3bc1f935e401c7230475b218f";
+    sha256 = "1a4e66691d0e95bf84b88b14dd0a679c98bb318824385edd4dd2a3533f92e722";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_ethercat/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "a8a7d89bbc37d8a9d3ec09e153606e23e550a173c7d3f2d43871b466d83afe00";
+    sha256 = "748f8a1eeb8bd873a5e38773d49ec469b64d4d5f1befe06509c159adf6f21a5b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-examples/default.nix
+++ b/distros/melodic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-examples";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_examples/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "31d6f42572d4617e96e8ee5e3463c21858c4209a19b3f92038eaf7a6c20fced9";
+    sha256 = "00c7804accaaab9f2442f1f8bf78251d21bef5289002f5a4d4c00d2024f50aad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-factory/default.nix
+++ b/distros/melodic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-factory";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_factory/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "31f5306165a8514b119d8b368f22ca9be401adba4ba7dc904c8887dfc6d9a571";
+    sha256 = "0e9da745fd972b2e8d4a4621257ad829f7e653eff97cdd5cb02942d3e641980c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-manager/default.nix
+++ b/distros/melodic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_manager/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "3ab6842e3499ce5e6dffe21121836340e0c8b6f41ac56558425c5ad84940df50";
+    sha256 = "fd31e28977901f106e7b7a9f1cd802ab7a7732618c784a2135de22365fd1e226";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_msgs/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "d729657f0083cf898cb4afbb270aa266966f16b19be6ffd30d5a62ae22316a9c";
+    sha256 = "3a5fa76dbd212169366a65a9601ee54efe0ad7087ea9e69eefa350b542fd40b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+{ lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini_serial/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "e0e8419092f2c060974ae1ac7b53077de2b473e33a6fa9bf0cb66b1dd1cb2f40";
+    sha256 = "1351db0b1a798f50e21e7241ecea33163040d123343e02d2525500dc58f87aee";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  propagatedBuildInputs = [ avrdude rokubimini rokubimini-bus-manager rokubimini-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, roslib, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/melodic/rokubimini/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "b8968f21789b570c4e5348abe78774b86bc4237301f64d91c2de44bda2954db6";
+    sha256 = "e1b1466a0d14d496cd0b72cd2a1801189ca7d32f8aca7a44aa7631e549d640cc";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp roslib sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/sdc21x0/default.nix
+++ b/distros/melodic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sdc21x0";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/sdc21x0/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "91e585a1503232cb2fa85e9ac2464a88c93a85f2f9b1706d41c0f9f400f55106";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/sdc21x0/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1196af31b64c8eaf7e1d3338de2fc35915731af10ce73cbd6fd4b22d434ff874";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-bringup/default.nix
+++ b/distros/melodic/toposens-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-gui, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-bringup";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_bringup/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_bringup/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "8070e4fc87ea31059e71d41c0961b6ab39ef6feed24b667207c3a9d8a5e44d66";
+    sha256 = "91273ce263e58099513fe873d4f476197838cfbbf19686910f13180834869745";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-gui rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-description/default.nix
+++ b/distros/melodic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-toposens-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_description/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "1bd77a491c96473f5a1bb563090149c58c421324891f14a3681fc3103e0e553e";
+    sha256 = "a83a1be665872d6d05897663efafc6bd9916305ad03612cf49ce0aecb04edc19";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-driver/default.nix
+++ b/distros/melodic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-driver";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_driver/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "fa52fa15587860d0f954e2da53460251dd6f788bf7e696bf46f9ac8ed9f2b334";
+    sha256 = "b99465a27bd93bdbfe26c614b0b0efcd6b1faf6e35fbab5ba14846ca86cba57b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-markers/default.nix
+++ b/distros/melodic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-markers";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_markers/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "caa8dc40b5a17cd9f98149587ef3afeb0191599c4cf0aa5ef2bd5beaeb9cafa6";
+    sha256 = "f9ea71cf2a72b36e53338975a606fd23c32887181bf7998d04ad5ec7fbf3cb0a";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-description toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/toposens-msgs/default.nix
+++ b/distros/melodic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_msgs/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "e74ec8411e4507b36e9cf326903e425c90f4b02e24541d39bb30980ad9b15730";
+    sha256 = "364983248412d2a13e4401be96f94057c48f3215ee0bd553996f3ed3c6031a25";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-pointcloud/default.nix
+++ b/distros/melodic/toposens-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-pointcloud";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_pointcloud/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "d720d6d42394732c5d894e904bed47a21b3b04cf5bd3faed434e661105e9bad0";
+    sha256 = "7c64677f261879f46b1396a09d4f4a5f8eb5b11e65a62e607e4464052adaf42b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens-sync/default.nix
+++ b/distros/melodic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-melodic-toposens-sync";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens_sync/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "449c7fbdc4adefc79797eb9a74f9c2a86daae76a9a5e365872bdc056adcbec65";
+    sha256 = "8b335639bbfe9eb1c3920dbd89ff81038b32d6d74e4f8fea8e2dc2607d4a9b8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/toposens/default.nix
+++ b/distros/melodic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-melodic-toposens";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/melodic/toposens/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "703e1844de02b4ebaa27df9a4f71822c1848d00cf9e3ae62e7f970a81867c50a";
+    sha256 = "b06783b6e3c68901707a394ca70364589bdbba0712a917b47e6098ff0b102681";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-device-driver/default.nix
+++ b/distros/noetic/bota-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-noetic-bota-device-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_device_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_device_driver/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "b8ebc073955c3761a70674d21d4fbcd8010654e53b74d8d4d80f2b37f7cc1e94";
+    sha256 = "1b4bdfb6807b00eb8ebb4f3f03ec2b8dd2be770635c0d88a3352a13f002bc076";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_driver/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_driver/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "d3d8ccd3219c9fa2d054781dd7b84b055b08331ce6edd3fd1a0b4966865d93cf";
+    sha256 = "b91c969b41fdb6e591fe6496802352e747e9530bd7e175b41b508a59e9456a63";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-node";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_node/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_node/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "026bfb7f50aa82b35f766444db2315bd1ff876d8e9dc48013941bd9ddbe87aeb";
+    sha256 = "e33c5635ea758df02c42765993d8f50fbe5552a123bea54ca5515056d7bc4cb9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-signal-handler";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_signal_handler/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_signal_handler/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "489dec973794dc77d424e6ce8b4da17618963d57fa4019b0c591ddcfbbbf8277";
+    sha256 = "753ab413cd3a282318ad19b6a9d3665e321e21d360d266edeb1d598656170bb2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-worker";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_worker/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/bota_worker/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "7ab383e91f34051013936e3ec6c4ab5882460f0d6758bf873f030ebfc4b986fe";
+    sha256 = "a94b41c6fb964d15a4960024bd1655d670aabc53d30b094321cb18cb97024a45";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "4.0.1-r1";
+  version = "4.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "5aa3df95d58c0cd6272a61c1cb04c43df264df6201c56d6263530d8f44eb2fff";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "160c506d8d1479424985e185a8fd6968efb551ff2cc7dd93f8515bf5e1de3fb7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.3.1-r2";
+  version = "4.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.1-2.tar.gz";
-    name = "4.3.1-2.tar.gz";
-    sha256 = "8a1fd3f295fd3c94027b4b91ea4f99094c9efbcd806ee426672a6ac4f11377ca";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-1.tar.gz";
+    name = "4.3.3-1.tar.gz";
+    sha256 = "a401d342b397518e996ce616f30940883f126a611acd9d87de526543d4384632";
   };
 
   buildType = "cmake";

--- a/distros/noetic/laser-geometry/default.nix
+++ b/distros/noetic/laser-geometry/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, python3Packages, roscpp, rosunit, sensor-msgs, tf, tf2 }:
+{ lib, buildRosPackage, fetchurl, angles, boost, catkin, eigen, python3Packages, roscpp, rosunit, sensor-msgs, tf, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-noetic-laser-geometry";
-  version = "1.6.5-r1";
+  version = "1.6.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/noetic/laser_geometry/1.6.5-1.tar.gz";
-    name = "1.6.5-1.tar.gz";
-    sha256 = "323b9869bfd32eb57e048ec23f4d7b12f3a975fe617820ac8f9555c950f8a759";
+    url = "https://github.com/ros-gbp/laser_geometry-release/archive/release/noetic/laser_geometry/1.6.7-1.tar.gz";
+    name = "1.6.7-1.tar.gz";
+    sha256 = "81c363c1ab9719c59cf41d01c0624af2307259f711a2de85ef3287137c0794e5";
   };
 
   buildType = "catkin";
+  buildInputs = [ tf2-geometry-msgs ];
   checkInputs = [ rosunit ];
   propagatedBuildInputs = [ angles boost eigen python3Packages.numpy roscpp sensor-msgs tf tf2 ];
   nativeBuildInputs = [ catkin ];

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "696d80ef298147072b3a9d063e0c6b330788781b963d9936cffd0b6e443f2a34";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "76d377568bad346652d1e6b01850e99fc213bd84bba3dbeb0fb659bd58512662";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "fa83d7d210cd5de7311904374e9dd2967dd0c01f493fa6c7b90cc1a6f298e76e";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e28b9a52c0adda80b2d63af468cc283a4f10b97c4469d663efcc0deb80c3ad5b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "952968b0eb67219d6f122d5eb6b331ff230a900da3a48f69af68b640f639b456";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "e9ae4fdf0e182562d0f31ecd6b456bb48714c09c0b9c719761fe17209cb55039";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "3250eaf643c73dca60c16778be5634e09b474b28b40e47172dd241f059a6bdd7";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "ee8e6e0bf786a042779c6d5dcfacb51840bb4330daad9497ed26cea28151cef8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-actions/default.nix
+++ b/distros/noetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-actions";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "1263401d92c26b9a187bda6909a463f5762ec6a78740cb4e7f2afd3f173f165c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1403ef21f683c48af660faa6d022f356f741a8d2195e61e70fb5866be6abb42e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-description/default.nix
+++ b/distros/noetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mir-description";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "96f00a1306122ccc1a0be17b9182b6dbf307ffd5ae80f95b6b552787336e44d8";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "bc2cd5ae680e667c6b68054f6460e16dac7db4dd360b41c5531a86936da9caf6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-dwb-critics/default.nix
+++ b/distros/noetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, python3Packages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-dwb-critics";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "3ef8c7e272b9b6df4fc9f50475257b28d0396a81b4d7badb137dce2446a0b2c8";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "962d8a94037fc110a0a007caccb591594cf4c64c625d66463d31c724804cd795";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-gazebo/default.nix
+++ b/distros/noetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mir-gazebo";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "01a221a8d2769cce52ee5a6fda68a7e4faa41a63d12ad6cc8d9f168aedf6edb2";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d615cd1976c607b67855f7dc38b5d5aeec5fc1ab7b1b3afc91fbe5f5a4fdf38a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-msgs/default.nix
+++ b/distros/noetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-mir-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "243b63e42dc40d4fc69becc351c8a1c9c42b94ca79815b50e3fa07d6be1c353a";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "5be240e6ff4067ef2182a8151f36eeb0b94de347f3054538ff35d739bafd8556";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-navigation/default.nix
+++ b/distros/noetic/mir-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner }:
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-noetic-mir-navigation";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0959034c2f702c0658895ab307b611e3d85b83bf7feadd878aa6d2673e03c87f";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "e81bc632ad1ef28c7181c2fbee62dacd22d2dedf008388371d835e942523fdf7";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner ];
+  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mir-robot/default.nix
+++ b/distros/noetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-noetic-mir-robot";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "53758e8ce0d92eb25b1c3fed43c63f7cb4878afaed7b2bc982169958acec85cd";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b44682fe2a45b73811e34f7ae350657df1aac3c0aee32a58de2c6b3ab04b6c38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-testutils";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_industrial_motion_testutils/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "819302e83331cc5ee9fef601ea175f8ac109de426b635360f273983a0d1be146";
+    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_industrial_motion_testutils/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "fd2e4a3f4c386eec28fe42fe92f53b64bbeef13b013d3dcf6f79cbf106a572ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-msgs/default.nix
+++ b/distros/noetic/pilz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-pilz-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "9aff81c4fe49199573b81d29e493946aac762565545ad3da60e1248f7cb6ac6c";
+    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "2b3d25c920f029fa70ce25f7189c24b933b9db2e901835fb0b6ef0618f519dbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-testutils/default.nix
+++ b/distros/noetic/pilz-testutils/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-utils, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-utils, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pilz-testutils";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_testutils/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e201872b6f08576a6b71e119fc59c0de078c33fc12b5866d795adcae8c072792";
+    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_testutils/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "a26eecef74aadd16dc7c5f8f1d9c57b54e139504a61d0725276167a026231960";
   };
 
   buildType = "catkin";
   buildInputs = [ pilz-utils roscpp sensor-msgs ];
-  checkInputs = [ code-coverage ];
+  checkInputs = [ code-coverage rostest ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/pilz-utils/default.nix
+++ b/distros/noetic/pilz-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, clang, cmake-modules, code-coverage, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-pilz-utils";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_utils/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "8ac7d40019d37984f6ebe72bb8c65a63f80019f9c15d40a9f68c60e514f6c922";
+    url = "https://github.com/PilzDE/pilz_common-release/archive/release/noetic/pilz_utils/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "90a7aaec8293d761ba0e226e730c49c5ca6bf7fe337318c857de368f10387176";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-camera/default.nix
+++ b/distros/noetic/rc-genicam-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, image-transport, message-generation, message-runtime, nodelet, rc-genicam-api, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-camera";
-  version = "1.2.4-r1";
+  version = "1.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_camera-release/archive/release/noetic/rc_genicam_camera/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "8ea918ece41e66baaf826ed9e1bb1335b3c8c5f12883a3de31b10a87a025a108";
+    url = "https://github.com/roboception-gbp/rc_genicam_camera-release/archive/release/noetic/rc_genicam_camera/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "7c69ed776b4a4c8bb7a46ddd4e4b69cfe0b02824af7d89675ff78500917f0d75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-bus-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_bus_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_bus_manager/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "46ddeb924599940f63dd3d27c55d0db4e9280d896a298913e9a52be863ff22fd";
+    sha256 = "ff396a9b277198412f37a54da54c1069bbaca79d9fd6bf15e4ae6ab0d01a8c91";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-description";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_description/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_description/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "4ee26763d78c841b0620a8674829e0eb065fa3a262a409b3207f3863a40285cf";
+    sha256 = "616ec7eee94597dcd54e2635b8c6fc8d3d8765b9c58ec69589c3c1526a668d8f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-ethercat";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_ethercat/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_ethercat/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "019b97869a35db3db0b81b43fa8b80e82d747546e161f7598ca6d0cd1d4e2447";
+    sha256 = "ac605cb0172a634cc1e4604c9126bce6f7204b23913f0f8bd78914c1d0f165ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-examples/default.nix
+++ b/distros/noetic/rokubimini-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-manager }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-examples";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_examples/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_examples/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "c6d557a91b23578f71da48dc93e20b2795a0f4d25fb058e01e765f1204bc3934";
+    sha256 = "9657b49e144a3419fbeb650a99b4fbe28e66c0b9860b911f3b2436283d8526ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-factory/default.nix
+++ b/distros/noetic/rokubimini-factory/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-factory";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_factory/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_factory/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "2d3a99e4b97a4d476873d6c2f44e312e67ada31d73fe0ea785cf5fe0bd9ec02f";
+    sha256 = "8003e515d5c1f73eeca8a3ec22e4d1d42b81314f90351b558bac2f197330849d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-manager/default.nix
+++ b/distros/noetic/rokubimini-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, libyamlcpp, rokubimini, rokubimini-bus-manager, rokubimini-factory }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-manager";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_manager/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_manager/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "97643ff3334cd6e9f911243ed9ce94693152442a70647a46c87e11c6f30feebb";
+    sha256 = "1e33a187ed015416f80c55ae7933d626d3d949dfe5dc9d52276b6a6d21b2fe9a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-msgs";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_msgs/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_msgs/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "399e5a2b33f13a4999c82fea8944f48c68da813c97a38b60beb0089ecb64aa77";
+    sha256 = "a09c7a5c37c3abd031998ef376064571b0fb0c3080df0b9e7523e91b3155188c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
+{ lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-serial";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_serial/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini_serial/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "ce035926d9171d380ec0c5aefc94d6d731edaadafc3b4c8b4eb101e0333f56f9";
+    sha256 = "10de7aac1127d3ef784714289bd1b7295534b682b5db4eb2a0de28c19324d1c5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs ];
+  propagatedBuildInputs = [ avrdude rokubimini rokubimini-bus-manager rokubimini-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, roslib, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini/0.5.8-1";
+    url = "https://gitlab.com/botasys/bota_driver-release/repository/archive.tar.gz?ref=release/noetic/rokubimini/0.5.9-1";
     name = "archive.tar.gz";
-    sha256 = "e94405dcd9f7e838749a53fccf9f7227601ec5ddb67cef69fb14d0e5e768f093";
+    sha256 = "7a0e3cf4712ba9319fb1a5019868ab45ebd73d1f95684c90d838c9fb94c7bea0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp sensor-msgs ];
+  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp roslib sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sdc21x0/default.nix
+++ b/distros/noetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sdc21x0";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "92722bd2f214c2c4c57548292139497cf1dea5514a9004f82b6a6d8b8d459bca";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a452f391d4d28527ad083caa028f55c3ab22a2ed3268741eb5254d2df3864a68";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.3-r2";
+  version = "4.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.3-2.tar.gz";
-    name = "4.11.3-2.tar.gz";
-    sha256 = "5bbad67538f9b0cb5b6983798677c90213f40005757981440b414f476c4af81e";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-1.tar.gz";
+    name = "4.11.4-1.tar.gz";
+    sha256 = "a6cfbdcf769d02193be0e56cee7fdf5a6acede7fd4f00a2f6b3b276f1f363cf8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.5.1-r1";
+  version = "1.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.5.1-1.tar.gz";
-    name = "1.5.1-1.tar.gz";
-    sha256 = "35ff5ac85f54363b8837b6efcc95b37fdddeb9564682eb628ae18595dd0c768f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.5.2-1.tar.gz";
+    name = "1.5.2-1.tar.gz";
+    sha256 = "f29268717566d7c3cf94e55c2cf01105b112f0830a5e44d82674444a3aa82cc4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-bringup/default.nix
+++ b/distros/noetic/toposens-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rqt-gui, rqt-reconfigure, rviz, socketcan-bridge, toposens-description, toposens-driver, toposens-markers, toposens-pointcloud, turtlebot3-bringup, turtlebot3-teleop, xacro }:
 buildRosPackage {
   pname = "ros-noetic-toposens-bringup";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_bringup/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_bringup/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "efe7df738acf96ae0db6743081dde793ed4b0f59b0d0ee777bf7d1f170fe5a3e";
+    sha256 = "b7011315a2d70769b2a487d01ce960436b3bdbc78f5046a8427d8c5d4f72dcdf";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
+  propagatedBuildInputs = [ joint-state-publisher robot-state-publisher rqt-gui rqt-reconfigure rviz socketcan-bridge toposens-description toposens-driver toposens-markers toposens-pointcloud turtlebot3-bringup turtlebot3-teleop xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/toposens-description/default.nix
+++ b/distros/noetic/toposens-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, robot-state-publisher, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-toposens-description";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_description/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_description/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "7382b0380ebc322f9048da8cafae81500b3f38dafd6cb077ce45697c8c18e9ad";
+    sha256 = "750ef8995aaa2d2e788dbb2c2c7c0b681d90076d141a5ad1632a1e443ee81e8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-driver/default.nix
+++ b/distros/noetic/toposens-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, toposens-msgs }:
 buildRosPackage {
   pname = "ros-noetic-toposens-driver";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_driver/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_driver/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "61a68366695b41b35f2db96c2044ed7463011b4b6eebe86c49072ca911482729";
+    sha256 = "58b14c6aa9002d7806a78dd5c38591d28d8e24c06b23783a79627c06b251d5e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-markers/default.nix
+++ b/distros/noetic/toposens-markers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-driver, toposens-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-runtime, roscpp, roslaunch, rostest, rviz-visual-tools, tf2-geometry-msgs, toposens-description, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-noetic-toposens-markers";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_markers/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_markers/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "b13697c65debd53352283e9cdf9ac40360388023bc97bd7aaa5e7d96b78ffa4a";
+    sha256 = "cfe0ca9899df0092010c8712a2cc6de68413fb6a702858279a77257e5ecc8e8e";
   };
 
   buildType = "catkin";
   checkInputs = [ roslaunch rostest ];
-  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-driver toposens-msgs ];
+  propagatedBuildInputs = [ dynamic-reconfigure message-runtime roscpp rviz-visual-tools tf2-geometry-msgs toposens-description toposens-driver toposens-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/toposens-msgs/default.nix
+++ b/distros/noetic/toposens-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-toposens-msgs";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_msgs/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_msgs/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "b3ef9b6944cc3ca9049c41def4e8ca50ab6d71f184d88c15b352e515cb33c661";
+    sha256 = "1d711b6b6f4d05ee86ea2c9a2d4290aef3876163de3294cba610ead5a9b17b0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-pointcloud/default.nix
+++ b/distros/noetic/toposens-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-runtime, pcl-ros, roscpp, roslaunch, rostest, tf2, tf2-geometry-msgs, toposens-driver, toposens-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-toposens-pointcloud";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_pointcloud/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_pointcloud/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "91acf806538ab42f694b5a05849e0c67cd90a58c3750edc57db77e48c2fcdfb6";
+    sha256 = "6138f8316780d7878411313f52d8e7c81931bae7bdcae3f2b26eb226034d62a1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens-sync/default.nix
+++ b/distros/noetic/toposens-sync/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, message-runtime, roscpp, roslaunch, rostest, toposens-driver, toposens-msgs }:
 buildRosPackage {
   pname = "ros-noetic-toposens-sync";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_sync/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens_sync/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "c7fba8d2196e90029ac42cda4287f6dedc29b2cb562b3c1c18734ffc4a46e0e1";
+    sha256 = "a7e116b3876a81fa4eaac8f53ce15207335ebe315f7fec07bb9a65295982b46b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/toposens/default.nix
+++ b/distros/noetic/toposens/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, toposens-bringup, toposens-description, toposens-driver, toposens-markers, toposens-msgs, toposens-pointcloud, toposens-sync }:
 buildRosPackage {
   pname = "ros-noetic-toposens";
-  version = "2.1.0-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens/2.1.0-1";
+    url = "https://gitlab.com/toposens/public/toposens-release/repository/archive.tar.gz?ref=release/noetic/toposens/2.2.0-1";
     name = "archive.tar.gz";
-    sha256 = "351b1c1ea2c15c083ca0387ef8096cfd19a6e62f6d211dc59dc9531e1fa71bc1";
+    sha256 = "c79defb22d4907b194c444090949a1803d4fe6d6544587e3990be978497c2b58";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 32ca9d5e4447afc7a717836fbb4b5b0568888a2b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *rqt 1.0.5-r1 --> 1.0.7-r1*
* *rqt-gui 1.0.5-r1 --> 1.0.7-r1*
* *rqt-gui-cpp 1.0.5-r1 --> 1.0.7-r1*
* *rqt-gui-py 1.0.5-r1 --> 1.0.7-r1*
* *rqt-py-common 1.0.5-r1 --> 1.0.7-r1*

Foxy Changes:
-------------
* *bno055 0.1.1-r3*
* *controller-interface 0.1.5-r1 --> 0.1.6-r1*
* *controller-manager 0.1.5-r1 --> 0.1.6-r1*
* *controller-manager-msgs 0.1.5-r1 --> 0.1.6-r1*
* *diff-drive-controller 0.1.2-r1 --> 0.2.0-r1*
* *effort-controllers 0.1.2-r1 --> 0.2.0-r1*
* *forward-command-controller 0.1.2-r1 --> 0.2.0-r1*
* *gazebo-ros2-control 0.0.1-r1*
* *gazebo-ros2-control-demos 0.0.1-r1*
* *hardware-interface 0.1.5-r1 --> 0.1.6-r1*
* *joint-state-controller 0.1.2-r1 --> 0.2.0-r1*
* *joint-trajectory-controller 0.1.2-r1 --> 0.2.0-r1*
* *position-controllers 0.1.2-r1 --> 0.2.0-r1*
* *ros2-control 0.1.5-r1 --> 0.1.6-r1*
* *ros2-control-test-assets 0.1.5-r1 --> 0.1.6-r1*
* *ros2-controllers 0.1.2-r1 --> 0.2.0-r1*
* *ros2controlcli 0.1.5-r1 --> 0.1.6-r1*
* *rqt 1.0.6-r1 --> 1.0.7-r1*
* *rqt-gui 1.0.6-r1 --> 1.0.7-r1*
* *rqt-gui-cpp 1.0.6-r1 --> 1.0.7-r1*
* *rqt-gui-py 1.0.6-r1 --> 1.0.7-r1*
* *rqt-py-common 1.0.6-r1 --> 1.0.7-r1*
* *transmission-interface 0.1.5-r1 --> 0.1.6-r1*
* *velocity-controllers 0.1.2-r1 --> 0.2.0-r1*

Kinetic Changes:
----------------
* *bota-device-driver 0.5.8-r1 --> 0.5.9-r2*
* *bota-driver 0.5.8-r1 --> 0.5.9-r2*
* *bota-node 0.5.8-r1 --> 0.5.9-r2*
* *bota-signal-handler 0.5.8-r1 --> 0.5.9-r2*
* *bota-worker 0.5.8-r1 --> 0.5.9-r2*
* *laser-geometry 1.6.5-r1 --> 1.6.7-r1*
* *mir-actions 1.0.6-r1 --> 1.0.7-r2*
* *mir-description 1.0.6-r1 --> 1.0.7-r2*
* *mir-driver 1.0.6-r1 --> 1.0.7-r2*
* *mir-dwb-critics 1.0.6-r1 --> 1.0.7-r2*
* *mir-gazebo 1.0.6-r1 --> 1.0.7-r2*
* *mir-msgs 1.0.6-r1 --> 1.0.7-r2*
* *mir-navigation 1.0.6-r1 --> 1.0.7-r2*
* *mir-robot 1.0.6-r1 --> 1.0.7-r2*
* *rokubimini 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-bus-manager 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-description 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-ethercat 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-examples 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-factory 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-manager 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-msgs 0.5.8-r1 --> 0.5.9-r2*
* *rokubimini-serial 0.5.8-r1 --> 0.5.9-r2*
* *sdc21x0 1.0.6-r1 --> 1.0.7-r2*
* *toposens 2.1.1-r1 --> 2.2.0-r3*
* *toposens-bringup 2.1.1-r1 --> 2.2.0-r3*
* *toposens-description 2.1.1-r1 --> 2.2.0-r3*
* *toposens-driver 2.1.1-r1 --> 2.2.0-r3*
* *toposens-markers 2.1.1-r1 --> 2.2.0-r3*
* *toposens-msgs 2.1.1-r1 --> 2.2.0-r3*
* *toposens-pointcloud 2.1.1-r1 --> 2.2.0-r3*
* *toposens-sync 2.1.1-r1 --> 2.2.0-r3*
* *ueye-cam 1.0.18-r1 --> 1.0.16*

Melodic Changes:
----------------
* *bota-device-driver 0.5.8-r1 --> 0.5.9-r1*
* *bota-driver 0.5.8-r1 --> 0.5.9-r1*
* *bota-node 0.5.8-r1 --> 0.5.9-r1*
* *bota-signal-handler 0.5.8-r1 --> 0.5.9-r1*
* *bota-worker 0.5.8-r1 --> 0.5.9-r1*
* *laser-geometry 1.6.5-r1 --> 1.6.7-r1*
* *mir-actions 1.0.6-r1 --> 1.0.7-r1*
* *mir-description 1.0.6-r1 --> 1.0.7-r1*
* *mir-driver 1.0.6-r1 --> 1.0.7-r1*
* *mir-dwb-critics 1.0.6-r1 --> 1.0.7-r1*
* *mir-gazebo 1.0.6-r1 --> 1.0.7-r1*
* *mir-msgs 1.0.6-r1 --> 1.0.7-r1*
* *mir-navigation 1.0.6-r1 --> 1.0.7-r1*
* *mir-robot 1.0.6-r1 --> 1.0.7-r1*
* *rc-genicam-camera 1.2.4-r1 --> 1.3.0-r1*
* *rokubimini 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-bus-manager 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-description 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-ethercat 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-examples 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-factory 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-manager 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-msgs 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-serial 0.5.8-r1 --> 0.5.9-r1*
* *sdc21x0 1.0.6-r1 --> 1.0.7-r1*
* *toposens 2.1.0-r1 --> 2.2.0-r1*
* *toposens-bringup 2.1.0-r1 --> 2.2.0-r1*
* *toposens-description 2.1.0-r1 --> 2.2.0-r1*
* *toposens-driver 2.1.0-r1 --> 2.2.0-r1*
* *toposens-markers 2.1.0-r1 --> 2.2.0-r1*
* *toposens-msgs 2.1.0-r1 --> 2.2.0-r1*
* *toposens-pointcloud 2.1.0-r1 --> 2.2.0-r1*
* *toposens-sync 2.1.0-r1 --> 2.2.0-r1*

Noetic Changes:
---------------
* *bota-device-driver 0.5.8-r1 --> 0.5.9-r1*
* *bota-driver 0.5.8-r1 --> 0.5.9-r1*
* *bota-node 0.5.8-r1 --> 0.5.9-r1*
* *bota-signal-handler 0.5.8-r1 --> 0.5.9-r1*
* *bota-worker 0.5.8-r1 --> 0.5.9-r1*
* *dynamic-graph 4.3.1-r2 --> 4.3.3-r1*
* *dynamic-graph-python 4.0.1-r1 --> 4.0.2-r1*
* *laser-geometry 1.6.5-r1 --> 1.6.7-r1*
* *libmavconn 1.5.1-r1 --> 1.5.2-r1*
* *mavros 1.5.1-r1 --> 1.5.2-r1*
* *mavros-extras 1.5.1-r1 --> 1.5.2-r1*
* *mavros-msgs 1.5.1-r1 --> 1.5.2-r1*
* *mir-actions 1.1.0-r1 --> 1.1.1-r1*
* *mir-description 1.1.0-r1 --> 1.1.1-r1*
* *mir-dwb-critics 1.1.0-r1 --> 1.1.1-r1*
* *mir-gazebo 1.1.0-r1 --> 1.1.1-r1*
* *mir-msgs 1.1.0-r1 --> 1.1.1-r1*
* *mir-navigation 1.1.0-r1 --> 1.1.1-r1*
* *mir-robot 1.1.0-r1 --> 1.1.1-r1*
* *pilz-industrial-motion-testutils 0.7.1-r1 --> 0.7.2-r1*
* *pilz-msgs 0.7.1-r1 --> 0.7.2-r1*
* *pilz-testutils 0.7.1-r1 --> 0.7.2-r1*
* *pilz-utils 0.7.1-r1 --> 0.7.2-r1*
* *rc-genicam-camera 1.2.4-r1 --> 1.3.0-r1*
* *rokubimini 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-bus-manager 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-description 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-ethercat 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-examples 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-factory 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-manager 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-msgs 0.5.8-r1 --> 0.5.9-r1*
* *rokubimini-serial 0.5.8-r1 --> 0.5.9-r1*
* *sdc21x0 1.1.0-r1 --> 1.1.1-r1*
* *sot-core 4.11.3-r2 --> 4.11.4-r1*
* *test-mavros 1.5.1-r1 --> 1.5.2-r1*
* *toposens 2.1.0-r1 --> 2.2.0-r1*
* *toposens-bringup 2.1.0-r1 --> 2.2.0-r1*
* *toposens-description 2.1.0-r1 --> 2.2.0-r1*
* *toposens-driver 2.1.0-r1 --> 2.2.0-r1*
* *toposens-markers 2.1.0-r1 --> 2.2.0-r1*
* *toposens-msgs 2.1.0-r1 --> 2.2.0-r1*
* *toposens-pointcloud 2.1.0-r1 --> 2.2.0-r1*
* *toposens-sync 2.1.0-r1 --> 2.2.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] cmake_common_scripts
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] fmt
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-mapnik
 * [ ] python3-msgpack
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pymongo
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

