### PR TITLE
rosdistro sync, Fri Feb 26 13:08:42 2021

### DIFF
--- a/distros/dashing/rqt-reconfigure/default.nix
+++ b/distros/dashing/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-dashing-rqt-reconfigure";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/dashing/rqt_reconfigure/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "49bf8bf8e7406d4e8f696328d02412132105e33cdc1fe7f09a055e73f30d35c5";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/dashing/rqt_reconfigure/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a05a92faa48019e57e6a95956612f10d2f61ffdcf72c9fa4a5f89136bf540087";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/turtlebot3-fake-node/default.nix
+++ b/distros/dashing/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-fake-node";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_fake_node/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "b8e4012f0c132ca25b72edc6eaa5c3a1fd4fa8eef7f99ab9e1048175a7768fd4";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_fake_node/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4ec191f0a14cd58a8bad3d2abcf2a1ab2a0e4cb065cc636c301d6c630bcaa753";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/turtlebot3-gazebo/default.nix
+++ b/distros/dashing/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-gazebo";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_gazebo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "f9d883c497b96843ec4d4b12db694ff062a5817c3703cdcfd5156b99d72bec5f";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "33c47c80fee3b6bdf32bd5a6f8c48a4ffb75030455b4308406c5071b9a4dae6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/turtlebot3-simulations/default.nix
+++ b/distros/dashing/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-simulations";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_simulations/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a02d21996dc765f43c036e03255ca4a7e3d4d3a745a2e46a424c791efe8c01b9";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_simulations/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3616377a1d32e5e885eeaf869b02a7378c3559246ea81eae5dde099d42a49ecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/contracts-lite-vendor/default.nix
+++ b/distros/foxy/contracts-lite-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-contracts-lite-vendor";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "98016a6194f9b9f14872d2223776144370788f0247391886046d2735ed0635c8";
+    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "14ea41bbb384648b7195fb8adc8c2bc7e4883bc6ea9622f462790632c1e87e22";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.2-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "ed5b0af5ca9257b9b83f527ff2e835da45153e74f405d64a08be2980deaee420";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "f503676f1f84b55b0b5d89c90257b93870cc519391b17c2f4642470c72a44e3d";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -716,6 +716,8 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ ntpd-driver = self.callPackage ./ntpd-driver {};
+
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
  octomap = self.callPackage ./octomap {};

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "68a97494e0d6ea89366c6ceebc27306bc3bf2b0b163360ade505a8f918b1c0d3";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "4bf17bb40850d0130541079431abded90c270976d6c39ad680ec821394ff22bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "ac3424248eb63e6e02649d8ce2ac51b6500e67006e60f3599ea83ac7e791d3fd";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.2.15-1.tar.gz";
+    name = "2021.2.15-1.tar.gz";
+    sha256 = "18c0d9636d41c5909145c0c7a238cc8eeda7d56c230ed8ca0c665356a987b659";
   };
 
   buildType = "cmake";

--- a/distros/foxy/ntpd-driver/default.nix
+++ b/distros/foxy/ntpd-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, poco, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-ntpd-driver";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/vooon/ntpd_driver-release/archive/release/foxy/ntpd_driver/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "abb8a8eeaa2b0264523d44faa0d7afcb92737eed9228f7180e58a7516d1e23b0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ class-loader poco rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ntpd_driver sends TimeReference message time to ntpd server'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "31b0002a94b50db20ee4b0eb579898d4d950e94c243746d162c459e80d4d0327";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "62a5482d872bfec6b880b5b8d79a01502541bf873076b9c33ea50d9be52546cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "38a40ec949b46dc7e8e7f54c517fe2c636a050eae425265f0fde9535a79f77bb";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "7ebb01ce220b9af81dd8592eb0207891fc000249921c0d455aa677a6fbf69d04";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "6a44440f3abc7e9830caa61259241358e451a63a4bc0f68da9cd66c71ef20124";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "83c10f575bb5616e743d1337d24dfd230b6b114aabeea4e283b7f66cdaaf1f4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2bag/default.nix
+++ b/distros/foxy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-foxy-ros2bag";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "b2a42fd7131025033010daa064db13ecbd7b17d549d15b044f1c48b5a2816c7e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "c1f119bc19d6aaec54d67f22543f4194184cc0e8e9691ab5bc45277fac9ec1c8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-compression/default.nix
+++ b/distros/foxy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-compression";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "fabd90fdb34ec1a2d78ab99d64a51247eb11d5ab984053547b052aeed853fb75";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "4e5ad66b1101e9033790c0de6176592224306da2b2baa4b16616305af2628212";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-converter-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-converter-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rmw, rmw-fastrtps-cpp, rosbag2-cpp, rosbag2-test-common, rosidl-runtime-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-converter-default-plugins";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "7ced6a7668fcf83e9c0d77f76152bf319616214a93711c0269c74ae57ef81c3e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "cdc8e0eb24507b17d35901dcbef059ddfe5fd0693d4ed4a05f479411cb9fa9dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-cpp/default.nix
+++ b/distros/foxy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-cpp";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "f05bec85974fe54e7bb36759892dd0ec9d55922d0e31fc8d6a494855f2dd216c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "44f309ee0baa98bb78e1a3671157c1f277dc7fe5dfcd3f4b4ddedd087ebdd7b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-default-plugins";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "e6dc64d046beb7323d98c6ca267f03a4e80d70aa5b9b8c29aed963469d32ee2a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "c85a806a2d9993d37c1a2fe9d3a4d44eee50500a68edd1f8ed7af759ee7a33d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage/default.nix
+++ b/distros/foxy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "8ce2c4d5eefe8f1fb4f6132b56bffe3ce209cc686b9df11d1ac13950627a7d00";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "adfc0c2cdc07d5d5e217106eeae1045fc8784754893571f246be540ceaa7a10f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-test-common/default.nix
+++ b/distros/foxy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-test-common";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "09ecc028f22225b452e2c1833e7c3ab2083b5c23482e63b78e21dda44f3e39bb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "31801b834882ef8140cad8a72b4e8c550797087d3972119cf0a3a8f9b9fda48b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-tests/default.nix
+++ b/distros/foxy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-tests";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "86f52cc64f52b17796cd00aa53d4c72d4a20b0a47c5371b411f5c58702748438";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "1821b3f30a46de5947f6e5e241b0e472d07cf61043a152d05634da675ee88985";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-transport/default.nix
+++ b/distros/foxy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, rpyutils, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-transport";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "b261e9a001b958150934ab8815762f0500e2387e5271670f70e0e0c189ff8576";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "b60ba321facfe5c320a584f0be99f8ee610a24d5a8ba30e8461882ffcc5c7d30";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2/default.nix
+++ b/distros/foxy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "d6cf17ff1a0adc012bf7ff4c3a4362c0e2c7c2e7620d0c283c3a273be6869c25";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "3615c2633742f8fb39d2515ce258d17331c794661142e6e4135643621418a2fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-reconfigure/default.nix
+++ b/distros/foxy/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-reconfigure";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "78760bd8d3c72cbb27930460470dffd1394c29f1b9488e466281435fe970c6cd";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "db98b17e679c17aee40633d7fb3ff0473b9e94b925ebaf2979d6a04d9eb37858";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/shared-queues-vendor/default.nix
+++ b/distros/foxy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-shared-queues-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "35e613f26a58d6db78fa22530fc0b6270d4089432c71ad52c9ed4f667fd0a349";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "edc644c9982602ab644b676900819cd3ae7d318d9877a352a9dc01186a463afa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sqlite3-vendor/default.nix
+++ b/distros/foxy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-foxy-sqlite3-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "345a8ac8a2a8076518ea4b93cb138574378c394d9293897de289ee81b540cbdb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "5fecf846cf536ebf09b6463103e80e99d3b2f2abae683dc7b19f98037df0b8af";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-fake-node/default.nix
+++ b/distros/foxy/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-fake-node";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "63f57e007e4154cdd7d31014cebcf41ff78cbf30941492fcede8d94262b86476";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "fff9bb4bbb00f9025a2fa3299e9d72b142115b01bd52ae02ed875eb8759664ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-gazebo/default.nix
+++ b/distros/foxy/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-gazebo";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "027bf83d55c83aa72352917cbd04393fd5f5cdbe805dcfa887a9c8a9c11fd0aa";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "006fbfb6cb78cff7556e7452b3d6c8207cb77e880b08481127bb0f1ad6528fea";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-simulations/default.nix
+++ b/distros/foxy/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-simulations";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "0b360d856d4582ad57caf0334b32d2d8dc055b4547f96699c3c5b9e6e701a72a";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c75666dd3406bec6dd0490246e77ac6d2dbbb2e6fbbcabe375e49216fcba3b7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/zstd-vendor/default.nix
+++ b/distros/foxy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-foxy-zstd-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "7b0d901a8f4b3f66d7078f15fb3271593be6c6c85cf6d06a6cc4270144713c22";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "4768326423dccd4ac7d044447a78c89cf71acfc2d4840d64c3fffc12c9daa4b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/face-detector/default.nix
+++ b/distros/kinetic/face-detector/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslib, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-face-detector";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/face_detector/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "beee8a3d733efcf3121360ea3f3a6c0b73c33f1b988265527c5953eff6addcd0";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/face_detector/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "3dc98f0e26f9bd1d6319d47c5f16155be4799c0f45b516b84c28b4bade3af692";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ rostest stereo-image-proc ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
   propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2382,6 +2382,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-optitrack = self.callPackage ./mocap-optitrack {};
+
  modelica-bridge = self.callPackage ./modelica-bridge {};
 
  mongodb-log = self.callPackage ./mongodb-log {};
@@ -2415,6 +2417,8 @@ self: super: {
  move-base-flex = self.callPackage ./move-base-flex {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
+
+ move-base-sequence = self.callPackage ./move-base-sequence {};
 
  move-base-to-manip = self.callPackage ./move-base-to-manip {};
 

--- a/distros/kinetic/heron-control/default.nix
+++ b/distros/kinetic/heron-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-control";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cb88dca5fcf62f7494ba71d537bcbf28eb2188d889bb7d3e9fb709e6168e64cc";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "adc579ed13b8e3f29bb8962aabe433617fe94f88cf17bafc6e17d3483d7efa25";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-description/default.nix
+++ b/distros/kinetic/heron-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-description";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "01c01835d8ae989155db69b46aee38c0fff65f2cad0c12e92c0fee9d67c581f0";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ff37a5729512e8cd7f2a7fdecc99b27441a62b165a584144a463c0e0719cfb71";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-gazebo/default.nix
+++ b/distros/kinetic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-kinetic-heron-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f2d064595e670ae9183b6e375003131a6587e5da7edba5620c418dbd2946f372";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "0e06e8db73f76846b64ed20d520eec0c62bc3c790b362bbcf317830cffccfbb5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-msgs/default.nix
+++ b/distros/kinetic/heron-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-msgs";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "5a1c10d556e227adaaa649d6f1fdddd211eea0f65cbb15253b391131de244a07";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "7a73423506fbf3e3c9843b779164ed5784357b0c05982d7b338126ca323cc4e6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-simulator/default.nix
+++ b/distros/kinetic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-simulator";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "dff15b0a803e1af7bbff9225387964bc4b37c97b1b18336e0939093f84cf527e";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "813bd6c0cc9014071fd82074f863ff1c389f0bba3cc12a175f9490d06a8f7d10";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/leg-detector/default.nix
+++ b/distros/kinetic/leg-detector/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-leg-detector";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/leg_detector/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4935c2169ea3e899c9d0137c37dcf3d6f9bfb4196c54486cd29f1d90662ab7bd";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/leg_detector/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "791c039d2429226a37eff43c3ee352024626491179f8b2f9dd7a68f9e5ab9287";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl dynamic-reconfigure geometry-msgs image-geometry laser-filters laser-geometry map-laser message-filters people-msgs people-tracking-filter roscpp sensor-msgs std-msgs std-srvs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/libmavconn/default.nix
+++ b/distros/kinetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "20e0249f2ca6f1fc7aa46ba9978ff60e72c1df8b942c7b53d07a02651020e0ba";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "1ad69f90ca883e8e47f145ecc7ac3a69e41744c43f923610206633d507ea701a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "c466edb6377c7b36160bdd386c88ec83c627167986f10b0fb08c3760fde103a7";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "b6e5e80de9dbc2a4d6221d9e231514520da68d72219f1019d004c30e02c26b4f";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "b1c08ae12e1fd9b619f3b79a46f12ee4b86b7754bbf8fcc43eb8d76c18c3e385";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2021.2.15-1.tar.gz";
+    name = "2021.2.15-1.tar.gz";
+    sha256 = "2fa978f3ccf34e5412b7c0e48a16c8093801d49d6879c8830784f702de06dd4e";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mavros-extras/default.nix
+++ b/distros/kinetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "bab3135721cd4b25b0ff625f5d0b348c3bf83f5270f83ac552442d8daed44a39";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "53297aaa3085aa51dcb9faa4a98e1cf98626078c3036e98bb6d887ea238b0d03";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros-msgs/default.nix
+++ b/distros/kinetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "0a7f46c5b438dc821431d9a9e023bc87418e72e80b7f84594cb79feb68c37550";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f95fd9bdfa0b3014a45d2c47bbebb0a7e57c3d3b82c87e79a426c02eeb1c3499";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros/default.nix
+++ b/distros/kinetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "4aef42c05465841c3401b86f398a50cde8282b5ce53d75d0e8b60be3a05f05f5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "dd056f40b8a909b4e1329801b102525df275a510fc4b33362c287733f60143a5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mocap-optitrack/default.nix
+++ b/distros/kinetic/mocap-optitrack/default.nix
@@ -1,0 +1,40 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-mocap-optitrack";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/kinetic/mocap_optitrack/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5ae4a7ec067aa4b7e735f1db0c057204707916d9568f1a90b1ad523ee9ac67a5";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs nav-msgs roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Streaming of OptiTrack mocap data to tf
+    <p>
+    This package contains a node that translates motion capture data from an
+    OptiTrack rig to tf transforms, poses and 2D poses. The node receives
+    packets that are streamed by a NatNet compliant source, decodes them and
+    broadcasts the poses of configured rigid bodies as tf transforms, poses,
+    and/or 2D poses.
+    </p>
+    <p>
+    Currently, this node supports the NatNet streaming protocol v3.0
+    </p>
+    <p>
+    Copyright (c) 2013, Clearpath Robotics<br/> 
+    Copyright (c) 2010, University of Bonn, Computer Science Institute VI<br/>
+    All rights reserved.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/move-base-sequence/default.nix
+++ b/distros/kinetic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-move-base-sequence";
+  version = "0.0.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/kinetic/move_base_sequence/0.0.1-6.tar.gz";
+    name = "0.0.1-6.tar.gz";
+    sha256 = "66709c4a6323d7770f03ac43a1a00b126503f3712b2b6ed9cf331dc08ecfbc3b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/kinetic/people-msgs/default.nix
+++ b/distros/kinetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-people-msgs";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a702db9ce6e5196d9b00e025b069e9be10ebf9f38828b4726569d5e6f4bcdec1";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_msgs/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "0eeaed58e5efe8dc6e0fdfdaf122199edc681055f5f42fba3f8e528709d68c94";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/people-tracking-filter/default.nix
+++ b/distros/kinetic/people-tracking-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-people-tracking-filter";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_tracking_filter/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "dcc5c4c48372f86d64edb2d9fbe200f3bf5990cac1382732b781dc374dae5641";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_tracking_filter/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "f00936d2c829b1bcfbd159e2e45f74d3a806ecaaef61c338ec276dae500a2af2";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl geometry-msgs message-filters people-msgs roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/people-velocity-tracker/default.nix
+++ b/distros/kinetic/people-velocity-tracker/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslib, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-people-velocity-tracker";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_velocity_tracker/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "24595ad999e124490d6648ef5732faa5518d4a45dabe4e58da8a6348cce95bbc";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_velocity_tracker/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "e9b446cc526b8d32534ae11ae56a7cb3b0133793ddfe4bad11bda507f36f4d81";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/people/default.nix
+++ b/distros/kinetic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-people";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "20e548c7174f57519c1b387f9fb970cd483da33777ae4e34e959bfb54500992b";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "74d5128047b88c0c1aae71d57e7386b10197639e1ea69f9c54ca613f5b7d3ca0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "af5f1e1abf290794613308e27960125be401667aa484e699f46358863cd94010";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "4f0c18a8294c6c617c41081d87cf4a9d41eaee84049d08d1d97ab27618ef2cfe";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "1462e7cf5de2d497427586677ee92539cf42db729849b322df26d6da79dbe1ad";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "d60211f7fd3a04701a3073798ebbccda87e9b3fa378ec26ea6ee850a48dd0f91";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ros-control-boilerplate/default.nix
+++ b/distros/kinetic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-ros-control-boilerplate";
-  version = "0.4.1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/davetcoleman/ros_control_boilerplate-release/archive/release/kinetic/ros_control_boilerplate/0.4.1-0.tar.gz";
-    name = "0.4.1-0.tar.gz";
-    sha256 = "549a61a022dc82b3c28a2fa180a965a35cf74e171e937a56b0e1466dcd2a679a";
+    url = "https://github.com/davetcoleman/ros_control_boilerplate-release/archive/release/kinetic/ros_control_boilerplate/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "65102150a54122d63ba24c22ea5032db8e284d262b7d17c1d1cb600881b237c9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rqt-plot/default.nix
+++ b/distros/kinetic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-plot";
-  version = "0.4.8";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/kinetic/rqt_plot/0.4.8-0.tar.gz";
-    name = "0.4.8-0.tar.gz";
-    sha256 = "a5af60dcd95878b5b9cb7c8195cecc9d7ecd88f1666ed22662d6d325acebaf9b";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/kinetic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "7e3019d3d908cdf352a306c6ab1bc6e188578e8c0e65299375fe39034346c255";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/test-mavros/default.nix
+++ b/distros/kinetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "9d5727aacf6cda1224aaec140f67601893a1eb6097ff6a48d3817aed4b1a7f7f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f7a876b30213b4ddd385d4aa4b0aef07638177e23a31017c49c160f058f6c6ba";
   };
 
   buildType = "catkin";

--- a/distros/melodic/async-web-server-cpp/default.nix
+++ b/distros/melodic/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, openssl, pythonPackages, roslib, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-async-web-server-cpp";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/async_web_server_cpp-release/archive/release/melodic/async_web_server_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "6e4642671a9b19d4bcf46d080a17c1873a9d3c40905150d93684eb09d5efd346";
+    url = "https://github.com/fkie-release/async_web_server_cpp-release/archive/release/melodic/async_web_server_cpp/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f1094d659202fb2ed57ef45efe72c8748e7086c122be0f064e3804657c14d630";
   };
 
   buildType = "catkin";

--- a/distros/melodic/face-detector/default.nix
+++ b/distros/melodic/face-detector/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslib, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-face-detector";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/face_detector/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "4fc58742d316d190c2cddf54fbfda33d9bcde0cd5fcc80eb6687b083d4fd4874";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/face_detector/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "3e1b62d50cd5401f37c4e8ad3e7af62c315905bc3aebe3681bc7333a07b2b57d";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ rostest stereo-image-proc ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
   propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2012,6 +2012,8 @@ self: super: {
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
+ move-base-sequence = self.callPackage ./move-base-sequence {};
+
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
  moveback-recovery = self.callPackage ./moveback-recovery {};

--- a/distros/melodic/heron-control/default.nix
+++ b/distros/melodic/heron-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-heron-control";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_control/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "579c60f33d46897fc2a13ca3d0506c3d94c09bda498cc4417aed3c167d11e536";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "fd775e78508739fa2e7860a3c9b23c24e37f1b9015a75de364c91693aed01738";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-description/default.nix
+++ b/distros/melodic/heron-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-heron-description";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_description/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "1c381c2f5386fb22014eb10112ba4601c0bb76ac7a37db77e78b162ee6b7877c";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "8f667197332029beffb8c146923e072566af0eea4a53b913f07843853dfdfa4c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-gazebo/default.nix
+++ b/distros/melodic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-melodic-heron-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ce6d68691e4895ec7fa2bd83e0623441b5d43503c968ff5106b75101f7e96a5a";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "036573f4c61aa358f8a720804de68b0f1d47af000e109348fef9be4d0001eb6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-msgs/default.nix
+++ b/distros/melodic/heron-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-heron-msgs";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_msgs/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "2933e0b40e335841c756ee738d66fd9ab2e52cbfb21f105495e721d155773500";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "899a24ec3766be77d115b0d13f93a17e06975b9d1efc66af3f760df81e0555ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-simulator/default.nix
+++ b/distros/melodic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-heron-simulator";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1cc88488c8fc27c30383db03366ed7b99c191e833e3c5e495dc97386b345b8b3";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "c37d22db9e753e629036e6398a75a6e295b6438d3328d4dc954ba561615898a3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leg-detector/default.nix
+++ b/distros/melodic/leg-detector/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-leg-detector";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/leg_detector/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "aaf47802eea191142252e69d7044c0b308fd70350c8fd2650e7c682069e2e9de";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/leg_detector/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "44076e4c01655df0b855678ab2f2012a6ca559b527b4c258fb382a6df739f07f";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl dynamic-reconfigure geometry-msgs image-geometry laser-filters laser-geometry map-laser message-filters people-msgs people-tracking-filter roscpp sensor-msgs std-msgs std-srvs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "eb68da47fb1ae73f1ca0fbb5f3d9e5123a0e9d45270799813f9d15ffe92d0a10";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "bde0eab7a5c5ee5665ac856df66f554a63512dc6eddfbfb82f9ca5447893240b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "65975e28f3f1134aafb1fceeffae868b7c5f2522ed5b731c5831507640af8f7e";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "1f6da14bb91f55648ae2a69a0a8b3785748bcac1072763fabaf7835aa716a790";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "95e1d03a2b9090fc2c68ce8fed55b8228e93c02743755f41e130e8659b8bac59";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.2.15-1.tar.gz";
+    name = "2021.2.15-1.tar.gz";
+    sha256 = "a850843806248e5ee68292e8c7877c2b1172d60b392a62e5e0296592375544a1";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "62642bbd36b8a722d71dc950d411038ac82a7ec3ec5f31903983b51d20060272";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "28cfa744e66e5d707981f3273ae439f516b918567e363bd701b81fc3230f81bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e91fa2a6c12a4122897ad35060e0d66ce190bc6d862b95f36dd2869f3549982c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "5759c7719ae5250552c7a7beffbb2b224bc2f8e61ec5780d0f6b70572e2a7b5e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "2724719cd73f6eae2b89218d1cd18960341e1fbfe3dd0228d73708d39cc0be92";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "3ad0309798fd060b88acab25d1b09135b15871191fc54de6dc9ca34c004f7bb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-base-sequence/default.nix
+++ b/distros/melodic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-move-base-sequence";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/melodic/move_base_sequence/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "0dd3d48f276425cf5c51be52e9845c7732e9a988a5c07456e3e63ca8e8e91f99";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/melodic/people-msgs/default.nix
+++ b/distros/melodic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-people-msgs";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "34ea58081f5b53566700ebf0728e024148a0b653f57b5a82560da05848f30f82";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_msgs/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "56ee89ae2ab0cf449cf03e4a3db22356a5dba6e71a28d818ce90167a206e2bb4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/people-tracking-filter/default.nix
+++ b/distros/melodic/people-tracking-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-people-tracking-filter";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_tracking_filter/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "c248a935edf57a2326396a576622a79a75ec6d74679bf851a35c7004f0b2c8c1";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_tracking_filter/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "c865fb866c756894069ec3c6565a742ce0927c3f42b2359cd0f46f31230ad87c";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl geometry-msgs message-filters people-msgs roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/people-velocity-tracker/default.nix
+++ b/distros/melodic/people-velocity-tracker/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslib, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-melodic-people-velocity-tracker";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_velocity_tracker/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8058c2f01c299a3204c1ca5e6dc6e16e37afc35d10ae63d644ea0f21741c9ac8";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_velocity_tracker/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "dacb341d242868f85f245a5bb14821c4eeeb205b300ed187a78d9577bf052861";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/people/default.nix
+++ b/distros/melodic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-melodic-people";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6261e11750ff43c0eecd09034928197e6266c0410bc1d8310dfa0dc899798a00";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "3257e4cec2b4985b1b8f0530bb4a37820ec2100a60f9694b36aff8c9df32c154";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "8d809c1388903c07009bf016d6c89784d3fa05527ab2bfa4da4f3e0206018fb8";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "c9f50a6966ae731c360aab484e1b7fda21fc24aa5deb028eaac0b58cc0353319";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "c7bd91bef49ba8f1c6c9ff8c3596161b25f288d6f1d4578e162d2ed6b9c322b5";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "930fc359ec864cbe8ac7f8c68b334189b0140c453785469ac503ecae411d76d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-control-boilerplate/default.nix
+++ b/distros/melodic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ros-control-boilerplate";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0a7ce80db50a833c0ac201c31caba85ebdc1192a279adcc9b5e61ab86c1b7899";
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ef24a60447530fb1c62e086164715eae45cd02d5d46f105020c9664d81712a8e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-bag-plugins/default.nix
+++ b/distros/melodic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag-plugins";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "ca99407bcee6772429093e5a980a88a8c5b0f71ebd2166bd7ab0feb574e2084e";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ec47dd8d2efc2accd606964cb40a5531a46d57551a49b35558bedbd2a08f9d9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-bag/default.nix
+++ b/distros/melodic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "576d8412c68894c8430619ed33113e43406d2b6e56ece10c2cf5c24b62cdea36";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "182a0246366034f55abc0285d2f018819c1b455ce54cbf526d4880395be4396e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-plot/default.nix
+++ b/distros/melodic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-plot";
-  version = "0.4.9";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/melodic/rqt_plot/0.4.9-0.tar.gz";
-    name = "0.4.9-0.tar.gz";
-    sha256 = "226ffb18dfbf7e879f20e2aecae2243582a4fae28e74a1f7d3b291e68f6a28fb";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/melodic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "8ad543629315c87c8694d9efe79df4026582cea73d9183774b523e6fcb8a089a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "0774c44d48b2cba0a802d8813429c5ec6df04f36aeecd0233d6de007dcaf4d10";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "7c5e57d85e0f2938c39dacc1714c0b83824d56d4da08681567c411dd5ab5e285";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-description/default.nix
+++ b/distros/melodic/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-description";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "fe90909d6349e64ba5c7fa3eff8f0a1b64f7a0cf96fcae3042eeac2e8c2853b6";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_description/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "111bc30a33cd409c18c0f1c32ff2a6c8be55d29d14907d5d7627e872c2ae0671";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-gazebo-plugins/default.nix
+++ b/distros/melodic/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-gazebo-plugins";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_gazebo_plugins/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "9c6b9afee31c4833579b49a331d63aeee21ba565ecb05c67b8782a6b9291520b";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_gazebo_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "72db3cc09652427898487a4ffad1187fe9d5e61dd14492864ec5e561b21d87d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-simulator/default.nix
+++ b/distros/melodic/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-simulator";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_simulator/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "cdefbbe70f5ca2ebbfed172169054f6697252a29c23d24c53ae234b800fd0a38";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_simulator/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "665e8d0899eb6dbb9321ca9665e1406154db0fc7530bf17397d05af9c654d671";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamic-edt-3d/default.nix
+++ b/distros/noetic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-edt-3d";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "63235da0946f9e97a0126a7e1c21a0a431e330f44845cc3d7523413503ede4ca";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "a520fefda72b7919a8d500bbf94dc0ad88c4388e3c6a29df74e621b71785e88a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "4.0.2-r1";
+  version = "4.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "160c506d8d1479424985e185a8fd6968efb551ff2cc7dd93f8515bf5e1de3fb7";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-3.tar.gz";
+    name = "4.0.2-3.tar.gz";
+    sha256 = "3c79a0eb15c9f4dd046a1c8e19d69aabe77d00dcc2e24fb1f0de7583a87c5fdc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-tutorial/default.nix
+++ b/distros/noetic/dynamic-graph-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-tutorial";
-  version = "1.2.2-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "33213cea4468eb12ca6710d99006ed1b4ef7fb9586b2771d014830182bf1ba21";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a5499ce3759b782a0ce47408c2dcc025ccef46c53dd64e3080968beee6a08a60";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.3.3-r1";
+  version = "4.3.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-1.tar.gz";
-    name = "4.3.3-1.tar.gz";
-    sha256 = "a401d342b397518e996ce616f30940883f126a611acd9d87de526543d4384632";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-4.tar.gz";
+    name = "4.3.3-4.tar.gz";
+    sha256 = "3e27d8b75c9a57bfa976987ebe9db9f12796d4d3971a7f53767cafc6e1f020f1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eml/default.nix
+++ b/distros/noetic/eml/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-eml";
+  version = "1.8.15-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/eml-release/archive/release/noetic/eml/1.8.15-3.tar.gz";
+    name = "1.8.15-3.tar.gz";
+    sha256 = "8219ab24d7b0b32720cd1897a7ceaa28b4d912537986291cfa0c36b75b2ac5d0";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This is an implementation of the EtherCAT master protocol for the PR2
+      robot based on the work done at Flanders' Mechatronics Technology Centre.'';
+    license = with lib.licenses; [ "Binary Only" ];
+  };
+}

--- a/distros/noetic/face-detector/default.nix
+++ b/distros/noetic/face-detector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-face-detector";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "74644b234954d858f362cf03a515b03b553f0cdb350df9e6fb741c4614f44b83";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Face detection in images.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-auto-dock-msgs/default.nix
+++ b/distros/noetic/fetch-auto-dock-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-auto-dock-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_msgs-release/archive/release/noetic/fetch_auto_dock_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "07d675e227e9e0a6143af6c101cfc62d0bb4b0907e07f8143bba2fa148a67cb2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for fetch_auto_dock package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-driver-msgs/default.nix
+++ b/distros/noetic/fetch-driver-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, power-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-driver-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_msgs-release/archive/release/noetic/fetch_driver_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "83afff86291e1c3b3ffd1b96b10da679dea0bb2f4f127e456aaf7e7876bea27c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime power-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for the fetch_drivers package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-open-auto-dock/default.nix
+++ b/distros/noetic/fetch-open-auto-dock/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, eigen, fetch-auto-dock-msgs, fetch-driver-msgs, geometry-msgs, nav-msgs, roscpp, roslib, rospy, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-open-auto-dock";
+  version = "0.1.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp/archive/release/noetic/fetch_open_auto_dock/0.1.3-2.tar.gz";
+    name = "0.1.3-2.tar.gz";
+    sha256 = "ec396187a30b9ef904c934d7f3bdbf625980138227e511927ada69c8b61fbd6b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles ];
+  propagatedBuildInputs = [ actionlib eigen fetch-auto-dock-msgs fetch-driver-msgs geometry-msgs nav-msgs roscpp roslib rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An open-source version of the Fetch charge docking system.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -608,6 +608,8 @@ self: super: {
 
  eiquadprog = self.callPackage ./eiquadprog {};
 
+ eml = self.callPackage ./eml {};
+
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
 
  executive-smach = self.callPackage ./executive-smach {};
@@ -660,11 +662,19 @@ self: super: {
 
  explore-lite = self.callPackage ./explore-lite {};
 
+ face-detector = self.callPackage ./face-detector {};
+
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
 
  fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
 
  fake-localization = self.callPackage ./fake-localization {};
+
+ fetch-auto-dock-msgs = self.callPackage ./fetch-auto-dock-msgs {};
+
+ fetch-driver-msgs = self.callPackage ./fetch-driver-msgs {};
+
+ fetch-open-auto-dock = self.callPackage ./fetch-open-auto-dock {};
 
  ff = self.callPackage ./ff {};
 
@@ -872,6 +882,8 @@ self: super: {
 
  hector-imu-tools = self.callPackage ./hector-imu-tools {};
 
+ hector-localization = self.callPackage ./hector-localization {};
+
  hector-map-server = self.callPackage ./hector-map-server {};
 
  hector-map-tools = self.callPackage ./hector-map-tools {};
@@ -883,6 +895,10 @@ self: super: {
  hector-models = self.callPackage ./hector-models {};
 
  hector-nav-msgs = self.callPackage ./hector-nav-msgs {};
+
+ hector-pose-estimation = self.callPackage ./hector-pose-estimation {};
+
+ hector-pose-estimation-core = self.callPackage ./hector-pose-estimation-core {};
 
  hector-sensors-description = self.callPackage ./hector-sensors-description {};
 
@@ -1082,11 +1098,19 @@ self: super: {
 
  laser-geometry = self.callPackage ./laser-geometry {};
 
+ laser-ortho-projector = self.callPackage ./laser-ortho-projector {};
+
  laser-pipeline = self.callPackage ./laser-pipeline {};
 
  laser-proc = self.callPackage ./laser-proc {};
 
  laser-scan-densifier = self.callPackage ./laser-scan-densifier {};
+
+ laser-scan-matcher = self.callPackage ./laser-scan-matcher {};
+
+ laser-scan-sparsifier = self.callPackage ./laser-scan-sparsifier {};
+
+ laser-scan-splitter = self.callPackage ./laser-scan-splitter {};
 
  leo = self.callPackage ./leo {};
 
@@ -1127,6 +1151,8 @@ self: super: {
  librviz-tutorial = self.callPackage ./librviz-tutorial {};
 
  libsiftfast = self.callPackage ./libsiftfast {};
+
+ libuvc-ros = self.callPackage ./libuvc-ros {};
 
  lms1xx = self.callPackage ./lms1xx {};
 
@@ -1238,6 +1264,8 @@ self: super: {
 
  message-runtime = self.callPackage ./message-runtime {};
 
+ message-to-tf = self.callPackage ./message-to-tf {};
+
  microstrain-3dmgx2-imu = self.callPackage ./microstrain-3dmgx2-imu {};
 
  mini-maxwell = self.callPackage ./mini-maxwell {};
@@ -1269,6 +1297,8 @@ self: super: {
  move-base-flex = self.callPackage ./move-base-flex {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
+
+ move-base-sequence = self.callPackage ./move-base-sequence {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
@@ -1392,6 +1422,8 @@ self: super: {
 
  navigation-experimental = self.callPackage ./navigation-experimental {};
 
+ ncd-parser = self.callPackage ./ncd-parser {};
+
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
  neonavigation = self.callPackage ./neonavigation {};
@@ -1465,6 +1497,8 @@ self: super: {
  openzen-sensor = self.callPackage ./openzen-sensor {};
 
  opt-camera = self.callPackage ./opt-camera {};
+
+ opw-kinematics = self.callPackage ./opw-kinematics {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
@@ -1561,6 +1595,8 @@ self: super: {
  pointgrey-camera-driver = self.callPackage ./pointgrey-camera-driver {};
 
  points-preprocessor = self.callPackage ./points-preprocessor {};
+
+ polar-scan-matcher = self.callPackage ./polar-scan-matcher {};
 
  polled-camera = self.callPackage ./polled-camera {};
 
@@ -1677,6 +1713,12 @@ self: super: {
  robot-calibration = self.callPackage ./robot-calibration {};
 
  robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
+
+ robot-controllers = self.callPackage ./robot-controllers {};
+
+ robot-controllers-interface = self.callPackage ./robot-controllers-interface {};
+
+ robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
 
  robot-localization = self.callPackage ./robot-localization {};
 
@@ -2016,6 +2058,10 @@ self: super: {
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
 
+ scan-to-cloud-converter = self.callPackage ./scan-to-cloud-converter {};
+
+ scan-tools = self.callPackage ./scan-tools {};
+
  scenario-test-tools = self.callPackage ./scenario-test-tools {};
 
  schunk-description = self.callPackage ./schunk-description {};
@@ -2093,6 +2139,8 @@ self: super: {
  sophus = self.callPackage ./sophus {};
 
  sot-core = self.callPackage ./sot-core {};
+
+ sot-tools = self.callPackage ./sot-tools {};
 
  sparse-bundle-adjustment = self.callPackage ./sparse-bundle-adjustment {};
 

--- a/distros/noetic/hector-localization/default.nix
+++ b/distros/noetic/hector-localization/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hector-pose-estimation, hector-pose-estimation-core, message-to-tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-localization";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_localization/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "52d0f3a992929764e42fdd81bbe55db731b3df7d6ee55e15a516fd2d764fb31c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hector-pose-estimation hector-pose-estimation-core message-to-tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The hector_localization stack is a collection of packages, that provide the full 6DOF pose of a robot or platform.
+    It uses various sensor sources, which are fused using an Extended Kalman filter.
+
+    Acceleration and angular rates from an inertial measurement unit (IMU) serve as primary measurements.
+    The usage of other sensors is application-dependent. The hector_localization stack currently supports
+    GPS, magnetometer, barometric pressure sensors and other external sources that provide a geometry_msgs/PoseWithCovariance
+    message via the poseupdate topic.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hector-pose-estimation-core/default.nix
+++ b/distros/noetic/hector-pose-estimation-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geographic-msgs, geometry-msgs, nav-msgs, rosconsole, roscpp, rostime, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-pose-estimation-core";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_pose_estimation_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "82bcb640addfa021a8bd61913060f27e9e2827ddef0f6c9d41fe6664c1ce96ed";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ eigen geographic-msgs geometry-msgs nav-msgs rosconsole roscpp rostime sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''hector_pose_estimation_core is the core package of the hector_localization stack. It contains the Extended Kalman Filter (EKF)
+    that estimates the 6DOF pose of the robot. hector_pose_estimation can be used either as a library, as a nodelet or as a standalone node.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hector-pose-estimation/default.nix
+++ b/distros/noetic/hector-pose-estimation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-pose-estimation-core, message-filters, nav-msgs, nodelet, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-pose-estimation";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_pose_estimation/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "063f74d15fd503381172f8811622a54def961b5372b423807a181f7c012d9edf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs hector-pose-estimation-core message-filters nav-msgs nodelet sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''hector_pose_estimation provides the hector_pose_estimation node and the hector_pose_estimation nodelet.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-ortho-projector/default.nix
+++ b/distros/noetic/laser-ortho-projector/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-filters, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-laser-ortho-projector";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_ortho_projector/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "9f40b03eae8a2194ec41a9a803ca9305d0ee905be908d2ebac11ba6dcfb80349";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_ortho_projector package calculates orthogonal projections of LaserScan messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-scan-matcher/default.nix
+++ b/distros/noetic/laser-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, csm, geometry-msgs, nav-msgs, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-matcher";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_matcher/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6000f160af9d500dc98962fe003cc963573abbcec0bc7d7a0b6092896c49d285";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ csm geometry-msgs nav-msgs nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+     An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher (CSM) implementation. See <a href="http://censi.mit.edu/software/csm/">the web site</a> for more about CSM. NOTE the CSM library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/noetic/laser-scan-sparsifier/default.nix
+++ b/distros/noetic/laser-scan-sparsifier/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-sparsifier";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_sparsifier/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "5afafd970b7168c341b18704b5592f793957f9d08870509ab3e46922d6f79741";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_sparsifier takes in a LaserScan message and sparsifies it.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-scan-splitter/default.nix
+++ b/distros/noetic/laser-scan-splitter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-splitter";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_splitter/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e2232be64fc25cc003de31a38c986fe4104262f07fabe7de66f33e676463404c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_splitter takes in a LaserScan message and splits it into a number of other LaserScan messages. Each of the resulting laser scans can be assigned an arbitrary coordinate frame, and is published on a separate topic.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "76d377568bad346652d1e6b01850e99fc213bd84bba3dbeb0fb659bd58512662";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "ef871b7674836b36b46dae524788b9625c99fb2f7f2d99950e03c1cb81ce1afc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "780ad7a395eea6fe77921563d6c0eaa1db48a66c9ec09beff0d19cc98a22d2a4";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "850d0729ca79fa340f020894279f3474f80b7476c349cbafde239a25f1fb2b1d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libuvc-ros/default.nix
+++ b/distros/noetic/libuvc-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libuvc-camera }:
+buildRosPackage {
+  pname = "ros-noetic-libuvc-ros";
+  version = "0.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/libuvc_ros-release/archive/release/noetic/libuvc_ros/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "b2da80d64e704f65aa4833edcc0c34868326d9cae3a32ededd99a3202ac9a790";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libuvc-camera ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''libuvc_ros metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.2.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "6e9fd280eaa921e379a5efa2b25471a7d037c80f15599b0a6f270bf3d7385af1";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.2.15-1.tar.gz";
+    name = "2021.2.15-1.tar.gz";
+    sha256 = "2e3a9bf8aa8d650a38e77994d01e4d717a151292f47638152c0c131e39b5aaa1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e28b9a52c0adda80b2d63af468cc283a4f10b97c4469d663efcc0deb80c3ad5b";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "126858018a7517646e615ca4226809ff158549e8681808de540bfcb0e98af950";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e9ae4fdf0e182562d0f31ecd6b456bb48714c09c0b9c719761fe17209cb55039";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "a5c00f6560de7f60c447a47210774af37d7f21c2bd4c7bc657ca78677300eaa3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "ee8e6e0bf786a042779c6d5dcfacb51840bb4330daad9497ed26cea28151cef8";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "61b74992d49a6ddd1aca85e5294ee11e265251807e71142b665ce1cdd23945cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-to-tf/default.nix
+++ b/distros/noetic/message-to-tf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-message-to-tf";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/message_to_tf/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fedfa6c5ab7ac1807512c9cbe4047d165fada0658fbf612b4fcef8397d3d4c11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs tf topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message_to_tf translates pose information from different kind of common_msgs message types to tf. Currently the node supports nav_msgs/Odometry, geometry_msgs/PoseStamped and sensor_msgs/Imu messages as input.
+    The resulting transform is divided into three subtransforms with intermediate frames for the footprint and the stabilized base frame (without roll and pitch).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/move-base-sequence/default.nix
+++ b/distros/noetic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-move-base-sequence";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/noetic/move_base_sequence/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b3dc4489b880f87708249280f6b9eb3b5fb7b6b827563cec478326fad010a6ad";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/ncd-parser/default.nix
+++ b/distros/noetic/ncd-parser/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-ncd-parser";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/ncd_parser/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "b407bd8c0f11e9d1098373daaaaeca94fe2cddd7e05b0db427287a83ff880782";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ncd_parser package reads in .alog data files from the New College Dataset and broadcasts scan and odometry messages to ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/octomap/default.nix
+++ b/distros/noetic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-octomap";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "c77e3e57696d76a69bd4c6fa731b14dcce92eb63c7db6675d8b841ca816714fc";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "8c374f5ef014c9d5496aa7bccb496dba458a5ce2c4d3ace2d6f4c4104cda3296";
   };
 
   buildType = "cmake";

--- a/distros/noetic/octovis/default.nix
+++ b/distros/noetic/octovis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-noetic-octovis";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "feb098684affecd77636c6992084628036bf9101a41a42438723bb855b77401a";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "6fb47ca3b08da643c13d00d9a7c0ecd5454ddb05ab30247bd9bf753d69701713";
   };
 
   buildType = "cmake";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
+buildRosPackage {
+  pname = "ros-noetic-opw-kinematics";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "22a484c86d5a90211d3f76f4ce7c77da3820c4810b7b95568ec89daaec7e54af";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A simple, analytical inverse kinematic library for industrial robots with parallel bases and
+    spherical wrists. Based on the paper &quot;An Analytical Solution of the Inverse Kinematics Problem
+    of Industrial Serial Manipulators with an Ortho-parallel Basis and a Spherical Wrist&quot; by
+    Mathias Brandstötter, Arthur Angerer, and Michael Hofbaur.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/people-msgs/default.nix
+++ b/distros/noetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-people-msgs";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "0fc16f697e58974184b80ffbd67d294db3548012597e9803d4093dd7cb282e25";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "23c5aadea89b2d9eb9f8f5bc712313ef205a9db3844d47f25bfe5e167525b840";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people-velocity-tracker/default.nix
+++ b/distros/noetic/people-velocity-tracker/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, people-msgs, roslib, roslint, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-noetic-people-velocity-tracker";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "9ce69647385152fc6877470b7f1aa545a3ce53e3c639cc71f474e8ad3357f1bf";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "e01129e7da9a70ca43d9612728c1f44677c8ab050f5af95dc246abbf4f3e64b7";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint ];
-  propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter people-msgs roslib rospy ];
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/people/default.nix
+++ b/distros/noetic/people/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, people-msgs, people-velocity-tracker }:
+{ lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-noetic-people";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "95a6dbcd69d0e0556b34ff693ed87b1a596118ddf9d147e43c071617391696ed";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "38081a790261ca2b7dc8a6ab0fed886eb53c401af72e5c805aa2c8388d96391c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ people-msgs people-velocity-tracker ];
+  propagatedBuildInputs = [ face-detector leg-detector people-msgs people-tracking-filter people-velocity-tracker ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/polar-scan-matcher/default.nix
+++ b/distros/noetic/polar-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-polar-scan-matcher";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/polar_scan_matcher/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "3e7d8367dfee2ad64dade2bb79db331c814c1a4f594c09eb41fc3f1263cf9833";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+    A wrapper around Polar Scan Matcher by Albert Diosi and Lindsay Kleeman, used for laser scan registration.
+    </p>'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "4be92ffa0206116943937ab207c0b081ec67add33ab6ca7458a81ce1cc51653c";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "08c5d55e48d1152bcf20bdad3b6b0ff77c72e3cd79ddce93bc4f5c078b03409f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "4ea4c7835c28db3bdfe100680f24d3464555e782d8e281eefe405b10dbc03f8e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "641098008e6d40aaee4fd97dfc77164cbb4b074b48d615cebf6319a854253494";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-controllers-interface/default.nix
+++ b/distros/noetic/robot-controllers-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pluginlib, robot-controllers-msgs, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers-interface";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers_interface/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "2aefb653301e9f46d2d82c4a26dd10a4d8c9e28342899429c90490e854122c7a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pluginlib robot-controllers-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic framework for robot controls.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-controllers-msgs/default.nix
+++ b/distros/noetic/robot-controllers-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers-msgs";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b715c23f4e9e5732c317cb39f76d0bff7981d28d2671005d9f6aa6353c036ca1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for use with robot_controllers framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-controllers/default.nix
+++ b/distros/noetic/robot-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-parser, nav-msgs, orocos-kdl, pluginlib, robot-controllers-interface, roscpp, sensor-msgs, std-msgs, tf, tf-conversions, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "cd13b537617dbdb7619f16bb991be69f9106df73970c9429dede5db6430ce1ae";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs control-msgs geometry-msgs kdl-parser nav-msgs orocos-kdl pluginlib robot-controllers-interface roscpp sensor-msgs std-msgs tf tf-conversions trajectory-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Some basic robot controllers for use with robot_controllers_interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros-control-boilerplate/default.nix
+++ b/distros/noetic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-ros-control-boilerplate";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/noetic/ros_control_boilerplate/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "008938614602fb9b50ad8bae0d0dc5a8526179bba7509f03d45d77e1fbf727fa";
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/noetic/ros_control_boilerplate/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "41db741a7cbc512777dc79ee4457457394989c4c367296f68fa4a79c0d9983ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag-plugins/default.nix
+++ b/distros/noetic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag-plugins";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0a79f66d0f2f1eea4e5aa1f8ce9070d06ac7e3b3ce90cf683da9d77a7d1596c4";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "b6bfae17347d4d64fa1b40bc3663d4cb4a8fef9de8aa2b1e3138c4394561b6cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag/default.nix
+++ b/distros/noetic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "6d6231e94ceedf1940d5b0a80d302b420f2536e5c243bfd1660a41bb39e804bb";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "864c0851f8c2a470246555831630a5d7108ad76bde6e9fd5775113b35e722e8d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-plot/default.nix
+++ b/distros/noetic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-plot";
-  version = "0.4.12-r1";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "ec87f7987fbfd36412dec72aa8c840e5ee5aea7ae8dc330843828e4b533590fe";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "8507faa21362446af958f585d33f525dcc308af701462a4645fd07785bf8aa39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scan-to-cloud-converter/default.nix
+++ b/distros/noetic/scan-to-cloud-converter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl, pcl-conversions, pcl-ros, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-scan-to-cloud-converter";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/scan_to_cloud_converter/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "005fe4afd4fcd083d4dab47ef1cc4d0eb151b02829ae642921eab81068cbe276";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pcl pcl-conversions pcl-ros roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts LaserScan to PointCloud messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/scan-tools/default.nix
+++ b/distros/noetic/scan-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-ortho-projector, laser-scan-matcher, laser-scan-sparsifier, laser-scan-splitter, ncd-parser, polar-scan-matcher, scan-to-cloud-converter }:
+buildRosPackage {
+  pname = "ros-noetic-scan-tools";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/scan_tools/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "31cb07d1a7024f28b127689d2c323ff38b1293cc629dab21f068d706424e3bfa";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laser-ortho-projector laser-scan-matcher laser-scan-sparsifier laser-scan-splitter ncd-parser polar-scan-matcher scan-to-cloud-converter ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Laser scan processing tools.'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.4-r1";
+  version = "4.11.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-1.tar.gz";
-    name = "4.11.4-1.tar.gz";
-    sha256 = "a6cfbdcf769d02193be0e56cee7fdf5a6acede7fd4f00a2f6b3b276f1f363cf8";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-3.tar.gz";
+    name = "4.11.4-3.tar.gz";
+    sha256 = "86254a36195818093461ccf5817fc66b08d05582d8d6ada5e7d43b45b218ed9f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sot-tools/default.nix
+++ b/distros/noetic/sot-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
+buildRosPackage {
+  pname = "ros-noetic-sot-tools";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5cd8cbd6e819505af7dc8b6e5eb2d08d79927bbe1791fb52d76ddce29b9eac7e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ catkin dynamic-graph-python sot-core ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Miscellanous entities for the stack of tasks'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "f29268717566d7c3cf94e55c2cf01105b112f0830a5e44d82674444a3aa82cc4";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "aaa59cfe3cd6399b7973da80cb806b833e032b4fcb54301e067c24e16c446a3a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-description/default.nix
+++ b/distros/noetic/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-description";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "47a189a291e43123e41f453a07c2ac2717d82e53f30975738171e0542e61022f";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "255d082bfdf62a6556c1405d9cc31bae5f1f0099cd497d64741716357881a420";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-gazebo-plugins/default.nix
+++ b/distros/noetic/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-gazebo-plugins";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "dfc2984ce676713530285a72bbad74953428520f4f828232367535df3743b731";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "756f181dd70579c0923f254a8031d73ed71f21fb9a24316abdc35b0bfff98d52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-simulator/default.nix
+++ b/distros/noetic/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-simulator";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "7babe2f16292fc4d8119d674252c07005b380679e2413328644a968dae139148";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "34810fce2fce720cad0500c5fdd58403e9774cbbbb04520cabb886029b20e035";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit cff345f1dc1a3ada3be82e8456ce2ab73be03198.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *rqt-reconfigure 1.0.6-r1 --> 1.0.7-r1*
* *turtlebot3-fake-node 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-gazebo 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-simulations 2.2.1-r1 --> 2.2.2-r1*

Foxy Changes:
-------------
* *contracts-lite-vendor 0.4.1-r1 --> 0.5.0-r1*
* *fastrtps 2.0.2-r1 --> 2.0.2-r2*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *mavlink 2021.2.2-r1 --> 2021.2.15-r1*
* *ntpd-driver 2.0.1-r1*
* *realsense2-camera 3.1.3-r1 --> 3.1.4-r1*
* *realsense2-camera-msgs 3.1.3-r1 --> 3.1.4-r1*
* *realsense2-description 3.1.3-r1 --> 3.1.4-r1*
* *ros2bag 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-compression 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-converter-default-plugins 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-cpp 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-storage 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-storage-default-plugins 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-test-common 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-tests 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-transport 0.3.6-r1 --> 0.3.7-r1*
* *rqt-reconfigure 1.0.6-r1 --> 1.0.7-r1*
* *shared-queues-vendor 0.3.6-r1 --> 0.3.7-r1*
* *sqlite3-vendor 0.3.6-r1 --> 0.3.7-r1*
* *turtlebot3-fake-node 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-gazebo 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-simulations 2.2.1-r1 --> 2.2.2-r1*
* *zstd-vendor 0.3.6-r1 --> 0.3.7-r1*

Kinetic Changes:
----------------
* *face-detector 1.1.3-r1 --> 1.4.0-r2*
* *heron-control 0.3.3-r1 --> 0.3.4-r1*
* *heron-description 0.3.3-r1 --> 0.3.4-r1*
* *heron-gazebo 0.3.0-r1 --> 0.3.2-r1*
* *heron-msgs 0.3.3-r1 --> 0.3.4-r1*
* *heron-simulator 0.3.0-r1 --> 0.3.2-r1*
* *leg-detector 1.1.3-r1 --> 1.4.0-r2*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *mavlink 2021.2.2-r1 --> 2021.2.15-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *mocap-optitrack 0.1.0-r1*
* *move-base-sequence 0.0.1-r6*
* *people 1.1.3-r1 --> 1.4.0-r2*
* *people-msgs 1.1.3-r1 --> 1.4.0-r2*
* *people-tracking-filter 1.1.3-r1 --> 1.4.0-r2*
* *people-velocity-tracker 1.1.3-r1 --> 1.4.0-r2*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *ros-control-boilerplate 0.4.1 --> 0.4.2-r1*
* *rqt-plot 0.4.8 --> 0.4.13-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*

Melodic Changes:
----------------
* *async-web-server-cpp 1.0.2-r1 --> 1.0.3-r1*
* *face-detector 1.2.0-r1 --> 1.4.0-r4*
* *heron-control 0.3.3-r1 --> 0.3.4-r1*
* *heron-description 0.3.3-r1 --> 0.3.4-r1*
* *heron-gazebo 0.3.0-r1 --> 0.3.2-r1*
* *heron-msgs 0.3.3-r1 --> 0.3.4-r1*
* *heron-simulator 0.3.0-r1 --> 0.3.2-r1*
* *leg-detector 1.2.0-r1 --> 1.4.0-r4*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *mavlink 2021.2.2-r1 --> 2021.2.15-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *move-base-sequence 0.0.1-r2*
* *people 1.2.0-r1 --> 1.4.0-r4*
* *people-msgs 1.2.0-r1 --> 1.4.0-r4*
* *people-tracking-filter 1.2.0-r1 --> 1.4.0-r4*
* *people-velocity-tracker 1.2.0-r1 --> 1.4.0-r4*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *ros-control-boilerplate 0.5.0-r1 --> 0.5.1-r1*
* *rqt-bag 0.5.0-r1 --> 0.5.1-r1*
* *rqt-bag-plugins 0.5.0-r1 --> 0.5.1-r1*
* *rqt-plot 0.4.9 --> 0.4.13-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*
* *velodyne-description 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-gazebo-plugins 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-simulator 1.0.10-r1 --> 1.0.11-r1*

Noetic Changes:
---------------
* *dynamic-edt-3d 1.9.6-r1 --> 1.9.6-r2*
* *dynamic-graph 4.3.3-r1 --> 4.3.3-r4*
* *dynamic-graph-python 4.0.2-r1 --> 4.0.2-r3*
* *dynamic-graph-tutorial 1.2.2-r1 --> 1.3.2-r1*
* *eml 1.8.15-r3*
* *face-detector 1.4.0-r1*
* *fetch-auto-dock-msgs 1.2.0-r1*
* *fetch-driver-msgs 1.2.0-r1*
* *fetch-open-auto-dock 0.1.3-r2*
* *hector-localization 0.4.0-r1*
* *hector-pose-estimation 0.4.0-r1*
* *hector-pose-estimation-core 0.4.0-r1*
* *laser-ortho-projector 0.3.3-r1*
* *laser-scan-matcher 0.3.3-r1*
* *laser-scan-sparsifier 0.3.3-r1*
* *laser-scan-splitter 0.3.3-r1*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *libuvc-ros 0.0.11-r1*
* *mavlink 2021.2.2-r1 --> 2021.2.15-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *message-to-tf 0.4.0-r1*
* *move-base-sequence 0.0.1-r1*
* *ncd-parser 0.3.3-r1*
* *octomap 1.9.6-r1 --> 1.9.6-r2*
* *octovis 1.9.6-r1 --> 1.9.6-r2*
* *opw-kinematics 0.4.0-r1*
* *people 1.2.2-r1 --> 1.4.0-r1*
* *people-msgs 1.2.2-r1 --> 1.4.0-r1*
* *people-velocity-tracker 1.2.2-r1 --> 1.4.0-r1*
* *polar-scan-matcher 0.3.3-r1*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *robot-controllers 0.7.0-r1*
* *robot-controllers-interface 0.7.0-r1*
* *robot-controllers-msgs 0.7.0-r1*
* *ros-control-boilerplate 0.6.0-r1 --> 0.6.1-r1*
* *rqt-bag 0.5.0-r1 --> 0.5.1-r1*
* *rqt-bag-plugins 0.5.0-r1 --> 0.5.1-r1*
* *rqt-plot 0.4.12-r1 --> 0.4.13-r1*
* *scan-to-cloud-converter 0.3.3-r1*
* *scan-tools 0.3.3-r1*
* *sot-core 4.11.4-r1 --> 4.11.4-r3*
* *sot-tools 2.3.3-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*
* *velodyne-description 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-gazebo-plugins 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-simulator 1.0.10-r1 --> 1.0.11-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] fmt
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] ipython3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-grpc-tools
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-msgpack
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyaudio
 * [ ] python3-pymongo
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-simplejson
 * [ ] python3-termcolor
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

