### PR TITLE
rosdistro sync, Sat Mar  6 02:47:22 2021

### DIFF
--- a/distros/dashing/fastrtps/default.nix
+++ b/distros/dashing/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-dashing-fastrtps";
-  version = "1.8.4-r1";
+  version = "1.8.4-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/dashing/fastrtps/1.8.4-1.tar.gz";
-    name = "1.8.4-1.tar.gz";
-    sha256 = "33b7d2d637ca29c50429d2dd8f44f7acff7583a5762780c13819cc0eebc496ab";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/dashing/fastrtps/1.8.4-3.tar.gz";
+    name = "1.8.4-3.tar.gz";
+    sha256 = "824613176c8bf6fd47fe37c4d3a7a9181eda87e5db22b651886a87338141ddba";
   };
 
   buildType = "cmake";

--- a/distros/dashing/rclc-examples/default.nix
+++ b/distros/dashing/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclc-examples";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc_examples/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "2d5d516d627014a8f25ff7f2106f122ede33da239f5d77f001f6c6e77a92104e";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "5a1912f28f67cafb506d8609ef2c6383f5d09fbd0b5c3ea2dffc6011d08a399c";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclc-lifecycle/default.nix
+++ b/distros/dashing/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-dashing-rclc-lifecycle";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc_lifecycle/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "1672471c46e3b897ce78919ce581a1e7d7f8485b2fc7eebd43dfcda90e49db62";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc_lifecycle/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "a5881f4b4e139323a3a63bf2527b7d3b05ffc4341fd63aeb8bbeca562555bcc2";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rclc/default.nix
+++ b/distros/dashing/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-dashing-rclc";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "b7721bb8a1d31811186e3a0fc7ec58494fbc78d7b2e6de34735dd3ea08a170aa";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/dashing/rclc/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3ea70814f5760ad0ff02989460b5da2c8ed7bd2dbc1d3efb1817cf598a753387";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/rqt-reconfigure/default.nix
+++ b/distros/dashing/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-dashing-rqt-reconfigure";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/dashing/rqt_reconfigure/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "49bf8bf8e7406d4e8f696328d02412132105e33cdc1fe7f09a055e73f30d35c5";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/dashing/rqt_reconfigure/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a05a92faa48019e57e6a95956612f10d2f61ffdcf72c9fa4a5f89136bf540087";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/turtlebot3-fake-node/default.nix
+++ b/distros/dashing/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-fake-node";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_fake_node/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "b8e4012f0c132ca25b72edc6eaa5c3a1fd4fa8eef7f99ab9e1048175a7768fd4";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_fake_node/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "4ec191f0a14cd58a8bad3d2abcf2a1ab2a0e4cb065cc636c301d6c630bcaa753";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/turtlebot3-gazebo/default.nix
+++ b/distros/dashing/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-gazebo";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_gazebo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "f9d883c497b96843ec4d4b12db694ff062a5817c3703cdcfd5156b99d72bec5f";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "33c47c80fee3b6bdf32bd5a6f8c48a4ffb75030455b4308406c5071b9a4dae6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/turtlebot3-simulations/default.nix
+++ b/distros/dashing/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-dashing-turtlebot3-simulations";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_simulations/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a02d21996dc765f43c036e03255ca4a7e3d4d3a745a2e46a424c791efe8c01b9";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/dashing/turtlebot3_simulations/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "3616377a1d32e5e885eeaf869b02a7378c3559246ea81eae5dde099d42a49ecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/xacro/default.nix
+++ b/distros/dashing/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-xacro";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "0ada324dbe09600c9700687752f7885cab696de06a8438e0d624c0bf2d522a23";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "577b7d1a594c81c114317cd310738aefa3ea8a28c3adc7a72a1c6dcae3144ead";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/contracts-lite-vendor/default.nix
+++ b/distros/foxy/contracts-lite-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-contracts-lite-vendor";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "98016a6194f9b9f14872d2223776144370788f0247391886046d2735ed0635c8";
+    url = "https://github.com/ros-safety/contracts_lite_vendor-release/archive/release/foxy/contracts_lite_vendor/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "14ea41bbb384648b7195fb8adc8c2bc7e4883bc6ea9622f462790632c1e87e22";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "156744121274b37e535b5a60a4ebffc6c116793f90514ae4992d8c27e329602a";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "de6215623e70a5cb2f47677d879c449ce57405180ffd1ac05f9b460e0aa56552";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "34050b6ee19dbbd64e9800341af5258f37bad0650fb5546a8eefd3e63114137f";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "7ebcc029faa0fc742c68a97a422a069abd6b2b96ca145417c0bc622dd1e5f95d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, rclcpp, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "8f53aca102ba02f3b72b8831474e2c4e34ab2d9fd05ac63b3767ca75458c7656";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8e47d3e5320e4adf8be2d46c03bb7e933bfe5dba295cf7a0ec113d181d239791";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-aggregator/default.nix
+++ b/distros/foxy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-aggregator";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "6c492b0fc6be6791546eaf9a84278867db28ffebc189bdce6bef28c0880e6cbc";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "36f9ceeb869ae722d3f1ba5c8c486fe7165e4b963d8a28e17d653a3049795c43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-updater/default.nix
+++ b/distros/foxy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-updater";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "7c949bd3da3e4ae19176f42a448dee2a28453c0f10a5ac56e7783db72307e531";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "83d7525f87936c881a6328abb045af63d9de7a91e71ddd185207be85b0ea7601";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.2-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "ed5b0af5ca9257b9b83f527ff2e835da45153e74f405d64a08be2980deaee420";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "f503676f1f84b55b0b5d89c90257b93870cc519391b17c2f4642470c72a44e3d";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -716,6 +716,8 @@ self: super: {
 
  novatel-gps-msgs = self.callPackage ./novatel-gps-msgs {};
 
+ ntpd-driver = self.callPackage ./ntpd-driver {};
+
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
  octomap = self.callPackage ./octomap {};

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "b501141645cca3aa1a875ed09586c75aecd81c1f65e741f85589ade72c219a9d";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "f1a4f068c89d1feba5d3a41382fa403079e392cf8a7287bf49351a6f755b9859";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "68a97494e0d6ea89366c6ceebc27306bc3bf2b0b163360ade505a8f918b1c0d3";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "4bf17bb40850d0130541079431abded90c270976d6c39ad680ec821394ff22bf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "ac3424248eb63e6e02649d8ce2ac51b6500e67006e60f3599ea83ac7e791d3fd";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.3.3-1.tar.gz";
+    name = "2021.3.3-1.tar.gz";
+    sha256 = "190624eca5a37550ddd648887adacedbd8025ca9dd7d97c7f74f77d4dd27d1ce";
   };
 
   buildType = "cmake";

--- a/distros/foxy/ntpd-driver/default.nix
+++ b/distros/foxy/ntpd-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, poco, rclcpp, rclcpp-components, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-ntpd-driver";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/vooon/ntpd_driver-release/archive/release/foxy/ntpd_driver/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4d39b8402566ab65301a49eea80a7d29f65d0fb8cf896a5dcaba770b3c00519d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ class-loader poco rclcpp rclcpp-components sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ntpd_driver sends TimeReference message time to ntpd server'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rc-genicam-api/default.nix
+++ b/distros/foxy/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-api";
-  version = "2.4.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "a6391e42c080f4b9437d6364da972c53fee6674576e4f47e4eac3fa84fa31202";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "bb26ba22885c4fa58e28dfb71fb879cf703761eab6d789efb4daff2d22a08b1e";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rclc-examples/default.nix
+++ b/distros/foxy/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclc-examples";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_examples/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "b0823127bf5d89f15e9b6b66c81b274ef114aaf1a96c9b0b671d7533d0863e0a";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "095d08ea05eb55fe47eb587f0768c8d2eff9c913a1fa955bc774092e1d02f945";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclc-lifecycle/default.nix
+++ b/distros/foxy/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-foxy-rclc-lifecycle";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_lifecycle/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "a40fdc73c4c9f97f6abd00b8ba151e4ab1422306079913fd278388efcda7aa59";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_lifecycle/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "15b2a1f47b2f5f47acb4041352525b7d73b64206b2cd4a2c79ffc501d8089d70";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclc/default.nix
+++ b/distros/foxy/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclc";
-  version = "0.1.7-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "ae613e0d60080465fd519e985c62121e95a41f0a00603a1a3e4117968f768aa5";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1a910dedc390f603316b41c67f01a0d2361b247430a9de6cc86ebd5b70596044";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "31b0002a94b50db20ee4b0eb579898d4d950e94c243746d162c459e80d4d0327";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "62a5482d872bfec6b880b5b8d79a01502541bf873076b9c33ea50d9be52546cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, diagnostic-updater, eigen, geometry-msgs, image-transport, launch-ros, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "38a40ec949b46dc7e8e7f54c517fe2c636a050eae425265f0fde9535a79f77bb";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "7ebb01ce220b9af81dd8592eb0207891fc000249921c0d455aa677a6fbf69d04";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.1.3-r1";
+  version = "3.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.1.3-1.tar.gz";
-    name = "3.1.3-1.tar.gz";
-    sha256 = "6a44440f3abc7e9830caa61259241358e451a63a4bc0f68da9cd66c71ef20124";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.1.4-1.tar.gz";
+    name = "3.1.4-1.tar.gz";
+    sha256 = "83c10f575bb5616e743d1337d24dfd230b6b114aabeea4e283b7f66cdaaf1f4e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "095e4b47a5e4964e6de046fac70e86b2ab2c0524fd270d6c679e1515c0dc30dd";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "b1b96e096dc5c62440c7aa6295374c76c8d6a13814a244b0609b55979222c95a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "9f1305546222300cf7f0ec3bc6689b43272274c5f91ff2752933edae2f765276";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "e1fac79247c73f151a609fed30b696ecae68a1e80821e1924d445a2977bbb899";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2bag/default.nix
+++ b/distros/foxy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-foxy-ros2bag";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "b2a42fd7131025033010daa064db13ecbd7b17d549d15b044f1c48b5a2816c7e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "c1f119bc19d6aaec54d67f22543f4194184cc0e8e9691ab5bc45277fac9ec1c8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "fc30166757a5aa5e5cf76963e759bd910815594f045ede6a9f5b8212d161695e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "c740f78393ab15fd1d944ced255513a34025749da0396e744fc627a573ec82f5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-compression/default.nix
+++ b/distros/foxy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-compression";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "fabd90fdb34ec1a2d78ab99d64a51247eb11d5ab984053547b052aeed853fb75";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "4e5ad66b1101e9033790c0de6176592224306da2b2baa4b16616305af2628212";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-converter-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-converter-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rmw, rmw-fastrtps-cpp, rosbag2-cpp, rosbag2-test-common, rosidl-runtime-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-converter-default-plugins";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "7ced6a7668fcf83e9c0d77f76152bf319616214a93711c0269c74ae57ef81c3e";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "cdc8e0eb24507b17d35901dcbef059ddfe5fd0693d4ed4a05f479411cb9fa9dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-cpp/default.nix
+++ b/distros/foxy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-cpp";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "f05bec85974fe54e7bb36759892dd0ec9d55922d0e31fc8d6a494855f2dd216c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "44f309ee0baa98bb78e1a3671157c1f277dc7fe5dfcd3f4b4ddedd087ebdd7b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-default-plugins";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "e6dc64d046beb7323d98c6ca267f03a4e80d70aa5b9b8c29aed963469d32ee2a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "c85a806a2d9993d37c1a2fe9d3a4d44eee50500a68edd1f8ed7af759ee7a33d2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage/default.nix
+++ b/distros/foxy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "8ce2c4d5eefe8f1fb4f6132b56bffe3ce209cc686b9df11d1ac13950627a7d00";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "adfc0c2cdc07d5d5e217106eeae1045fc8784754893571f246be540ceaa7a10f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-test-common/default.nix
+++ b/distros/foxy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-test-common";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "09ecc028f22225b452e2c1833e7c3ab2083b5c23482e63b78e21dda44f3e39bb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "31801b834882ef8140cad8a72b4e8c550797087d3972119cf0a3a8f9b9fda48b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-tests/default.nix
+++ b/distros/foxy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-tests";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "86f52cc64f52b17796cd00aa53d4c72d4a20b0a47c5371b411f5c58702748438";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "1821b3f30a46de5947f6e5e241b0e472d07cf61043a152d05634da675ee88985";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-transport/default.nix
+++ b/distros/foxy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, rpyutils, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-transport";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "b261e9a001b958150934ab8815762f0500e2387e5271670f70e0e0c189ff8576";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "b60ba321facfe5c320a584f0be99f8ee610a24d5a8ba30e8461882ffcc5c7d30";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2/default.nix
+++ b/distros/foxy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "d6cf17ff1a0adc012bf7ff4c3a4362c0e2c7c2e7620d0c283c3a273be6869c25";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "3615c2633742f8fb39d2515ce258d17331c794661142e6e4135643621418a2fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-plot/default.nix
+++ b/distros/foxy/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rqt-plot";
-  version = "1.0.8-r1";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.0.8-1.tar.gz";
-    name = "1.0.8-1.tar.gz";
-    sha256 = "02e8ed9477db59e78f14ebe9944d7f0e61abf475be23438c09aa2837db06f9f4";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "956100cd548a6540b7311f68d0da39e3d5c22588ae1ef93ee769e69c0388916c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-reconfigure/default.nix
+++ b/distros/foxy/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-reconfigure";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "78760bd8d3c72cbb27930460470dffd1394c29f1b9488e466281435fe970c6cd";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "db98b17e679c17aee40633d7fb3ff0473b9e94b925ebaf2979d6a04d9eb37858";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/self-test/default.nix
+++ b/distros/foxy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-self-test";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "800861e2dafa8762833a4cb1fa1cb56b3045c458e30182528b6cf1f5179baca8";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "a65c4f1449ab6dfecfe242367fe13ec976c74487b279ad1550c971ea572c4ac8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shared-queues-vendor/default.nix
+++ b/distros/foxy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-shared-queues-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "35e613f26a58d6db78fa22530fc0b6270d4089432c71ad52c9ed4f667fd0a349";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "edc644c9982602ab644b676900819cd3ae7d318d9877a352a9dc01186a463afa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sick-safetyscanners2/default.nix
+++ b/distros/foxy/sick-safetyscanners2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
 buildRosPackage {
   pname = "ros-foxy-sick-safetyscanners2";
-  version = "1.0.0-r2";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.0-2.tar.gz";
-    name = "1.0.0-2.tar.gz";
-    sha256 = "8151a4349dfb65f1f2202dd5ae40d8b217bb13cd9e9d3833cbd0b8253f96f77c";
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "5847246ad4523ae0563e881b7fc6fb37071eddee47283a9b89b5b102f59da3af";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sqlite3-vendor/default.nix
+++ b/distros/foxy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-foxy-sqlite3-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "345a8ac8a2a8076518ea4b93cb138574378c394d9293897de289ee81b540cbdb";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "5fecf846cf536ebf09b6463103e80e99d3b2f2abae683dc7b19f98037df0b8af";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "6c43b307ed5fede0bcecfe6f03c9c11076fcae39db4d76fcd630ec12b48ec75e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2d6c7027294e35fd144f7302583bfa06cee47571ea59a932018b200d22ea455e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-fake-node/default.nix
+++ b/distros/foxy/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-fake-node";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "63f57e007e4154cdd7d31014cebcf41ff78cbf30941492fcede8d94262b86476";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "fff9bb4bbb00f9025a2fa3299e9d72b142115b01bd52ae02ed875eb8759664ec";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-gazebo/default.nix
+++ b/distros/foxy/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-gazebo";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "027bf83d55c83aa72352917cbd04393fd5f5cdbe805dcfa887a9c8a9c11fd0aa";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "006fbfb6cb78cff7556e7452b3d6c8207cb77e880b08481127bb0f1ad6528fea";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-simulations/default.nix
+++ b/distros/foxy/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-simulations";
-  version = "2.2.1-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "0b360d856d4582ad57caf0334b32d2d8dc055b4547f96699c3c5b9e6e701a72a";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c75666dd3406bec6dd0490246e77ac6d2dbbb2e6fbbcabe375e49216fcba3b7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/xacro/default.nix
+++ b/distros/foxy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-xacro";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "8587a520398bf2811e889c3dd40a2f3a03ba6476e0bfdbf5e36db88eca05ce05";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "89ed2a540f3b582d58596ef45f2db063ca61dad2710720cd6f405948b118312c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/zstd-vendor/default.nix
+++ b/distros/foxy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-foxy-zstd-vendor";
-  version = "0.3.6-r1";
+  version = "0.3.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "7b0d901a8f4b3f66d7078f15fb3271593be6c6c85cf6d06a6cc4270144713c22";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.7-1.tar.gz";
+    name = "0.3.7-1.tar.gz";
+    sha256 = "4768326423dccd4ac7d044447a78c89cf71acfc2d4840d64c3fffc12c9daa4b7";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/face-detector/default.nix
+++ b/distros/kinetic/face-detector/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslib, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-face-detector";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/face_detector/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "beee8a3d733efcf3121360ea3f3a6c0b73c33f1b988265527c5953eff6addcd0";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/face_detector/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "3dc98f0e26f9bd1d6319d47c5f16155be4799c0f45b516b84c28b4bade3af692";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ rostest stereo-image-proc ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
   propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2382,6 +2382,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-optitrack = self.callPackage ./mocap-optitrack {};
+
  modelica-bridge = self.callPackage ./modelica-bridge {};
 
  mongodb-log = self.callPackage ./mongodb-log {};
@@ -2415,6 +2417,8 @@ self: super: {
  move-base-flex = self.callPackage ./move-base-flex {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
+
+ move-base-sequence = self.callPackage ./move-base-sequence {};
 
  move-base-to-manip = self.callPackage ./move-base-to-manip {};
 

--- a/distros/kinetic/heron-control/default.nix
+++ b/distros/kinetic/heron-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-control";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cb88dca5fcf62f7494ba71d537bcbf28eb2188d889bb7d3e9fb709e6168e64cc";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "adc579ed13b8e3f29bb8962aabe433617fe94f88cf17bafc6e17d3483d7efa25";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-description/default.nix
+++ b/distros/kinetic/heron-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-description";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "01c01835d8ae989155db69b46aee38c0fff65f2cad0c12e92c0fee9d67c581f0";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "ff37a5729512e8cd7f2a7fdecc99b27441a62b165a584144a463c0e0719cfb71";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-gazebo/default.nix
+++ b/distros/kinetic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-kinetic-heron-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f2d064595e670ae9183b6e375003131a6587e5da7edba5620c418dbd2946f372";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "0e06e8db73f76846b64ed20d520eec0c62bc3c790b362bbcf317830cffccfbb5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-msgs/default.nix
+++ b/distros/kinetic/heron-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-heron-msgs";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "5a1c10d556e227adaaa649d6f1fdddd211eea0f65cbb15253b391131de244a07";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/kinetic/heron_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "7a73423506fbf3e3c9843b779164ed5784357b0c05982d7b338126ca323cc4e6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-simulator/default.nix
+++ b/distros/kinetic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-simulator";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "dff15b0a803e1af7bbff9225387964bc4b37c97b1b18336e0939093f84cf527e";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "813bd6c0cc9014071fd82074f863ff1c389f0bba3cc12a175f9490d06a8f7d10";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/leg-detector/default.nix
+++ b/distros/kinetic/leg-detector/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-leg-detector";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/leg_detector/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "4935c2169ea3e899c9d0137c37dcf3d6f9bfb4196c54486cd29f1d90662ab7bd";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/leg_detector/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "791c039d2429226a37eff43c3ee352024626491179f8b2f9dd7a68f9e5ab9287";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl dynamic-reconfigure geometry-msgs image-geometry laser-filters laser-geometry map-laser message-filters people-msgs people-tracking-filter roscpp sensor-msgs std-msgs std-srvs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/libmavconn/default.nix
+++ b/distros/kinetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-kinetic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "20e0249f2ca6f1fc7aa46ba9978ff60e72c1df8b942c7b53d07a02651020e0ba";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "1ad69f90ca883e8e47f145ecc7ac3a69e41744c43f923610206633d507ea701a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "c466edb6377c7b36160bdd386c88ec83c627167986f10b0fb08c3760fde103a7";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "b6e5e80de9dbc2a4d6221d9e231514520da68d72219f1019d004c30e02c26b4f";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/log-view/default.nix
+++ b/distros/kinetic/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ncurses, roscpp, xclip }:
 buildRosPackage {
   pname = "ros-kinetic-log-view";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/kinetic/log_view/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "97fb07d1fa563d28b4535e6b2f7c43b7818a800885cb36796cb6d780a99145e8";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/kinetic/log_view/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "d9ed1334fbd271510b5e34f56ca9f74759ce0025184f3dd880a62310d8805660";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavlink/default.nix
+++ b/distros/kinetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "b1c08ae12e1fd9b619f3b79a46f12ee4b86b7754bbf8fcc43eb8d76c18c3e385";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/kinetic/mavlink/2021.3.3-1.tar.gz";
+    name = "2021.3.3-1.tar.gz";
+    sha256 = "dee06a1432d00385ca8b22832598f6597c3bbb72c6591ba4cebaceb196250c94";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/mavros-extras/default.nix
+++ b/distros/kinetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "bab3135721cd4b25b0ff625f5d0b348c3bf83f5270f83ac552442d8daed44a39";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "53297aaa3085aa51dcb9faa4a98e1cf98626078c3036e98bb6d887ea238b0d03";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros-msgs/default.nix
+++ b/distros/kinetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "0a7f46c5b438dc821431d9a9e023bc87418e72e80b7f84594cb79feb68c37550";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f95fd9bdfa0b3014a45d2c47bbebb0a7e57c3d3b82c87e79a426c02eeb1c3499";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mavros/default.nix
+++ b/distros/kinetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "4aef42c05465841c3401b86f398a50cde8282b5ce53d75d0e8b60be3a05f05f5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "dd056f40b8a909b4e1329801b102525df275a510fc4b33362c287733f60143a5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "2a7f7cc79af9c09e680d6196d9ec76a75f1e181c7b7a267ad92705e039d26eae";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "27950680b89b14dde24561eda4a95bad8c1ef174c374386bc91252f1c81f956d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mocap-optitrack/default.nix
+++ b/distros/kinetic/mocap-optitrack/default.nix
@@ -1,0 +1,40 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-mocap-optitrack";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/kinetic/mocap_optitrack/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "5ae4a7ec067aa4b7e735f1db0c057204707916d9568f1a90b1ad523ee9ac67a5";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs nav-msgs roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Streaming of OptiTrack mocap data to tf
+    <p>
+    This package contains a node that translates motion capture data from an
+    OptiTrack rig to tf transforms, poses and 2D poses. The node receives
+    packets that are streamed by a NatNet compliant source, decodes them and
+    broadcasts the poses of configured rigid bodies as tf transforms, poses,
+    and/or 2D poses.
+    </p>
+    <p>
+    Currently, this node supports the NatNet streaming protocol v3.0
+    </p>
+    <p>
+    Copyright (c) 2013, Clearpath Robotics<br/> 
+    Copyright (c) 2010, University of Bonn, Computer Science Institute VI<br/>
+    All rights reserved.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/move-base-sequence/default.nix
+++ b/distros/kinetic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-move-base-sequence";
+  version = "0.0.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/kinetic/move_base_sequence/0.0.1-6.tar.gz";
+    name = "0.0.1-6.tar.gz";
+    sha256 = "66709c4a6323d7770f03ac43a1a00b126503f3712b2b6ed9cf331dc08ecfbc3b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/kinetic/people-msgs/default.nix
+++ b/distros/kinetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-people-msgs";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_msgs/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "a702db9ce6e5196d9b00e025b069e9be10ebf9f38828b4726569d5e6f4bcdec1";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_msgs/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "0eeaed58e5efe8dc6e0fdfdaf122199edc681055f5f42fba3f8e528709d68c94";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/people-tracking-filter/default.nix
+++ b/distros/kinetic/people-tracking-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-people-tracking-filter";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_tracking_filter/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "dcc5c4c48372f86d64edb2d9fbe200f3bf5990cac1382732b781dc374dae5641";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_tracking_filter/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "f00936d2c829b1bcfbd159e2e45f74d3a806ecaaef61c338ec276dae500a2af2";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl geometry-msgs message-filters people-msgs roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/people-velocity-tracker/default.nix
+++ b/distros/kinetic/people-velocity-tracker/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslib, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-people-velocity-tracker";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_velocity_tracker/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "24595ad999e124490d6648ef5732faa5518d4a45dabe4e58da8a6348cce95bbc";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people_velocity_tracker/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "e9b446cc526b8d32534ae11ae56a7cb3b0133793ddfe4bad11bda507f36f4d81";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/kinetic/people/default.nix
+++ b/distros/kinetic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-people";
-  version = "1.1.3-r1";
+  version = "1.4.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "20e548c7174f57519c1b387f9fb970cd483da33777ae4e34e959bfb54500992b";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/kinetic/people/1.4.0-2.tar.gz";
+    name = "1.4.0-2.tar.gz";
+    sha256 = "74d5128047b88c0c1aae71d57e7386b10197639e1ea69f9c54ca613f5b7d3ca0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "af5f1e1abf290794613308e27960125be401667aa484e699f46358863cd94010";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "4f0c18a8294c6c617c41081d87cf4a9d41eaee84049d08d1d97ab27618ef2cfe";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "1462e7cf5de2d497427586677ee92539cf42db729849b322df26d6da79dbe1ad";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "d60211f7fd3a04701a3073798ebbccda87e9b3fa378ec26ea6ee850a48dd0f91";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/robot-upstart/default.nix
+++ b/distros/kinetic/robot-upstart/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, daemontools, roslaunch, roslint, rosunit, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-robot-upstart";
-  version = "0.3.0";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/kinetic/robot_upstart/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "ec7dae737ea612be27888afd2836acdf4ce2f398afaeddf31a5d27acd687e5dd";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/kinetic/robot_upstart/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "dc09fc57b4f7a187139ccd3c554e4ae12727f8ba2549ea421807fbb23ab7ec16";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rosunit ];
-  propagatedBuildInputs = [ daemontools roslaunch xacro ];
+  propagatedBuildInputs = [ daemontools nettools roslaunch xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/ros-control-boilerplate/default.nix
+++ b/distros/kinetic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-ros-control-boilerplate";
-  version = "0.4.1";
+  version = "0.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/davetcoleman/ros_control_boilerplate-release/archive/release/kinetic/ros_control_boilerplate/0.4.1-0.tar.gz";
-    name = "0.4.1-0.tar.gz";
-    sha256 = "549a61a022dc82b3c28a2fa180a965a35cf74e171e937a56b0e1466dcd2a679a";
+    url = "https://github.com/davetcoleman/ros_control_boilerplate-release/archive/release/kinetic/ros_control_boilerplate/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "65102150a54122d63ba24c22ea5032db8e284d262b7d17c1d1cb600881b237c9";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rospy-message-converter/default.nix
+++ b/distros/kinetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-rospy-message-converter";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "b408446cb6167cb0c3d83ea8cec046971ac82ad84a81baa55057d3f12c094661";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/kinetic/rospy_message_converter/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "d2507792b1bac78c3ddee65d92bf6301a4f329a338a5a80acfcc8dcaab357489";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rqt-plot/default.nix
+++ b/distros/kinetic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-rqt-plot";
-  version = "0.4.8";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/kinetic/rqt_plot/0.4.8-0.tar.gz";
-    name = "0.4.8-0.tar.gz";
-    sha256 = "a5af60dcd95878b5b9cb7c8195cecc9d7ecd88f1666ed22662d6d325acebaf9b";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/kinetic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "7e3019d3d908cdf352a306c6ab1bc6e188578e8c0e65299375fe39034346c255";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/test-mavros/default.nix
+++ b/distros/kinetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "9d5727aacf6cda1224aaec140f67601893a1eb6097ff6a48d3817aed4b1a7f7f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/kinetic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "f7a876b30213b4ddd385d4aa4b0aef07638177e23a31017c49c160f058f6c6ba";
   };
 
   buildType = "catkin";

--- a/distros/melodic/async-web-server-cpp/default.nix
+++ b/distros/melodic/async-web-server-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, openssl, pythonPackages, roslib, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-async-web-server-cpp";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fkie-release/async_web_server_cpp-release/archive/release/melodic/async_web_server_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "6e4642671a9b19d4bcf46d080a17c1873a9d3c40905150d93684eb09d5efd346";
+    url = "https://github.com/fkie-release/async_web_server_cpp-release/archive/release/melodic/async_web_server_cpp/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "f1094d659202fb2ed57ef45efe72c8748e7086c122be0f064e3804657c14d630";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-assets/default.nix
+++ b/distros/melodic/drone-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-drone-assets";
-  version = "1.3.6-r1";
+  version = "1.3.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "0bc0546c4f1ab41f080eea59fecf80e9e239368359f3ddf22693a6db38bd3606";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.7-3.tar.gz";
+    name = "1.3.7-3.tar.gz";
+    sha256 = "ac97d1219300c698c4ee91347f65f3f452f21b40cf9e49cb95e088e440db62c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.3.6-r1";
+  version = "1.3.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "060e7e8c85dd778ba3cf7acb92f1ae1bddf97aef84896cced232e328ba3267a9";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.7-3.tar.gz";
+    name = "1.3.7-3.tar.gz";
+    sha256 = "77d3e15f0fa014cbe4d437a9a12845908c7d03ca9292801b16903d77139610ae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/face-detector/default.nix
+++ b/distros/melodic/face-detector/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslib, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-face-detector";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/face_detector/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "4fc58742d316d190c2cddf54fbfda33d9bcde0cd5fcc80eb6687b083d4fd4874";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/face_detector/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "3e1b62d50cd5401f37c4e8ad3e7af62c315905bc3aebe3681bc7333a07b2b57d";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ rostest stereo-image-proc ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
   propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1284,11 +1284,15 @@ self: super: {
 
  heron-description = self.callPackage ./heron-description {};
 
+ heron-desktop = self.callPackage ./heron-desktop {};
+
  heron-gazebo = self.callPackage ./heron-gazebo {};
 
  heron-msgs = self.callPackage ./heron-msgs {};
 
  heron-simulator = self.callPackage ./heron-simulator {};
+
+ heron-viz = self.callPackage ./heron-viz {};
 
  hfl-driver = self.callPackage ./hfl-driver {};
 
@@ -1633,6 +1637,8 @@ self: super: {
  kinesis-video-msgs = self.callPackage ./kinesis-video-msgs {};
 
  kinesis-video-streamer = self.callPackage ./kinesis-video-streamer {};
+
+ knowledge-representation = self.callPackage ./knowledge-representation {};
 
  kobuki-core = self.callPackage ./kobuki-core {};
 
@@ -1984,6 +1990,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-optitrack = self.callPackage ./mocap-optitrack {};
+
  mongodb-log = self.callPackage ./mongodb-log {};
 
  mongodb-store-msgs = self.callPackage ./mongodb-store-msgs {};
@@ -2011,6 +2019,8 @@ self: super: {
  move-base-flex = self.callPackage ./move-base-flex {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
+
+ move-base-sequence = self.callPackage ./move-base-sequence {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
@@ -2773,6 +2783,8 @@ self: super: {
  ps3joy = self.callPackage ./ps3joy {};
 
  psen-scan = self.callPackage ./psen-scan {};
+
+ psen-scan-v2 = self.callPackage ./psen-scan-v2 {};
 
  px4-msgs = self.callPackage ./px4-msgs {};
 

--- a/distros/melodic/heron-control/default.nix
+++ b/distros/melodic/heron-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, robot-localization, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-heron-control";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_control/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "579c60f33d46897fc2a13ca3d0506c3d94c09bda498cc4417aed3c167d11e536";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_control/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "fd775e78508739fa2e7860a3c9b23c24e37f1b9015a75de364c91693aed01738";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-description/default.nix
+++ b/distros/melodic/heron-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-heron-description";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_description/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "1c381c2f5386fb22014eb10112ba4601c0bb76ac7a37db77e78b162ee6b7877c";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_description/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "8f667197332029beffb8c146923e072566af0eea4a53b913f07843853dfdfa4c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-desktop/default.nix
+++ b/distros/melodic/heron-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, heron-msgs, heron-viz }:
+buildRosPackage {
+  pname = "ros-melodic-heron-desktop";
+  version = "0.0.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/heron_desktop-release/archive/release/melodic/heron_desktop/0.0.3-2.tar.gz";
+    name = "0.0.3-2.tar.gz";
+    sha256 = "9f85ce7a3ac1b2946097bf03585b55b9577ace9bed0bf395ab331ac2749c6f46";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ heron-msgs heron-viz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The heron_desktop metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/heron-gazebo/default.nix
+++ b/distros/melodic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-melodic-heron-gazebo";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "ce6d68691e4895ec7fa2bd83e0623441b5d43503c968ff5106b75101f7e96a5a";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "036573f4c61aa358f8a720804de68b0f1d47af000e109348fef9be4d0001eb6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-msgs/default.nix
+++ b/distros/melodic/heron-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-heron-msgs";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_msgs/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "2933e0b40e335841c756ee738d66fd9ab2e52cbfb21f105495e721d155773500";
+    url = "https://github.com/clearpath-gbp/heron-release/archive/release/melodic/heron_msgs/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "899a24ec3766be77d115b0d13f93a17e06975b9d1efc66af3f760df81e0555ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-simulator/default.nix
+++ b/distros/melodic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-heron-simulator";
-  version = "0.3.0-r1";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "1cc88488c8fc27c30383db03366ed7b99c191e833e3c5e495dc97386b345b8b3";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "c37d22db9e753e629036e6398a75a6e295b6438d3328d4dc954ba561615898a3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-viz/default.nix
+++ b/distros/melodic/heron-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, heron-description, joint-state-publisher, roslaunch, rviz }:
+buildRosPackage {
+  pname = "ros-melodic-heron-viz";
+  version = "0.0.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/heron_desktop-release/archive/release/melodic/heron_viz/0.0.3-2.tar.gz";
+    name = "0.0.3-2.tar.gz";
+    sha256 = "d884b05c99242ce6154dd63a8bbe69bafa8d85dc5efdd640cf7ab524f96600f9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ heron-description joint-state-publisher rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Visualization and rviz helpers for Heron.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-drones";
-  version = "1.3.6-r1";
+  version = "1.3.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "c052379afb0e6e0517ad780ed323f924a2508ce6b582832dc210570d1d670db2";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.7-3.tar.gz";
+    name = "1.3.7-3.tar.gz";
+    sha256 = "7261c3ca84fec7223d490cd7a882cd42bfcce72effdc04b1c3eb4fadbb91bb6c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/knowledge-representation/default.nix
+++ b/distros/melodic/knowledge-representation/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, libpqxx, postgresql, python, pythonPackages, roslint, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-knowledge-representation";
+  version = "0.9.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/melodic/knowledge_representation/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "37052ecadaa9888e16018694a23ba7e0dc36a96d6273097d3b6005fb27df2a90";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ boost libpqxx postgresql python pythonPackages.pillow ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
+
+  meta = {
+    description = ''APIs for storing and querying information about the world.
+    Provides C++ and Python API's to make getting facts in and out easy (while still exposing a full SQL interface).
+        Supports PostgreSQL and MySQL backends.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/leg-detector/default.nix
+++ b/distros/melodic/leg-detector/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, dynamic-reconfigure, geometry-msgs, image-geometry, laser-filters, laser-geometry, map-laser, message-filters, people-msgs, people-tracking-filter, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, std-srvs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-leg-detector";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/leg_detector/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "aaf47802eea191142252e69d7044c0b308fd70350c8fd2650e7c682069e2e9de";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/leg_detector/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "44076e4c01655df0b855678ab2f2012a6ca559b527b4c258fb382a6df739f07f";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl dynamic-reconfigure geometry-msgs image-geometry laser-filters laser-geometry map-laser message-filters people-msgs people-tracking-filter roscpp sensor-msgs std-msgs std-srvs tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "eb68da47fb1ae73f1ca0fbb5f3d9e5123a0e9d45270799813f9d15ffe92d0a10";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "bde0eab7a5c5ee5665ac856df66f554a63512dc6eddfbfb82f9ca5447893240b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "65975e28f3f1134aafb1fceeffae868b7c5f2522ed5b731c5831507640af8f7e";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "1f6da14bb91f55648ae2a69a0a8b3785748bcac1072763fabaf7835aa716a790";
   };
 
   buildType = "cmake";

--- a/distros/melodic/log-view/default.nix
+++ b/distros/melodic/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ncurses, roscpp, xclip }:
 buildRosPackage {
   pname = "ros-melodic-log-view";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/melodic/log_view/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "823227e66081c3e8bfcfd9955d2f56edeb6d4468f71736909fbb9d76d014092a";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/melodic/log_view/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "c1e9390e841e44f84c5a55bf2ff00596abb7bbb0a663bb86027f6d901645e71d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "95e1d03a2b9090fc2c68ce8fed55b8228e93c02743755f41e130e8659b8bac59";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.3.3-1.tar.gz";
+    name = "2021.3.3-1.tar.gz";
+    sha256 = "046d27e6c9c806a9c10c1f0cc3dc750afe4b308650a03c9563e8164e95311046";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "62642bbd36b8a722d71dc950d411038ac82a7ec3ec5f31903983b51d20060272";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "28cfa744e66e5d707981f3273ae439f516b918567e363bd701b81fc3230f81bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e91fa2a6c12a4122897ad35060e0d66ce190bc6d862b95f36dd2869f3549982c";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "5759c7719ae5250552c7a7beffbb2b224bc2f8e61ec5780d0f6b70572e2a7b5e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "2724719cd73f6eae2b89218d1cd18960341e1fbfe3dd0228d73708d39cc0be92";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "3ad0309798fd060b88acab25d1b09135b15871191fc54de6dc9ca34c004f7bb9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "bf0677ba2b61b080b63ad4bdb32742566863cb0f8d46eba0bc3cdff8428f86f2";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "540c5728dbb160edcca1fc7265bc49e5b89f1fc1e6b6bb86aea51cc676549132";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-optitrack/default.nix
+++ b/distros/melodic/mocap-optitrack/default.nix
@@ -1,0 +1,40 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
+buildRosPackage {
+  pname = "ros-melodic-mocap-optitrack";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "26c631a93df50d62e137b502d5f942e99ae9df69416cb3fc225a99b2ff450599";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs nav-msgs roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Streaming of OptiTrack mocap data to tf
+    <p>
+    This package contains a node that translates motion capture data from an
+    OptiTrack rig to tf transforms, poses and 2D poses. The node receives
+    packets that are streamed by a NatNet compliant source, decodes them and
+    broadcasts the poses of configured rigid bodies as tf transforms, poses,
+    and/or 2D poses.
+    </p>
+    <p>
+    Currently, this node supports the NatNet streaming protocol v3.0
+    </p>
+    <p>
+    Copyright (c) 2013, Clearpath Robotics<br/> 
+    Copyright (c) 2010, University of Bonn, Computer Science Institute VI<br/>
+    All rights reserved.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/move-base-sequence/default.nix
+++ b/distros/melodic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-move-base-sequence";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/melodic/move_base_sequence/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "0dd3d48f276425cf5c51be52e9845c7732e9a988a5c07456e3e63ca8e8e91f99";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/melodic/people-msgs/default.nix
+++ b/distros/melodic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-people-msgs";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "34ea58081f5b53566700ebf0728e024148a0b653f57b5a82560da05848f30f82";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_msgs/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "56ee89ae2ab0cf449cf03e4a3db22356a5dba6e71a28d818ce90167a206e2bb4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/people-tracking-filter/default.nix
+++ b/distros/melodic/people-tracking-filter/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, bfl, catkin, geometry-msgs, message-filters, people-msgs, roscpp, roslaunch, roslint, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-people-tracking-filter";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_tracking_filter/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "c248a935edf57a2326396a576622a79a75ec6d74679bf851a35c7004f0b2c8c1";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_tracking_filter/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "c865fb866c756894069ec3c6565a742ce0927c3f42b2359cd0f46f31230ad87c";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ bfl geometry-msgs message-filters people-msgs roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/people-velocity-tracker/default.nix
+++ b/distros/melodic/people-velocity-tracker/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslib, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-melodic-people-velocity-tracker";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_velocity_tracker/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8058c2f01c299a3204c1ca5e6dc6e16e37afc35d10ae63d644ea0f21741c9ac8";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people_velocity_tracker/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "dacb341d242868f85f245a5bb14821c4eeeb205b300ed187a78d9577bf052861";
   };
 
   buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
   propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/people/default.nix
+++ b/distros/melodic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-melodic-people";
-  version = "1.2.0-r1";
+  version = "1.4.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6261e11750ff43c0eecd09034928197e6266c0410bc1d8310dfa0dc899798a00";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/melodic/people/1.4.0-4.tar.gz";
+    name = "1.4.0-4.tar.gz";
+    sha256 = "3257e4cec2b4985b1b8f0530bb4a37820ec2100a60f9694b36aff8c9df32c154";
   };
 
   buildType = "catkin";

--- a/distros/melodic/points-preprocessor/default.nix
+++ b/distros/melodic/points-preprocessor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-points-preprocessor";
-  version = "1.14.9-r1";
+  version = "1.14.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/core_perception-release/archive/release/melodic/points_preprocessor/1.14.9-1.tar.gz";
-    name = "1.14.9-1.tar.gz";
-    sha256 = "ec1ca55fc68caf0269ea67efa6168e5879cf7f99f761f2c5a9b3ea253af15720";
+    url = "https://github.com/nobleo/core_perception-release/archive/release/melodic/points_preprocessor/1.14.13-1.tar.gz";
+    name = "1.14.13-1.tar.gz";
+    sha256 = "e43cbb9152646cf440ff29a36b6b6107eb1ae8ebfa8ff182bc42c4847733547b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -1,21 +1,21 @@
 
-# Copyright 2020 Open Source Robotics Foundation
+# Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, rosfmt, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.1.2-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "27bbef543a3dd4dc5863544afa3fa5d6b73c531f5000ff9e40c60876767087dc";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "83518f290847262a7fa2a1517fe31aed7bf881f85a1f1e0f8ca8231338f061b9";
   };
 
   buildType = "catkin";
   checkInputs = [ code-coverage pilz-testutils rosbag roslaunch rostest rosunit ];
-  propagatedBuildInputs = [ robot-state-publisher rosconsole-bridge roscpp rosfmt roslaunch rviz sensor-msgs xacro ];
+  propagatedBuildInputs = [ fmt robot-state-publisher rosconsole-bridge roscpp roslaunch rviz sensor-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rc-genicam-api/default.nix
+++ b/distros/melodic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
-  version = "2.4.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "67e2028a30bc44c397950eb191d98c5d9a03e08f295c167d04607d92c4c0b864";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "b4dc36dd3b80e25866b175147f4af04b29988efc97f6441bf3dc7bed1d4ca9e5";
   };
 
   buildType = "cmake";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "8d809c1388903c07009bf016d6c89784d3fa05527ab2bfa4da4f3e0206018fb8";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "c9f50a6966ae731c360aab484e1b7fda21fc24aa5deb028eaac0b58cc0353319";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "c7bd91bef49ba8f1c6c9ff8c3596161b25f288d6f1d4578e162d2ed6b9c322b5";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "930fc359ec864cbe8ac7f8c68b334189b0140c453785469ac503ecae411d76d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-upstart/default.nix
+++ b/distros/melodic/robot-upstart/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, daemontools, roslaunch, roslint, rosunit, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-robot-upstart";
-  version = "0.3.0";
+  version = "0.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/melodic/robot_upstart/0.3.0-0.tar.gz";
-    name = "0.3.0-0.tar.gz";
-    sha256 = "a275ce760e7a19ed7b1f120e6b1a3e3c1043f35c5b9bc116a0ba9ed8a633531e";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/melodic/robot_upstart/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "63ba9b49a0439bb01b5f36bc0a25200b82751e9af2ba8a751a8a8de6e76ea121";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rosunit ];
-  propagatedBuildInputs = [ daemontools roslaunch xacro ];
+  propagatedBuildInputs = [ daemontools nettools roslaunch xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-control-boilerplate/default.nix
+++ b/distros/melodic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ros-control-boilerplate";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0a7ce80db50a833c0ac201c31caba85ebdc1192a279adcc9b5e61ab86c1b7899";
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ef24a60447530fb1c62e086164715eae45cd02d5d46f105020c9664d81712a8e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "051cb5fcc3c00598cf4c225e77bf6a71a14bda79bd90376c305e7a7921eb9dd8";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "f4ba994c272d9ed2e6bfb6ba9e76aeec2a0aa0a56f399efef5395d80cb009893";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-bag-plugins/default.nix
+++ b/distros/melodic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag-plugins";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "ca99407bcee6772429093e5a980a88a8c5b0f71ebd2166bd7ab0feb574e2084e";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag_plugins/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "ec47dd8d2efc2accd606964cb40a5531a46d57551a49b35558bedbd2a08f9d9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-bag/default.nix
+++ b/distros/melodic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-bag";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "576d8412c68894c8430619ed33113e43406d2b6e56ece10c2cf5c24b62cdea36";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/melodic/rqt_bag/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "182a0246366034f55abc0285d2f018819c1b455ce54cbf526d4880395be4396e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.3.6-r1";
+  version = "1.3.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "b4d44dff8d2eb16563250173c9d004286b26fc093e74f036dba7b94a878e6ae6";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.7-3.tar.gz";
+    name = "1.3.7-3.tar.gz";
+    sha256 = "2ce82e22304f925b0cfb0f520560d6ecef1af1552a3ff2a270e29db6fc8d9df8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.3.6-r1";
+  version = "1.3.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.6-1.tar.gz";
-    name = "1.3.6-1.tar.gz";
-    sha256 = "0889076e263c9e9ed29028537180ce4d9f8d510292c4e05173a4ec5ccae6e516";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.7-3.tar.gz";
+    name = "1.3.7-3.tar.gz";
+    sha256 = "1513c291a25a66ab29560861223d934a3b9fc05e2f1782fe95936170e9d81c35";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-plot/default.nix
+++ b/distros/melodic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-plot";
-  version = "0.4.9";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/melodic/rqt_plot/0.4.9-0.tar.gz";
-    name = "0.4.9-0.tar.gz";
-    sha256 = "226ffb18dfbf7e879f20e2aecae2243582a4fae28e74a1f7d3b291e68f6a28fb";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/melodic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "8ad543629315c87c8694d9efe79df4026582cea73d9183774b523e6fcb8a089a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.15-r1";
+  version = "1.13.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.15-1.tar.gz";
-    name = "1.13.15-1.tar.gz";
-    sha256 = "2231a3c4f10650e37f5650cc85a25590474a6d1a1e26e2fd00cd8303581f6c02";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.16-1.tar.gz";
+    name = "1.13.16-1.tar.gz";
+    sha256 = "1addd391a6fc14528987b99bab69b59b99d22140d9c4ba90b3c925ca6ab80da2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "0774c44d48b2cba0a802d8813429c5ec6df04f36aeecd0233d6de007dcaf4d10";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "7c5e57d85e0f2938c39dacc1714c0b83824d56d4da08681567c411dd5ab5e285";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-description/default.nix
+++ b/distros/melodic/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-description";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "fe90909d6349e64ba5c7fa3eff8f0a1b64f7a0cf96fcae3042eeac2e8c2853b6";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_description/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "111bc30a33cd409c18c0f1c32ff2a6c8be55d29d14907d5d7627e872c2ae0671";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-gazebo-plugins/default.nix
+++ b/distros/melodic/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-gazebo-plugins";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_gazebo_plugins/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "9c6b9afee31c4833579b49a331d63aeee21ba565ecb05c67b8782a6b9291520b";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_gazebo_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "72db3cc09652427898487a4ffad1187fe9d5e61dd14492864ec5e561b21d87d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/velodyne-simulator/default.nix
+++ b/distros/melodic/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-velodyne-simulator";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_simulator/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "cdefbbe70f5ca2ebbfed172169054f6697252a29c23d24c53ae234b800fd0a38";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/melodic/velodyne_simulator/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "665e8d0899eb6dbb9321ca9665e1406154db0fc7530bf17397d05af9c654d671";
   };
 
   buildType = "catkin";

--- a/distros/noetic/app-manager/default.nix
+++ b/distros/noetic/app-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rosgraph, roslaunch, rospack, rospy, rosunit, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-app-manager";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/app_manager-release/archive/release/noetic/app_manager/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "3b17f326c828d6c15dc352cbfd125605b3af0a1c9225e5af50a88f7c4cd9a98a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rosgraph roslaunch rospack rospy rosunit std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''app_manager'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cob-script-server/default.nix
+++ b/distros/noetic/cob-script-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cob-actions, cob-light, cob-mimic, cob-sound, control-msgs, geometry-msgs, message-generation, message-runtime, move-base-msgs, python3Packages, pythonPackages, rospy, rostest, std-msgs, std-srvs, tf, trajectory-msgs, urdfdom-py }:
+buildRosPackage {
+  pname = "ros-noetic-cob-script-server";
+  version = "0.6.20-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_command_tools-release/archive/release/noetic/cob_script_server/0.6.20-1.tar.gz";
+    name = "0.6.20-1.tar.gz";
+    sha256 = "0b16d3e6cf3c8e11355774a05fda4fef0b1698917492e6de84bf81199df15b8e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cob-actions cob-light cob-mimic cob-sound control-msgs geometry-msgs message-runtime move-base-msgs python3Packages.ipython python3Packages.pygraphviz pythonPackages.six rospy rostest std-msgs std-srvs tf trajectory-msgs urdfdom-py ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''The cob_script_server package provides a simple interface to operate Care-O-bot. It can be used via the python API or the actionlib interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/criutils/default.nix
+++ b/distros/noetic/criutils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, baldor, catkin, cv-bridge, geometry-msgs, image-geometry, python3Packages, resource-retriever, rostopic, sensor-msgs, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-criutils";
+  version = "0.1.4-r2";
+
+  src = fetchurl {
+    url = "https://github.com/crigroup/criutils-release/archive/release/noetic/criutils/0.1.4-2.tar.gz";
+    name = "0.1.4-2.tar.gz";
+    sha256 = "04ebb642b895d176a9a777f4f2e0493a25a17a3f3e990e7617e21a7184fb4918";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ baldor cv-bridge geometry-msgs image-geometry python3Packages.numpy python3Packages.termcolor resource-retriever rostopic sensor-msgs std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The criutils package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/dynamic-edt-3d/default.nix
+++ b/distros/noetic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, octomap }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-edt-3d";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "63235da0946f9e97a0126a7e1c21a0a431e330f44845cc3d7523413503ede4ca";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "a520fefda72b7919a8d500bbf94dc0ad88c4388e3c6a29df74e621b71785e88a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "4.0.2-r1";
+  version = "4.0.2-r3";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "160c506d8d1479424985e185a8fd6968efb551ff2cc7dd93f8515bf5e1de3fb7";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-3.tar.gz";
+    name = "4.0.2-3.tar.gz";
+    sha256 = "3c79a0eb15c9f4dd046a1c8e19d69aabe77d00dcc2e24fb1f0de7583a87c5fdc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph-tutorial/default.nix
+++ b/distros/noetic/dynamic-graph-tutorial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-tutorial";
-  version = "1.2.2-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "33213cea4468eb12ca6710d99006ed1b4ef7fb9586b2771d014830182bf1ba21";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-tutorial-ros-release/archive/release/noetic/dynamic-graph-tutorial/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "a5499ce3759b782a0ce47408c2dcc025ccef46c53dd64e3080968beee6a08a60";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.3.3-r1";
+  version = "4.3.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-1.tar.gz";
-    name = "4.3.3-1.tar.gz";
-    sha256 = "a401d342b397518e996ce616f30940883f126a611acd9d87de526543d4384632";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-4.tar.gz";
+    name = "4.3.3-4.tar.gz";
+    sha256 = "3e27d8b75c9a57bfa976987ebe9db9f12796d4d3971a7f53767cafc6e1f020f1";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eml/default.nix
+++ b/distros/noetic/eml/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-eml";
+  version = "1.8.15-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/eml-release/archive/release/noetic/eml/1.8.15-7.tar.gz";
+    name = "1.8.15-7.tar.gz";
+    sha256 = "6144c6c41ee52929ac4063e0c79e33bae44f2ba3ea823299b8e383b0bc3b6f68";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ catkin ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This is an implementation of the EtherCAT master protocol for the PR2 robot based on the work done at Flanders' Mechatronics Technology Centre.'';
+    license = with lib.licenses; [ "Binary Only" ];
+  };
+}

--- a/distros/noetic/ethercat-hardware/default.nix
+++ b/distros/noetic/ethercat-hardware/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, eml, log4cxx, message-generation, message-runtime, pluginlib, pr2-hardware-interface, pr2-msgs, realtime-tools, roscpp, tinyxml }:
+buildRosPackage {
+  pname = "ros-noetic-ethercat-hardware";
+  version = "1.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_ethercat_drivers-release/archive/release/noetic/ethercat_hardware/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "3371eebcc2688f122467e861a6ca78f6a7c29d68013ee3e0f3ea8ebac7f9e879";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater eml log4cxx message-runtime pluginlib pr2-hardware-interface pr2-msgs realtime-tools roscpp tinyxml ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for creating a hardware interface to the robot using the EtherCAT motor controller/driver'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/face-detector/default.nix
+++ b/distros/noetic/face-detector/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-face-detector";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "74644b234954d858f362cf03a515b03b553f0cdb350df9e6fb741c4614f44b83";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Face detection in images.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-auto-dock-msgs/default.nix
+++ b/distros/noetic/fetch-auto-dock-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-auto-dock-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_msgs-release/archive/release/noetic/fetch_auto_dock_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "07d675e227e9e0a6143af6c101cfc62d0bb4b0907e07f8143bba2fa148a67cb2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for fetch_auto_dock package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-calibration/default.nix
+++ b/distros/noetic/fetch-calibration/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, robot-calibration }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-calibration";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_calibration/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "3ea8566a720e400ae76449b5c54ffc5bd1733d9caf964260e4684caef1bcb912";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-calibration ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Launch and configuration files for calibrating Fetch using the 'robot_calibration' package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/fetch-depth-layer/default.nix
+++ b/distros/noetic/fetch-depth-layer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, costmap-2d, cv-bridge, geometry-msgs, image-transport, nav-msgs, pluginlib, roscpp, sensor-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-depth-layer";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_depth_layer/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a486778a773b3f05efccaec69c6e2500a85f178300594cf835ff9d59f6b5e088";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ costmap-2d cv-bridge geometry-msgs image-transport nav-msgs pluginlib roscpp sensor-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fetch_depth_layer package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-description/default.nix
+++ b/distros/noetic/fetch-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-description";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_description/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "f59f7ad66e1a9e07ab1c5b581b2ae2f6ebb2864c84f0f64cec0f536e030e0c8f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF for Fetch Robot.'';
+    license = with lib.licenses; [ "CC-BY-SA-3.0" ];
+  };
+}

--- a/distros/noetic/fetch-driver-msgs/default.nix
+++ b/distros/noetic/fetch-driver-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, power-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-driver-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_msgs-release/archive/release/noetic/fetch_driver_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "83afff86291e1c3b3ffd1b96b10da679dea0bb2f4f127e456aaf7e7876bea27c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime power-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for the fetch_drivers package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-ikfast-plugin/default.nix
+++ b/distros/noetic/fetch-ikfast-plugin/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, liblapack, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-ikfast-plugin";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ikfast_plugin/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "7f27ca168fe00fbd9a1e50dc5407bbf623d6a2cc54aa47b2876ff29707704242";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ tf2-eigen tf2-kdl ];
+  propagatedBuildInputs = [ eigen-conversions liblapack moveit-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Kinematics plugin for Fetch robot, generated through IKFast'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/fetch-maps/default.nix
+++ b/distros/noetic/fetch-maps/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-maps";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_maps/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "6d30d9bd13cf660c83350a3f9181654ad9788809f867289b00a1cf3a4534f533";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fetch_maps package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-moveit-config/default.nix
+++ b/distros/noetic/fetch-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fetch-description, fetch-ikfast-plugin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-python, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, rospy, rostest, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-moveit-config";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_moveit_config/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "03c5926ed7872fe04a801ab4e79feefef1089bdde445539e81cbcfe381740a15";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ fetch-description fetch-ikfast-plugin joint-state-publisher moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-python moveit-ros-move-group moveit-ros-visualization moveit-simple-controller-manager robot-state-publisher rospy xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the fetch_urdf with the MoveIt Motion Planning Framework'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-navigation/default.nix
+++ b/distros/noetic/fetch-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, clear-costmap-recovery, costmap-2d, fetch-depth-layer, fetch-maps, map-server, move-base, move-base-msgs, navfn, roslaunch, rotate-recovery, slam-karto, voxel-grid }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-navigation";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_navigation/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b9d6ed800f2c34e96cb15e4c846dafca23fd60f95fd8fa9889b4c9ff141fbe98";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ amcl base-local-planner clear-costmap-recovery costmap-2d fetch-depth-layer fetch-maps map-server move-base move-base-msgs navfn rotate-recovery slam-karto voxel-grid ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Configuration and launch files for running ROS navigation on Fetch.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-open-auto-dock/default.nix
+++ b/distros/noetic/fetch-open-auto-dock/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, eigen, fetch-auto-dock-msgs, fetch-driver-msgs, geometry-msgs, nav-msgs, roscpp, roslib, rospy, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-open-auto-dock";
+  version = "0.1.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_open_auto_dock-gbp/archive/release/noetic/fetch_open_auto_dock/0.1.3-2.tar.gz";
+    name = "0.1.3-2.tar.gz";
+    sha256 = "ec396187a30b9ef904c934d7f3bdbf625980138227e511927ada69c8b61fbd6b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles ];
+  propagatedBuildInputs = [ actionlib eigen fetch-auto-dock-msgs fetch-driver-msgs geometry-msgs nav-msgs roscpp roslib rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An open-source version of the Fetch charge docking system.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/fetch-ros/default.nix
+++ b/distros/noetic/fetch-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fetch-calibration, fetch-depth-layer, fetch-description, fetch-ikfast-plugin, fetch-maps, fetch-moveit-config, fetch-navigation, fetch-teleop }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-ros";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ros/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "17e138f2c1a1175d72581680f757122f66f1a598838f1f10a0361baa1719ceb3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fetch-calibration fetch-depth-layer fetch-description fetch-ikfast-plugin fetch-maps fetch-moveit-config fetch-navigation fetch-teleop ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Fetch ROS, packages for working with Fetch and Freight'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fetch-teleop/default.nix
+++ b/distros/noetic/fetch-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, geometry-msgs, nav-msgs, roscpp, sensor-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-teleop";
+  version = "0.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_teleop/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "56e5095105103697e77fc71e05938a115349f0f4596974f749c6252ba5052164";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib control-msgs geometry-msgs nav-msgs roscpp sensor-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Teleoperation for fetch and freight.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fingertip-pressure/default.nix
+++ b/distros/noetic/fingertip-pressure/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, pr2-msgs, rospy, rostest, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fingertip-pressure";
+  version = "1.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_ethercat_drivers-release/archive/release/noetic/fingertip_pressure/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "b381fcb28a88b68e16de43e618c341be01483c918815793cbf81e98b392fbe73";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation rostest ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime pr2-msgs rospy std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides access to the PR2 fingertip pressure sensors. This information includes:'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fkie-multimaster-msgs/default.nix
+++ b/distros/noetic/fkie-multimaster-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fkie-multimaster-msgs";
+  version = "1.2.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fkie-release/multimaster_fkie-release/archive/release/noetic/fkie_multimaster_msgs/1.2.7-1.tar.gz";
+    name = "1.2.7-1.tar.gz";
+    sha256 = "dc900162eb805de7db2f86c7e61e069ae6c814577a17a591dce54e422574c5fe";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation python3Packages.grpcio-tools ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The messages required by multimaster packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -22,6 +22,8 @@ self: super: {
 
  angles = self.callPackage ./angles {};
 
+ app-manager = self.callPackage ./app-manager {};
+
  apriltag = self.callPackage ./apriltag {};
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
@@ -320,6 +322,8 @@ self: super: {
 
  cob-scan-unifier = self.callPackage ./cob-scan-unifier {};
 
+ cob-script-server = self.callPackage ./cob-script-server {};
+
  cob-sick-lms1xx = self.callPackage ./cob-sick-lms1xx {};
 
  cob-sick-s300 = self.callPackage ./cob-sick-s300 {};
@@ -393,6 +397,8 @@ self: super: {
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cpp-common = self.callPackage ./cpp-common {};
+
+ criutils = self.callPackage ./criutils {};
 
  csm = self.callPackage ./csm {};
 
@@ -608,7 +614,11 @@ self: super: {
 
  eiquadprog = self.callPackage ./eiquadprog {};
 
+ eml = self.callPackage ./eml {};
+
  ergodic-exploration = self.callPackage ./ergodic-exploration {};
+
+ ethercat-hardware = self.callPackage ./ethercat-hardware {};
 
  executive-smach = self.callPackage ./executive-smach {};
 
@@ -660,11 +670,37 @@ self: super: {
 
  explore-lite = self.callPackage ./explore-lite {};
 
+ face-detector = self.callPackage ./face-detector {};
+
  fadecandy-driver = self.callPackage ./fadecandy-driver {};
 
  fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
 
  fake-localization = self.callPackage ./fake-localization {};
+
+ fetch-auto-dock-msgs = self.callPackage ./fetch-auto-dock-msgs {};
+
+ fetch-calibration = self.callPackage ./fetch-calibration {};
+
+ fetch-depth-layer = self.callPackage ./fetch-depth-layer {};
+
+ fetch-description = self.callPackage ./fetch-description {};
+
+ fetch-driver-msgs = self.callPackage ./fetch-driver-msgs {};
+
+ fetch-ikfast-plugin = self.callPackage ./fetch-ikfast-plugin {};
+
+ fetch-maps = self.callPackage ./fetch-maps {};
+
+ fetch-moveit-config = self.callPackage ./fetch-moveit-config {};
+
+ fetch-navigation = self.callPackage ./fetch-navigation {};
+
+ fetch-open-auto-dock = self.callPackage ./fetch-open-auto-dock {};
+
+ fetch-ros = self.callPackage ./fetch-ros {};
+
+ fetch-teleop = self.callPackage ./fetch-teleop {};
 
  ff = self.callPackage ./ff {};
 
@@ -674,6 +710,8 @@ self: super: {
 
  find-object-2d = self.callPackage ./find-object-2d {};
 
+ fingertip-pressure = self.callPackage ./fingertip-pressure {};
+
  fkie-master-discovery = self.callPackage ./fkie-master-discovery {};
 
  fkie-master-sync = self.callPackage ./fkie-master-sync {};
@@ -681,6 +719,8 @@ self: super: {
  fkie-message-filters = self.callPackage ./fkie-message-filters {};
 
  fkie-multimaster = self.callPackage ./fkie-multimaster {};
+
+ fkie-multimaster-msgs = self.callPackage ./fkie-multimaster-msgs {};
 
  fkie-node-manager-daemon = self.callPackage ./fkie-node-manager-daemon {};
 
@@ -872,6 +912,8 @@ self: super: {
 
  hector-imu-tools = self.callPackage ./hector-imu-tools {};
 
+ hector-localization = self.callPackage ./hector-localization {};
+
  hector-map-server = self.callPackage ./hector-map-server {};
 
  hector-map-tools = self.callPackage ./hector-map-tools {};
@@ -883,6 +925,10 @@ self: super: {
  hector-models = self.callPackage ./hector-models {};
 
  hector-nav-msgs = self.callPackage ./hector-nav-msgs {};
+
+ hector-pose-estimation = self.callPackage ./hector-pose-estimation {};
+
+ hector-pose-estimation-core = self.callPackage ./hector-pose-estimation-core {};
 
  hector-sensors-description = self.callPackage ./hector-sensors-description {};
 
@@ -1042,6 +1088,8 @@ self: super: {
 
  key-teleop = self.callPackage ./key-teleop {};
 
+ knowledge-representation = self.callPackage ./knowledge-representation {};
+
  kobuki-core = self.callPackage ./kobuki-core {};
 
  kobuki-dock-drive = self.callPackage ./kobuki-dock-drive {};
@@ -1082,11 +1130,19 @@ self: super: {
 
  laser-geometry = self.callPackage ./laser-geometry {};
 
+ laser-ortho-projector = self.callPackage ./laser-ortho-projector {};
+
  laser-pipeline = self.callPackage ./laser-pipeline {};
 
  laser-proc = self.callPackage ./laser-proc {};
 
  laser-scan-densifier = self.callPackage ./laser-scan-densifier {};
+
+ laser-scan-matcher = self.callPackage ./laser-scan-matcher {};
+
+ laser-scan-sparsifier = self.callPackage ./laser-scan-sparsifier {};
+
+ laser-scan-splitter = self.callPackage ./laser-scan-splitter {};
 
  leo = self.callPackage ./leo {};
 
@@ -1127,6 +1183,8 @@ self: super: {
  librviz-tutorial = self.callPackage ./librviz-tutorial {};
 
  libsiftfast = self.callPackage ./libsiftfast {};
+
+ libuvc-ros = self.callPackage ./libuvc-ros {};
 
  lms1xx = self.callPackage ./lms1xx {};
 
@@ -1238,6 +1296,8 @@ self: super: {
 
  message-runtime = self.callPackage ./message-runtime {};
 
+ message-to-tf = self.callPackage ./message-to-tf {};
+
  microstrain-3dmgx2-imu = self.callPackage ./microstrain-3dmgx2-imu {};
 
  mini-maxwell = self.callPackage ./mini-maxwell {};
@@ -1262,6 +1322,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-optitrack = self.callPackage ./mocap-optitrack {};
+
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
  move-base = self.callPackage ./move-base {};
@@ -1269,6 +1331,8 @@ self: super: {
  move-base-flex = self.callPackage ./move-base-flex {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
+
+ move-base-sequence = self.callPackage ./move-base-sequence {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
@@ -1392,6 +1456,8 @@ self: super: {
 
  navigation-experimental = self.callPackage ./navigation-experimental {};
 
+ ncd-parser = self.callPackage ./ncd-parser {};
+
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
  neonavigation = self.callPackage ./neonavigation {};
@@ -1405,6 +1471,8 @@ self: super: {
  neonavigation-rviz-plugins = self.callPackage ./neonavigation-rviz-plugins {};
 
  nerian-stereo = self.callPackage ./nerian-stereo {};
+
+ network-interface = self.callPackage ./network-interface {};
 
  nmea-comms = self.callPackage ./nmea-comms {};
 
@@ -1465,6 +1533,8 @@ self: super: {
  openzen-sensor = self.callPackage ./openzen-sensor {};
 
  opt-camera = self.callPackage ./opt-camera {};
+
+ opw-kinematics = self.callPackage ./opw-kinematics {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
@@ -1562,6 +1632,8 @@ self: super: {
 
  points-preprocessor = self.callPackage ./points-preprocessor {};
 
+ polar-scan-matcher = self.callPackage ./polar-scan-matcher {};
+
  polled-camera = self.callPackage ./polled-camera {};
 
  pose-base-controller = self.callPackage ./pose-base-controller {};
@@ -1584,6 +1656,8 @@ self: super: {
 
  pr2-description = self.callPackage ./pr2-description {};
 
+ pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
+
  pr2-hardware-interface = self.callPackage ./pr2-hardware-interface {};
 
  pr2-machine = self.callPackage ./pr2-machine {};
@@ -1600,9 +1674,13 @@ self: super: {
 
  ps3joy = self.callPackage ./ps3joy {};
 
+ psen-scan-v2 = self.callPackage ./psen-scan-v2 {};
+
  py-trees = self.callPackage ./py-trees {};
 
  py-trees-msgs = self.callPackage ./py-trees-msgs {};
+
+ py-trees-ros = self.callPackage ./py-trees-ros {};
 
  pybind11-catkin = self.callPackage ./pybind11-catkin {};
 
@@ -1678,6 +1756,12 @@ self: super: {
 
  robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
 
+ robot-controllers = self.callPackage ./robot-controllers {};
+
+ robot-controllers-interface = self.callPackage ./robot-controllers-interface {};
+
+ robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
+
  robot-localization = self.callPackage ./robot-localization {};
 
  robot-nav-rviz-plugins = self.callPackage ./robot-nav-rviz-plugins {};
@@ -1691,6 +1775,8 @@ self: super: {
  robot-self-filter = self.callPackage ./robot-self-filter {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
+
+ robot-upstart = self.callPackage ./robot-upstart {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
 
@@ -1956,6 +2042,8 @@ self: super: {
 
  rqt-py-console = self.callPackage ./rqt-py-console {};
 
+ rqt-py-trees = self.callPackage ./rqt-py-trees {};
+
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
 
  rqt-robot-dashboard = self.callPackage ./rqt-robot-dashboard {};
@@ -2015,6 +2103,10 @@ self: super: {
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
+
+ scan-to-cloud-converter = self.callPackage ./scan-to-cloud-converter {};
+
+ scan-tools = self.callPackage ./scan-tools {};
 
  scenario-test-tools = self.callPackage ./scenario-test-tools {};
 
@@ -2093,6 +2185,8 @@ self: super: {
  sophus = self.callPackage ./sophus {};
 
  sot-core = self.callPackage ./sot-core {};
+
+ sot-tools = self.callPackage ./sot-tools {};
 
  sparse-bundle-adjustment = self.callPackage ./sparse-bundle-adjustment {};
 

--- a/distros/noetic/hector-localization/default.nix
+++ b/distros/noetic/hector-localization/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hector-pose-estimation, hector-pose-estimation-core, message-to-tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-localization";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_localization/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "52d0f3a992929764e42fdd81bbe55db731b3df7d6ee55e15a516fd2d764fb31c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hector-pose-estimation hector-pose-estimation-core message-to-tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The hector_localization stack is a collection of packages, that provide the full 6DOF pose of a robot or platform.
+    It uses various sensor sources, which are fused using an Extended Kalman filter.
+
+    Acceleration and angular rates from an inertial measurement unit (IMU) serve as primary measurements.
+    The usage of other sensors is application-dependent. The hector_localization stack currently supports
+    GPS, magnetometer, barometric pressure sensors and other external sources that provide a geometry_msgs/PoseWithCovariance
+    message via the poseupdate topic.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hector-pose-estimation-core/default.nix
+++ b/distros/noetic/hector-pose-estimation-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, geographic-msgs, geometry-msgs, nav-msgs, rosconsole, roscpp, rostime, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-pose-estimation-core";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_pose_estimation_core/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "82bcb640addfa021a8bd61913060f27e9e2827ddef0f6c9d41fe6664c1ce96ed";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ eigen geographic-msgs geometry-msgs nav-msgs rosconsole roscpp rostime sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''hector_pose_estimation_core is the core package of the hector_localization stack. It contains the Extended Kalman Filter (EKF)
+    that estimates the 6DOF pose of the robot. hector_pose_estimation can be used either as a library, as a nodelet or as a standalone node.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/hector-pose-estimation/default.nix
+++ b/distros/noetic/hector-pose-estimation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-pose-estimation-core, message-filters, nav-msgs, nodelet, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-hector-pose-estimation";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/hector_pose_estimation/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "063f74d15fd503381172f8811622a54def961b5372b423807a181f7c012d9edf";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs hector-pose-estimation-core message-filters nav-msgs nodelet sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''hector_pose_estimation provides the hector_pose_estimation node and the hector_pose_estimation nodelet.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/knowledge-representation/default.nix
+++ b/distros/noetic/knowledge-representation/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, libpqxx, postgresql, python3, python3Packages, roslint, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-knowledge-representation";
+  version = "0.9.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/noetic/knowledge_representation/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "8aec57c3d83d986d5b4f140431480cd9e0451c77f87ca18493d6a308e67a5376";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ boost libpqxx postgresql python3 python3Packages.pillow ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''APIs for storing and querying information about the world.
+    Provides C++ and Python API's to make getting facts in and out easy (while still exposing a full SQL interface).
+        Supports PostgreSQL and MySQL backends.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-ortho-projector/default.nix
+++ b/distros/noetic/laser-ortho-projector/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-filters, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-laser-ortho-projector";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_ortho_projector/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "9f40b03eae8a2194ec41a9a803ca9305d0ee905be908d2ebac11ba6dcfb80349";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_ortho_projector package calculates orthogonal projections of LaserScan messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-scan-matcher/default.nix
+++ b/distros/noetic/laser-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, csm, geometry-msgs, nav-msgs, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-matcher";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_matcher/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6000f160af9d500dc98962fe003cc963573abbcec0bc7d7a0b6092896c49d285";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ csm geometry-msgs nav-msgs nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+     An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher (CSM) implementation. See <a href="http://censi.mit.edu/software/csm/">the web site</a> for more about CSM. NOTE the CSM library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/noetic/laser-scan-sparsifier/default.nix
+++ b/distros/noetic/laser-scan-sparsifier/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-sparsifier";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_sparsifier/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "5afafd970b7168c341b18704b5592f793957f9d08870509ab3e46922d6f79741";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_sparsifier takes in a LaserScan message and sparsifies it.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-scan-splitter/default.nix
+++ b/distros/noetic/laser-scan-splitter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-scan-splitter";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/laser_scan_splitter/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e2232be64fc25cc003de31a38c986fe4104262f07fabe7de66f33e676463404c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_splitter takes in a LaserScan message and splits it into a number of other LaserScan messages. Each of the resulting laser scans can be assigned an arbitrary coordinate frame, and is published on a separate topic.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "76d377568bad346652d1e6b01850e99fc213bd84bba3dbeb0fb659bd58512662";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "ef871b7674836b36b46dae524788b9625c99fb2f7f2d99950e03c1cb81ce1afc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.41.0-r1";
+  version = "2.42.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.41.0-1.tar.gz";
-    name = "2.41.0-1.tar.gz";
-    sha256 = "780ad7a395eea6fe77921563d6c0eaa1db48a66c9ec09beff0d19cc98a22d2a4";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.42.0-1.tar.gz";
+    name = "2.42.0-1.tar.gz";
+    sha256 = "850d0729ca79fa340f020894279f3474f80b7476c349cbafde239a25f1fb2b1d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/libuvc-ros/default.nix
+++ b/distros/noetic/libuvc-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libuvc-camera }:
+buildRosPackage {
+  pname = "ros-noetic-libuvc-ros";
+  version = "0.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/libuvc_ros-release/archive/release/noetic/libuvc_ros/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "b2da80d64e704f65aa4833edcc0c34868326d9cae3a32ededd99a3202ac9a790";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ libuvc-camera ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''libuvc_ros metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/log-view/default.nix
+++ b/distros/noetic/log-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ncurses, roscpp, xclip }:
 buildRosPackage {
   pname = "ros-noetic-log-view";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/hatchbed/log_view-release/archive/release/noetic/log_view/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "93c01620d5b4e3c4b6511ee532ad2caffd0245064536f7447ba77facf16849ae";
+    url = "https://github.com/hatchbed/log_view-release/archive/release/noetic/log_view/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "ae83c301379e194490f5aa2a392d6a2b20986be11b5a36ff1d8bfff993c24e1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.2.2-r1";
+  version = "2021.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.2.2-1.tar.gz";
-    name = "2021.2.2-1.tar.gz";
-    sha256 = "6e9fd280eaa921e379a5efa2b25471a7d037c80f15599b0a6f270bf3d7385af1";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.3.3-1.tar.gz";
+    name = "2021.3.3-1.tar.gz";
+    sha256 = "2c9642a5167e362ba6c067f50cdf14ba78c92e5075161aac3898397292b7abc9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e28b9a52c0adda80b2d63af468cc283a4f10b97c4469d663efcc0deb80c3ad5b";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "126858018a7517646e615ca4226809ff158549e8681808de540bfcb0e98af950";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "e9ae4fdf0e182562d0f31ecd6b456bb48714c09c0b9c719761fe17209cb55039";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "a5c00f6560de7f60c447a47210774af37d7f21c2bd4c7bc657ca78677300eaa3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "ee8e6e0bf786a042779c6d5dcfacb51840bb4330daad9497ed26cea28151cef8";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "61b74992d49a6ddd1aca85e5294ee11e265251807e71142b665ce1cdd23945cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.5.2-r1";
+  version = "0.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "728b5a6523f7ac2c8a8914eb90112a5088d0c90eb2a9ae4e7f31105e354fb88d";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.3-1.tar.gz";
+    name = "0.5.3-1.tar.gz";
+    sha256 = "4789dd5b0d5bb799e6a831c12c0a236169c12a57bdc54f5d57014f1128f6c775";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-to-tf/default.nix
+++ b/distros/noetic/message-to-tf/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf, topic-tools }:
+buildRosPackage {
+  pname = "ros-noetic-message-to-tf";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_localization-release/archive/release/noetic/message_to_tf/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fedfa6c5ab7ac1807512c9cbe4047d165fada0658fbf612b4fcef8397d3d4c11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs roscpp sensor-msgs tf topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message_to_tf translates pose information from different kind of common_msgs message types to tf. Currently the node supports nav_msgs/Odometry, geometry_msgs/PoseStamped and sensor_msgs/Imu messages as input.
+    The resulting transform is divided into three subtransforms with intermediate frames for the footprint and the stabilized base frame (without roll and pitch).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mocap-optitrack/default.nix
+++ b/distros/noetic/mocap-optitrack/default.nix
@@ -1,0 +1,40 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
+buildRosPackage {
+  pname = "ros-noetic-mocap-optitrack";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "bb2cc1e00ae9ab1d2061ad8975ed6e7a3c312789f9c1173019174540c4b3723e";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs nav-msgs roscpp tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Streaming of OptiTrack mocap data to tf
+    <p>
+    This package contains a node that translates motion capture data from an
+    OptiTrack rig to tf transforms, poses and 2D poses. The node receives
+    packets that are streamed by a NatNet compliant source, decodes them and
+    broadcasts the poses of configured rigid bodies as tf transforms, poses,
+    and/or 2D poses.
+    </p>
+    <p>
+    Currently, this node supports the NatNet streaming protocol v3.0
+    </p>
+    <p>
+    Copyright (c) 2013, Clearpath Robotics<br/> 
+    Copyright (c) 2010, University of Bonn, Computer Science Institute VI<br/>
+    All rights reserved.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/move-base-sequence/default.nix
+++ b/distros/noetic/move-base-sequence/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-move-base-sequence";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MarkNaeem/move_base_sequence-release/archive/release/noetic/move_base_sequence/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "b3dc4489b880f87708249280f6b9eb3b5fb7b6b827563cec478326fad010a6ad";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime move-base-msgs nav-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The move_base_sequence package'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/noetic/ncd-parser/default.nix
+++ b/distros/noetic/ncd-parser/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-ncd-parser";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/ncd_parser/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "b407bd8c0f11e9d1098373daaaaeca94fe2cddd7e05b0db427287a83ff880782";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ncd_parser package reads in .alog data files from the New College Dataset and broadcasts scan and odometry messages to ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/network-interface/default.nix
+++ b/distros/noetic/network-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslint, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-network-interface";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/network_interface-release/archive/release/noetic/network_interface/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "6ba8757292ea0ae9499c9142cf2b47cac91ac0f5f2ffd21c977801657ae38d64";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Network interfaces and messages.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/octomap/default.nix
+++ b/distros/noetic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-octomap";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "c77e3e57696d76a69bd4c6fa731b14dcce92eb63c7db6675d8b841ca816714fc";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "8c374f5ef014c9d5496aa7bccb496dba458a5ce2c4d3ace2d6f4c4104cda3296";
   };
 
   buildType = "cmake";

--- a/distros/noetic/octovis/default.nix
+++ b/distros/noetic/octovis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-noetic-octovis";
-  version = "1.9.6-r1";
+  version = "1.9.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-1.tar.gz";
-    name = "1.9.6-1.tar.gz";
-    sha256 = "feb098684affecd77636c6992084628036bf9101a41a42438723bb855b77401a";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-2.tar.gz";
+    name = "1.9.6-2.tar.gz";
+    sha256 = "6fb47ca3b08da643c13d00d9a7c0ecd5454ddb05ab30247bd9bf753d69701713";
   };
 
   buildType = "cmake";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
+buildRosPackage {
+  pname = "ros-noetic-opw-kinematics";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "22a484c86d5a90211d3f76f4ce7c77da3820c4810b7b95568ec89daaec7e54af";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ eigen ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''A simple, analytical inverse kinematic library for industrial robots with parallel bases and
+    spherical wrists. Based on the paper &quot;An Analytical Solution of the Inverse Kinematics Problem
+    of Industrial Serial Manipulators with an Ortho-parallel Basis and a Spherical Wrist&quot; by
+    Mathias Brandstötter, Arthur Angerer, and Michael Hofbaur.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/people-msgs/default.nix
+++ b/distros/noetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-people-msgs";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "0fc16f697e58974184b80ffbd67d294db3548012597e9803d4093dd7cb282e25";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "23c5aadea89b2d9eb9f8f5bc712313ef205a9db3844d47f25bfe5e167525b840";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people-velocity-tracker/default.nix
+++ b/distros/noetic/people-velocity-tracker/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, people-msgs, roslib, roslint, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-noetic-people-velocity-tracker";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "9ce69647385152fc6877470b7f1aa545a3ce53e3c639cc71f474e8ad3357f1bf";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "e01129e7da9a70ca43d9612728c1f44677c8ab050f5af95dc246abbf4f3e64b7";
   };
 
   buildType = "catkin";
-  checkInputs = [ roslint ];
-  propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter people-msgs roslib rospy ];
+  checkInputs = [ roslaunch roslint ];
+  propagatedBuildInputs = [ easy-markers geometry-msgs kalman-filter leg-detector people-msgs roslib rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/people/default.nix
+++ b/distros/noetic/people/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, people-msgs, people-velocity-tracker }:
+{ lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-noetic-people";
-  version = "1.2.2-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "95a6dbcd69d0e0556b34ff693ed87b1a596118ddf9d147e43c071617391696ed";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "38081a790261ca2b7dc8a6ab0fed886eb53c401af72e5c805aa2c8388d96391c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ people-msgs people-velocity-tracker ];
+  propagatedBuildInputs = [ face-detector leg-detector people-msgs people-tracking-filter people-velocity-tracker ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/points-preprocessor/default.nix
+++ b/distros/noetic/points-preprocessor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pcl }:
 buildRosPackage {
   pname = "ros-noetic-points-preprocessor";
-  version = "1.14.10-r1";
+  version = "1.14.11-r2";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/core_perception-release/archive/release/noetic/points_preprocessor/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "6e5c22a3dc855829fb1b62ed64d9031ddb35193ffec0ae4073028393350d3a07";
+    url = "https://github.com/nobleo/core_perception-release/archive/release/noetic/points_preprocessor/1.14.11-2.tar.gz";
+    name = "1.14.11-2.tar.gz";
+    sha256 = "08ac3278a045c28b3fc6763c035db7479b739c4cdd126f18b14cf793fabf9b3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/polar-scan-matcher/default.nix
+++ b/distros/noetic/polar-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-polar-scan-matcher";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/polar_scan_matcher/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "3e7d8367dfee2ad64dade2bb79db331c814c1a4f594c09eb41fc3f1263cf9833";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+    A wrapper around Polar Scan Matcher by Albert Diosi and Lindsay Kleeman, used for laser scan registration.
+    </p>'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/pr2-ethercat-drivers/default.nix
+++ b/distros/noetic/pr2-ethercat-drivers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-hardware, fingertip-pressure }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-ethercat-drivers";
+  version = "1.9.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_ethercat_drivers-release/archive/release/noetic/pr2_ethercat_drivers/1.9.0-1.tar.gz";
+    name = "1.9.0-1.tar.gz";
+    sha256 = "a5f9b21836a44729c9c169a59601d14be248abd6ffee90716e770e362e0b88b5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ethercat-hardware fingertip-pressure ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack contains drivers for the ethercat system and the peripherals
+    that connect to it: motor control boards, fingertip sensors, texture
+    projector, hand accelerometer.'';
+    license = with lib.licenses; [ bsdOriginal gpl1 ];
+  };
+}

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-psen-scan-v2";
+  version = "0.1.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "6d0336683936565129598cea9c880e3e72e274c094caf3b264ed89b432a676d8";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ code-coverage pilz-testutils rosbag roslaunch rostest rosunit ];
+  propagatedBuildInputs = [ fmt robot-state-publisher rosconsole-bridge roscpp roslaunch rviz sensor-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS support for the Pilz laser scanner'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/py-trees-ros/default.nix
+++ b/distros/noetic/py-trees-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, py-trees, py-trees-msgs, python-qt-binding, python3Packages, rosbag, rospy, rostest, rosunit, sensor-msgs, std-msgs, unique-id, uuid-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-py-trees-ros";
+  version = "0.6.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/noetic/py_trees_ros/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "7f6488f258163a4693f30ec99f789ffab6d59b97981949f5b7ce7d700c085319";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.setuptools ];
+  checkInputs = [ geometry-msgs py-trees python-qt-binding rostest rosunit ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs py-trees py-trees-msgs python3Packages.rospkg python3Packages.termcolor rosbag rospy sensor-msgs std-msgs unique-id uuid-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Ros extensions and behaviours for py_trees.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.4.4-r1";
+  version = "2.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.4.4-1.tar.gz";
-    name = "2.4.4-1.tar.gz";
-    sha256 = "a59af0e94c6da4e181f410df23e230edeb8bb122bd91c3eb12fe0877c8ae3428";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.5.0-1.tar.gz";
+    name = "2.5.0-1.tar.gz";
+    sha256 = "51cd256ebff104f226ffa2e131c977c774f1789e0099e3e572a4162401f83371";
   };
 
   buildType = "cmake";

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "4be92ffa0206116943937ab207c0b081ec67add33ab6ca7458a81ce1cc51653c";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "08c5d55e48d1152bcf20bdad3b6b0ff77c72e3cd79ddce93bc4f5c078b03409f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge ddynamic-reconfigure diagnostic-updater eigen genmsg image-transport librealsense2 message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.2.21-r1";
+  version = "2.2.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.21-1.tar.gz";
-    name = "2.2.21-1.tar.gz";
-    sha256 = "4ea4c7835c28db3bdfe100680f24d3464555e782d8e281eefe405b10dbc03f8e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.22-1.tar.gz";
+    name = "2.2.22-1.tar.gz";
+    sha256 = "641098008e6d40aaee4fd97dfc77164cbb4b074b48d615cebf6319a854253494";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-controllers-interface/default.nix
+++ b/distros/noetic/robot-controllers-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pluginlib, robot-controllers-msgs, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers-interface";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers_interface/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "2aefb653301e9f46d2d82c4a26dd10a4d8c9e28342899429c90490e854122c7a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pluginlib robot-controllers-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic framework for robot controls.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-controllers-msgs/default.nix
+++ b/distros/noetic/robot-controllers-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers-msgs";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b715c23f4e9e5732c317cb39f76d0bff7981d28d2671005d9f6aa6353c036ca1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for use with robot_controllers framework.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-controllers/default.nix
+++ b/distros/noetic/robot-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, angles, catkin, control-msgs, geometry-msgs, kdl-parser, nav-msgs, orocos-kdl, pluginlib, robot-controllers-interface, roscpp, sensor-msgs, std-msgs, tf, tf-conversions, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-robot-controllers";
+  version = "0.7.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/robot_controllers-release/archive/release/noetic/robot_controllers/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "cd13b537617dbdb7619f16bb991be69f9106df73970c9429dede5db6430ce1ae";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ angles ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs control-msgs geometry-msgs kdl-parser nav-msgs orocos-kdl pluginlib robot-controllers-interface roscpp sensor-msgs std-msgs tf tf-conversions trajectory-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Some basic robot controllers for use with robot_controllers_interface.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-upstart/default.nix
+++ b/distros/noetic/robot-upstart/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-robot-upstart";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/noetic/robot_upstart/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "2d3beafd758405574d42425cc0515e3a6918cb0cb423bca696cd49ee319837e9";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rosunit ];
+  propagatedBuildInputs = [ daemontools nettools roslaunch xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The robot_upstart package provides scripts which may be used to install
+    and uninstall Ubuntu Linux upstart jobs which launch groups of roslaunch files.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros-control-boilerplate/default.nix
+++ b/distros/noetic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-ros-control-boilerplate";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/noetic/ros_control_boilerplate/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "008938614602fb9b50ad8bae0d0dc5a8526179bba7509f03d45d77e1fbf727fa";
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/noetic/ros_control_boilerplate/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "41db741a7cbc512777dc79ee4457457394989c4c367296f68fa4a79c0d9983ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "e9be4a0711b9268d8c7f3c875d2fbb1d787aaa43f7907e08e4204dcbb9a178ba";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "701b88b355e63656be43cd0a1819d5bc9d1d598b3f238d67e85ed769b13e65de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag-plugins/default.nix
+++ b/distros/noetic/rqt-bag-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, rosbag, roslib, rospy, rqt-bag, rqt-gui, rqt-gui-py, rqt-plot, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag-plugins";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "0a79f66d0f2f1eea4e5aa1f8ce9070d06ac7e3b3ce90cf683da9d77a7d1596c4";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag_plugins/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "b6bfae17347d4d64fa1b40bc3663d4cb4a8fef9de8aa2b1e3138c4394561b6cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-bag/default.nix
+++ b/distros/noetic/rqt-bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rosbag, rosgraph-msgs, roslib, rosnode, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-bag";
-  version = "0.5.0-r1";
+  version = "0.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "6d6231e94ceedf1940d5b0a80d302b420f2536e5c243bfd1660a41bb39e804bb";
+    url = "https://github.com/ros-gbp/rqt_bag-release/archive/release/noetic/rqt_bag/0.5.1-1.tar.gz";
+    name = "0.5.1-1.tar.gz";
+    sha256 = "864c0851f8c2a470246555831630a5d7108ad76bde6e9fd5775113b35e722e8d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-plot/default.nix
+++ b/distros/noetic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, qwt-dependency, rosgraph, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-plot";
-  version = "0.4.12-r1";
+  version = "0.4.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "ec87f7987fbfd36412dec72aa8c840e5ee5aea7ae8dc330843828e4b533590fe";
+    url = "https://github.com/ros-gbp/rqt_plot-release/archive/release/noetic/rqt_plot/0.4.13-1.tar.gz";
+    name = "0.4.13-1.tar.gz";
+    sha256 = "8507faa21362446af958f585d33f525dcc308af701462a4645fd07785bf8aa39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-py-trees/default.nix
+++ b/distros/noetic/rqt-py-trees/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, py-trees, py-trees-msgs, python3Packages, qt-dotgraph, rospy, rqt-bag, rqt-graph, rqt-gui, rqt-gui-py, unique-id }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-py-trees";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stonier/rqt_py_trees-release/archive/release/noetic/rqt_py_trees/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "78101685d5cb8d67ab3ba9a7a263d297b64e52b0fe81bc7ab2182167a05e2408";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ python3Packages.mock ];
+  propagatedBuildInputs = [ geometry-msgs py-trees py-trees-msgs python3Packages.pygraphviz python3Packages.rospkg python3Packages.termcolor qt-dotgraph rospy rqt-bag rqt-graph rqt-gui rqt-gui-py unique-id ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt_py_trees provides a GUI plugin for visualizing py_trees behaviour trees based on rqt_tf_tree.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.4-r1";
+  version = "1.14.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.4-1.tar.gz";
-    name = "1.14.4-1.tar.gz";
-    sha256 = "17654e17b751ce995990ed5b61c5b296622512d4c30571b69f33238b37ffb79b";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.5-1.tar.gz";
+    name = "1.14.5-1.tar.gz";
+    sha256 = "5af081200832c88f692fb56d68ecaef5baf53605c18cfbef8f7253700b493d08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/scan-to-cloud-converter/default.nix
+++ b/distros/noetic/scan-to-cloud-converter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl, pcl-conversions, pcl-ros, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-scan-to-cloud-converter";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/scan_to_cloud_converter/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "005fe4afd4fcd083d4dab47ef1cc4d0eb151b02829ae642921eab81068cbe276";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pcl pcl-conversions pcl-ros roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts LaserScan to PointCloud messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/scan-tools/default.nix
+++ b/distros/noetic/scan-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-ortho-projector, laser-scan-matcher, laser-scan-sparsifier, laser-scan-splitter, ncd-parser, polar-scan-matcher, scan-to-cloud-converter }:
+buildRosPackage {
+  pname = "ros-noetic-scan-tools";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/noetic/scan_tools/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "31cb07d1a7024f28b127689d2c323ff38b1293cc629dab21f068d706424e3bfa";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laser-ortho-projector laser-scan-matcher laser-scan-sparsifier laser-scan-splitter ncd-parser polar-scan-matcher scan-to-cloud-converter ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Laser scan processing tools.'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.4-r1";
+  version = "4.11.4-r6";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-1.tar.gz";
-    name = "4.11.4-1.tar.gz";
-    sha256 = "a6cfbdcf769d02193be0e56cee7fdf5a6acede7fd4f00a2f6b3b276f1f363cf8";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-6.tar.gz";
+    name = "4.11.4-6.tar.gz";
+    sha256 = "cea10b4a9edaf20948e1f84303227f82cb12a741c68633a86a0d64c2e18c5b44";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sot-tools/default.nix
+++ b/distros/noetic/sot-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
+buildRosPackage {
+  pname = "ros-noetic-sot-tools";
+  version = "2.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.3-1.tar.gz";
+    name = "2.3.3-1.tar.gz";
+    sha256 = "5cd8cbd6e819505af7dc8b6e5eb2d08d79927bbe1791fb52d76ddce29b9eac7e";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  propagatedBuildInputs = [ catkin dynamic-graph-python sot-core ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Miscellanous entities for the stack of tasks'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.5.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.5.2-1.tar.gz";
-    name = "1.5.2-1.tar.gz";
-    sha256 = "f29268717566d7c3cf94e55c2cf01105b112f0830a5e44d82674444a3aa82cc4";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "aaa59cfe3cd6399b7973da80cb806b833e032b4fcb54301e067c24e16c446a3a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-description/default.nix
+++ b/distros/noetic/velodyne-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-description";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "47a189a291e43123e41f453a07c2ac2717d82e53f30975738171e0542e61022f";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_description/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "255d082bfdf62a6556c1405d9cc31bae5f1f0099cd497d64741716357881a420";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-gazebo-plugins/default.nix
+++ b/distros/noetic/velodyne-gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-gazebo-plugins";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "dfc2984ce676713530285a72bbad74953428520f4f828232367535df3743b731";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_gazebo_plugins/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "756f181dd70579c0923f254a8031d73ed71f21fb9a24316abdc35b0bfff98d52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/velodyne-simulator/default.nix
+++ b/distros/noetic/velodyne-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, velodyne-description, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-velodyne-simulator";
-  version = "1.0.10-r1";
+  version = "1.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "7babe2f16292fc4d8119d674252c07005b380679e2413328644a968dae139148";
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/noetic/velodyne_simulator/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "34810fce2fce720cad0500c5fdd58403e9774cbbbb04520cabb886029b20e035";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.5-r1";
+  version = "1.14.6-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "fb0c7fae5f85a4544d594d3c6470b6c37f1484ecf6c846e0895c4c594265dddb";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.6-2.tar.gz";
+    name = "1.14.6-2.tar.gz";
+    sha256 = "81a7d1d5350182f96998a12ab4971558c6eccc67821a85e523d04b63dff49584";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit cff345f1dc1a3ada3be82e8456ce2ab73be03198.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *fastrtps 1.8.4-r1 --> 1.8.4-r3*
* *rclc 0.1.7-r1 --> 1.0.0-r1*
* *rclc-examples 0.1.7-r1 --> 1.0.0-r1*
* *rclc-lifecycle 0.1.7-r1 --> 1.0.0-r1*
* *rqt-reconfigure 1.0.6-r1 --> 1.0.7-r1*
* *turtlebot3-fake-node 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-gazebo 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-simulations 2.2.1-r1 --> 2.2.2-r1*
* *xacro 2.0.4-r1 --> 2.0.5-r1*

Foxy Changes:
-------------
* *contracts-lite-vendor 0.4.1-r1 --> 0.5.0-r1*
* *controller-interface 0.1.6-r1 --> 0.2.1-r1*
* *controller-manager 0.1.6-r1 --> 0.2.1-r1*
* *controller-manager-msgs 0.1.6-r1 --> 0.2.1-r1*
* *diagnostic-aggregator 2.0.6-r1 --> 2.0.7-r1*
* *diagnostic-updater 2.0.6-r1 --> 2.0.7-r1*
* *fastrtps 2.0.2-r1 --> 2.0.2-r2*
* *hardware-interface 0.1.6-r1 --> 0.2.1-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *mavlink 2021.2.2-r1 --> 2021.3.3-r1*
* *ntpd-driver 2.0.2-r1*
* *rc-genicam-api 2.4.4-r1 --> 2.5.0-r1*
* *rclc 0.1.7-r1 --> 1.0.0-r1*
* *rclc-examples 0.1.7-r1 --> 1.0.0-r1*
* *rclc-lifecycle 0.1.7-r1 --> 1.0.0-r1*
* *realsense2-camera 3.1.3-r1 --> 3.1.4-r1*
* *realsense2-camera-msgs 3.1.3-r1 --> 3.1.4-r1*
* *realsense2-description 3.1.3-r1 --> 3.1.4-r1*
* *ros2-control 0.1.6-r1 --> 0.2.1-r1*
* *ros2-control-test-assets 0.1.6-r1 --> 0.2.1-r1*
* *ros2bag 0.3.6-r1 --> 0.3.7-r1*
* *ros2controlcli 0.1.6-r1 --> 0.2.1-r1*
* *rosbag2 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-compression 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-converter-default-plugins 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-cpp 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-storage 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-storage-default-plugins 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-test-common 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-tests 0.3.6-r1 --> 0.3.7-r1*
* *rosbag2-transport 0.3.6-r1 --> 0.3.7-r1*
* *rqt-plot 1.0.8-r1 --> 1.0.9-r1*
* *rqt-reconfigure 1.0.6-r1 --> 1.0.7-r1*
* *self-test 2.0.6-r1 --> 2.0.7-r1*
* *shared-queues-vendor 0.3.6-r1 --> 0.3.7-r1*
* *sick-safetyscanners2 1.0.0-r2 --> 1.0.1-r2*
* *sqlite3-vendor 0.3.6-r1 --> 0.3.7-r1*
* *transmission-interface 0.1.6-r1 --> 0.2.1-r1*
* *turtlebot3-fake-node 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-gazebo 2.2.1-r1 --> 2.2.2-r1*
* *turtlebot3-simulations 2.2.1-r1 --> 2.2.2-r1*
* *xacro 2.0.4-r1 --> 2.0.5-r1*
* *zstd-vendor 0.3.6-r1 --> 0.3.7-r1*

Kinetic Changes:
----------------
* *face-detector 1.1.3-r1 --> 1.4.0-r2*
* *heron-control 0.3.3-r1 --> 0.3.4-r1*
* *heron-description 0.3.3-r1 --> 0.3.4-r1*
* *heron-gazebo 0.3.0-r1 --> 0.3.2-r1*
* *heron-msgs 0.3.3-r1 --> 0.3.4-r1*
* *heron-simulator 0.3.0-r1 --> 0.3.2-r1*
* *leg-detector 1.1.3-r1 --> 1.4.0-r2*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *log-view 0.1.2-r1 --> 0.1.3-r1*
* *mavlink 2021.2.2-r1 --> 2021.3.3-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *mcl-3dl 0.5.2-r1 --> 0.5.3-r1*
* *mocap-optitrack 0.1.0-r1*
* *move-base-sequence 0.0.1-r6*
* *people 1.1.3-r1 --> 1.4.0-r2*
* *people-msgs 1.1.3-r1 --> 1.4.0-r2*
* *people-tracking-filter 1.1.3-r1 --> 1.4.0-r2*
* *people-velocity-tracker 1.1.3-r1 --> 1.4.0-r2*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *robot-upstart 0.3.0 --> 0.3.1-r1*
* *ros-control-boilerplate 0.4.1 --> 0.4.2-r1*
* *rospy-message-converter 0.5.5-r1 --> 0.5.6-r1*
* *rqt-plot 0.4.8 --> 0.4.13-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*

Melodic Changes:
----------------
* *async-web-server-cpp 1.0.2-r1 --> 1.0.3-r1*
* *drone-assets 1.3.6-r1 --> 1.3.7-r3*
* *drone-wrapper 1.3.6-r1 --> 1.3.7-r3*
* *face-detector 1.2.0-r1 --> 1.4.0-r4*
* *heron-control 0.3.3-r1 --> 0.3.4-r1*
* *heron-description 0.3.3-r1 --> 0.3.4-r1*
* *heron-desktop 0.0.3-r2*
* *heron-gazebo 0.3.0-r1 --> 0.3.2-r1*
* *heron-msgs 0.3.3-r1 --> 0.3.4-r1*
* *heron-simulator 0.3.0-r1 --> 0.3.2-r1*
* *heron-viz 0.0.3-r2*
* *jderobot-drones 1.3.6-r1 --> 1.3.7-r3*
* *knowledge-representation 0.9.3-r1*
* *leg-detector 1.2.0-r1 --> 1.4.0-r4*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *log-view 0.1.2-r1 --> 0.1.3-r1*
* *mavlink 2021.2.2-r1 --> 2021.3.3-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *mcl-3dl 0.5.2-r1 --> 0.5.3-r1*
* *mocap-optitrack 0.1.0-r1*
* *move-base-sequence 0.0.1-r2*
* *people 1.2.0-r1 --> 1.4.0-r4*
* *people-msgs 1.2.0-r1 --> 1.4.0-r4*
* *people-tracking-filter 1.2.0-r1 --> 1.4.0-r4*
* *people-velocity-tracker 1.2.0-r1 --> 1.4.0-r4*
* *points-preprocessor 1.14.9-r1 --> 1.14.13-r1*
* *psen-scan-v2 0.1.2-r1 --> 0.1.4-r1*
* *rc-genicam-api 2.4.4-r1 --> 2.5.0-r1*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *robot-upstart 0.3.0 --> 0.3.2-r1*
* *ros-control-boilerplate 0.5.0-r1 --> 0.5.1-r1*
* *rospy-message-converter 0.5.5-r1 --> 0.5.6-r1*
* *rqt-bag 0.5.0-r1 --> 0.5.1-r1*
* *rqt-bag-plugins 0.5.0-r1 --> 0.5.1-r1*
* *rqt-drone-teleop 1.3.6-r1 --> 1.3.7-r3*
* *rqt-ground-robot-teleop 1.3.6-r1 --> 1.3.7-r3*
* *rqt-plot 0.4.9 --> 0.4.13-r1*
* *rviz 1.13.15-r1 --> 1.13.16-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*
* *velodyne-description 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-gazebo-plugins 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-simulator 1.0.10-r1 --> 1.0.11-r1*

Noetic Changes:
---------------
* *app-manager 1.2.0-r1*
* *cob-script-server 0.6.20-r1*
* *criutils 0.1.4-r2*
* *dynamic-edt-3d 1.9.6-r1 --> 1.9.6-r2*
* *dynamic-graph 4.3.3-r1 --> 4.3.3-r4*
* *dynamic-graph-python 4.0.2-r1 --> 4.0.2-r3*
* *dynamic-graph-tutorial 1.2.2-r1 --> 1.3.2-r1*
* *eml 1.8.15-r7*
* *ethercat-hardware 1.9.0-r1*
* *face-detector 1.4.0-r1*
* *fetch-auto-dock-msgs 1.2.0-r1*
* *fetch-calibration 0.9.0-r1*
* *fetch-depth-layer 0.9.0-r1*
* *fetch-description 0.9.0-r1*
* *fetch-driver-msgs 1.2.0-r1*
* *fetch-ikfast-plugin 0.9.0-r1*
* *fetch-maps 0.9.0-r1*
* *fetch-moveit-config 0.9.0-r1*
* *fetch-navigation 0.9.0-r1*
* *fetch-open-auto-dock 0.1.3-r2*
* *fetch-ros 0.9.0-r1*
* *fetch-teleop 0.9.0-r1*
* *fingertip-pressure 1.9.0-r1*
* *fkie-multimaster-msgs 1.2.7-r1*
* *hector-localization 0.4.0-r1*
* *hector-pose-estimation 0.4.0-r1*
* *hector-pose-estimation-core 0.4.0-r1*
* *knowledge-representation 0.9.3-r1*
* *laser-ortho-projector 0.3.3-r1*
* *laser-scan-matcher 0.3.3-r1*
* *laser-scan-sparsifier 0.3.3-r1*
* *laser-scan-splitter 0.3.3-r1*
* *libmavconn 1.5.2-r1 --> 1.6.0-r1*
* *librealsense2 2.41.0-r1 --> 2.42.0-r1*
* *libuvc-ros 0.0.11-r1*
* *log-view 0.1.2-r1 --> 0.1.3-r1*
* *mavlink 2021.2.2-r1 --> 2021.3.3-r1*
* *mavros 1.5.2-r1 --> 1.6.0-r1*
* *mavros-extras 1.5.2-r1 --> 1.6.0-r1*
* *mavros-msgs 1.5.2-r1 --> 1.6.0-r1*
* *mcl-3dl 0.5.2-r1 --> 0.5.3-r1*
* *message-to-tf 0.4.0-r1*
* *mocap-optitrack 0.1.0-r1*
* *move-base-sequence 0.0.1-r1*
* *ncd-parser 0.3.3-r1*
* *network-interface 3.0.0-r1*
* *octomap 1.9.6-r1 --> 1.9.6-r2*
* *octovis 1.9.6-r1 --> 1.9.6-r2*
* *opw-kinematics 0.4.0-r1*
* *people 1.2.2-r1 --> 1.4.0-r1*
* *people-msgs 1.2.2-r1 --> 1.4.0-r1*
* *people-velocity-tracker 1.2.2-r1 --> 1.4.0-r1*
* *points-preprocessor 1.14.10-r1 --> 1.14.11-r2*
* *polar-scan-matcher 0.3.3-r1*
* *pr2-ethercat-drivers 1.9.0-r1*
* *psen-scan-v2 0.1.4-r1*
* *py-trees-ros 0.6.1-r1*
* *rc-genicam-api 2.4.4-r1 --> 2.5.0-r1*
* *realsense2-camera 2.2.21-r1 --> 2.2.22-r1*
* *realsense2-description 2.2.21-r1 --> 2.2.22-r1*
* *robot-controllers 0.7.0-r1*
* *robot-controllers-interface 0.7.0-r1*
* *robot-controllers-msgs 0.7.0-r1*
* *robot-upstart 0.4.0-r1*
* *ros-control-boilerplate 0.6.0-r1 --> 0.6.1-r1*
* *rospy-message-converter 0.5.5-r1 --> 0.5.6-r1*
* *rqt-bag 0.5.0-r1 --> 0.5.1-r1*
* *rqt-bag-plugins 0.5.0-r1 --> 0.5.1-r1*
* *rqt-plot 0.4.12-r1 --> 0.4.13-r1*
* *rqt-py-trees 0.4.0-r1*
* *rviz 1.14.4-r1 --> 1.14.5-r1*
* *scan-to-cloud-converter 0.3.3-r1*
* *scan-tools 0.3.3-r1*
* *sot-core 4.11.4-r1 --> 4.11.4-r6*
* *sot-tools 2.3.3-r1*
* *test-mavros 1.5.2-r1 --> 1.6.0-r1*
* *velodyne-description 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-gazebo-plugins 1.0.10-r1 --> 1.0.11-r1*
* *velodyne-simulator 1.0.10-r1 --> 1.0.11-r1*
* *xacro 1.14.5-r1 --> 1.14.6-r2*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

