### PR TITLE
rosdistro sync, Fri Mar 12 14:44:32 2021

### DIFF
--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -740,6 +740,8 @@ self: super: {
 
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 
+ pal-gazebo-worlds = self.callPackage ./pal-gazebo-worlds {};
+
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
  pcl-msgs = self.callPackage ./pcl-msgs {};

--- a/distros/foxy/pal-gazebo-worlds/default.nix
+++ b/distros/foxy/pal-gazebo-worlds/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, gazebo-msgs, gazebo-ros, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-pal-gazebo-worlds";
+  version = "3.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release/archive/release/foxy/pal_gazebo_worlds/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "e5931f7ab146d082b390e936ab1c231039b55d648e72aec181ba8d4b7d62e4ed";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  propagatedBuildInputs = [ gazebo-msgs gazebo-ros rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Simulation worlds for PAL robots.'';
+    license = with lib.licenses; [ "LGPL-3.0" ];
+  };
+}

--- a/distros/foxy/udp-msgs/default.nix
+++ b/distros/foxy/udp-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-udp-msgs";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/udp_msgs-release/archive/release/foxy/udp_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "72a28f37207063ace66e6c9d495b744eec81ba381dd55c23af3bb9e9aad5b8a8";
+    url = "https://github.com/flynneva/udp_msgs-release/archive/release/foxy/udp_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "7b8d5517aa76084998a225508489812d0650a003c489af6bb94d5f743a3565a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "e669d8f230926351052d2cc2f200c74a5935e9aeca93b297ddfc9133771a6aa9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "cca5f6e23c62e383aa488b0d64a2f6a60a689b6116cc76b0434eb42a8810f338";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -2366,6 +2366,8 @@ self: super: {
 
  mir-robot = self.callPackage ./mir-robot {};
 
+ mitre-fast-layered-map = self.callPackage ./mitre-fast-layered-map {};
+
  mk = self.callPackage ./mk {};
 
  ml-classifiers = self.callPackage ./ml-classifiers {};

--- a/distros/kinetic/heron-gazebo/default.nix
+++ b/distros/kinetic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-kinetic-heron-gazebo";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "0e06e8db73f76846b64ed20d520eec0c62bc3c790b362bbcf317830cffccfbb5";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_gazebo/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "3f880f88cba2df907dc8bb42ccef0474a218792d3111f431373528e52d2aa585";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/heron-simulator/default.nix
+++ b/distros/kinetic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-heron-simulator";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "813bd6c0cc9014071fd82074f863ff1c389f0bba3cc12a175f9490d06a8f7d10";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/kinetic/heron_simulator/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "e324468c085cd403b1d10f1f4066f7b0dadee60ea1b48f87dcdacb264b511d8d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "7b455bcdfe44f6abd5a877a65b3e8ac0fce914142635762e4ad9eb0e00939014";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "01ec612b71542929b730254cba8ca25b3b603e6f19c828fbdee0db79f4d59bee";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "f4453f4db70b7038763a826b074faaa74f34792f9902f1bc7d50e71cd91c3b07";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "35108a5b2201d5ffaa4c2841cce7fb43bd41146114cce93face8c5c514753aa6";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mcl-3dl/default.nix
+++ b/distros/kinetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-mcl-3dl";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "27950680b89b14dde24561eda4a95bad8c1ef174c374386bc91252f1c81f956d";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/kinetic/mcl_3dl/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "497f94f46c7e119a7a3a66af827baec78ed6e30298298570b4edb57ed3895e23";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/mitre-fast-layered-map/default.nix
+++ b/distros/kinetic/mitre-fast-layered-map/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, filters, geometry-msgs, grid-map-core, grid-map-loader, grid-map-msgs, grid-map-ros, grid-map-rviz-plugin, grid-map-visualization, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-mitre-fast-layered-map";
+  version = "0.1.4-r2";
+
+  src = fetchurl {
+    url = "https://github.com/mitre/mitre_fast_layered_map-release/archive/release/kinetic/mitre_fast_layered_map/0.1.4-2.tar.gz";
+    name = "0.1.4-2.tar.gz";
+    sha256 = "79b647f6ac3ffd1de812465fafd04893d96aad8af4cc108f571dbed96e2acb0d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cv-bridge filters geometry-msgs grid-map-core grid-map-loader grid-map-msgs grid-map-ros grid-map-rviz-plugin grid-map-visualization pcl pcl-conversions pcl-ros pluginlib roscpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The mitre_fast_layered_map package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/mocap-optitrack/default.nix
+++ b/distros/kinetic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-kinetic-mocap-optitrack";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/kinetic/mocap_optitrack/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "5ae4a7ec067aa4b7e735f1db0c057204707916d9568f1a90b1ad523ee9ac67a5";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/kinetic/mocap_optitrack/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "8397bdd9d400eb22fcd6fada5a16ad8e159d7f8b669790af2e79cf39c8fa4aee";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moose-control/default.nix
+++ b/distros/kinetic/moose-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, interactive-marker-twist-server, joint-state-controller, joy, nav-msgs, realtime-tools, robot-localization, roslaunch, teleop-twist-joy, tf, topic-tools, twist-mux, urdf }:
 buildRosPackage {
   pname = "ros-kinetic-moose-control";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_control/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f6210417ae71de6184cccf52ac51b5e728b9ca3566090df1053b9b5dd5ef0420";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_control/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "9ac98f4ed52f4dfc3ac7bfe1bf729c4f728b951879bdb60e5b0c1457b2382426";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moose-description/default.nix
+++ b/distros/kinetic/moose-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-moose-description";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_description/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "b186388f48dc5a1ea8df9275ed8ee33992af0f7f19adca4f30a7631aa291d5a1";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_description/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "9097fd1a806ccac394431d01cfe2a9fde0036bfc53ae3ef0ff10717261eeffe4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/moose-msgs/default.nix
+++ b/distros/kinetic/moose-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-moose-msgs";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_msgs/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "ee23bfa96ff206ad36ff8a79d33aa766ef553d56ebc2bd6ed25d881a6ce1e485";
+    url = "https://github.com/clearpath-gbp/moose-release/archive/release/kinetic/moose_msgs/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "bbd34560235b416669445bc21ed8fd2a34fd3fe9fbd1808f61e464cb7099a9a3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "6f3f0b710ebeccbd0488d996a7f3d604a7e2f2af1a0443a96b2b9bcdbc0600fe";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "b7fd70adb935b2ed1f547f6dce5ecfbda824840bec526fafd946df473f474830";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "a9e368bef1ec8ab2ff1c3e54c03b0c6a25df86ba2df157354cda68c7d0de3dd9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "bfff26cd54e45d2d3ce6eaf124980d6bec820e89977776e7b333b88fed6e4403";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "ec4310978a8c5dd312a86f5a1a79e508cebf916ce7bf6b23d6d20181271fb4c1";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "af18c0bd4afeac0b254e03fdcdfdd974898edd12004b438c5a01ca433498d266";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "81525e2aa6010feea93e5c6d8cf31879c62d639a15146ed35ecd698e9fb74cb6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "26cec629ee36303a641ea85d5feed5fb5e5a0713312db1d7088a7113354d3549";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "d6b5544920d9c1b30d3c3839db31ca2088ad5fe2b5b81c47f00a0039853f6639";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "2deae5427cc28d69667ee97bfdf9a21272b7f216e4c843992c85a509a52e65aa";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "12e1735d6906f96b694c32c509532b57768fc4765d94f8a6557294080a3484a8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "e4ec05064dd9ccd7fc5dd2f50ab09e56d719140f0dcc6672aeb6d44dbee38298";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "b33e5406abfe8a30be7211f2138d4086f6651076dfebd0665ee2ce57c64ed739";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "af55888a7442040959c25825f6be51aafca37148e2cfc5f67032813ec6b7a93b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "fce3aa3ba1635826125f1e999a03a75caabf2cf00a8e27b71e2150bff745a1a2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "fe22012ae1f70928a45b14ebc6c5e58acd207cd6defb2528b7377a43f3781c77";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-stamped/default.nix
+++ b/distros/kinetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-urg-stamped";
-  version = "0.0.7-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "9cf5e6b989ed6b8bd15cde7f3e0ede22beab3f15d6e72c79d529222fa36d7eda";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "1a1a5e08544ef30e67e942025e039c53ef88b423297df9fb6c51682b972333ed";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/warthog-control/default.nix
+++ b/distros/kinetic/warthog-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-kinetic-warthog-control";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_control/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "951358c64940fd908d444f21db8fe8ce2c2d79102eb66f49718f19eae0a56972";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_control/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "93c5f5a311b0f63dcfc45487599c8a29bab2a6f69137f3c6345f4d22b417b8e3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/warthog-description/default.nix
+++ b/distros/kinetic/warthog-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-warthog-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "deea19be5e4b864192987893852c0f2c82d748340cf80d12d44fe0063ab01fcc";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "9dbd43644fcdd87bbfec083febe98ad46a9ffa69fe3e7b712e699f907a21ffa5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/warthog-msgs/default.nix
+++ b/distros/kinetic/warthog-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-warthog-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "437a06c5a0973eb681c63dc0b0ca6552315c4eeea5160cf9979fd383068db9be";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/kinetic/warthog_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "4351edd85eafcec7280517806f7cceac8d9ff7239204092b26cbd03bb1553315";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ypspur/default.nix
+++ b/distros/kinetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-kinetic-ypspur";
-  version = "1.20.0-r1";
+  version = "1.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.20.0-1.tar.gz";
-    name = "1.20.0-1.tar.gz";
-    sha256 = "663ba5556d1e74927eafd40dc86854fbdc20abf53d9c047332fcf2237f582e03";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.20.1-1.tar.gz";
+    name = "1.20.1-1.tar.gz";
+    sha256 = "8dedf2bc1f1211b4ffc52e40edf7bee227d4f4db1305662b5d2676582957bb12";
   };
 
   buildType = "cmake";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "bd30c6512a006d5a47ba9874610b5c95989904e5815834848d402d668688f6b0";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "08f9b0124adadcdda13d5220bdfc8b8da6cf5c94ae1376dc4f1e89bb29ad587e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.6-r2";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.6-2.tar.gz";
-    name = "0.1.6-2.tar.gz";
-    sha256 = "08e085f69b9630ff958671a10f4a5ac853400292e08a0e731ab6a57541db0a00";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "bffd079ad13b14d2e8b3a82e8b5a37fc4f98827ef63702e61de5ab4049656aae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.6-r2";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.6-2.tar.gz";
-    name = "0.1.6-2.tar.gz";
-    sha256 = "bf32717669e0a1a8d334923d88a89eb3344f1bc10e0ebbe3498e557f3c508566";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "4119569ed9a102c3dd5df8de8a2f2e179c1dbe7950f57bb3702d203af94b3101";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ lms1xx realsense2-description robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ lms1xx realsense2-description robot-state-publisher urdf velodyne-description xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.6-r2";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.6-2.tar.gz";
-    name = "0.1.6-2.tar.gz";
-    sha256 = "8579c7e0ba871f0109885574793c1f2ece1b3af8f4bb03901288c462fddfd537";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "d2f61fe166eeda77fbdd0bde3f1ff2af766be6cfc40bd8b8e6a8f5c90338c987";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.6-r2";
+  version = "0.1.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.6-2.tar.gz";
-    name = "0.1.6-2.tar.gz";
-    sha256 = "a9ae461767c657e0aabb2a859db88bc8ffc65ea3070c0d03fbe1140e77d56059";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.7-1.tar.gz";
+    name = "0.1.7-1.tar.gz";
+    sha256 = "74524222298f52e02fde55f90690f132a5fb5662193c0a97205d949dc1d326b9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-graph-python/default.nix
+++ b/distros/melodic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph-python";
-  version = "4.0.1-r1";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "158a2774643b8697772ec940d99383d845d006fea9cb7cc6a7a5699593b9f66c";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/melodic/dynamic-graph-python/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "434872a6e2b6d482095a5bf4d12ab4dd3712e36e4d39d28dcd284ff57bc6a67f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/dynamic-graph/default.nix
+++ b/distros/melodic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-graph";
-  version = "4.3.1-r3";
+  version = "4.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.3.1-3.tar.gz";
-    name = "4.3.1-3.tar.gz";
-    sha256 = "7f68c3b43312d04898a5199fc48cdd48303ba413dd6f5f5a9223bfe95dd127f0";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/melodic/dynamic-graph/4.3.4-1.tar.gz";
+    name = "4.3.4-1.tar.gz";
+    sha256 = "621521f87a4002ffae23a5a7555d17d637b68b77c5dd1d5cdf4d181b8f71e720";
   };
 
   buildType = "cmake";

--- a/distros/melodic/eiquadprog/default.nix
+++ b/distros/melodic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-melodic-eiquadprog";
-  version = "1.2.2-r2";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.2-2.tar.gz";
-    name = "1.2.2-2.tar.gz";
-    sha256 = "5e30b47aad8598eeda3301ef6a834392123d3a2f1c3ba9a112b32cc4844158ca";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/melodic/eiquadprog/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "7e0ba9f0b290dd7934fe2e4e66330edcc3434b4fb070f9636bd19b39c202310d";
   };
 
   buildType = "cmake";

--- a/distros/melodic/fetch-bringup/default.nix
+++ b/distros/melodic/fetch-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-moveit-config, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, image-proc, joy, openni2-launch, ps3joy, robot-state-publisher, sensor-msgs, sick-tim }:
+{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-moveit-config, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, image-proc, joy, openni2-launch, ps3joy, robot-state-publisher, sensor-msgs, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-fetch-bringup";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/fetch_bringup/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "d2cc0bed589bf30ce12f119f1970ae8523af35977276098724b3c508bda9bc3a";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/fetch_bringup/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "120c683bc11d44db7062a463603c0f9246e77c30ab72cb722ade4fb45cef81ef";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ depth-image-proc diagnostic-aggregator fetch-description fetch-drivers fetch-moveit-config fetch-navigation fetch-open-auto-dock fetch-teleop graft image-proc joy openni2-launch ps3joy robot-state-publisher sensor-msgs sick-tim ];
+  propagatedBuildInputs = [ depth-image-proc diagnostic-aggregator fetch-description fetch-drivers fetch-moveit-config fetch-navigation fetch-open-auto-dock fetch-teleop graft image-proc joy openni2-launch ps3joy robot-state-publisher sensor-msgs sick-tim sound-play ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/fetch-calibration/default.nix
+++ b/distros/melodic/fetch-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-calibration }:
 buildRosPackage {
   pname = "ros-melodic-fetch-calibration";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_calibration/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "246ba4835fc72780262b5f3444bf03a93039c0b407594e84e7fb8274a3b7d2ee";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_calibration/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "3e2fafdcabe870e9a85de7e96582f8d42371e6cd23354f8f3da19f2331598178";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-depth-layer/default.nix
+++ b/distros/melodic/fetch-depth-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, cv-bridge, geometry-msgs, image-transport, nav-msgs, pluginlib, roscpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-fetch-depth-layer";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_depth_layer/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "2282dd7a2307b872015212dcdca14f3efba3e36f80f930d8b98a5ef728f8f99b";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_depth_layer/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "490e0726b5855cdb1b1d6185c3d7960b6898854b580c19b44405af2f9c089439";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-description/default.nix
+++ b/distros/melodic/fetch-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-fetch-description";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_description/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "3549d0508da99e8e906159816f711a15e035697ad013c1fcb13cbb767692dd14";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_description/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "687e90ba5a74c8f638c2141f710509056186288a9b58291c6cec54c017680347";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-drivers/default.nix
+++ b/distros/melodic/fetch-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, libyamlcpp, mk, nav-msgs, power-msgs, python, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-fetch-drivers";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/fetch_drivers/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "1a93f3a08200d27d455c1fffb0d9aaf712183b52e4627161f9c3a65ba5164a62";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/fetch_drivers/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "21476cf4eb010a51179a0700644ac8a15f5aaa5ccb4d704e9d1d7ab102048f80";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-ikfast-plugin/default.nix
+++ b/distros/melodic/fetch-ikfast-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, liblapack, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-fetch-ikfast-plugin";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_ikfast_plugin/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "24429d173975f72b6920d831762c727198d523f38dcd462c08beae779dc72643";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_ikfast_plugin/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "a0544a3c2d4320f714505bee02841026dddbdd25819836b0bafce8ef8e5d9e64";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-maps/default.nix
+++ b/distros/melodic/fetch-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-fetch-maps";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_maps/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "6e100cd6d0b97d8afd7cfedd71b7a371200312b09c5d9f3feee2e38c1597346c";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_maps/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "db4c4c0bf852af0c3cb9b87e7021a2576e30fafe715edc8a4c4cdc3c36edc02f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-moveit-config/default.nix
+++ b/distros/melodic/fetch-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fetch-description, fetch-ikfast-plugin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-python, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, rospy, rostest, xacro }:
 buildRosPackage {
   pname = "ros-melodic-fetch-moveit-config";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_moveit_config/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "4f73b1e8be984225f273f28a4ad0796aff7b509e036f0445ced3453c4476ec18";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_moveit_config/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "310f13774d6806737101b5f8a11d6dd03df7f6f3858592b43e8b2d20900b7a62";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-navigation/default.nix
+++ b/distros/melodic/fetch-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, clear-costmap-recovery, costmap-2d, fetch-depth-layer, fetch-maps, map-server, move-base, move-base-msgs, navfn, roslaunch, rotate-recovery, slam-karto, voxel-grid }:
 buildRosPackage {
   pname = "ros-melodic-fetch-navigation";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_navigation/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "255b963a72a9b38af080fad62427a9f9ed35ca395ed6d944880e1e9511d678c7";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_navigation/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "95caf008d946b5af25d11443d21a5cbb791185b54f91825b928894e27706ecdb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-ros/default.nix
+++ b/distros/melodic/fetch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fetch-calibration, fetch-depth-layer, fetch-description, fetch-ikfast-plugin, fetch-maps, fetch-moveit-config, fetch-navigation, fetch-teleop }:
 buildRosPackage {
   pname = "ros-melodic-fetch-ros";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_ros/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "280ad8771e06d8c58d969ec8266fb0ab5da3e6f55bd593b552c3c72503ae677f";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_ros/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "0352c66a6b59ab197e607345b2fe5c6f68de8600eaa6dc0b241e7e47b9984888";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fetch-teleop/default.nix
+++ b/distros/melodic/fetch-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, geometry-msgs, nav-msgs, roscpp, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-fetch-teleop";
-  version = "0.8.2-r1";
+  version = "0.8.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_teleop/0.8.2-1.tar.gz";
-    name = "0.8.2-1.tar.gz";
-    sha256 = "1dda678e097766b8ada664db041b3e591fb58d2441ccbfd11e91dabf3a6354a4";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/melodic/fetch_teleop/0.8.3-1.tar.gz";
+    name = "0.8.3-1.tar.gz";
+    sha256 = "8546502b0596bab3a981a2f3d7aeb935e5dafac7a59a51a9c1204d0da771cadf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/freight-bringup/default.nix
+++ b/distros/melodic/freight-bringup/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, joy, ps3joy, robot-state-publisher, sick-tim }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, joy, ps3joy, robot-state-publisher, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-freight-bringup";
-  version = "0.8.8-r1";
+  version = "0.8.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/freight_bringup/0.8.8-1.tar.gz";
-    name = "0.8.8-1.tar.gz";
-    sha256 = "4c838cc7caa4015cd00c8f8e1ba9e513b82094ae0982e120dd09497ec05c2d6d";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/melodic/freight_bringup/0.8.9-1.tar.gz";
+    name = "0.8.9-1.tar.gz";
+    sha256 = "7b06775c7543e57a19625778ee7165df819dcf336947f32b751772a841c6cc78";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-aggregator fetch-description fetch-drivers fetch-navigation fetch-open-auto-dock fetch-teleop graft joy ps3joy robot-state-publisher sick-tim ];
+  propagatedBuildInputs = [ diagnostic-aggregator fetch-description fetch-drivers fetch-navigation fetch-open-auto-dock fetch-teleop graft joy ps3joy robot-state-publisher sick-tim sound-play ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/heron-gazebo/default.nix
+++ b/distros/melodic/heron-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hector-gazebo-plugins, heron-msgs, interactive-marker-twist-server, nav-msgs, rospy, sensor-msgs, tf, uuv-gazebo-ros-plugins-msgs, uuv-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-melodic-heron-gazebo";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "036573f4c61aa358f8a720804de68b0f1d47af000e109348fef9be4d0001eb6d";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_gazebo/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "f4d7452f43a628c49f32212655878cc2a69d42a5e502ef85eb629e002f027d8c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/heron-simulator/default.nix
+++ b/distros/melodic/heron-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-heron-simulator";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c37d22db9e753e629036e6398a75a6e295b6438d3328d4dc954ba561615898a3";
+    url = "https://github.com/clearpath-gbp/heron_simulator-release/archive/release/melodic/heron_simulator/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "01e62741f3b4ac972fe81036559221d1c85baa78e0b6c9a6e4e42ad2013b3e77";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "2fa281f65e6afaf8b6e8ac7c05bbe97efc496d4a3ea32728fb4757ca93733a13";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "013f11ab82a8b764419cb6785db7e9ad0307f5e30ea84680ca6516fa6812b05f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7 }:
+{ lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "8ee4b074244706090dd8e209fd09f23ddb0c10eca83bbe75af9d444c2240a064";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "665941dd6185046ddd487b0e7cd7e6dba827d2d9ffd985e80ed6af5d83105d1f";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ husky-base husky-control husky-description imu-filter-madgwick imu-transformer lms1xx microstrain-3dmgx2-imu microstrain-mips nmea-comms nmea-navsat-driver pythonPackages.scipy realsense2-camera robot-localization robot-upstart tf tf2-ros um6 um7 ];
+  propagatedBuildInputs = [ husky-base husky-control husky-description imu-filter-madgwick imu-transformer lms1xx microstrain-3dmgx2-imu microstrain-mips nmea-comms nmea-navsat-driver pythonPackages.scipy realsense2-camera robot-localization robot-upstart tf tf2-ros um6 um7 velodyne-pointcloud ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "02886edfb9a8e6a1734730757bbe5403fb33787279267e5a9cf5e87afc929f27";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "fa1f6596f56130d8684fdb9f449b14f9261dd18bd1a059f76bb68b914f4a42b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "980c10791338954e46ca3031019fd02dbe252dc76515e87e563c4adacec1f376";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "b4dd2796cab46a9cd3c9bb22bbc59bb38292fca8ec90533862e584ba3cb8d719";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx realsense2-description urdf xacro ];
+  propagatedBuildInputs = [ lms1xx realsense2-description urdf velodyne-description xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "5f54dea54f351b8fb8c79251ccce794e2a6546f935734494a9b3d85db597ccdd";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "636ddd6c4036a1243dd154d30ad8d03ab752bea67826f05fd9afb56242fa307a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "e414939f01f7fee51ae251f22fa35a2eee8beabe70d22c06bb3283b9d3d75203";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "3fb125be6de1e0792d55af5e2a6248880cfb5bf28f5fd1af7107970daa90e5c1";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ controller-manager gazebo-plugins gazebo-ros gazebo-ros-control hector-gazebo-plugins husky-control husky-description multimaster-launch pointcloud-to-laserscan rostopic ];
+  propagatedBuildInputs = [ controller-manager gazebo-plugins gazebo-ros gazebo-ros-control hector-gazebo-plugins husky-control husky-description multimaster-launch pointcloud-to-laserscan rostopic velodyne-gazebo-plugins ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "cf1e24c63d7b0b85922ab4b04e6b8d5dcbf7f951adc52a9c77fe7c3640b10741";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "518669703738a7912486e91bb5b4bbfa041db88afdd5c33f11ec8a04aaa35c06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "4a95a84c72a3d470892d9892ebf602113385e0625eb616609c082be997a4b0bd";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "60e5615ec49010db27830b0cd69386ee5472853e07614c2e179b6a07ee688ba5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "4c668f8a691815dfcbd99ba0855dbb17ac6edfa150b32e845df6c401d8fcf687";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "837f228834cbf7858a7e500bfdff47332ec5e7f241bad8d427283b22a9396696";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "b3d8ded5e1c4cdaa4afa3558478af213b197b1a08a4905809e61220e71eceb5a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "ca407416e1585a648fec551a510bf4a7cc1a93682a275c31b913b6f0e2a9c27c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "aa6202e03289524edfc9d6eb70bcf6f494db77b7b330e9a4659c7afa9e8c0891";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "b56e630bee5cf37d2561f14095d9b261074def8a345d714425a1145cc90a30e5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "6dd2cc6ccd638584dcdf7c35b28e1e151b6cde2be8d2f8890cd967086def42e4";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "e6d4e3e89a930a815835ca04d8a3064c81c6f4a281ec248030e81d99c1c02345";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "7afd26fd109053baa9ef1e0b4f2daef5ab66b5b690b7d4e3e1c8ec1bb9b211d9";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "2eea4025bee71c480ef80f20bba5a73ebc8b9f8eef4e7677e6c80b6d22b3b560";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf xacro ];
+  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf velodyne-description xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "33548602caf997ac54844b8308f8284cf5cd60e758125b7ad8f3b44efe8741e0";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "a474b7bcab4d3da4c40cf8fb18e0ba7626829ebbe92bf9218fc43b755eac1a32";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "6f553f799ac5c79faea1e04c35ea3e2de88633611789e65e8f5eced6147c05df";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "f82c63ffae977dfea5387c2d3b9d83b90013030b6a0937a09c762ff3638f7160";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "0d6f7be0ae8ef69cc1233bfdfbde0ab45599e859cb473a9a459d6cf191bb76cf";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "d954e9fdbec0114f9043491b896763e34547aa9ff7a5af14ea014dc14e3afc92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "fee9fb49912bc031a3013085b813c66cc56bf1ce4e4877951918b881c7e607a4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "8e48159fa3ee1c5e2494715744d8a7a5fb5c15c3120e40d457e326f6227267c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "7a74619c8e44a2f719525ca845788a50112f850279895b99740073a549f9769d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "4f8568cad7e04a536d25b39fc776d1cacd1637a6d55fa459cb8cd0364aee4567";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "540c5728dbb160edcca1fc7265bc49e5b89f1fc1e6b6bb86aea51cc676549132";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "2d8ac0768cc58ead32e0a1216e6b3fc8ffca6709eb7deb2ad0329b2b4efc2ef3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-optitrack/default.nix
+++ b/distros/melodic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-melodic-mocap-optitrack";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "26c631a93df50d62e137b502d5f942e99ae9df69416cb3fc225a99b2ff450599";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "97e8658dd34f099357b71e07c30623813c8298f5eb8be291194c2e6268e53f89";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "685e41caef0c36db53023cc2ed1d2717083e469d45f8fff8fa87854936c30766";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "3ff1b854a503e0326187932aaef0bf612e7db0958acdc0e74507e820a60db5bf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "d7c49f35a6bbbcb2094c65811a75614b1bfb8dc42737c0a6bc672bed4091dad5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "36602f4b427009c99c88607c009a630fc0bae4db8df855a7cfcdb4381542211e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "69ebc422dbb64b26e3891687f86b0eb51160f314656a36eb9584b6df6093c2df";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "277ea22ff1815abc3c373939887c7df67b822ee13cce2fdc6bac8b32e5f98dce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "1c36cd250a0e782d58fa6cc7d6e459495225bc56a3b2bfc053e19888c26ee45c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "891d6b13145969194a0d76738a604393d7c451223afccbab2411886ea16c999c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "7a6061d6f8f2b747af64a0de6ecd3094f9f1f31357c27070bd0eed8a21016a45";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "d59d77886b28f4bec1e4e0b0a945419bfb5c0a3dd7c5c3a4ee5b4facd785ede6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "83518f290847262a7fa2a1517fe31aed7bf881f85a1f1e0f8ca8231338f061b9";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "ab79da9df5bab6b8bff2a185cf106337672ddaa7873702f8577caceed3a69900";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "3af3621e8db901908e86fffa32e609d4cb37ee2eca8d9567d7e7b513fc832afa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "9f3a12c9910cfeeb041978dadcba9f1cddf8632e7e866d8a6174dd2f8bb5fb9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sot-core/default.nix
+++ b/distros/melodic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-melodic-sot-core";
-  version = "4.11.2-r3";
+  version = "4.11.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.2-3.tar.gz";
-    name = "4.11.2-3.tar.gz";
-    sha256 = "7b4219479c4a883da36a9068c5f61cd23fafec5f0e88dc6919c82da981f373f5";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.5-2.tar.gz";
+    name = "4.11.5-2.tar.gz";
+    sha256 = "cd97257236edad1d9299d1c9e26ac664760ecee65a28dcf4fc6af301ca5910d4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/sot-tools/default.nix
+++ b/distros/melodic/sot-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
 buildRosPackage {
   pname = "ros-melodic-sot-tools";
-  version = "2.3.2-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/melodic/sot-tools/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "27e2611dd23d5da8e7881daced1dcee22abdcd81f59b2a10ed56614e2978ab49";
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/melodic/sot-tools/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "972af1477b8121140c5b5a19b0baec03fd4b66de6f1bc92a2e6c100deb891617";
   };
 
   buildType = "cmake";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "798fef16feaf9fc0bed81c616b2c7707bd966c322f444d8939f7f862bc245f8d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "23213af1a09807c5a2699cfa911259e1f27321a3e4b082647fa7d0daa0001f8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "b126b52feb66eaca496393037fa4621d7655945a6ad48fd9408ee778d6a83500";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "9e2238f8698b0cee477fbeda67890643615c558883cbfb4c133ec6aa29910369";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.7-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "737ff7ded85fd08a2e373ffaf1be8ac2a4a28e71cca1bde78d3a2472567f9663";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "17819d6be60366c1c6d586d33658734e8fc008e6b95b1420c9edef5e1e2e2a43";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-control/default.nix
+++ b/distros/melodic/warthog-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-warthog-control";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "b005fc1de6847771e3b4062f6319cd940dd334f78844d532c5c0f83b7f4a0c2d";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "5d0aa4fa339942dbed6eb901307332befc8ce052f1d01eef3c74439b7622dad6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-description/default.nix
+++ b/distros/melodic/warthog-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-warthog-description";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "243a1ad878d4c901df8ebecfa588a6076fa6ed204bf892ac84012cc66a9a1d5f";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "7fb3fe0903dfeed8112c5c68854e6952136d1588d495a85d902d92a46f3e82af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-msgs/default.nix
+++ b/distros/melodic/warthog-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-warthog-msgs";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "506d668bc4254f8b197bc74dfb67f870ded037461ec696936cbc325a35b494bc";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "bf3be025e0b3929028832d7220b11ecc76957a37db0dd553909ca706f8bf8896";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ypspur/default.nix
+++ b/distros/melodic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-melodic-ypspur";
-  version = "1.20.0-r1";
+  version = "1.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.20.0-1.tar.gz";
-    name = "1.20.0-1.tar.gz";
-    sha256 = "64d9f83ecdc7906944cb3d51701a91f8a9d06cf4eb9c39e326790b3f19045f8d";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.20.1-1.tar.gz";
+    name = "1.20.1-1.tar.gz";
+    sha256 = "8bde2bd9c59e1ee972ebf54b8d473c25c4d97c311fa5ff10becc69d9bcdfe32f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "db9b9473071f9dfcfbb93baf8b08f9eae30baeaa8f2155dae8923bf94cd86627";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "bb85a93a9afc36c9c7054cbe04c5469f03d1ff10a760a065a2e5f9d1d11f9140";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-bringup/default.nix
+++ b/distros/noetic/fetch-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, depth-image-proc, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-moveit-config, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, image-proc, joy, openni2-launch, robot-state-publisher, sensor-msgs, sick-tim, sound-play }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-bringup";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_bringup/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "7c5fc91b4d57c5ee2e755615c8fd7e6dbe9b5d4c0f7204a19b945dce2e0c6d95";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ depth-image-proc diagnostic-aggregator fetch-description fetch-drivers fetch-moveit-config fetch-navigation fetch-open-auto-dock fetch-teleop graft image-proc joy openni2-launch robot-state-publisher sensor-msgs sick-tim sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Bringup for fetch'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/fetch-calibration/default.nix
+++ b/distros/noetic/fetch-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, robot-calibration }:
 buildRosPackage {
   pname = "ros-noetic-fetch-calibration";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_calibration/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "3ea8566a720e400ae76449b5c54ffc5bd1733d9caf964260e4684caef1bcb912";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_calibration/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "c11144a32a9706f74aec372cde05591232580d7d20824eeabd270f8d8c03b79b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-depth-layer/default.nix
+++ b/distros/noetic/fetch-depth-layer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-2d, cv-bridge, geometry-msgs, image-transport, nav-msgs, pluginlib, roscpp, sensor-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-fetch-depth-layer";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_depth_layer/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "a486778a773b3f05efccaec69c6e2500a85f178300594cf835ff9d59f6b5e088";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_depth_layer/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "42b7005d4a31d5ef1c928f52c0dc93f8106833a1a5170cec4e7f10f9defec6be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-description/default.nix
+++ b/distros/noetic/fetch-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-fetch-description";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_description/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "f59f7ad66e1a9e07ab1c5b581b2ae2f6ebb2864c84f0f64cec0f536e030e0c8f";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_description/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "e9b0b5bac52c230f416305f0cb8ff4cdb5a5567a3df8143795e6fda8e57f78d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-drivers/default.nix
+++ b/distros/noetic/fetch-drivers/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, libyamlcpp, mk, nav-msgs, power-msgs, python3, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom }:
+buildRosPackage {
+  pname = "ros-noetic-fetch-drivers";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_drivers/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "6258a13ea84a294420bcc474fd2c75ef88d7d276cd0571b57e6b908826978bc1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ mk rospack ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs boost curl diagnostic-msgs fetch-auto-dock-msgs fetch-driver-msgs libyamlcpp nav-msgs power-msgs python3 robot-calibration-msgs robot-controllers robot-controllers-interface rosconsole roscpp roscpp-serialization rostime sensor-msgs urdf urdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The public fetch_drivers package is a binary only release.
+
+    fetch_drivers contains both the drivers and firmware for the fetch and freight research robots.
+    There should be no reason to use these drivers unless you're running on a fetch or a freight research robot.
+    This package, is a cmake/make only package which installs the binaries for the drivers and firmware.'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/fetch-ikfast-plugin/default.nix
+++ b/distros/noetic/fetch-ikfast-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, liblapack, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-noetic-fetch-ikfast-plugin";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ikfast_plugin/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "7f27ca168fe00fbd9a1e50dc5407bbf623d6a2cc54aa47b2876ff29707704242";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ikfast_plugin/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "dd967690c06c97e3cb82db0bdd22bd8ef9d29e653308b324bf9904e964d32d48";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-maps/default.nix
+++ b/distros/noetic/fetch-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-fetch-maps";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_maps/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "6d30d9bd13cf660c83350a3f9181654ad9788809f867289b00a1cf3a4534f533";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_maps/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "4679e269f796a687cef2c846602aec7a1de7873f1c0fcaa624b87f14a1efa265";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-moveit-config/default.nix
+++ b/distros/noetic/fetch-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fetch-description, fetch-ikfast-plugin, joint-state-publisher, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-python, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, rospy, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-fetch-moveit-config";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_moveit_config/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "03c5926ed7872fe04a801ab4e79feefef1089bdde445539e81cbcfe381740a15";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_moveit_config/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "9dc3b097e595365fa0262b98d1c77dbd4cd3c592e23a2bad6da000f1940ce8dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-navigation/default.nix
+++ b/distros/noetic/fetch-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, clear-costmap-recovery, costmap-2d, fetch-depth-layer, fetch-maps, map-server, move-base, move-base-msgs, navfn, roslaunch, rotate-recovery, slam-karto, voxel-grid }:
 buildRosPackage {
   pname = "ros-noetic-fetch-navigation";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_navigation/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "b9d6ed800f2c34e96cb15e4c846dafca23fd60f95fd8fa9889b4c9ff141fbe98";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_navigation/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "9e4ea90921f157347f53637387de35f39d9143820a8ceb15436cc51397513906";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-ros/default.nix
+++ b/distros/noetic/fetch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, fetch-calibration, fetch-depth-layer, fetch-description, fetch-ikfast-plugin, fetch-maps, fetch-moveit-config, fetch-navigation, fetch-teleop }:
 buildRosPackage {
   pname = "ros-noetic-fetch-ros";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ros/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "17e138f2c1a1175d72581680f757122f66f1a598838f1f10a0361baa1719ceb3";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_ros/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "a66c52e9776e1a30f4b2c0b9c51cf615a3bc68f227add45537d970f9c82c6464";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-teleop/default.nix
+++ b/distros/noetic/fetch-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, geometry-msgs, nav-msgs, roscpp, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-fetch-teleop";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_teleop/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "56e5095105103697e77fc71e05938a115349f0f4596974f749c6252ba5052164";
+    url = "https://github.com/fetchrobotics-gbp/fetch_ros-release/archive/release/noetic/fetch_teleop/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "dc4741dbb66f037b5e75769730a6b35dc40dd5b53a8b5a456f053b23e9e62a0e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/freight-bringup/default.nix
+++ b/distros/noetic/freight-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, joy, robot-state-publisher, sick-tim, sound-play }:
+buildRosPackage {
+  pname = "ros-noetic-freight-bringup";
+  version = "0.9.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/freight_bringup/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "b4bf4ed64d3dbc1065bdd7417fa3e13a96501b335ab19760ecd59273a00a3fc0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-aggregator fetch-description fetch-drivers fetch-navigation fetch-open-auto-dock fetch-teleop graft joy robot-state-publisher sick-tim sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Bringup for freight'';
+    license = with lib.licenses; [ "Proprietary" ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -680,6 +680,8 @@ self: super: {
 
  fetch-auto-dock-msgs = self.callPackage ./fetch-auto-dock-msgs {};
 
+ fetch-bringup = self.callPackage ./fetch-bringup {};
+
  fetch-calibration = self.callPackage ./fetch-calibration {};
 
  fetch-depth-layer = self.callPackage ./fetch-depth-layer {};
@@ -687,6 +689,8 @@ self: super: {
  fetch-description = self.callPackage ./fetch-description {};
 
  fetch-driver-msgs = self.callPackage ./fetch-driver-msgs {};
+
+ fetch-drivers = self.callPackage ./fetch-drivers {};
 
  fetch-ikfast-plugin = self.callPackage ./fetch-ikfast-plugin {};
 
@@ -767,6 +771,8 @@ self: super: {
  franka-msgs = self.callPackage ./franka-msgs {};
 
  franka-visualization = self.callPackage ./franka-visualization {};
+
+ freight-bringup = self.callPackage ./freight-bringup {};
 
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
@@ -1143,6 +1149,8 @@ self: super: {
  laser-scan-sparsifier = self.callPackage ./laser-scan-sparsifier {};
 
  laser-scan-splitter = self.callPackage ./laser-scan-splitter {};
+
+ led-msgs = self.callPackage ./led-msgs {};
 
  leo = self.callPackage ./leo {};
 
@@ -1671,6 +1679,8 @@ self: super: {
  pr2-mechanism-msgs = self.callPackage ./pr2-mechanism-msgs {};
 
  pr2-msgs = self.callPackage ./pr2-msgs {};
+
+ prosilica-gige-sdk = self.callPackage ./prosilica-gige-sdk {};
 
  ps3joy = self.callPackage ./ps3joy {};
 
@@ -2481,6 +2491,8 @@ self: super: {
  wireless-msgs = self.callPackage ./wireless-msgs {};
 
  wireless-watcher = self.callPackage ./wireless-watcher {};
+
+ ws281x = self.callPackage ./ws281x {};
 
  wu-ros-tools = self.callPackage ./wu-ros-tools {};
 

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "ef430550fdcad1b38f8c0224121ac1d8d453e855036fb93efcbbd7f341579617";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "51af8ed8041bcb65b894975bbf7164e1ca92e2d0b6368709f21b50edf90190f3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/led-msgs/default.nix
+++ b/distros/noetic/led-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-led-msgs";
+  version = "0.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/ros_led-release/archive/release/noetic/led_msgs/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "b439cf190c5c582ef99e48cc946c9997f994e4afc97c19a0c89124cc497c1062";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for LEDs and LED strips'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "cb3c5d6c110815d1352bb290d85763a34f9e304d1a7e37299eea27e75ebadf8c";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "13448a827747b404a950c49df14ba9adec5d38b60d62dde4e3add13f337d213a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "e70688b82f7ff63a48a4a8caa476a043b7c28496b75e2c7d159238a225f6bed3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "e158f43b8d2a72f761f9dbb88d9e541dea791a09ca235a3ae2c00f6a104c2cb9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "4789dd5b0d5bb799e6a831c12c0a236169c12a57bdc54f5d57014f1128f6c775";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "377051c7668e2ca049915362a394f6f641643d5775b88ff60d02abad163e3b48";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mocap-optitrack/default.nix
+++ b/distros/noetic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-mocap-optitrack";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "bb2cc1e00ae9ab1d2061ad8975ed6e7a3c312789f9c1173019174540c4b3723e";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "f4276d130103cd56cc62122401ba36c8fe890ee9ea146ada174fee635b07e029";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "acdea97e27cecfba83a32f922aef0ae7d7c51c966ff05ab46620643d6af753d3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "50e9fe14ab5ecaf164fead2d164e3c950f41aff9d327d3f675f843eff5cc07d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "cfcaf119a9f7506f57c8d504a10efb9240d184de5f475eab7304d9b61e07f20c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "1443d2699ee13a74f16f97e14aafad66a425fef5eb02d13d1b19d4c55be7fba2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "7be823daceb21053b6e100e62b3cd9f024086961fb3f6de479b7618171c9d514";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "f42a1ff6e567a378af914c1baf1baafb0a6030998c01295d7432cc4a39d1778b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "e1a2b5a4b07e4787ccee12cd3d7511b690de1064cf19f7e7750dd18381a3ac5f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "4c304f0da001659f23db183b259fb335e239d5717468e63005cadfdd1c6c3a8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "2711b04fb49d94d74caba25cc6ce6dff6b755f84fd5f27215f098bd92cd55904";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "9973c4e460483bea8ab2fe76f976fb9faf9708ee05d42ed408877d507c85889b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "33695e7f1a90c9390da8363f144693740ef9024a9d60642fe45583fa94def41f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "7dcd2bc2cd5afced604837687f56a436fc3ddd1195402ee25721773bf42d14dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "20009c1554c652d1bb8ec9af96392dc94dedd4c52470e426101859b93556aeb9";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "82c3c565bca2961eadb2acc1d543bd1a8369579859ee668016f9edda4a3cc5bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d55a8c8962d4990cc76401536f7977ffb02bb037a26d37c58ce8c14ef39bd902";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "92813a56daf204152b99a1d41b67093ccda583ae6f878bbe7d7fa6c5d2ce7114";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "24267f25fd7866564d2bb5e6551eae348e7aa3abe2916ef374c9c6c15bb567e3";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "82b8e84fab49ae6f80529cc0f18fe3124548ba34b8f1fc5e3d359a3694c66f67";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6d7897d4c1a1d91fe3e5e35fece4f517d2100c61ed833cfeb3c0df031fba99e4";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "f5cac996d9547056119ed4af8495d511f868d89121f0cb2098f348648ef7a2bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "25d3f37691542c6f371b970880ef2dc5bc6a1c876582e391c7fd0a3767084761";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "0f2f44967ed4f81e33e6ba841c2293b2196ccd3e5dab4c7eec0f7ddffc5136c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "efddecf8d7e49d2684f858143f6ea9e4f766d6b5d0194872604595b800acb08b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "46053584a6ca253e2a530e85166bb92f81a82587fc080b89a4808da202c4d574";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "3e035d67786cb21822bc512aecc4464e932cfc2673e081e22895be8de2fddc58";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d14222ef6400806227923f5e6414e59100c05c73874c0ac88de53dc26ea0e205";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "959e23d3cfa5768dab4dfb1a5ba4440585354dbc4dda2a823a4691f4ec8dbb9c";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a5758231079a6729f9c64926031db941dd0ff0efd0704baf45d1c31fc755dbfd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "6489d6a3c5947eb91203a86095e5341a7b870d97ead941e92cb68a524cbb5edd";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "87d56112414a32f4e10c118e46ffbed311366c780604733c960d3d30f46a8cd6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "0c1ee6ed6227df2236e1fd0bfa0fe3df314e87a7be3fcdc8ac5b529c9876c4aa";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a8c2cd6af1a49a18bd30abbd3778bd91ecdeb04e75a89b4afeb5e425b996db01";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c4f675a64cce4931b95b19317f30d500d638dbb0869aacb0e185c815e1ed98ab";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "499c1bf8bf2d771b102881cd05fd1cde6c0224c85bb49d88cd968ea03f2e6af2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "fcc58db08288de3212288902b3480bb0d505fa37a73d6d0bd77b9d2a9bd4ef6b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "7ce183c877cfd658a29b64dd24533651816043ab3c84eba33820d38fb56ea134";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "139884dab4de402e96b1880b239d9fcfdddc1b8e0820db9dd603509784c11bab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "dbf9134bd43a071dcfd14db58168c9863f371d05fc100f4fe288e2b1f395ec9b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/prosilica-gige-sdk/default.nix
+++ b/distros/noetic/prosilica-gige-sdk/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-prosilica-gige-sdk";
+  version = "1.26.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/prosilica_gige_sdk-release/archive/release/noetic/prosilica_gige_sdk/1.26.3-2.tar.gz";
+    name = "1.26.3-2.tar.gz";
+    sha256 = "9f6c2b87f379e186ffb2f156befd99157cad4c3532ff644ec84471fd3cd26bcc";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AVT GigE SDK version 1.26 for ROS'';
+    license = with lib.licenses; [ "Commercial" ];
+  };
+}

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.1.4-r1";
+  version = "0.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.1.4-1.tar.gz";
-    name = "0.1.4-1.tar.gz";
-    sha256 = "6d0336683936565129598cea9c880e3e72e274c094caf3b264ed89b432a676d8";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.1.5-1.tar.gz";
+    name = "0.1.5-1.tar.gz";
+    sha256 = "da787273f4bb736da02862eb60b778b10c0d7e2b3ce3b99f2811a889768b391c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "f9b88eaaa62c18e46dfd9d3f905a2059b363d5b46360736ca6aff435067810a9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "a1b56f0e95703a559f310e3c4f2a901c3653ba0890621dfd70f4371bd2f79447";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "123d6a743318aca5535b8e4b814075cd9e8425ac1c63e03af484e0486b9880cb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "7f3efa8a1730aba05694988a0e4a783b31e85e08f30b2d8052594b49a3548fae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.6-r1";
+  version = "0.10.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.6-1.tar.gz";
-    name = "0.10.6-1.tar.gz";
-    sha256 = "5845c470dc1108b1bed93c1374f46114f46fe389b8c0839c6973c0d0c7dc7c80";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.8-1.tar.gz";
+    name = "0.10.8-1.tar.gz";
+    sha256 = "af0e2975ccfd5598527033fcde650cf972e27896f42cd8cac5622cf291b1c4dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.7-r1";
+  version = "0.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.7-1.tar.gz";
-    name = "0.0.7-1.tar.gz";
-    sha256 = "7283de5098c02c02af06a2e83445edcec7f9e22c4aa909736fe7e72d765e208c";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "0e86a87b09f308c92c34f886047b0e4af43e2cfe50199745afe0faaf5286f44e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ws281x/default.nix
+++ b/distros/noetic/ws281x/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, led-msgs, message-generation, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-ws281x";
+  version = "0.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/ros_led-release/archive/release/noetic/ws281x/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "8186be07107e1a14a5f6a482e01ac32a26dcda22bdb93beb6c90b0ce95088c5e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ led-msgs message-generation roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for rpi_ws281x LED strip driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/ypspur/default.nix
+++ b/distros/noetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-noetic-ypspur";
-  version = "1.20.0-r1";
+  version = "1.20.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.0-1.tar.gz";
-    name = "1.20.0-1.tar.gz";
-    sha256 = "a5223be33258004a08da6931960c07008da0044d936fb0651005c9eedf04aab1";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.1-1.tar.gz";
+    name = "1.20.1-1.tar.gz";
+    sha256 = "a124cf7f8c0086c08713246861cc9e26243e149778cef569e9098bb15805c07b";
   };
 
   buildType = "cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 2ebc4e62427cd2fc4818342151f35bd7f5097817.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *pal-gazebo-worlds 3.0.2-r1*
* *udp-msgs 0.0.2-r1 --> 0.0.3-r1*

Kinetic Changes:
----------------
* *costmap-cspace 0.10.6-r1 --> 0.10.8-r1*
* *heron-gazebo 0.3.2-r1 --> 0.3.3-r1*
* *heron-simulator 0.3.2-r1 --> 0.3.3-r1*
* *joystick-interrupt 0.10.6-r1 --> 0.10.8-r1*
* *map-organizer 0.10.6-r1 --> 0.10.8-r1*
* *mcl-3dl 0.5.3-r1 --> 0.5.4-r1*
* *mitre-fast-layered-map 0.1.4-r2*
* *mocap-optitrack 0.1.0-r1 --> 0.1.1-r1*
* *moose-control 0.1.0-r1 --> 0.1.1-r1*
* *moose-description 0.1.0-r1 --> 0.1.1-r1*
* *moose-msgs 0.1.0-r1 --> 0.1.1-r1*
* *neonavigation 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-common 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-launch 0.10.6-r1 --> 0.10.8-r1*
* *obj-to-pointcloud 0.10.6-r1 --> 0.10.8-r1*
* *planner-cspace 0.10.6-r1 --> 0.10.8-r1*
* *safety-limiter 0.10.6-r1 --> 0.10.8-r1*
* *track-odometry 0.10.6-r1 --> 0.10.8-r1*
* *trajectory-tracker 0.10.6-r1 --> 0.10.8-r1*
* *urg-stamped 0.0.7-r1 --> 0.0.9-r1*
* *warthog-control 0.1.2-r1 --> 0.1.3-r1*
* *warthog-description 0.1.2-r1 --> 0.1.3-r1*
* *warthog-msgs 0.1.2-r1 --> 0.1.3-r1*
* *ypspur 1.20.0-r1 --> 1.20.1-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.10.6-r1 --> 0.10.8-r1*
* *dingo-control 0.1.6-r2 --> 0.1.7-r1*
* *dingo-description 0.1.6-r2 --> 0.1.7-r1*
* *dingo-msgs 0.1.6-r2 --> 0.1.7-r1*
* *dingo-navigation 0.1.6-r2 --> 0.1.7-r1*
* *dynamic-graph 4.3.1-r3 --> 4.3.4-r1*
* *dynamic-graph-python 4.0.1-r1 --> 4.0.3-r1*
* *eiquadprog 1.2.2-r2 --> 1.2.3-r1*
* *fetch-bringup 0.8.8-r1 --> 0.8.9-r1*
* *fetch-calibration 0.8.2-r1 --> 0.8.3-r1*
* *fetch-depth-layer 0.8.2-r1 --> 0.8.3-r1*
* *fetch-description 0.8.2-r1 --> 0.8.3-r1*
* *fetch-drivers 0.8.8-r1 --> 0.8.9-r1*
* *fetch-ikfast-plugin 0.8.2-r1 --> 0.8.3-r1*
* *fetch-maps 0.8.2-r1 --> 0.8.3-r1*
* *fetch-moveit-config 0.8.2-r1 --> 0.8.3-r1*
* *fetch-navigation 0.8.2-r1 --> 0.8.3-r1*
* *fetch-ros 0.8.2-r1 --> 0.8.3-r1*
* *fetch-teleop 0.8.2-r1 --> 0.8.3-r1*
* *freight-bringup 0.8.8-r1 --> 0.8.9-r1*
* *heron-gazebo 0.3.2-r1 --> 0.3.3-r1*
* *heron-simulator 0.3.2-r1 --> 0.3.3-r1*
* *husky-base 0.4.5-r1 --> 0.4.6-r1*
* *husky-bringup 0.4.5-r1 --> 0.4.6-r1*
* *husky-control 0.4.5-r1 --> 0.4.6-r1*
* *husky-description 0.4.5-r1 --> 0.4.6-r1*
* *husky-desktop 0.4.5-r1 --> 0.4.6-r1*
* *husky-gazebo 0.4.5-r1 --> 0.4.6-r1*
* *husky-msgs 0.4.5-r1 --> 0.4.6-r1*
* *husky-navigation 0.4.5-r1 --> 0.4.6-r1*
* *husky-robot 0.4.5-r1 --> 0.4.6-r1*
* *husky-simulator 0.4.5-r1 --> 0.4.6-r1*
* *husky-viz 0.4.5-r1 --> 0.4.6-r1*
* *jackal-control 0.7.2-r1 --> 0.7.3-r1*
* *jackal-description 0.7.2-r1 --> 0.7.3-r1*
* *jackal-msgs 0.7.2-r1 --> 0.7.3-r1*
* *jackal-navigation 0.7.2-r1 --> 0.7.3-r1*
* *jackal-tutorials 0.7.2-r1 --> 0.7.3-r1*
* *joystick-interrupt 0.10.6-r1 --> 0.10.8-r1*
* *map-organizer 0.10.6-r1 --> 0.10.8-r1*
* *mcl-3dl 0.5.3-r1 --> 0.5.4-r1*
* *mocap-optitrack 0.1.0-r1 --> 0.1.1-r1*
* *neonavigation 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-common 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-launch 0.10.6-r1 --> 0.10.8-r1*
* *obj-to-pointcloud 0.10.6-r1 --> 0.10.8-r1*
* *planner-cspace 0.10.6-r1 --> 0.10.8-r1*
* *psen-scan-v2 0.1.4-r1 --> 0.1.5-r1*
* *safety-limiter 0.10.6-r1 --> 0.10.8-r1*
* *sot-core 4.11.2-r3 --> 4.11.5-r2*
* *sot-tools 2.3.2-r1 --> 2.3.4-r1*
* *track-odometry 0.10.6-r1 --> 0.10.8-r1*
* *trajectory-tracker 0.10.6-r1 --> 0.10.8-r1*
* *urg-stamped 0.0.7-r1 --> 0.0.9-r1*
* *warthog-control 0.1.2-r1 --> 0.1.3-r1*
* *warthog-description 0.1.2-r1 --> 0.1.3-r1*
* *warthog-msgs 0.1.2-r1 --> 0.1.3-r1*
* *ypspur 1.20.0-r1 --> 1.20.1-r1*

Noetic Changes:
---------------
* *costmap-cspace 0.10.6-r1 --> 0.10.8-r1*
* *fetch-bringup 0.9.1-r1*
* *fetch-calibration 0.9.0-r1 --> 0.9.1-r1*
* *fetch-depth-layer 0.9.0-r1 --> 0.9.1-r1*
* *fetch-description 0.9.0-r1 --> 0.9.1-r1*
* *fetch-drivers 0.9.1-r1*
* *fetch-ikfast-plugin 0.9.0-r1 --> 0.9.1-r1*
* *fetch-maps 0.9.0-r1 --> 0.9.1-r1*
* *fetch-moveit-config 0.9.0-r1 --> 0.9.1-r1*
* *fetch-navigation 0.9.0-r1 --> 0.9.1-r1*
* *fetch-ros 0.9.0-r1 --> 0.9.1-r1*
* *fetch-teleop 0.9.0-r1 --> 0.9.1-r1*
* *freight-bringup 0.9.1-r1*
* *joystick-interrupt 0.10.6-r1 --> 0.10.8-r1*
* *led-msgs 0.0.9-r1*
* *libphidget22 1.0.1-r1 --> 1.0.2-r1*
* *map-organizer 0.10.6-r1 --> 0.10.8-r1*
* *mcl-3dl 0.5.3-r1 --> 0.5.4-r1*
* *mocap-optitrack 0.1.0-r1 --> 0.1.1-r1*
* *neonavigation 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-common 0.10.6-r1 --> 0.10.8-r1*
* *neonavigation-launch 0.10.6-r1 --> 0.10.8-r1*
* *obj-to-pointcloud 0.10.6-r1 --> 0.10.8-r1*
* *phidgets-accelerometer 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-analog-inputs 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-api 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-digital-inputs 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-digital-outputs 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-drivers 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-gyroscope 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-high-speed-encoder 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-ik 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-magnetometer 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-motors 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-msgs 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-spatial 1.0.1-r1 --> 1.0.2-r1*
* *phidgets-temperature 1.0.1-r1 --> 1.0.2-r1*
* *planner-cspace 0.10.6-r1 --> 0.10.8-r1*
* *prosilica-gige-sdk 1.26.3-r2*
* *psen-scan-v2 0.1.4-r1 --> 0.1.5-r1*
* *safety-limiter 0.10.6-r1 --> 0.10.8-r1*
* *track-odometry 0.10.6-r1 --> 0.10.8-r1*
* *trajectory-tracker 0.10.6-r1 --> 0.10.8-r1*
* *urg-stamped 0.0.7-r1 --> 0.0.9-r1*
* *ws281x 0.0.9-r1*
* *ypspur 1.20.0-r1 --> 1.20.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

