### PR TITLE
rosdistro sync, Fri Mar 19 13:19:05 2021

### DIFF
--- a/distros/dashing/system-modes-examples/default.nix
+++ b/distros/dashing/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes }:
 buildRosPackage {
   pname = "ros-dashing-system-modes-examples";
-  version = "0.4.2-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "c43b844a99a1dc127b1d3df083c551f39f4b7e2ac6738b7e12dae105f6d5f657";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes_examples/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "3d248062bd0c22c9c486037f696aa9d435b0ea95fd4df0eb7af72bec48c84412";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/system-modes/default.nix
+++ b/distros/dashing/system-modes/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, builtin-interfaces, launch-ros, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-dashing-system-modes";
-  version = "0.4.2-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "1604a4140ba1f90a9d7da13791ad7101f905fb8afd956abc2f1185f08fac1aa5";
+    url = "https://github.com/microROS/system_modes-release/archive/release/dashing/system_modes/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "8a2b67f1634911709fa9a3105446333f6346ec3987f9abd061457c598585a11d";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-index-python ament-lint-auto ];
   propagatedBuildInputs = [ builtin-interfaces launch-ros rclcpp rclcpp-lifecycle rosidl-default-generators std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/ament-package/default.nix
+++ b/distros/foxy/ament-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-package";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/foxy/ament_package/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "1e2abd458a2d64f43f57fe1796ee8457fb2667493b78a22584862d71acb86319";
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/foxy/ament_package/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "84219be6b42aeb1888041a18448ec08fbe176658419241d6c71576bc95e89772";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/cascade-lifecycle-msgs/default.nix
+++ b/distros/foxy/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-foxy-cascade-lifecycle-msgs";
-  version = "0.0.6-r1";
+  version = "0.0.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/cascade_lifecycle_msgs/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "d1c5fc2fce98d13e55663a70e763c687542d444c5ece61434a2310db4dca332e";
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/cascade_lifecycle_msgs/0.0.7-4.tar.gz";
+    name = "0.0.7-4.tar.gz";
+    sha256 = "efe3b41e8c2b10db244b8bde561b31438dc51b9bbc3fe1d077c6117e6506d360";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/example-interfaces/default.nix
+++ b/distros/foxy/example-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-example-interfaces";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/example_interfaces-release/archive/release/foxy/example_interfaces/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "cd5d69ea3a7eea5f2ec562a6ab2f15f6d3b58ff0bbbd67a53c06b3058b9b6699";
+    url = "https://github.com/ros2-gbp/example_interfaces-release/archive/release/foxy/example_interfaces/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "74a5cd21a531a90d5117d482943d18ad44f0b5b3679ec28a3331f32f660aa77d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -538,6 +538,8 @@ self: super: {
 
  launch = self.callPackage ./launch {};
 
+ launch-pal = self.callPackage ./launch-pal {};
+
  launch-ros = self.callPackage ./launch-ros {};
 
  launch-testing = self.callPackage ./launch-testing {};
@@ -1088,6 +1090,8 @@ self: super: {
 
  rosidl-typesupport-introspection-cpp = self.callPackage ./rosidl-typesupport-introspection-cpp {};
 
+ rosxbeepy = self.callPackage ./rosxbeepy {};
+
  rover-bringup = self.callPackage ./rover-bringup {};
 
  rover-description = self.callPackage ./rover-description {};
@@ -1435,6 +1439,10 @@ self: super: {
  webots-ros2-universal-robot = self.callPackage ./webots-ros2-universal-robot {};
 
  webots-ros2-ur-e-description = self.callPackage ./webots-ros2-ur-e-description {};
+
+ wiimote = self.callPackage ./wiimote {};
+
+ wiimote-msgs = self.callPackage ./wiimote-msgs {};
 
  xacro = self.callPackage ./xacro {};
 

--- a/distros/foxy/joy-linux/default.nix
+++ b/distros/foxy/joy-linux/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joy-linux";
-  version = "2.4.1-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/joy_linux/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "96ae1a94bed6df421605b1afd9075ed93c0248f8b3c4ca40348322dd09a9f5bf";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/joy_linux/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "ea5d00c7f2893d8726d79e5ca28dd34a4f927b9b412172100bb6a84da83fd806";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rclcpp sensor-msgs ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater rclcpp sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/joy/default.nix
+++ b/distros/foxy/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-components, sdl2-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joy";
-  version = "2.4.1-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/joy/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "66cc05b742c9949dfa8b43da5b48e9990d31e4dc87ae6cfa9a2292a3301b8781";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/joy/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "55031e817b472428e3b32eab9dc1bc605414d2d7253f0601dcd07b456d12348b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-pal/default.nix
+++ b/distros/foxy/launch-pal/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-foxy-launch-pal";
+  version = "0.0.2-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.2-3.tar.gz";
+    name = "0.0.2-3.tar.gz";
+    sha256 = "40d7edd6eb447e7a05dbb6e0b42159c722caf4882a056e656542404ca2c0e954";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python launch python3Packages.pyyaml ];
+
+  meta = {
+    description = ''Utilities for launch files'';
+    license = with lib.licenses; [ "Apache-1.0" ];
+  };
+}

--- a/distros/foxy/plansys2-bringup/default.nix
+++ b/distros/foxy/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-bringup";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bringup/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "398924110651c3034a74d8843414f872abde99ac5111a0c2f86f90139959b12c";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bringup/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "2443a7c4806ece4713d9df44b6c69a4c5c577f9a5755c6a056799eccf23f1903";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-bt-actions/default.nix
+++ b/distros/foxy/plansys2-bt-actions/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-bt-actions";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bt_actions/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "bc984c8927f984e3b6eda5ad30a988227c8d0f066ad076fab09627d0c0cf32dc";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bt_actions/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "24a95ec8285f690b0d760c6a0c780075665110a9f254e6bf56b03fc749b23977";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs plansys2-msgs test-msgs ];
-  propagatedBuildInputs = [ action-msgs behaviortree-cpp-v3 plansys2-executor rclcpp rclcpp-action rclcpp-lifecycle ];
+  propagatedBuildInputs = [ action-msgs behaviortree-cpp-v3 cppzmq plansys2-executor rclcpp rclcpp-action rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-core/default.nix
+++ b/distros/foxy/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-core";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_core/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "948c105a3b52aee54785003e421fceac0c522837623d0895c6395b8cb0fb0c9e";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_core/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "19c9e0a528b22d31a6635489affa5ba4ba006786fbb90b2ca99688502b6b06fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-domain-expert/default.nix
+++ b/distros/foxy/plansys2-domain-expert/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-domain-expert";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_domain_expert/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "13a32a74ccd01ffd565782a368ab118ef3585335301532175bae5e3095d30b9f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_domain_expert/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "35cfe2c7766dc735f2e1fabef276d5e299f8fe9eba8cdb915c94bfbfcf95246c";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-executor/default.nix
+++ b/distros/foxy/plansys2-executor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-executor";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_executor/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "62fa9a656175b29271b713ce1da365905db2642fc024ab6409b73ef82d7899f8";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_executor/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "1926203c16dcb18ebf54a39a5f577db9dc74487438f83939b6f5cf530ad376da";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-lifecycle-manager/default.nix
+++ b/distros/foxy/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-lifecycle-manager";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_lifecycle_manager/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "5eb08479fc66b784da81301be6d197acd1c4912532e1cd183fa6af3a5c106885";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_lifecycle_manager/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "b95d720d45cac0085d3babc9c160b3a78caa594e87845e848466f2e70635c1b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-msgs/default.nix
+++ b/distros/foxy/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-msgs";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_msgs/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "380b75e4fe7bbdc53e2709cf466294cb4d16adf39c949e138d5b471ad036fb50";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_msgs/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "75665655c8684d4b3bc4fb66b4848bc5a93dc8e37688c7f69ea8e95aa822d16f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-pddl-parser/default.nix
+++ b/distros/foxy/plansys2-pddl-parser/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-pddl-parser";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_pddl_parser/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "f0763fa12bb1997831b469557d8ddfbf161978e54b6927f588f53297a27901de";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_pddl_parser/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "a3149ef24c0b6f6a1e3eed4158408365a315f12215abb4624cc590b8b9252ede";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-planner/default.nix
+++ b/distros/foxy/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-planner";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_planner/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "6b898968ee75c4b62f39f7c5a869ab566d48bb7386a150d0b6e36754edf36c16";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_planner/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "d34f1778874c3a81c8df1c2006e9a6273f3ab7ae8b5a1513a2df07d2f06fb4fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-popf-plan-solver/default.nix
+++ b/distros/foxy/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-popf-plan-solver";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_popf_plan_solver/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "325fe2dd521b58c255a2786abaa636b9a3b9b769402af30b08f4a86152a940ab";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_popf_plan_solver/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "244d81b6ca0ba7fd43bcfd39d3acf63a946a26f5d932905fa872330dd7d6b098";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-problem-expert/default.nix
+++ b/distros/foxy/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-problem-expert";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_problem_expert/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "e39e8bf4f2b53493dcbb9409ace5dac8b4103bc00e62dac6fb54d5404ad4cc21";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_problem_expert/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "0707b99cf6f4f1556d497228633e76d18a948cdd27fdfe0c26aaa80620aabec4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-terminal/default.nix
+++ b/distros/foxy/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-terminal";
-  version = "1.0.7-r2";
+  version = "1.0.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_terminal/1.0.7-2.tar.gz";
-    name = "1.0.7-2.tar.gz";
-    sha256 = "e2d4e2ad49f253cdadcb3ae453c962d588d33f8cd4e5c950ff83f340185af44a";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_terminal/1.0.9-1.tar.gz";
+    name = "1.0.9-1.tar.gz";
+    sha256 = "49d62a4000552cbe64469d08693ca6a55f19ec42feea7786a0a3825dff2e1846";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/python-cmake-module/default.nix
+++ b/distros/foxy/python-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, python3 }:
 buildRosPackage {
   pname = "ros-foxy-python-cmake-module";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/python_cmake_module-release/archive/release/foxy/python_cmake_module/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "eb1cce14aa1c234781fb0ddc2d9f037125758d48fd3c1ce00a4ce1c0fa53c617";
+    url = "https://github.com/ros2-gbp/python_cmake_module-release/archive/release/foxy/python_cmake_module/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "8693f665b38570b167804d0bb681fd8ffcccc1b0d634a13dcaa67750bd9cceeb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-cascade-lifecycle";
-  version = "0.0.6-r1";
+  version = "0.0.7-r4";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/rclcpp_cascade_lifecycle/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "e8a85a1fc0c67567eb150bc0ce2f3f89ba7551273c5112cbba4703478c84d371";
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/rclcpp_cascade_lifecycle/0.0.7-4.tar.gz";
+    name = "0.0.7-4.tar.gz";
+    sha256 = "92bfb8ad368e90dc726a9d815ccaedb91814809efad10f9b70d134733af36cb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2cli-common-extensions/default.nix
+++ b/distros/foxy/ros2cli-common-extensions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-xml, launch-yaml, ros2action, ros2cli, ros2component, ros2doctor, ros2interface, ros2launch, ros2lifecycle, ros2multicast, ros2node, ros2param, ros2pkg, ros2run, ros2service, ros2topic, sros2 }:
 buildRosPackage {
   pname = "ros-foxy-ros2cli-common-extensions";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli_common_extensions-release/archive/release/foxy/ros2cli_common_extensions/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "1a431b3ad5c3b44c607b8cd0420cacac18d22836f8feb98c59b40efd3d2e463d";
+    url = "https://github.com/ros2-gbp/ros2cli_common_extensions-release/archive/release/foxy/ros2cli_common_extensions/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "a4084d90a9eb5802668306ea9c563eb6e882015707e21f3a9c6ec6ef58927c0a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-runtime-py/default.nix
+++ b/distros/foxy/rosidl-runtime-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rosidl-parser, std-msgs, std-srvs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-runtime-py";
-  version = "0.9.0-r1";
+  version = "0.9.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/foxy/rosidl_runtime_py/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e937cd207763bba46e6282b61f78eee9ca7440c96aee5fad878586d90c885389";
+    url = "https://github.com/ros2-gbp/rosidl_runtime_py-release/archive/release/foxy/rosidl_runtime_py/0.9.1-1.tar.gz";
+    name = "0.9.1-1.tar.gz";
+    sha256 = "473cc66ae02a7bea0bcc51802a1d2547ae4fd13181370ceaa626e7a482b8b02f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosxbeepy/default.nix
+++ b/distros/foxy/rosxbeepy/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-rosxbeepy";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Sudharsan10/ROSXBee-release/archive/release/foxy/rosxbeepy/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "e54e519941091da234061390d26f379e90f26f705125f4a1f9bcca6a27fa2617";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ rclpy ];
+
+  meta = {
+    description = ''A ROS2 wrapper for xbee devices using digi-xbee python API'';
+    license = with lib.licenses; [ "TODO: License declaration" ];
+  };
+}

--- a/distros/foxy/rqt-graph/default.nix
+++ b/distros/foxy/rqt-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-dotgraph, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-graph";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/foxy/rqt_graph/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b33331acc6e063a8236b324209946d3772011bcffdf822b6697ac5bcab95c7ae";
+    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/foxy/rqt_graph/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "ac3a1a37740445b2a0a015adf773bc2806cfeccf8adc8f673e877023e80b79bf";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-publisher/default.nix
+++ b/distros/foxy/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-publisher";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "b7e4b0c0e9c0e9d090100896c33b18c101347597977908f9e6df8ae2bdff5e93";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2c7b4a8994f7e70d35404c550a69a0e77d6bef71c666797b145c72cf96628cf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sdl2-vendor/default.nix
+++ b/distros/foxy/sdl2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, SDL2, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-sdl2-vendor";
-  version = "2.4.1-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/sdl2_vendor/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "2c886f34e6e193fbac370bd8cd3da4f687bc19f6b898bd72fe8b1e540c52cbb4";
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/sdl2_vendor/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "f9612cb3f4bac0857cb1d2cdfbb91099780d2965f920ce0a1425806e6a6d5fc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sick-safetyscanners2/default.nix
+++ b/distros/foxy/sick-safetyscanners2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, rclcpp, sensor-msgs, sick-safetyscanners-base, sick-safetyscanners2-interfaces }:
 buildRosPackage {
   pname = "ros-foxy-sick-safetyscanners2";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "5847246ad4523ae0563e881b7fc6fb37071eddee47283a9b89b5b102f59da3af";
+    url = "https://github.com/SICKAG/sick_safetyscanners2-release/archive/release/foxy/sick_safetyscanners2/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5e17224b0967885bc10abaaedc534a18068f39213fa8ec3be86243ed5a934f34";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs sick-safetyscanners-base sick-safetyscanners2-interfaces ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.4.2-r1";
+  version = "0.5.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "6b064430f36f46b70c1652125c87c00653926f649024ffe8bac4839b5b0d775b";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.5.0-6.tar.gz";
+    name = "0.5.0-6.tar.gz";
+    sha256 = "395f670cab9bb47bde78e61094e3d237edaf7dc95739547a09d1c83a40fa1c7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, builtin-interfaces, launch-ros, rclcpp, rclcpp-lifecycle, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.4.2-r1";
+  version = "0.5.0-r6";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.4.2-1.tar.gz";
-    name = "0.4.2-1.tar.gz";
-    sha256 = "55141cb5d3fba675cf3743d350b31419f268ec54934732d38ff6ebb66e381ba4";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.5.0-6.tar.gz";
+    name = "0.5.0-6.tar.gz";
+    sha256 = "bff1f9647b051843cd56e0f83e89e0198f74de1b682c2f936bc8954e994d580b";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-index-python ament-lint-auto launch-testing-ament-cmake launch-testing-ros ros2run ];
   propagatedBuildInputs = [ builtin-interfaces launch-ros rclcpp rclcpp-lifecycle rosidl-default-generators std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/teleop-twist-joy/default.nix
+++ b/distros/foxy/teleop-twist-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, joy, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-teleop-twist-joy";
-  version = "2.4.1-r1";
+  version = "2.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.1-1.tar.gz";
-    name = "2.4.1-1.tar.gz";
-    sha256 = "a0ad07e0d40fdab86cda58d749ac8c1d4abc02b6295f0c56310d95d9e74ed8cb";
+    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.2-1.tar.gz";
+    name = "2.4.2-1.tar.gz";
+    sha256 = "47c018a6195d9e8bae6cad5f537105657b2a3cbe209f669a0aceccadbf0443c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-interface-files/default.nix
+++ b/distros/foxy/test-interface-files/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-test-interface-files";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/foxy/test_interface_files/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "21839e5ca18524056a5e386ffeefa4923f2a9813a3cbf2502bdbc5a47d283568";
+    url = "https://github.com/ros2-gbp/test_interface_files-release/archive/release/foxy/test_interface_files/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "90359bb4913f6efa4a517faedbe243fff61b4824c6ec894bb96e70e75f166275";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tinyxml-vendor/default.nix
+++ b/distros/foxy/tinyxml-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tinyxml }:
 buildRosPackage {
   pname = "ros-foxy-tinyxml-vendor";
-  version = "0.8.0-r1";
+  version = "0.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tinyxml_vendor-release/archive/release/foxy/tinyxml_vendor/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "605c9858b70de41acd488ad71a9b2617af4833584ec60b9ba5657b3700d06de8";
+    url = "https://github.com/ros2-gbp/tinyxml_vendor-release/archive/release/foxy/tinyxml_vendor/0.8.2-1.tar.gz";
+    name = "0.8.2-1.tar.gz";
+    sha256 = "01d4cb774b1cbac4cd414d9ca3c11f9b8bc6848902990f25689f9a62f05958c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tinyxml2-vendor/default.nix
+++ b/distros/foxy/tinyxml2-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-tinyxml2-vendor";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/tinyxml2_vendor-release/archive/release/foxy/tinyxml2_vendor/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "47b312fe3dbc2b5f069437c90e1fdfac96ae13e864445978f23f02f4e696f9db";
+    url = "https://github.com/ros2-gbp/tinyxml2_vendor-release/archive/release/foxy/tinyxml2_vendor/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "56d1a7c6d3e3499724b9789195f307831ff7bd5ad0a67584169492997ee40659";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/wiimote-msgs/default.nix
+++ b/distros/foxy/wiimote-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-wiimote-msgs";
+  version = "3.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/wiimote_msgs/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "48880d97a45d963bd3267f60e1d21c74c50e543166f3e321d0928a855e1db0a8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used by wiimote package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/wiimote/default.nix
+++ b/distros/foxy/wiimote/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bluez, cwiid, rclcpp, rclcpp-components, rclcpp-lifecycle, sensor-msgs, std-srvs, wiimote-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-wiimote";
+  version = "3.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/joystick_drivers-release/archive/release/foxy/wiimote/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "a191252948cca561904c07a6b20c343791e5be9a8a3c35c5ad8140b7aad1d786";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ bluez cwiid rclcpp rclcpp-components rclcpp-lifecycle sensor-msgs std-srvs wiimote-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-auto ];
+
+  meta = {
+    description = ''The wiimote package allows ROS nodes to communicate with a Nintendo Wiimote
+    and its related peripherals, including the Nunchuk, Motion Plus, and
+    (experimentally) the Classic. The package implements a ROS node that uses
+    Bluetooth to communicate with the Wiimote device, obtaining accelerometer
+    and gyro data, the state of LEDs, the IR camera, rumble (vibrator),
+    buttons, joystick, and battery state. The node additionally enables ROS
+    nodes to control the Wiimote's LEDs and vibration for feedback to the human
+    Wiimote operator. LEDs and vibration may be switched on and off, or made to
+    operate according to a timed pattern.'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/kinetic/costmap-cspace/default.nix
+++ b/distros/kinetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-costmap-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "cca5f6e23c62e383aa488b0d64a2f6a60a689b6116cc76b0434eb42a8810f338";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/costmap_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "bab6052e161b23b306bff1070cc0a39d26d498e9bfab678d2d20092134a8c20b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -1484,6 +1484,8 @@ self: super: {
 
  heron-control = self.callPackage ./heron-control {};
 
+ heron-controller = self.callPackage ./heron-controller {};
+
  heron-description = self.callPackage ./heron-description {};
 
  heron-desktop = self.callPackage ./heron-desktop {};

--- a/distros/kinetic/heron-controller/default.nix
+++ b/distros/kinetic/heron-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, geometry-msgs, heron-msgs, nav-msgs, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-kinetic-heron-controller";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/heron_controller-release/archive/release/kinetic/heron_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "cd412061c907947151c475277f93b48b6db4d03bcfb200928e5f08e94068e34a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox geometry-msgs heron-msgs nav-msgs sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The heron_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/kinetic/joystick-interrupt/default.nix
+++ b/distros/kinetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-kinetic-joystick-interrupt";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "01ec612b71542929b730254cba8ca25b3b603e6f19c828fbdee0db79f4d59bee";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/joystick_interrupt/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "3d40b1398e054406e7ec969cf70eb04978abb747a70a1843ea12aeac9eaa9bce";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/map-organizer/default.nix
+++ b/distros/kinetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-map-organizer";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "35108a5b2201d5ffaa4c2841cce7fb43bd41146114cce93face8c5c514753aa6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/map_organizer/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "5c89970e1812da8399250c60cfb6d43b11886dd8447005d794a25e6919b19211";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-common/default.nix
+++ b/distros/kinetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-common";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "b7fd70adb935b2ed1f547f6dce5ecfbda824840bec526fafd946df473f474830";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_common/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "0cba619c02d3b51a3eee5b1394b1967e8cbafdd6e255e7998f7510c7a71145f5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation-launch/default.nix
+++ b/distros/kinetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation-launch";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "bfff26cd54e45d2d3ce6eaf124980d6bec820e89977776e7b333b88fed6e4403";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation_launch/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "2a820ce1123bbc1a6aaa8b33334e9d71575123b6fd7217de8dc927d96a89f563";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/neonavigation/default.nix
+++ b/distros/kinetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-neonavigation";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "af18c0bd4afeac0b254e03fdcdfdd974898edd12004b438c5a01ca433498d266";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/neonavigation/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "4715c478c921c187e107ab17e705754a35ba40df6ce88048830135f88fd30d43";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/obj-to-pointcloud/default.nix
+++ b/distros/kinetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-obj-to-pointcloud";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "26cec629ee36303a641ea85d5feed5fb5e5a0713312db1d7088a7113354d3549";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/obj_to_pointcloud/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "3a7c022db9a23a51878e5faa0b55bca4da4092de477560d34f3f98b70f88aa2e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/planner-cspace/default.nix
+++ b/distros/kinetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-planner-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "2deae5427cc28d69667ee97bfdf9a21272b7f216e4c843992c85a509a52e65aa";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/planner_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "ab00491fa2182d37849bfc8d0655df2725c3365306684dbee2767b5c8660d578";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/safety-limiter/default.nix
+++ b/distros/kinetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-kinetic-safety-limiter";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "e4ec05064dd9ccd7fc5dd2f50ab09e56d719140f0dcc6672aeb6d44dbee38298";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/safety_limiter/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "e0530da9cf749c3ac83c1a52d5f583a1b2206c7d98e3f090b0128ed78ed25e17";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/sick-scan/default.nix
+++ b/distros/kinetic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, rospy, sensor-msgs, tf, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-sick-scan";
-  version = "1.7.8-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.7.8-1.tar.gz";
-    name = "1.7.8-1.tar.gz";
-    sha256 = "3f33bea285bd0ad39d5c36eef815a6d0efabe45f9aaee668f7cc44af98951a5d";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/kinetic/sick_scan/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "d3e3d8f952d04fbcf0b3a3f8aeea3bc6ac84588b5a7f11fb3df1786f0a51321d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/track-odometry/default.nix
+++ b/distros/kinetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-track-odometry";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "af55888a7442040959c25825f6be51aafca37148e2cfc5f67032813ec6b7a93b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/track_odometry/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "384abf93017ed6b713b8219f2428b10e4b0ebd3c5f037db0609ed31d0101b45e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/trajectory-tracker/default.nix
+++ b/distros/kinetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-trajectory-tracker";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "fe22012ae1f70928a45b14ebc6c5e58acd207cd6defb2528b7377a43f3781c77";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/kinetic/trajectory_tracker/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "8253ff8d5daaded9c7bff6a968fe2d11011a88d386226bce528ba2fa10e88a9f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/vision-visp/default.nix
+++ b/distros/kinetic/vision-visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, visp-auto-tracker, visp-bridge, visp-camera-calibration, visp-hand2eye-calibration, visp-tracker }:
 buildRosPackage {
   pname = "ros-kinetic-vision-visp";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/vision_visp/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "7acc83ad9964e5258008a7551aca2785ea6d65f18d632eabdbbec62592b491ff";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/vision_visp/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "baad28fc882d65f718925044129b386e3ebcfe8b3ca92fb9bfdca0f62dcf5596";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/visp-auto-tracker/default.nix
+++ b/distros/kinetic/visp-auto-tracker/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, visp, visp-bridge, visp-tracker, zbar }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, usb-cam, visp, visp-bridge, visp-tracker, zbar }:
 buildRosPackage {
   pname = "ros-kinetic-visp-auto-tracker";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_auto_tracker/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "932449bfdec3f07765a70557d2c6262e1000dd4bd8e1d5766d31c9cffd8091e7";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_auto_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "2a2a6b7ff20a7c24b6f2064102e243a1283dbe473765944f3b673b3e49c0e774";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs libdmtx message-filters resource-retriever roscpp sensor-msgs std-msgs visp visp-bridge visp-tracker zbar ];
+  propagatedBuildInputs = [ geometry-msgs libdmtx message-filters resource-retriever roscpp sensor-msgs std-msgs usb-cam visp visp-bridge visp-tracker zbar ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/visp-bridge/default.nix
+++ b/distros/kinetic/visp-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, visp }:
 buildRosPackage {
   pname = "ros-kinetic-visp-bridge";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_bridge/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "c7507478f8a395017253b1e748009a1f8b823e0535f0084c8032f291986e68d6";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_bridge/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "295c0401fac1e2219382a0440398f43f3d61597c0fe8bafe3366df641f14bfe8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/visp-camera-calibration/default.nix
+++ b/distros/kinetic/visp-camera-calibration/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, rqt-console, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-kinetic-visp-camera-calibration";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_camera_calibration/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "48bea444004f594c136b9877b758bde415204ea1ef8a64c919f2ad8b7c2dd9ed";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_camera_calibration/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "48a0ab309aca4ec026a1764326a511c9b62b05e857ab5661560a1e30a52c14b1";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs message-generation message-runtime roscpp sensor-msgs std-msgs visp visp-bridge ];
+  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs message-generation message-runtime roscpp rqt-console sensor-msgs std-msgs visp visp-bridge ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/visp-hand2eye-calibration/default.nix
+++ b/distros/kinetic/visp-hand2eye-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-proc, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-kinetic-visp-hand2eye-calibration";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_hand2eye_calibration/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "6f7abea4c74171ac5b20dfbd06aeeede8bfa8c112a4f2be58e8a10cee7a04edb";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_hand2eye_calibration/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "f1a5d27fd578b3a815a0c54f49261406ccd4c8f636ce4dd9312021fa7528825d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/visp-tracker/default.nix
+++ b/distros/kinetic/visp-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, image-proc, image-transport, message-generation, message-runtime, nodelet, resource-retriever, roscpp, rospy, sensor-msgs, std-msgs, tf, visp }:
 buildRosPackage {
   pname = "ros-kinetic-visp-tracker";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_tracker/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "99cf6fac5f69483e1ef18bf59e7eef02bbccce9eb82758931d7be1988da526ce";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/kinetic/visp_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "bee2baab81485da81049f8544897e1a34d3cebde9bced604396b0e02869cb7a2";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ypspur/default.nix
+++ b/distros/kinetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-kinetic-ypspur";
-  version = "1.20.1-r1";
+  version = "1.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.20.1-1.tar.gz";
-    name = "1.20.1-1.tar.gz";
-    sha256 = "8dedf2bc1f1211b4ffc52e40edf7bee227d4f4db1305662b5d2676582957bb12";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/kinetic/ypspur/1.20.2-1.tar.gz";
+    name = "1.20.2-1.tar.gz";
+    sha256 = "b2b3dcb74e986b5ff0aea37e64a81eef5f43e7a5ebc2e9f03eb0b17c98bf54aa";
   };
 
   buildType = "cmake";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "08f9b0124adadcdda13d5220bdfc8b8da6cf5c94ae1376dc4f1e89bb29ad587e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "a23610a356631f3f0688da2b3646183ceeeb2da63a9cabe733493b30794a0a19";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "045535ace351382dff4fb1ce2221e7bcefd5a4aeb31e24b6183147db55383e49";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "1c37bcf9e56a5e35d433040ab75f65732c8fe33fdd504a6db9be60eb7e2c0ff0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "0edc0b00f3405bf966e9a985da932a5fcc5acf48ed3904b68d958183fbd97d22";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "b2a9c8bb46835fe9a413d9bdab72e5ec9bf11ef2ac6bf158e801f11c9820981b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "43703e1242f22727cb8d4d5eadeed221cf0eb08999cfcc2a4a126bde87b7fa6e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "f05184517ae9e0f5e59b1035a3e1bf4485867135648ca06de74635fe067a4d61";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "324a2eed1c981f62dd3d27e875188cc9fc8629adce84666dd13ebc88278b4d76";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "58d1bb3214af92deb3c2795a09fafa5dfdd66007aaa0564762e3417647993d40";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "4455c606bbd865b61a40cf7c6cc91f2136e5dfe838fd1918e2f495b83c5e37ee";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "f2f84199f113f2b9fe0ad85c78cc5cfe2fef14aef78856c853dbddd538437b2e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "2b5e35b26ee10d88bff953df43a62a5a86a4b014ce26a5141a3ae3fca42f0cfe";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "2a946e6e33d6098144acb2a0b75c56970a4a68cee7db3a590a14bde8959677e9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "fcae31092969adbb06b29e24f1dda68cffb0d97c0b9872ac75485d12bde83320";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "1bbb1fe645cc8c5c043b6637720c48a1c40e2a9dfd01f761ce924093ccd61dfc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "9cb64bbe70341f47f3a8db34792cdfe3f2ce8cc128ce6e554be62f8b175fc9bb";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "6844ab99905b9f6e7fd7f0f7fb3670913caac4a57806de36ad09ecf099c81312";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "72f131be7319f7af2fa98bb3d0b063c0a57fd34fdd4ecfeb7a7a2ce4846554bd";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "e4f896f0df54aa32a139dd9c5f9a3567120d5c8d5930be0ec7e7a12a5fec6c75";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "43c8feb9cafe87ee40393f9d5af579a82b6a804fe25f7f8177ba42f8214a465f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "422619d9d5f7203dff051ec4e720b14b565b69f0ce6ca12445ce205b6bfe3207";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "d208667fa6b93b7fab23f6f0214dce9118a4c835447cdcc5fa84f229d9652fd1";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "3a2e7d2dd9f69e06c3635f1ea69be4083d8f6023ef933a3fa2a8272bbdbfbc71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "a0c6fc203dfa9573dd400bf9903bc86bc16bb98b1e128d12e89347ed6741c26a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "47683f1b6d6a1b570a7c7929fc49ad13dee63a6562e0e454143edc65bae02c9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "fb1ac06bb3eda88d3b8f20d94a0fc3e9e0042ccddb2e9b80e619bfa592cd9488";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "6c4308e377eea29309c32a415e5008e6b82380e1ba3ab4779d2024c127f29488";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "6e925aaa3b621f517db3cf9167c8f4fa554dc12f1da6d903420bb3caea978e80";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "92f8451ca0a3359c867c12592e1b7137e5fb9a6ae784884bc2c92c34f45889bd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "5e1f65d905c3a850d75e52786a7b280431042b9c2b0be975b304b5c13b622ec6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "78795d7e8899a86e622ca4bf7d09f58de9a0119dcfd8cc7ea312d426898698aa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "9df0d9e883dcc61a4726cb9097e0106f219e1a2a09c27f3bb942018d4d2b792a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "ebec311b57c1932864f6ad34a887fef2bbc75c0db91c50ae69ba02c7cca698ff";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "d8a791f163194af27e966c53e57ac545fe582c8be98990a96f3b471ebb85084a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "28fb016fd85a2b0c1cb5f3c48474eb6284e96c58076c3505c21cb93d16f4490e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "0fda2c61f6c92accdfb947d798f579954b3e4add028a0ad763e2069b62e4dfe6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "a62e2cb2f6cbd85da77186d97b7568bdf6e3a22c3cfc2eecc434de4f800b125e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "d536d90050bee919a48926bed1aa91d232cff74737ce5cff9856b3937464c179";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "e8fb568668e587c81bcc59222031453c202ead2d904eca0ef5e4f421968239b0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "1d379b57f72eef23924d747bdde8a8e6df96f98973abb28f8df0864fd955b36a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "e5a7ec765b686a4d7f8aa8ffcc6b2a3c01fdc59cd7c1e3555d78d2404d536937";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "7debf72117c4c2224bb34761ac8544b2bb13e80a1238505d8fed2b7dbbdfcf28";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "8eade849573813a605c9882788a18aa09df0dc086280d8f4f34bd465edf212cc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1282,6 +1282,8 @@ self: super: {
 
  heron-control = self.callPackage ./heron-control {};
 
+ heron-controller = self.callPackage ./heron-controller {};
+
  heron-description = self.callPackage ./heron-description {};
 
  heron-desktop = self.callPackage ./heron-desktop {};
@@ -1713,6 +1715,8 @@ self: super: {
  lauv-description = self.callPackage ./lauv-description {};
 
  lauv-gazebo = self.callPackage ./lauv-gazebo {};
+
+ led-msgs = self.callPackage ./led-msgs {};
 
  leg-detector = self.callPackage ./leg-detector {};
 
@@ -4252,6 +4256,8 @@ self: super: {
 
  wireless-watcher = self.callPackage ./wireless-watcher {};
 
+ ws281x = self.callPackage ./ws281x {};
+
  wu-ros-tools = self.callPackage ./wu-ros-tools {};
 
  xacro = self.callPackage ./xacro {};
@@ -4321,6 +4327,8 @@ self: super: {
  ypspur-ros = self.callPackage ./ypspur-ros {};
 
  yujin-ocs = self.callPackage ./yujin-ocs {};
+
+ zbar-ros = self.callPackage ./zbar-ros {};
 
  zeroconf-msgs = self.callPackage ./zeroconf-msgs {};
 

--- a/distros/melodic/heron-controller/default.nix
+++ b/distros/melodic/heron-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, geometry-msgs, heron-msgs, nav-msgs, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-heron-controller";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/heron_controller-release/archive/release/melodic/heron_controller/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "fb128ac4dec46641368bc6fe28a399f18af9eb26da359d1e7c4edaf47e62bd61";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox geometry-msgs heron-msgs nav-msgs sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The heron_controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "013f11ab82a8b764419cb6785db7e9ad0307f5e30ea84680ca6516fa6812b05f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "e1c29062817242a7489703c017ead9e683a22583ecb1f0466f2c0ab01f7166d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "665941dd6185046ddd487b0e7cd7e6dba827d2d9ffd985e80ed6af5d83105d1f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "aa5875b5fbb97579a4bcde6ea36a5082c429ede9dc7ac39d1e55dc8ea012e5e7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "fa1f6596f56130d8684fdb9f449b14f9261dd18bd1a059f76bb68b914f4a42b0";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "789bbf2356bf61718f3f64f89e44a78f76ed1c8303fc0512bbbd58a0afd9ca6e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "b4dd2796cab46a9cd3c9bb22bbc59bb38292fca8ec90533862e584ba3cb8d719";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "db95f4a3635bae742945ef72b748e64ec724f43e10fa009f8cb7da4e782b09af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "636ddd6c4036a1243dd154d30ad8d03ab752bea67826f05fd9afb56242fa307a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "59247efa565fce4d331eb1c1c754baa119c9f73338c5802d54e1257c917545ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "3fb125be6de1e0792d55af5e2a6248880cfb5bf28f5fd1af7107970daa90e5c1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "b7c9f76575b7e36008e5ef46b9bc8fcd3d593714f81441cda49abe416b21cfc3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "518669703738a7912486e91bb5b4bbfa041db88afdd5c33f11ec8a04aaa35c06";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "37dbb27a2ad05a34555b056ee8fd6400436f6492e8f69cf0b5e95e0763e61962";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "60e5615ec49010db27830b0cd69386ee5472853e07614c2e179b6a07ee688ba5";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "871d44bfd52cdeb700f2644f1d37b91250397e1b6437fc6fc3955f5a29fb49c6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "837f228834cbf7858a7e500bfdff47332ec5e7f241bad8d427283b22a9396696";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "1793354b506e8066206a07214cbc9f9d19dfff1f7de0a339bd7461196cbf7199";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "ca407416e1585a648fec551a510bf4a7cc1a93682a275c31b913b6f0e2a9c27c";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "d63d064fc97b1daba093636583f9a57934fee8640ae75aba7bf8b52a9242ce52";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.6-r1";
+  version = "0.4.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.6-1.tar.gz";
-    name = "0.4.6-1.tar.gz";
-    sha256 = "b56e630bee5cf37d2561f14095d9b261074def8a345d714425a1145cc90a30e5";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.7-1.tar.gz";
+    name = "0.4.7-1.tar.gz";
+    sha256 = "0df99027ed713a8177c0092991fc99b386ddc1cb6de81219b5f8f1025cab9c32";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "e6d4e3e89a930a815835ca04d8a3064c81c6f4a281ec248030e81d99c1c02345";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "bf23d6de19605f4513ef13a38be1aa4db9a54d2cc3e510b82a782290159aaa46";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "2eea4025bee71c480ef80f20bba5a73ebc8b9f8eef4e7677e6c80b6d22b3b560";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "feedd3e11505db8b62c46c3dffa7c0dac1f51084e03ac177faaa2a70d44ac8d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "a474b7bcab4d3da4c40cf8fb18e0ba7626829ebbe92bf9218fc43b755eac1a32";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "f68458a0ced2066613fa37a6d0e08519768c7fca5a86ed014c50def6464457be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "f82c63ffae977dfea5387c2d3b9d83b90013030b6a0937a09c762ff3638f7160";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "c16d3ed45c90bb820a5cd08856c168b24221e48f0961bca6a4e6178d9a9c5aa3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.3-r1";
+  version = "0.7.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.3-1.tar.gz";
-    name = "0.7.3-1.tar.gz";
-    sha256 = "d954e9fdbec0114f9043491b896763e34547aa9ff7a5af14ea014dc14e3afc92";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.4-1.tar.gz";
+    name = "0.7.4-1.tar.gz";
+    sha256 = "b545abffb9cb3af5a05f9c07862e84af9e95d61253e72e3b4d822538ae23d6ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "8e48159fa3ee1c5e2494715744d8a7a5fb5c15c3120e40d457e326f6227267c2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "c8edd28c1e6b4f3b482691c05ed16a489fde9f9a208961ca4091a7edf332dcb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/led-msgs/default.nix
+++ b/distros/melodic/led-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-led-msgs";
+  version = "0.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/ros_led-release/archive/release/melodic/led_msgs/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "33f5828f59bb4c59a70c823c37f587210c1aaf1cf9524ae5762a93c10442c27f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for LEDs and LED strips'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "4f8568cad7e04a536d25b39fc776d1cacd1637a6d55fa459cb8cd0364aee4567";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "601ee3d4cf8420b0f4e295e673363fef6e1ed0454595c797abd5f19c3fbe66b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "3ff1b854a503e0326187932aaef0bf612e7db0958acdc0e74507e820a60db5bf";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "da76151565b6ae46dcaabc5e7e8c6bc7779bc66b406e6aef5719ba20e813a636";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "36602f4b427009c99c88607c009a630fc0bae4db8df855a7cfcdb4381542211e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "6c9a3e028b694663cb0858be0d7a08c75a54f0fe5f6a3420bd91b1c05514f2eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "277ea22ff1815abc3c373939887c7df67b822ee13cce2fdc6bac8b32e5f98dce";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "6e95b0c10eb833934c7c6ab3d8489ee355f5599a9425bc4bc65d29313a22a1eb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "891d6b13145969194a0d76738a604393d7c451223afccbab2411886ea16c999c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "4c26b2682d74788241b9ed6e54dc30d3b37d27cb8cb7a430560b467cf8633c8f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "d59d77886b28f4bec1e4e0b0a945419bfb5c0a3dd7c5c3a4ee5b4facd785ede6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "4dc661e773f89fade69bd6781adaee76e882859e8ab56bcdacaa4bc8f1e76c98";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-control-boilerplate/default.nix
+++ b/distros/melodic/ros-control-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, control-msgs, control-toolbox, controller-manager, gflags, hardware-interface, joint-limits-interface, roscpp, rosparam-shortcuts, sensor-msgs, std-msgs, trajectory-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-ros-control-boilerplate";
-  version = "0.5.1-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ef24a60447530fb1c62e086164715eae45cd02d5d46f105020c9664d81712a8e";
+    url = "https://github.com/PickNikRobotics/ros_control_boilerplate-release/archive/release/melodic/ros_control_boilerplate/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "32bc71c9a5eea76b805a56072ea0e638cdf78f8ea2d8de13fb8c0c72fc512514";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "9f3a12c9910cfeeb041978dadcba9f1cddf8632e7e866d8a6174dd2f8bb5fb9e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "26455c2ac67e48d5752daaeb58fad1e007e01f2ba07b6a53597555180030fa5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sick-scan/default.nix
+++ b/distros/melodic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, rospy, sensor-msgs, tf, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sick-scan";
-  version = "1.7.8-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.7.8-1.tar.gz";
-    name = "1.7.8-1.tar.gz";
-    sha256 = "7ae00d0d3c02e9a67d4eabf411f4c12c417b55a6ff95a2b6b4f6cfe5f4cab693";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/melodic/sick_scan/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "4fb58055785390aae3e9cdbf0dbb77e4f371865c63b6845ace206136ac85957f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sot-dynamic-pinocchio/default.nix
+++ b/distros/melodic/sot-dynamic-pinocchio/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, gtest, pinocchio, sot-core, sot-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, gtest, liblapack, openblas, pinocchio, sot-core, sot-tools }:
 buildRosPackage {
   pname = "ros-melodic-sot-dynamic-pinocchio";
-  version = "3.6.1-r1";
+  version = "3.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/melodic/sot-dynamic-pinocchio/3.6.1-1.tar.gz";
-    name = "3.6.1-1.tar.gz";
-    sha256 = "0dcbc6debb50129143eb8ad32384d82fe1331de1976105bbdfc63d990839e210";
+    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/melodic/sot-dynamic-pinocchio/3.6.3-1.tar.gz";
+    name = "3.6.3-1.tar.gz";
+    sha256 = "bcc7594f6cdd521f12b898a2a8f29b11cb75f76f429e8723ceae767005db238a";
   };
 
   buildType = "cmake";
   buildInputs = [ doxygen git ];
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ catkin dynamic-graph-python pinocchio sot-core sot-tools ];
+  propagatedBuildInputs = [ catkin dynamic-graph-python liblapack openblas pinocchio sot-core sot-tools ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "23213af1a09807c5a2699cfa911259e1f27321a3e4b082647fa7d0daa0001f8d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "38397b9f34e6ea684bedd145324fc5366619679e837e619933d8dab467782e3f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "9e2238f8698b0cee477fbeda67890643615c558883cbfb4c133ec6aa29910369";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "4d1b13e2f9f8fe0c5e196ba80c2849500274b75eadd22be60e9a324fb17ae000";
   };
 
   buildType = "catkin";

--- a/distros/melodic/tsid/default.nix
+++ b/distros/melodic/tsid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigenpy, eiquadprog, git, graphviz, pinocchio }:
 buildRosPackage {
   pname = "ros-melodic-tsid";
-  version = "1.4.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/melodic/tsid/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "5c757f23d9f4576cf244cc4db868a28bb58ac83e49084eadbd6f7ab61ad4f5c3";
+    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/melodic/tsid/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "d017f96c11562f550cfcafb5314598e1b302bdfa4ee3605d1f3bec01fb1e95e5";
   };
 
   buildType = "cmake";

--- a/distros/melodic/vision-visp/default.nix
+++ b/distros/melodic/vision-visp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, visp-auto-tracker, visp-bridge, visp-camera-calibration, visp-hand2eye-calibration, visp-tracker }:
 buildRosPackage {
   pname = "ros-melodic-vision-visp";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/vision_visp/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "ef04aa5ab2459ab1a2690f7386f223e98c86285200d45fd11f101195550dc1ef";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/vision_visp/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "a7a667d6a84b9deb255bd06e1925c63b299f41e4b610a2e80e5b9ef69d12380f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/visp-auto-tracker/default.nix
+++ b/distros/melodic/visp-auto-tracker/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, visp, visp-bridge, visp-tracker, zbar }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, usb-cam, visp, visp-bridge, visp-tracker, zbar }:
 buildRosPackage {
   pname = "ros-melodic-visp-auto-tracker";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_auto_tracker/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "5104d94e90ea8520a8556fe6293a20f31f824c7a178d2a332f95b69c4c05ee48";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_auto_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "5ac7fe7c10bcd97d521696c4ebe6a9f413356ded4c341b041af178af3aa894ba";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs libdmtx message-filters resource-retriever roscpp sensor-msgs std-msgs visp visp-bridge visp-tracker zbar ];
+  propagatedBuildInputs = [ geometry-msgs libdmtx message-filters resource-retriever roscpp sensor-msgs std-msgs usb-cam visp visp-bridge visp-tracker zbar ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/visp-bridge/default.nix
+++ b/distros/melodic/visp-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, visp }:
 buildRosPackage {
   pname = "ros-melodic-visp-bridge";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_bridge/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "fb3c65629562f788a601202f916a03a96138bb1486aa6f14b26d798261303f62";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_bridge/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "b4db42aa2bfba345b688738c06e27cc34c537e4100b2a88265e459db153229c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/visp-camera-calibration/default.nix
+++ b/distros/melodic/visp-camera-calibration/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, rqt-console, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-melodic-visp-camera-calibration";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_camera_calibration/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "ad0ec2a1443b13767d73f4e5769b764e1046498ad93b94c65454687e4ed574c0";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_camera_calibration/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "3a6a0b972d622f753c0f1b095ac9813974a29fc6bb55eb639acdd8183cc824fa";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs message-generation message-runtime roscpp sensor-msgs std-msgs visp visp-bridge ];
+  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs message-generation message-runtime roscpp rqt-console sensor-msgs std-msgs visp visp-bridge ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/visp-hand2eye-calibration/default.nix
+++ b/distros/melodic/visp-hand2eye-calibration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-proc, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
 buildRosPackage {
   pname = "ros-melodic-visp-hand2eye-calibration";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_hand2eye_calibration/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "75178b169e63d1052f93e19620f1f25d188948a6944eb55db8d169a33b8f065e";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_hand2eye_calibration/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "75ada8b6e046e7551305aea92545d36d90d2eaf34ab7c3037d85f1eabd9d7bc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/visp-tracker/default.nix
+++ b/distros/melodic/visp-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, image-proc, image-transport, message-generation, message-runtime, nodelet, resource-retriever, roscpp, rospy, sensor-msgs, std-msgs, tf, visp }:
 buildRosPackage {
   pname = "ros-melodic-visp-tracker";
-  version = "0.11.1-r1";
+  version = "0.12.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_tracker/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "f8f5b6ded7bc1e1a83f5e8ad2787c9e096a4e4a347bcdc9cd33665e8383e4b75";
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/melodic/visp_tracker/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "79361631cd6074296fdfd745be67548c32526a67080a3722a3b243963eadec53";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ws281x/default.nix
+++ b/distros/melodic/ws281x/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, led-msgs, message-generation, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-ws281x";
+  version = "0.0.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/ros_led-release/archive/release/melodic/ws281x/0.0.9-1.tar.gz";
+    name = "0.0.9-1.tar.gz";
+    sha256 = "cff689524aa1cdf1338233bd1c47de60be9242fa3f7aeb1a634c78b52ffa7523";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ led-msgs message-generation roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for rpi_ws281x LED strip driver'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/ypspur/default.nix
+++ b/distros/melodic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-melodic-ypspur";
-  version = "1.20.1-r1";
+  version = "1.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.20.1-1.tar.gz";
-    name = "1.20.1-1.tar.gz";
-    sha256 = "8bde2bd9c59e1ee972ebf54b8d473c25c4d97c311fa5ff10becc69d9bcdfe32f";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/melodic/ypspur/1.20.2-1.tar.gz";
+    name = "1.20.2-1.tar.gz";
+    sha256 = "f53c5d73a3a604bbd5f2e1bd286a16d094a8541c428e355129289145da471647";
   };
 
   buildType = "cmake";

--- a/distros/melodic/zbar-ros/default.nix
+++ b/distros/melodic/zbar-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, nodelet, roscpp, roslint, zbar }:
+buildRosPackage {
+  pname = "ros-melodic-zbar-ros";
+  version = "0.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/zbar_ros-release/archive/release/melodic/zbar_ros/0.3.0-2.tar.gz";
+    name = "0.3.0-2.tar.gz";
+    sha256 = "62350ba0852b9f2f140a2495a162190ae01ec361bebd28782115ac6d32366f87";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ cv-bridge nodelet roscpp zbar ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Lightweight ROS wrapper for Zbar barcode/qrcode reader library (http://zbar.sourceforge
+    .net/)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f95e786eb7480704f329bb2b62197397c6934e9b062500e297d6d4a35c7ffbdd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "437c49664504a107f5939e51c5bdc9f8e0de176ccc0af6acdf0d89f3e6790bd6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "bb85a93a9afc36c9c7054cbe04c5469f03d1ff10a760a065a2e5f9d1d11f9140";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "878eddb4b2d5a2e400ce201272886fc3357bf78375dd5b506bbb0154c85e4548";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-esr-msgs/default.nix
+++ b/distros/noetic/delphi-esr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-esr-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_esr_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d236ed106045469683804c304f3611446790b80cf12d70e021714c01c289e23d";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_esr_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "eddb38859f716d8d4b24bcca98afaf5a6a5e12950b28a2090852f46b6e4dcc11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-mrr-msgs/default.nix
+++ b/distros/noetic/delphi-mrr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-mrr-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_mrr_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "5cf30e3888aa7af565488a9b4fb3c436516e5f12da21428d9de7615017dd05ec";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_mrr_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "6a99916042065253f66a1ffbe11e5bffc84b34c49b8f9d7d1075af2e0dc66728";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-srr-msgs/default.nix
+++ b/distros/noetic/delphi-srr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-srr-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_srr_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "834206b1bbdfd3d085f06b442f4450805b36e46920a2e236214a3f676b5abaab";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_srr_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "8eefc78fbbbd7afa9f23b7ad39134a02f9a9ce9ce44e4e4bbc660324ba21f67a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/derived-object-msgs/default.nix
+++ b/distros/noetic/derived-object-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-derived-object-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/derived_object_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "d54214e708bf2c9cf7d0fb746f65e3d0ba1257f60b5ddb1576fe5b6b494a62d2";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/derived_object_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1fff6c0bd05b79f989d167655e30ea713e9b65bd501141402dd5f80bf780798c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diagnostic-aggregator/default.nix
+++ b/distros/noetic/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bondcpp, bondpy, catkin, diagnostic-msgs, pluginlib, roscpp, rospy, rostest, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-diagnostic-aggregator";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_aggregator/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "7dd96707460744a7d34fcabf80a8d8aad89da24f7e71d8892cb80fbd30bbb92b";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_aggregator/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "95dd1776865aa7d88acfd17fff500b8e29561122c381924c0902394a90168095";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diagnostic-analysis/default.nix
+++ b/distros/noetic/diagnostic-analysis/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, rosbag, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-diagnostic-analysis";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_analysis/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "a4a41cad96cbe9a1505626b63bad0fbc71ac4d4a97d961af690e112cb610c914";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_analysis/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "df593e728059ee56729a83b5e3a79debb651179c16f5a6a1d67f5800e638850d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diagnostic-common-diagnostics/default.nix
+++ b/distros/noetic/diagnostic-common-diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, hddtemp, python3Packages, rospy, rostest, tf }:
 buildRosPackage {
   pname = "ros-noetic-diagnostic-common-diagnostics";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_common_diagnostics/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "3dcdc4feaa3efa9bb0177403f9660671442a1fc1c96c98efb36e1739581823a7";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_common_diagnostics/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "280b746bb7e33a69b388fe26e7ab411052f263243dbe5da71f7b0a023f743ea6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diagnostic-updater/default.nix
+++ b/distros/noetic/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-diagnostic-updater";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_updater/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "e38e40c4e9eb985bcaf4091ea869678c4a20045460f5489d580b80e414f42869";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostic_updater/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "690b626c6015e30cb3bcb064930e12556b17fb0d5525ad6020bba4e3561a9458";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diagnostics/default.nix
+++ b/distros/noetic/diagnostics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-analysis, diagnostic-common-diagnostics, diagnostic-updater, self-test }:
 buildRosPackage {
   pname = "ros-noetic-diagnostics";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostics/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "72a92a5d1016fbbf70043615806e367f1e3e35add6c4561c9e10594370e19ae6";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/diagnostics/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "f500a1c6a6a3b672bb2f74aad99df99eb0080a3a69ef534a2994f539e7873570";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamic-graph-python/default.nix
+++ b/distros/noetic/dynamic-graph-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, eigenpy, git }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph-python";
-  version = "4.0.2-r3";
+  version = "4.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.2-3.tar.gz";
-    name = "4.0.2-3.tar.gz";
-    sha256 = "3c79a0eb15c9f4dd046a1c8e19d69aabe77d00dcc2e24fb1f0de7583a87c5fdc";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-python-ros-release/archive/release/noetic/dynamic-graph-python/4.0.3-1.tar.gz";
+    name = "4.0.3-1.tar.gz";
+    sha256 = "766f29edb9e7ddd38135f18f92dfb551786d94272989fc7ed8fe23acbb1c99ba";
   };
 
   buildType = "cmake";

--- a/distros/noetic/dynamic-graph/default.nix
+++ b/distros/noetic/dynamic-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-graph";
-  version = "4.3.3-r4";
+  version = "4.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.3-4.tar.gz";
-    name = "4.3.3-4.tar.gz";
-    sha256 = "3e27d8b75c9a57bfa976987ebe9db9f12796d4d3971a7f53767cafc6e1f020f1";
+    url = "https://github.com/stack-of-tasks/dynamic-graph-ros-release/archive/release/noetic/dynamic-graph/4.3.4-1.tar.gz";
+    name = "4.3.4-1.tar.gz";
+    sha256 = "7c7e7d4acdfdd35814e7271e14345bb2064cd869a1127bb066f770634e59cdc7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/eiquadprog/default.nix
+++ b/distros/noetic/eiquadprog/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, graphviz }:
 buildRosPackage {
   pname = "ros-noetic-eiquadprog";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "5750d5d79266d9b7117160d6464c0279c9a5cad73e0bc81f63e159ba57c5b384";
+    url = "https://github.com/stack-of-tasks/eiquadprog-ros-release/archive/release/noetic/eiquadprog/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "6bc4987dbf43030bd604ca64ef425b65195083702d79ee32fa6d909b2bdc7bce";
   };
 
   buildType = "cmake";

--- a/distros/noetic/exotica-aico-solver/default.nix
+++ b/distros/noetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-aico-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "719d3f4bd2e1533d5fb4f79bf7da8f81d5411821b210cd01f79209213432504a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "5b5be03d1bcdbac380b070c748d1d2c11389e85b1a897d852089b2bbf6311386";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-cartpole-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "927a5e6f5d7126ded4e56f7903cf6564f3e3a38efac3d86d01386837d3f23b44";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "d382b52b244950a8e2ea5cf12b580e7fab91398e3a324c8468d46176d8067ce0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-noetic-exotica-collision-scene-fcl-latest";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "fd63a22ba08911393e901997f2e865d9233fc44a26222a0b232cc7cbca3cb7ff";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "a6be506591819ab6eddfa88423bdf00caffffef09367270fc720a625dfa78c98";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-core-task-maps/default.nix
+++ b/distros/noetic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core-task-maps";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "7ed968a0c85224ddb515c1aab7802b1d262c6ffe2618dc8be5e376f7a65fa09c";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "9c60b36d459145f5b8d7e13b7433c53fa75b5da352b8801f5561c401c0cd5e20";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-core/default.nix
+++ b/distros/noetic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "59fe44d4a95fa8b7bb70fe6bfb5edefec00d8a99bebc2169df112f2564dfe2b4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "77a04ddae79ad2a08d66cc6282c7638cddb163eb2945e1e34f148a64c1bf0668";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ddp-solver/default.nix
+++ b/distros/noetic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ddp-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "f6035ff1310a0237c45b3bfac969e72714ed0fbf61fab3a6c45f645c6b67f86f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "1f98b28d264ffc206ff5d9a889f3fca436e772b4785cb58907aca72d951f176c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-double-integrator-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "e1c93caad607863f3a2c558fb8675e3104f8c88cdd4dd34727238bbe24eda7cd";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "56ece8684ee87ad2070abb9c586291276e7bbb269f7a89a8542acc38ce02cd73";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-dynamics-solvers/default.nix
+++ b/distros/noetic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica-dynamics-solvers";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "3a05abc0114ce0fe5100af6327353c7e1c7d669d35ac266e2ed5c0d2d55038ac";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "f0ed917aab8759118f80ff7a5ca64c8675a5fa7cf8b9266d072e17a0dbd0f331";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-examples/default.nix
+++ b/distros/noetic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python3Packages, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-exotica-examples";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "9c3081d1380d04ba745466ac72f22ea7d4fbf2f7f505d4e53a4931b5db112557";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "1af347453360f2f4c118de55c0c70a8ea8058def75205e8b481fb9a4a3cbb001";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ik-solver/default.nix
+++ b/distros/noetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ik-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "609d54af1da80b967251a7fccf832a67f54279c17c4804ebcb36d746051f62c9";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "885d31c6e1b78d998e922cdd0de451d2bf3c99df8df824723aba68c77721f71b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqg-solver/default.nix
+++ b/distros/noetic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqg-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "d87649861b2b84ee4a8778e8ea091ca6d551f6aed50f633f4b336d2b47406952";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "75215351c3799fcb498713887b0e2eb9217f6a1b32328bc4432da7f675054b40";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqr-solver/default.nix
+++ b/distros/noetic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqr-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "01715d5587abdce5d5d878d7be9e6b7c3c7cf4071ceba955f553c6536210c680";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "871a0e12975e026ce2940c28933fe6d5b25b450571a53336d28b8cfc814b5f9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-levenberg-marquardt-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "ac1b0dc1efc5317e02a4e490096e1f90d423c5325c6c0dd3d0ae7bfea1b3bf8a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "b787f57fdc21300e1cf3149321578aaae4fea3a687de53a58f1d4c40f3485b81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-control-solver/default.nix
+++ b/distros/noetic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-control-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "265bd3612a4fdebfcabe6c455a2c13540740f97bb14359fa1a28c0b04f4c27f1";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "507ed2bf4bc516fa619a8db8445635823ba34c7d8a2680f5493e9f81089a21fa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-solver/default.nix
+++ b/distros/noetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "34e85b8c726de2b45916637b54b1caf7f9ea3c1836bfd89470612c76843e74fe";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "a2121b86df6ede195d5a51b666e3f77cbfa8fcf382f4a1e1111f670830846bb7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pendulum-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "dbe50b7a79d56a2d18711beae16074d3fd5464ec0fe5e270377fb9a012c220e0";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "38e6fa8276bd9b2efba0761e8754e82fb72d4fe24c3572134034fe254d0ab357";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pinocchio-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "de67e1006bba67fb64af24543447a597ebe3f2843c48bf7f8d35fcca05a1274b";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "607ca0cdf507638bd2c582650955a3b60600a19346ed5cc4f4fbebe750135296";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-quadrotor-dynamics-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "ca09c63d00ed4e156f0d59ef8c96f51bd799a5085cabe2229f5a783b9336f1cd";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "af23d11cc5d3da7266496da1317270f2b5294f5ca7c63d0b6eefda9d9b5694de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-scipy-solver/default.nix
+++ b/distros/noetic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-exotica-scipy-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "88f1f1c4b71a3e0714b0467ad58afebf880cdb2151d6ee30252493ead2eabe9a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "7f4a0d6c55baadf49abac767620e3ada2204693487d743266cf38d6342c9abcf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "5b1c70f07883801191960dc4f97eca7fcb0ff625f962a6959f8c2fb0a0b65397";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "c59303eeaf59280a61ffd8ce660af82b0874ed5aa9aca702d0a044824b230472";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica/default.nix
+++ b/distros/noetic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica";
-  version = "6.0.2-r1";
+  version = "6.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.0.2-1.tar.gz";
-    name = "6.0.2-1.tar.gz";
-    sha256 = "8ae387eca6479a34939185ced9005242744282244c111dd6701e535e2e69fa2a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.1.0-1.tar.gz";
+    name = "6.1.0-1.tar.gz";
+    sha256 = "8e24e79d632d1562e474d7efa50724ae525fb321912957c8b10fe77174eaca1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-bringup/default.nix
+++ b/distros/noetic/fetch-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depth-image-proc, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-moveit-config, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, image-proc, joy, openni2-launch, robot-state-publisher, sensor-msgs, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-fetch-bringup";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_bringup/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "7c5fc91b4d57c5ee2e755615c8fd7e6dbe9b5d4c0f7204a19b945dce2e0c6d95";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_bringup/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "fdb2a6fbcfc4a9a5f8c06a5f037002ae252e34de6897e4adbfdedcb4f27a314a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-drivers/default.nix
+++ b/distros/noetic/fetch-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, libyamlcpp, mk, nav-msgs, power-msgs, python3, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-fetch-drivers";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_drivers/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "6258a13ea84a294420bcc474fd2c75ef88d7d276cd0571b57e6b908826978bc1";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_drivers/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "d504e7ef63e54745253de09244b81b3fb22b518de815de094924f773893c7647";
   };
 
   buildType = "catkin";

--- a/distros/noetic/freight-bringup/default.nix
+++ b/distros/noetic/freight-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, joy, robot-state-publisher, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-freight-bringup";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/freight_bringup/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "b4bf4ed64d3dbc1065bdd7417fa3e13a96501b335ab19760ecd59273a00a3fc0";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/freight_bringup/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "086782f7b8b80bb9bc94daf0d93bdc6f39bab06369ea872ae3f83c086a98f1ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -44,8 +44,6 @@ self: super: {
 
  assisted-teleop = self.callPackage ./assisted-teleop {};
 
- astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
-
  async-comm = self.callPackage ./async-comm {};
 
  audibot = self.callPackage ./audibot {};
@@ -1348,6 +1346,8 @@ self: super: {
 
  moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
 
+ moveit-core = self.callPackage ./moveit-core {};
+
  moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
@@ -1385,8 +1385,6 @@ self: super: {
  moveit-ros-move-group = self.callPackage ./moveit-ros-move-group {};
 
  moveit-ros-occupancy-map-monitor = self.callPackage ./moveit-ros-occupancy-map-monitor {};
-
- moveit-ros-perception = self.callPackage ./moveit-ros-perception {};
 
  moveit-ros-planning = self.callPackage ./moveit-ros-planning {};
 
@@ -1505,6 +1503,8 @@ self: super: {
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
+
+ ocean-battery-driver = self.callPackage ./ocean-battery-driver {};
 
  octomap = self.callPackage ./octomap {};
 
@@ -1652,6 +1652,8 @@ self: super: {
 
  position-controllers = self.callPackage ./position-controllers {};
 
+ power-monitor = self.callPackage ./power-monitor {};
+
  power-msgs = self.callPackage ./power-msgs {};
 
  pr2-common = self.callPackage ./pr2-common {};
@@ -1679,6 +1681,10 @@ self: super: {
  pr2-mechanism-msgs = self.callPackage ./pr2-mechanism-msgs {};
 
  pr2-msgs = self.callPackage ./pr2-msgs {};
+
+ pr2-power-board = self.callPackage ./pr2-power-board {};
+
+ pr2-power-drivers = self.callPackage ./pr2-power-drivers {};
 
  prosilica-gige-sdk = self.callPackage ./prosilica-gige-sdk {};
 
@@ -1713,6 +1719,8 @@ self: super: {
  qt-gui-py-common = self.callPackage ./qt-gui-py-common {};
 
  qwt-dependency = self.callPackage ./qwt-dependency {};
+
+ radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
 
@@ -2196,6 +2204,8 @@ self: super: {
 
  sot-core = self.callPackage ./sot-core {};
 
+ sot-dynamic-pinocchio = self.callPackage ./sot-dynamic-pinocchio {};
+
  sot-tools = self.callPackage ./sot-tools {};
 
  sparse-bundle-adjustment = self.callPackage ./sparse-bundle-adjustment {};
@@ -2325,6 +2335,16 @@ self: super: {
  toposens-pointcloud = self.callPackage ./toposens-pointcloud {};
 
  toposens-sync = self.callPackage ./toposens-sync {};
+
+ trac-ik = self.callPackage ./trac-ik {};
+
+ trac-ik-examples = self.callPackage ./trac-ik-examples {};
+
+ trac-ik-kinematics-plugin = self.callPackage ./trac-ik-kinematics-plugin {};
+
+ trac-ik-lib = self.callPackage ./trac-ik-lib {};
+
+ trac-ik-python = self.callPackage ./trac-ik-python {};
 
  track-odometry = self.callPackage ./track-odometry {};
 
@@ -2519,5 +2539,7 @@ self: super: {
  ypspur = self.callPackage ./ypspur {};
 
  ypspur-ros = self.callPackage ./ypspur-ros {};
+
+ zbar-ros = self.callPackage ./zbar-ros {};
 
 }

--- a/distros/noetic/ibeo-msgs/default.nix
+++ b/distros/noetic/ibeo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ibeo-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/ibeo_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ce05a2381af6287f1129a9dd02ae6de196938bbfcee7e01394b0fd3907c44242";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/ibeo_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "d3444d954ef9fb4ca54a1649051d275756f7bdf0312716a14a7c1ca60311dd8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "51af8ed8041bcb65b894975bbf7164e1ca92e2d0b6368709f21b50edf90190f3";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "4febe1a1361ed5ef1b2235aa97f9897a94b8db857af764beb5618d140b2af399";
   };
 
   buildType = "catkin";

--- a/distros/noetic/kartech-linear-actuator-msgs/default.nix
+++ b/distros/noetic/kartech-linear-actuator-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-kartech-linear-actuator-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/kartech_linear_actuator_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "6a4f2a58dbb3faed0221e5125d9022238071dc753e14719877487887affccd28";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/kartech_linear_actuator_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "409afffc6e63a693cb50418eba87e72cf78eb1ba0f7880a2f6e96f8a191d15d4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "e158f43b8d2a72f761f9dbb88d9e541dea791a09ca235a3ae2c00f6a104c2cb9";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "e3cae3b5f006219a14ea691e38003777e026d1bc1758d54cf6d9d5023b4676ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/message-filters/default.nix
+++ b/distros/noetic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-message-filters";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "247b9c7b12a05cb85a41a7f3b5b863d3f3fdc5257b626b0547717014cb0a6783";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/message_filters/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "b2cf74ea82760301f2ec3895743400848c179c3f5693a34f75291d347944ca60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mobileye-560-660-msgs/default.nix
+++ b/distros/noetic/mobileye-560-660-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mobileye-560-660-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/mobileye_560_660_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "7e706af2739240f6430b6323679afad3e39fd6e5bf08854d8655ef61b1796f1f";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/mobileye_560_660_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1cf02b923107a5819d73568f60334ef610f9282e50114caee919844b5d9bd889";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "7920ff964dea8bb88ab538a8dc82efe5411b1f2337e412771d958a82609ae914";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "811dede6f9a51f3ea2843521ba0ca495847cd8f7067abdac38aaab515e6503f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -1,5 +1,5 @@
 
-# Copyright 2020 Open Source Robotics Foundation
+# Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-conversions, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "85092d6793f3eb28bac6460ebbc089f33a1aab8857edaea659b44e35317d2dcc";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4f69e71740f055c9d61709224ad2d032ffac9d3f219003dffdeb6bb7c816e775";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "eda2c491967597f119103be8fe3bf208a37e80d68d36f1f302bc55d6117b44f7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a0a0c40fbf2cb6760683c8c3a725d68c26dd4f1d221c732f617b4604a4d3347d";
   };
 
   buildType = "catkin";
   checkInputs = [ moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning rostest xmlrpcpp ];
-  propagatedBuildInputs = [ eigen moveit-core orocos-kdl pluginlib pythonPackages.lxml roscpp tf2 tf2-kdl urdfdom ];
+  propagatedBuildInputs = [ eigen moveit-core orocos-kdl pluginlib python3Packages.lxml python3Packages.pyyaml roscpp tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6d945122b7badc0c210ed03653bc9b45b7f84e75d9722017e8f3991d3d245d81";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "aea0947d42ba0b4c4967ee8739effdd1331dd878f68ff42ae514fdde6022d960";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6e7be6f951d9fef52fd43455d94b31bb3fc87e9afa83ae676f378dc59693c52d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b3c4ca77f8d50bf4dbd1f6444b10d5a86fb0e4ae5b4abf37aad31a39ef898a9a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ee8eb2703ae14576e4157e83d1401e1ba466cebfbd765680cb7d893a286185a1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4279138b98f2d6232454b240c3e573ae46b23216fe266727859bbace664d1bf9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c0c08f7b183a52e538a7779afa93bf10532b92e4e72dfc6d84ad8afc0081e9b8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "bd66730e8026d8f85c35bde79fe46e068d11bc2b678aa2a75598cbdaad9c8a57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "bb6974dfc6981373ec95d8b6060cd655b22b72c38a762ef7aedbbeb1029f1a9b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "383ef555d28f94cba4d59314f51c1399923abd538a25a1c99a392520adfb2cf0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "97767dd85f04ceb0e57403053740eb9fe3dced140156eea592dad1e2df5147e0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "84fff910fb63a269901a775e1e74e04f61d0dd193f888288abe15e93fb51dbec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "182f09d7d08b7e9326ab655eee9b60eb474bf50c846a35a43cf3d07a41b985ce";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "61ec02da3362e899b7f707b792359395ed9dfab775db2a7ea5cd9c232c569969";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2e411868ea84e132e969547ef8b34a57714afe1f523e00100c3ede02215a26bd";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "56de3f06cbf7ce4d255f720fb26969e802c42944bc503feaaa5a7c5e7b56b580";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "24a9767e7097f0b5c2a311f99560177cd6860076650c07cba2833d6c84bc2f28";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "e84763fc2105e6121d901f62b96eff5dd5eb0c89e9e07ba101ad797708fd3263";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "0d9579035a7b0e634c00a8481b14916dee04e16e5dcd018bd7c391f63e718532";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "bcdcb8ee509881e37085fd4571f1e88871a66961d51cdf801cced618f9bc3b73";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8006c26757c668316a426cc58e60b2946d84ccba990c55f40fdcc5bfc1d176c1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "80b2752d63d6e5c7b241c027f24916f2a4b75091e2ffa7167505c40e6d7f7ef6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8884d1db4b6d0a84d4f9a6e4900cd5c9ffab26f1560cfcf1b0fec347264043e3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d7ea752b78b3e866f9ae395fc68b9964d1b93c3a70dc7755c33a03ba6bbaca57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "99943238d1165345ac91de722a57beb0ea156a1823846105bf5963f136e9ec92";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a2b72044b775ec9d6d5c5a204d034bed0cdf056e8d4b1473023d33d21d0c4fac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "3ab04c233fb727e91a62377d032ce5d4675413b2f36838b947e34437d1e31d2b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "20aaddd5a34ba135f1dc2af1c81fd6bca86d7e7edd2d9a884da576fa6cb4419d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4b6474363d53880899306d127ea643d5134c82ef90a8fc5fd17334b392de5c64";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "e47ec035b19bfa156470ac51a6ce5462fab6ebb6f3ff0769a818c7d0d25a0cb1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "07038e0d674444b70515974a98ff4201ff41befe38da4b35b47cc2dca54464ff";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "5ad31e65b766fab2f072548ee4bfd272c4bd87e535867a5a8b66ed7dc28ee54d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-msgs, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "8646f04afa3a7a9fa72e19232c35336bfcaae99cf28023643d67dc0ed67b32c9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "dd0e3ca93621aeb77306e70435cead2f8996a47b352ea408a2a980470ec9c5ef";
   };
 
   buildType = "catkin";
   checkInputs = [ moveit-resources-panda-moveit-config rostest ];
-  propagatedBuildInputs = [ control-msgs geometry-msgs joy-teleop moveit-msgs moveit-ros-planning-interface rosparam-shortcuts sensor-msgs spacenav-node std-msgs std-srvs trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy-teleop moveit-msgs moveit-ros-planning-interface rosparam-shortcuts sensor-msgs spacenav-node std-msgs std-srvs tf2-eigen trajectory-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "dde6077f673114e939de5284cc0dbc30c48ed92958f1e7670c711ded9ab28e5a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "8e518f0ecc87da513c02428b2aef364deb42cbb9f3fca4e58cc140e1c181d7b3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c29d289640838cc9e302718ff76bdd052294a90291884ed5a7bc71735ee55636";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6cff401a3627510d535eef507401580d770883d8a43eaa9b27ac4e93ecf7f27c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c9d73de89d7744f726820f57c9ebc02649b885db771c3985ec95b4d448048d96";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "db7f1f41fbed3931afe64539575878a326819471572d08b6cbde0b04b6446ff4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neobotix-usboard-msgs/default.nix
+++ b/distros/noetic/neobotix-usboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-neobotix-usboard-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/neobotix_usboard_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "1e27be9f0df01e460ab8b6502e1601a176e6e41507082de38f58df3f35445294";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/neobotix_usboard_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f94f71b1bdc621c541bc1035c9ed794dd6b7f79432d9a9482587108aa36b0b52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "50e9fe14ab5ecaf164fead2d164e3c950f41aff9d327d3f675f843eff5cc07d8";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "3bc18e0ea0715037267e9a0922144f521f50e30e049561db231876c5d226b9c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "1443d2699ee13a74f16f97e14aafad66a425fef5eb02d13d1b19d4c55be7fba2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "b888d6841d3370b3025166b8af0f2ef5816535a8f4ba5ecdbc000430b9f75bba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "f42a1ff6e567a378af914c1baf1baafb0a6030998c01295d7432cc4a39d1778b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "fbc67584929d31b357defd99f937ee341089b5b9cbcf540a8f9b2a86ee72b2cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "4c304f0da001659f23db183b259fb335e239d5717468e63005cadfdd1c6c3a8c";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "3c09ba3ff30562c0e8d363aad6be62cd424f0899ff71d442180c61924fc47c35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ocean-battery-driver/default.nix
+++ b/distros/noetic/ocean-battery-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, pr2-msgs, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-ocean-battery-driver";
+  version = "1.1.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/ocean_battery_driver/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "63b43358d280ade2900d4c1c45f06c8ccf5991df5aad1ff7124e2ddf8d8631c6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater log4cxx pr2-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This is an interface to the Ocean Server Technology Intelligent Battery and Power System.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pacmod-msgs/default.nix
+++ b/distros/noetic/pacmod-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pacmod-msgs";
-  version = "3.1.0-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/pacmod_msgs/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "db29215d9dbcab4ec317336b2cc6916dbe5173df51b186a4eebe1613e064310a";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/pacmod_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "89925d3c86b63efc2b0895533470a22f8f5daede220268f98042ea66fdc7f803";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "dbf9134bd43a071dcfd14db58168c9863f371d05fc100f4fe288e2b1f395ec9b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "05c679ad14e7bc7fd9f9347eb98b441ebe78ad215eb151edf89fe0c8fdde4850";
   };
 
   buildType = "catkin";

--- a/distros/noetic/power-monitor/default.nix
+++ b/distros/noetic/power-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, pr2-msgs, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-power-monitor";
+  version = "1.1.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/power_monitor/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "9940b21f21ffa19ba337411c0d23bd8580e9c03f9eece75f6b32ec5b02764267";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure pr2-msgs roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The power_monitor collects messages from the ocean_battery_server and
+     the pr2_power_board, and publishes a summary of their data in a
+     friendlier message format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-power-board/default.nix
+++ b/distros/noetic/pr2-power-board/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, message-generation, message-runtime, pr2-msgs, roscpp, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-power-board";
+  version = "1.1.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_board/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "5c2fa3882b2715207997d77c1660a0f3ac8bbe058b55d964472830d11b84084c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater log4cxx message-runtime pr2-msgs roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This provides a ROS node for the PR2 Power Board.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-power-drivers/default.nix
+++ b/distros/noetic/pr2-power-drivers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ocean-battery-driver, power-monitor, pr2-power-board }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-power-drivers";
+  version = "1.1.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_drivers/1.1.8-1.tar.gz";
+    name = "1.1.8-1.tar.gz";
+    sha256 = "b516414a382960abb0ed4d2092fa16c4f85ff984d36fbea56704927116e15a19";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ocean-battery-driver power-monitor pr2-power-board ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Power drivers for the PR2 robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/radar-msgs/default.nix
+++ b/distros/noetic/radar-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, uuid-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-radar-msgs";
+  version = "0.1.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/radar_msgs-release/archive/release/noetic/radar_msgs/0.1.0-2.tar.gz";
+    name = "0.1.0-2.tar.gz";
+    sha256 = "11f69076602e90734d55a57520c4b24bc317b15b4e57e1967df400e9a1cec083";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs uuid-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Standard ROS messages for radars'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ros-comm/default.nix
+++ b/distros/noetic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-ros-comm";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "492604249fab046c4c9e8085acad7b98765abbfee977db2b2e8e6632c6dd7c69";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/ros_comm/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "f0372d4fe96241aa8bdb4aebc50e4d9ee311145537aca9f7cde0da8cdafc1313";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag-storage/default.nix
+++ b/distros/noetic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosbag-storage";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "3d2a1090d7e68d3f4b37a78ee43a46ee1f519e9e0c4b54976e2bfc6e7ecb1446";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag_storage/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "ddd8d1f36a97df5d83b10d10e31ced65055846c5e54a4ef000403d47dfd06033";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbag/default.nix
+++ b/distros/noetic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, python3Packages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-rosbag";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "78550abd3d66a901f4339bd5db84adf3fa3086b9e0306a76a4dbb6c91b8ffbe0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosbag/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "e2486c67964299fdeab6f9475d309db29dd09f2804ad69f84f8f232f272f2650";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscpp/default.nix
+++ b/distros/noetic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-roscpp";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "9f5495c004ae08587407b0d50d91625861442277aa356ae318405dd50bd1449c";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roscpp/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "6e8a5ec2c21c8e5e44b0b4a739af9bb1ce316837750c62a8deb501b5d43c1102";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosdiagnostic/default.nix
+++ b/distros/noetic/rosdiagnostic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosdiagnostic";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/rosdiagnostic/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "729c21c32e984cdb425a25cda77543763bc23e7fcf5678a452beb9cf02524803";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/rosdiagnostic/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "02b36867f60e1ee9c6236d2271a2ceeb7ff7b937f993d0c8f6c7d167fd904676";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosgraph/default.nix
+++ b/distros/noetic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosgraph";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "f06d2bdf21f937d23f53fd6a2eb61d0e602a6592a4faa9f9378149ec93727b09";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosgraph/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "a3bf6501a6a1bed062e22e32a5fc97e3e6b88bf2bbdd7ca5fb4c9669a3aa59bd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslaunch/default.nix
+++ b/distros/noetic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslaunch";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "cbb4de18a756c535d3846ea9512a72ea6de3cba37daf4761ee8b50e34b4b3fff";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslaunch/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "32d02efd135b79682c07f4c99bee4d61a37256b563392a918e24b300bab773c1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslz4/default.nix
+++ b/distros/noetic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-roslz4";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "0ac27516f063cfd63e8dd8f497ad917ad4ae75268f4767bd05f54df72c6f1254";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roslz4/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "dab736fadc132e33b0e07c19a51979158f823b4a20589e81c0677c6d7979dce0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmaster/default.nix
+++ b/distros/noetic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosmaster";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "35698c8c1ef91b7a0729c7a8a5237098c903b08e7a2d06ccb4b79f67b269794b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmaster/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "399877398eb32bec4357a862bbcbf00a328a52515132be0fee2b4ef1e4298c2c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmsg/default.nix
+++ b/distros/noetic/rosmsg/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages, rosbag, roslib, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, genmsg, genpy, python3Packages, rosbag, roslib, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rosmsg";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "6aeec1dc094d3ecb4c286b6d583f4f014d5892de7061fa972b6a911e5ffe5b7a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosmsg/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "6f00ef6a51c837b03df6597c2ea8e219cc6fbbe25b40b25370c6109784e6be69";
   };
 
   buildType = "catkin";
-  checkInputs = [ std-msgs ];
+  checkInputs = [ diagnostic-msgs rostest std-msgs std-srvs ];
   propagatedBuildInputs = [ catkin genmsg genpy python3Packages.rospkg rosbag roslib ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/rosnode/default.nix
+++ b/distros/noetic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-noetic-rosnode";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "694d31596750daace4769698746bb902dc8a32266c134d63ef8eefc9d7318752";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosnode/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "92e12706269ebf4e9f1120fd4afdcbb5b746944b0653897162f6c529a5d92057";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosout/default.nix
+++ b/distros/noetic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosout";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "d7e89b1da20a068c590bc1fa28d168e19111964a5e9508bfd330f7227c7227ad";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosout/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "264df5f22d98ebb523bc6451c3fd3d48b5da1a2bed5654d842bc58f90c916fb5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosparam/default.nix
+++ b/distros/noetic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph }:
 buildRosPackage {
   pname = "ros-noetic-rosparam";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "e17f4dfea1a262337132b3e624953784ad5100ba9056a43e8645be81aa0b4f61";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosparam/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "9d6203dc08c2d5f62b856dc4f9a91812f75c79d3f066d6c5e057a3872dbf17da";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rospy/default.nix
+++ b/distros/noetic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, python3Packages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rospy";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "cf6bc6ef155e7a4ca34cacb220540d9146f532797add26b86ebdca99a829447b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rospy/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "39aa71105f2011a53554a35b5550bc79dde82cb696ec1f75910cfb1a1e8ea50e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosservice/default.nix
+++ b/distros/noetic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-noetic-rosservice";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "b39a5f1dbed5397750c8330df6285612726337c8d149abb20282320677585b7b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rosservice/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "131522ad96b2ca95dccee9fcd7cf7da6e7086b1c01c6903aae0ab683c4d1d232";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostest/default.nix
+++ b/distros/noetic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-rostest";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "158d7228b4ee0cdadf7ac75f971f9d6f66be6890f19d3cb8caf19b9ffa02c66a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostest/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "430e0b1913b046c0535fb9a0e256e605ac5d4ee7fe059c86e6b9ae6775f6cda1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rostopic/default.nix
+++ b/distros/noetic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-rostopic";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "4da32822c47727bc738182115cac815347def45d9a2e0fc364ef20774887ae77";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/rostopic/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "f67f3ca7065652a194a8216e837bf85e6ec624fff0a84a84fa23349790634713";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roswtf/default.nix
+++ b/distros/noetic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, python3Packages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-roswtf";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "ac660458237d451137e681c618faddcda49f2e2c85e6b109f2088634b9f36004";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/roswtf/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "16f15557ec5c0294aabb6fd25c7512e1db0d94c10e3e3972e483705a9faf455d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.5-r1";
+  version = "1.14.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.5-1.tar.gz";
-    name = "1.14.5-1.tar.gz";
-    sha256 = "5af081200832c88f692fb56d68ecaef5baf53605c18cfbef8f7253700b493d08";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.6-1.tar.gz";
+    name = "1.14.6-1.tar.gz";
+    sha256 = "d32a1a35764906a7cc12782d0cf5d057e23ddd337380ea8a6cb372de80184d51";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "a1b56f0e95703a559f310e3c4f2a901c3653ba0890621dfd70f4371bd2f79447";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "ed74eef1b4cae09479b1670ef699cadbf249b05705bbddcad18215d75ba37147";
   };
 
   buildType = "catkin";

--- a/distros/noetic/self-test/default.nix
+++ b/distros/noetic/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-self-test";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/self_test/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "102d17be7448516ee190a3d924116326f8eeaef81653b8ebf50fb18fab6298d3";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/self_test/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "0ed086d82821fa5ddc9952912b16e46c22871eb49ebde993fde9132cb3110d38";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sick-scan/default.nix
+++ b/distros/noetic/sick-scan/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, message-generation, message-runtime, pcl-conversions, pcl-ros, roscpp, rospy, sensor-msgs, tf, tf2, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sick-scan";
-  version = "1.7.8-r1";
+  version = "1.10.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.7.8-1.tar.gz";
-    name = "1.7.8-1.tar.gz";
-    sha256 = "03779ee8c369f4da0eaa8b73bd453ff8994b0c34ce7b89f41b528a31a4666bd6";
+    url = "https://github.com/SICKAG/sick_scan-release/archive/release/noetic/sick_scan/1.10.1-1.tar.gz";
+    name = "1.10.1-1.tar.gz";
+    sha256 = "733a8d4deaf6e4faa9977a175e435ec3c490c348606a411b13a5c4e733a5171e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.4-r6";
+  version = "4.11.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.4-6.tar.gz";
-    name = "4.11.4-6.tar.gz";
-    sha256 = "cea10b4a9edaf20948e1f84303227f82cb12a741c68633a86a0d64c2e18c5b44";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.5-2.tar.gz";
+    name = "4.11.5-2.tar.gz";
+    sha256 = "cbf16687c4ebb2226500c8fba4ffe6ffbea2bf15c5d09cf3fba151ba57d8327f";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sot-dynamic-pinocchio/default.nix
+++ b/distros/noetic/sot-dynamic-pinocchio/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, gtest, liblapack, openblas, pinocchio, sot-core, sot-tools }:
+buildRosPackage {
+  pname = "ros-noetic-sot-dynamic-pinocchio";
+  version = "3.6.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/stack-of-tasks/sot-dynamic-pinocchio-ros-release/archive/release/noetic/sot-dynamic-pinocchio/3.6.3-1.tar.gz";
+    name = "3.6.3-1.tar.gz";
+    sha256 = "50447cd2030f4dda6a737ffb9ecc4ab297b2803ff311c81718fac790a957679f";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ doxygen git ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ catkin dynamic-graph-python liblapack openblas pinocchio sot-core sot-tools ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Pinocchio bindings for dynamic-graph'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sot-tools/default.nix
+++ b/distros/noetic/sot-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, doxygen, dynamic-graph-python, git, sot-core }:
 buildRosPackage {
   pname = "ros-noetic-sot-tools";
-  version = "2.3.3-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.3-1.tar.gz";
-    name = "2.3.3-1.tar.gz";
-    sha256 = "5cd8cbd6e819505af7dc8b6e5eb2d08d79927bbe1791fb52d76ddce29b9eac7e";
+    url = "https://github.com/stack-of-tasks/sot-tools-ros-release/archive/release/noetic/sot-tools/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "d54e689070390d5ffe5606f2131f31848e71c83e3d1100435ed7fdceae8ef117";
   };
 
   buildType = "cmake";

--- a/distros/noetic/test-diagnostic-aggregator/default.nix
+++ b/distros/noetic/test-diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, pluginlib, roscpp, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-test-diagnostic-aggregator";
-  version = "1.10.3-r1";
+  version = "1.10.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/test_diagnostic_aggregator/1.10.3-1.tar.gz";
-    name = "1.10.3-1.tar.gz";
-    sha256 = "9cc2fc2fbde8b5714e61d04e8d08cbd36be3e8b1e79ff3c0a601634458387d92";
+    url = "https://github.com/ros-gbp/diagnostics-release/archive/release/noetic/test_diagnostic_aggregator/1.10.4-1.tar.gz";
+    name = "1.10.4-1.tar.gz";
+    sha256 = "d3267d8a07e6ac5b14a94b43dd32a2d1931df27ab18d881e38ef706345e86c4a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/topic-tools/default.nix
+++ b/distros/noetic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-topic-tools";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "fe8afc1ef2dbb5fa619f0a612d566e70768814f1650faf89eeccb39b4dafc60b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/topic_tools/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "29c6e400d482d27e426ac69233c9bdcb3075921bb6636e6837a775be7b6b6b34";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trac-ik-examples/default.nix
+++ b/distros/noetic/trac-ik-examples/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, orocos-kdl, trac-ik-lib, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-trac-ik-examples";
+  version = "1.6.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_examples/1.6.1-6.tar.gz";
+    name = "1.6.1-6.tar.gz";
+    sha256 = "c9821e136f5ad6139c4cc10166baf5316cf360e20dc31d390133098843d54a7b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost orocos-kdl trac-ik-lib xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the source code for testing and comparing trac_ik'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/trac-ik-kinematics-plugin/default.nix
+++ b/distros/noetic/trac-ik-kinematics-plugin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp, tf-conversions, trac-ik-lib }:
+buildRosPackage {
+  pname = "ros-noetic-trac-ik-kinematics-plugin";
+  version = "1.6.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_kinematics_plugin/1.6.1-6.tar.gz";
+    name = "1.6.1-6.tar.gz";
+    sha256 = "75a3e0da9b5cc99b5abdedcca241111b48354971b5faeb258f07d18bc56c748d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ moveit-core pluginlib roscpp tf-conversions trac-ik-lib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A MoveIt! Kinematics plugin using TRAC-IK'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/trac-ik-lib/default.nix
+++ b/distros/noetic/trac-ik-lib/default.nix
@@ -1,0 +1,31 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, eigen, kdl-parser, nlopt, pkg-config, roscpp, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-trac-ik-lib";
+  version = "1.6.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_lib/1.6.1-6.tar.gz";
+    name = "1.6.1-6.tar.gz";
+    sha256 = "1e3cf96735799225f4674ccd134181aa284168b7520c4a620c458e6027b1d1e7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules eigen pkg-config ];
+  propagatedBuildInputs = [ boost kdl-parser nlopt roscpp urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TRAC-IK is a faster, significantly more reliable drop-in replacement for
+    KDL's pseudoinverse Jacobian solver.
+
+    The TRAC-IK library has a very similar API to KDL's IK solver calls,
+    except that the user passes a maximum time instead of a maximum number of
+    search iterations.  Additionally, TRAC-IK allows for error tolerances to
+    be set independently for each Cartesian dimension (x,y,z,roll,pitch.yaw).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/trac-ik-python/default.nix
+++ b/distros/noetic/trac-ik-python/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rospy, swig, tf, tf-conversions, trac-ik-lib }:
+buildRosPackage {
+  pname = "ros-noetic-trac-ik-python";
+  version = "1.6.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_python/1.6.1-6.tar.gz";
+    name = "1.6.1-6.tar.gz";
+    sha256 = "83bd0dfb591bc4d63f8a3f3f4539ac0aa8a58c157689b715413f4d3f95a50733";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rospy swig tf tf-conversions trac-ik-lib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The trac_ik_python package contains a python wrapper using SWIG
+  for trac_ik_lib'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/trac-ik/default.nix
+++ b/distros/noetic/trac-ik/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, trac-ik-examples, trac-ik-kinematics-plugin, trac-ik-lib, trac-ik-python }:
+buildRosPackage {
+  pname = "ros-noetic-trac-ik";
+  version = "1.6.1-r6";
+
+  src = fetchurl {
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik/1.6.1-6.tar.gz";
+    name = "1.6.1-6.tar.gz";
+    sha256 = "042fe38815ad645a4c75974238ef30c8da3cc4b13a4e1217d4a2e71aa55c956b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ trac-ik-examples trac-ik-kinematics-plugin trac-ik-lib trac-ik-python ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ROS packages in this repository were created to provide an improved
+    alternative Inverse Kinematics solver to the popular inverse Jacobian
+    methods in KDL.  TRAC-IK handles joint-limited chains better than KDL
+    without increasing solve time.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "7f3efa8a1730aba05694988a0e4a783b31e85e08f30b2d8052594b49a3548fae";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "ed32b479352a1074d379510660eeeb41a62159ea8576f8373217b2e9bf19a264";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.8-r1";
+  version = "0.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.8-1.tar.gz";
-    name = "0.10.8-1.tar.gz";
-    sha256 = "af0e2975ccfd5598527033fcde650cf972e27896f42cd8cac5622cf291b1c4dd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.10-1.tar.gz";
+    name = "0.10.10-1.tar.gz";
+    sha256 = "612865f53e0d81e28ba6d089fa8c939a8cb8449b5ce13b9aeba24209c019419d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tsid/default.nix
+++ b/distros/noetic/tsid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigenpy, eiquadprog, git, graphviz, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-tsid";
-  version = "1.4.2-r1";
+  version = "1.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/noetic/tsid/1.4.2-1.tar.gz";
-    name = "1.4.2-1.tar.gz";
-    sha256 = "99b43a697219f69d23fe2404449829b87b213aacd96efa9bd93e3718a1a9a2b3";
+    url = "https://github.com/stack-of-tasks/tsid-ros-release/archive/release/noetic/tsid/1.6.0-1.tar.gz";
+    name = "1.6.0-1.tar.gz";
+    sha256 = "e4470ce6f447a5f1c4e79eb083e5a3696df58671c5b1663d918657cfe1948379";
   };
 
   buildType = "cmake";

--- a/distros/noetic/xmlrpcpp/default.nix
+++ b/distros/noetic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-noetic-xmlrpcpp";
-  version = "1.15.9-r1";
+  version = "1.15.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.9-1.tar.gz";
-    name = "1.15.9-1.tar.gz";
-    sha256 = "e9ede8e7537f5f07fbb6c49a7bae03b66a44b09779663384d21ada22942aa767";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/noetic/xmlrpcpp/1.15.10-1.tar.gz";
+    name = "1.15.10-1.tar.gz";
+    sha256 = "92d309e32b4ea9a04ebc59fcd6466346ae31ade8f2e33130a2b9f9da638d54e7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur/default.nix
+++ b/distros/noetic/ypspur/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, readline }:
 buildRosPackage {
   pname = "ros-noetic-ypspur";
-  version = "1.20.1-r1";
+  version = "1.20.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.1-1.tar.gz";
-    name = "1.20.1-1.tar.gz";
-    sha256 = "a124cf7f8c0086c08713246861cc9e26243e149778cef569e9098bb15805c07b";
+    url = "https://github.com/openspur/yp-spur-release/archive/release/noetic/ypspur/1.20.2-1.tar.gz";
+    name = "1.20.2-1.tar.gz";
+    sha256 = "3b6048cde6a08aaa82eaea43e86ddcd1e1c2dfe9e68dcc3dfee93e45d215ea4d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/zbar-ros/default.nix
+++ b/distros/noetic/zbar-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, nodelet, roscpp, roslint, zbar }:
+buildRosPackage {
+  pname = "ros-noetic-zbar-ros";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/zbar_ros-release/archive/release/noetic/zbar_ros/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "75e34b3033a0ff405b0a6e1c306813e89f0e2cb2351c754c4dd6206fd2540f55";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ cv-bridge nodelet roscpp zbar ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Lightweight ROS wrapper for Zbar barcode/qrcode reader library (http://zbar.sourceforge
+    .net/)'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 461e7cfee8b72f5a94c7f482779146f9b1e6779a.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *system-modes 0.4.2-r1 --> 0.5.0-r1*
* *system-modes-examples 0.4.2-r1 --> 0.5.0-r1*

Foxy Changes:
-------------
* *ament-package 0.9.3-r1 --> 0.9.4-r1*
* *cascade-lifecycle-msgs 0.0.6-r1 --> 0.0.7-r4*
* *example-interfaces 0.9.0-r1 --> 0.9.1-r1*
* *joy 2.4.1-r1 --> 3.0.0-r2*
* *joy-linux 2.4.1-r1 --> 3.0.0-r2*
* *launch-pal 0.0.2-r3*
* *plansys2-bringup 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-bt-actions 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-core 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-domain-expert 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-executor 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-lifecycle-manager 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-msgs 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-pddl-parser 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-planner 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-popf-plan-solver 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-problem-expert 1.0.7-r2 --> 1.0.9-r1*
* *plansys2-terminal 1.0.7-r2 --> 1.0.9-r1*
* *python-cmake-module 0.8.0-r1 --> 0.8.1-r1*
* *rclcpp-cascade-lifecycle 0.0.6-r1 --> 0.0.7-r4*
* *ros2cli-common-extensions 0.1.0-r1 --> 0.1.1-r1*
* *rosidl-runtime-py 0.9.0-r1 --> 0.9.1-r1*
* *rosxbeepy 0.0.1-r2*
* *rqt-graph 1.1.0-r1 --> 1.1.1-r1*
* *rqt-publisher 1.1.0-r1 --> 1.1.1-r1*
* *sdl2-vendor 2.4.1-r1 --> 3.0.0-r2*
* *sick-safetyscanners2 1.0.1-r2 --> 1.0.2-r1*
* *system-modes 0.4.2-r1 --> 0.5.0-r6*
* *system-modes-examples 0.4.2-r1 --> 0.5.0-r6*
* *teleop-twist-joy 2.4.1-r1 --> 2.4.2-r1*
* *test-interface-files 0.8.0-r1 --> 0.8.1-r1*
* *tinyxml-vendor 0.8.0-r1 --> 0.8.2-r1*
* *tinyxml2-vendor 0.7.3-r1 --> 0.7.4-r1*
* *wiimote 3.0.0-r2*
* *wiimote-msgs 3.0.0-r2*

Kinetic Changes:
----------------
* *costmap-cspace 0.10.8-r1 --> 0.10.10-r1*
* *heron-controller 0.2.0-r1*
* *joystick-interrupt 0.10.8-r1 --> 0.10.10-r1*
* *map-organizer 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-common 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-launch 0.10.8-r1 --> 0.10.10-r1*
* *obj-to-pointcloud 0.10.8-r1 --> 0.10.10-r1*
* *planner-cspace 0.10.8-r1 --> 0.10.10-r1*
* *safety-limiter 0.10.8-r1 --> 0.10.10-r1*
* *sick-scan 1.7.8-r1 --> 1.10.1-r1*
* *track-odometry 0.10.8-r1 --> 0.10.10-r1*
* *trajectory-tracker 0.10.8-r1 --> 0.10.10-r1*
* *vision-visp 0.11.1-r1 --> 0.12.0-r1*
* *visp-auto-tracker 0.11.1-r1 --> 0.12.0-r1*
* *visp-bridge 0.11.1-r1 --> 0.12.0-r1*
* *visp-camera-calibration 0.11.1-r1 --> 0.12.0-r1*
* *visp-hand2eye-calibration 0.11.1-r1 --> 0.12.0-r1*
* *visp-tracker 0.11.1-r1 --> 0.12.0-r1*
* *ypspur 1.20.1-r1 --> 1.20.2-r1*

Melodic Changes:
----------------
* *costmap-cspace 0.10.8-r1 --> 0.10.10-r1*
* *exotica 6.0.2-r1 --> 6.1.0-r1*
* *exotica-aico-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-cartpole-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-collision-scene-fcl-latest 6.0.2-r1 --> 6.1.0-r1*
* *exotica-core 6.0.2-r1 --> 6.1.0-r1*
* *exotica-core-task-maps 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ddp-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-double-integrator-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-dynamics-solvers 6.0.2-r1 --> 6.1.0-r1*
* *exotica-examples 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ik-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ilqg-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ilqr-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-levenberg-marquardt-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ompl-control-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ompl-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-pendulum-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-pinocchio-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-quadrotor-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-scipy-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.0.2-r1 --> 6.1.0-r1*
* *heron-controller 0.2.0-r1*
* *husky-base 0.4.6-r1 --> 0.4.7-r1*
* *husky-bringup 0.4.6-r1 --> 0.4.7-r1*
* *husky-control 0.4.6-r1 --> 0.4.7-r1*
* *husky-description 0.4.6-r1 --> 0.4.7-r1*
* *husky-desktop 0.4.6-r1 --> 0.4.7-r1*
* *husky-gazebo 0.4.6-r1 --> 0.4.7-r1*
* *husky-msgs 0.4.6-r1 --> 0.4.7-r1*
* *husky-navigation 0.4.6-r1 --> 0.4.7-r1*
* *husky-robot 0.4.6-r1 --> 0.4.7-r1*
* *husky-simulator 0.4.6-r1 --> 0.4.7-r1*
* *husky-viz 0.4.6-r1 --> 0.4.7-r1*
* *jackal-control 0.7.3-r1 --> 0.7.4-r1*
* *jackal-description 0.7.3-r1 --> 0.7.4-r1*
* *jackal-msgs 0.7.3-r1 --> 0.7.4-r1*
* *jackal-navigation 0.7.3-r1 --> 0.7.4-r1*
* *jackal-tutorials 0.7.3-r1 --> 0.7.4-r1*
* *joystick-interrupt 0.10.8-r1 --> 0.10.10-r1*
* *led-msgs 0.0.9-r1*
* *map-organizer 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-common 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-launch 0.10.8-r1 --> 0.10.10-r1*
* *obj-to-pointcloud 0.10.8-r1 --> 0.10.10-r1*
* *planner-cspace 0.10.8-r1 --> 0.10.10-r1*
* *ros-control-boilerplate 0.5.1-r1 --> 0.5.2-r1*
* *safety-limiter 0.10.8-r1 --> 0.10.10-r1*
* *sick-scan 1.7.8-r1 --> 1.10.1-r1*
* *sot-dynamic-pinocchio 3.6.1-r1 --> 3.6.3-r1*
* *track-odometry 0.10.8-r1 --> 0.10.10-r1*
* *trajectory-tracker 0.10.8-r1 --> 0.10.10-r1*
* *tsid 1.4.2-r1 --> 1.6.0-r1*
* *vision-visp 0.11.1-r1 --> 0.12.0-r1*
* *visp-auto-tracker 0.11.1-r1 --> 0.12.0-r1*
* *visp-bridge 0.11.1-r1 --> 0.12.0-r1*
* *visp-camera-calibration 0.11.1-r1 --> 0.12.0-r1*
* *visp-hand2eye-calibration 0.11.1-r1 --> 0.12.0-r1*
* *visp-tracker 0.11.1-r1 --> 0.12.0-r1*
* *ws281x 0.0.9-r1*
* *ypspur 1.20.1-r1 --> 1.20.2-r1*
* *zbar-ros 0.3.0-r2*

Noetic Changes:
---------------
* *chomp-motion-planner 1.1.0-r1 --> 1.1.1-r1*
* *costmap-cspace 0.10.8-r1 --> 0.10.10-r1*
* *delphi-esr-msgs 3.1.0-r1 --> 3.2.0-r1*
* *delphi-mrr-msgs 3.1.0-r1 --> 3.2.0-r1*
* *delphi-srr-msgs 3.1.0-r1 --> 3.2.0-r1*
* *derived-object-msgs 3.1.0-r1 --> 3.2.0-r1*
* *diagnostic-aggregator 1.10.3-r1 --> 1.10.4-r1*
* *diagnostic-analysis 1.10.3-r1 --> 1.10.4-r1*
* *diagnostic-common-diagnostics 1.10.3-r1 --> 1.10.4-r1*
* *diagnostic-updater 1.10.3-r1 --> 1.10.4-r1*
* *diagnostics 1.10.3-r1 --> 1.10.4-r1*
* *dynamic-graph 4.3.3-r4 --> 4.3.4-r1*
* *dynamic-graph-python 4.0.2-r3 --> 4.0.3-r1*
* *eiquadprog 1.2.2-r1 --> 1.2.3-r1*
* *exotica 6.0.2-r1 --> 6.1.0-r1*
* *exotica-aico-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-cartpole-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-collision-scene-fcl-latest 6.0.2-r1 --> 6.1.0-r1*
* *exotica-core 6.0.2-r1 --> 6.1.0-r1*
* *exotica-core-task-maps 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ddp-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-double-integrator-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-dynamics-solvers 6.0.2-r1 --> 6.1.0-r1*
* *exotica-examples 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ik-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ilqg-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ilqr-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-levenberg-marquardt-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ompl-control-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-ompl-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-pendulum-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-pinocchio-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-quadrotor-dynamics-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-scipy-solver 6.0.2-r1 --> 6.1.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.0.2-r1 --> 6.1.0-r1*
* *fetch-bringup 0.9.1-r1 --> 0.9.2-r1*
* *fetch-drivers 0.9.1-r1 --> 0.9.2-r1*
* *freight-bringup 0.9.1-r1 --> 0.9.2-r1*
* *ibeo-msgs 3.1.0-r1 --> 3.2.0-r1*
* *joystick-interrupt 0.10.8-r1 --> 0.10.10-r1*
* *kartech-linear-actuator-msgs 3.1.0-r1 --> 3.2.0-r1*
* *map-organizer 0.10.8-r1 --> 0.10.10-r1*
* *message-filters 1.15.9-r1 --> 1.15.10-r1*
* *mobileye-560-660-msgs 3.1.0-r1 --> 3.2.0-r1*
* *moveit 1.1.0-r1 --> 1.1.1-r1*
* *moveit-chomp-optimizer-adapter 1.1.0-r1 --> 1.1.1-r1*
* *moveit-fake-controller-manager 1.1.0-r1 --> 1.1.1-r1*
* *moveit-kinematics 1.1.0-r1 --> 1.1.1-r1*
* *moveit-planners 1.1.0-r1 --> 1.1.1-r1*
* *moveit-planners-chomp 1.1.0-r1 --> 1.1.1-r1*
* *moveit-planners-ompl 1.1.0-r1 --> 1.1.1-r1*
* *moveit-plugins 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-benchmarks 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-control-interface 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-manipulation 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-move-group 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-occupancy-map-monitor 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-planning 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-planning-interface 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-robot-interaction 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-visualization 1.1.0-r1 --> 1.1.1-r1*
* *moveit-ros-warehouse 1.1.0-r1 --> 1.1.1-r1*
* *moveit-runtime 1.1.0-r1 --> 1.1.1-r1*
* *moveit-servo 1.1.0-r1 --> 1.1.1-r1*
* *moveit-setup-assistant 1.1.0-r1 --> 1.1.1-r1*
* *moveit-simple-controller-manager 1.1.0-r1 --> 1.1.1-r1*
* *neobotix-usboard-msgs 3.1.0-r1 --> 3.2.0-r1*
* *neonavigation 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-common 0.10.8-r1 --> 0.10.10-r1*
* *neonavigation-launch 0.10.8-r1 --> 0.10.10-r1*
* *obj-to-pointcloud 0.10.8-r1 --> 0.10.10-r1*
* *ocean-battery-driver 1.1.8-r1*
* *pacmod-msgs 3.1.0-r1 --> 3.2.0-r1*
* *planner-cspace 0.10.8-r1 --> 0.10.10-r1*
* *power-monitor 1.1.8-r1*
* *pr2-power-board 1.1.8-r1*
* *pr2-power-drivers 1.1.8-r1*
* *radar-msgs 0.1.0-r2*
* *ros-comm 1.15.9-r1 --> 1.15.10-r1*
* *rosbag 1.15.9-r1 --> 1.15.10-r1*
* *rosbag-storage 1.15.9-r1 --> 1.15.10-r1*
* *roscpp 1.15.9-r1 --> 1.15.10-r1*
* *rosdiagnostic 1.10.3-r1 --> 1.10.4-r1*
* *rosgraph 1.15.9-r1 --> 1.15.10-r1*
* *roslaunch 1.15.9-r1 --> 1.15.10-r1*
* *roslz4 1.15.9-r1 --> 1.15.10-r1*
* *rosmaster 1.15.9-r1 --> 1.15.10-r1*
* *rosmsg 1.15.9-r1 --> 1.15.10-r1*
* *rosnode 1.15.9-r1 --> 1.15.10-r1*
* *rosout 1.15.9-r1 --> 1.15.10-r1*
* *rosparam 1.15.9-r1 --> 1.15.10-r1*
* *rospy 1.15.9-r1 --> 1.15.10-r1*
* *rosservice 1.15.9-r1 --> 1.15.10-r1*
* *rostest 1.15.9-r1 --> 1.15.10-r1*
* *rostopic 1.15.9-r1 --> 1.15.10-r1*
* *roswtf 1.15.9-r1 --> 1.15.10-r1*
* *rviz 1.14.5-r1 --> 1.14.6-r1*
* *safety-limiter 0.10.8-r1 --> 0.10.10-r1*
* *self-test 1.10.3-r1 --> 1.10.4-r1*
* *sick-scan 1.7.8-r1 --> 1.10.1-r1*
* *sot-core 4.11.4-r6 --> 4.11.5-r2*
* *sot-dynamic-pinocchio 3.6.3-r1*
* *sot-tools 2.3.3-r1 --> 2.3.4-r1*
* *test-diagnostic-aggregator 1.10.3-r1 --> 1.10.4-r1*
* *topic-tools 1.15.9-r1 --> 1.15.10-r1*
* *trac-ik 1.6.1-r6*
* *trac-ik-examples 1.6.1-r6*
* *trac-ik-kinematics-plugin 1.6.1-r6*
* *trac-ik-lib 1.6.1-r6*
* *trac-ik-python 1.6.1-r6*
* *track-odometry 0.10.8-r1 --> 0.10.10-r1*
* *trajectory-tracker 0.10.8-r1 --> 0.10.10-r1*
* *tsid 1.4.2-r1 --> 1.6.0-r1*
* *xmlrpcpp 1.15.9-r1 --> 1.15.10-r1*
* *ypspur 1.20.1-r1 --> 1.20.2-r1*
* *zbar-ros 0.3.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spacenavd
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

