### PR TITLE
rosdistro sync, Mon Apr 19 01:10:27 2021

### DIFF
--- a/distros/dashing/apex-test-tools/default.nix
+++ b/distros/dashing/apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/dashing/apex_test_tools/0.0.1-1/apex_test_tools-release-release-dashing-apex_test_tools-0.0.1-1.tar.gz";
     name = "apex_test_tools-release-release-dashing-apex_test_tools-0.0.1-1.tar.gz";
-    sha256 = "b6b2e089f91c2599d15173c41729109d70a03fc1e41823ffa1b293c9fdb461d4";
+    sha256 = "af1274a412a1f009810082131becd9f24130b28deb38e998203f974548bf6c39";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/dashing/dynamixel-sdk-custom-interfaces/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-dashing-dynamixel-sdk-custom-interfaces";
+  version = "3.7.40-r10";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk_custom_interfaces/3.7.40-10.tar.gz";
+    name = "3.7.40-10.tar.gz";
+    sha256 = "928d2d3d9f11b5fafd73e008431a0393404e8bf04932325bf700cb929efbeef9";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS2 custom interface examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/dynamixel-sdk-examples/default.nix
+++ b/distros/dashing/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+buildRosPackage {
+  pname = "ros-dashing-dynamixel-sdk-examples";
+  version = "3.7.40-r10";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk_examples/3.7.40-10.tar.gz";
+    name = "3.7.40-10.tar.gz";
+    sha256 = "a1dea37c6c95ee9c5c66a080179846e586b3a205c0ce1470cdf41b30efcc3715";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/dynamixel-sdk/default.nix
+++ b/distros/dashing/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-dashing-dynamixel-sdk";
-  version = "3.7.30-r1";
+  version = "3.7.40-r10";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk/3.7.30-1.tar.gz";
-    name = "3.7.30-1.tar.gz";
-    sha256 = "66cbfa21ac459da1c83a344434d1b6d5791298c80bbee2fe320f91b5aee5bb9a";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/dashing/dynamixel_sdk/3.7.40-10.tar.gz";
+    name = "3.7.40-10.tar.gz";
+    sha256 = "f97b7c73389da68b003a156684b903cf3d53412320853082dfca2028a2b6a4c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -270,6 +270,10 @@ self: super: {
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
+ dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
+
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-command-line = self.callPackage ./ecl-command-line {};

--- a/distros/dashing/marti-can-msgs/default.nix
+++ b/distros/dashing/marti-can-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_can_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_can_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "33faf4376266bb30b97ca0bd2e401a9c8019ce4d99e8a921dbf4414c4992c02a";
   };

--- a/distros/dashing/marti-common-msgs/default.nix
+++ b/distros/dashing/marti-common-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_common_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_common_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "8b2cbe0f16d6581366bfbdebd6e9b61bd22e19a5572bfa0272d351e9b1438d6c";
   };

--- a/distros/dashing/marti-dbw-msgs/default.nix
+++ b/distros/dashing/marti-dbw-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_dbw_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_dbw_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "7e9ac12d13db28e216c63f1d808635f3e0551e522b17bc0e9fe45e317513d365";
   };

--- a/distros/dashing/marti-nav-msgs/default.nix
+++ b/distros/dashing/marti-nav-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_nav_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_nav_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "2842dcd6f89310a02493f826632c56a515f1b9a35ebbd65b84540f539385b494";
   };

--- a/distros/dashing/marti-perception-msgs/default.nix
+++ b/distros/dashing/marti-perception-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_perception_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_perception_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "e76d3a25cc3ab559b0ee6b4162ff9b2ca9ba184f93e6faacd9d4a9a5d0fe2a1e";
   };

--- a/distros/dashing/marti-sensor-msgs/default.nix
+++ b/distros/dashing/marti-sensor-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_sensor_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_sensor_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "a1b125db8a086ecaf822ba2389d3bf637a4a21f6bf6f15b4437bd151b2ba04ba";
   };

--- a/distros/dashing/marti-status-msgs/default.nix
+++ b/distros/dashing/marti-status-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_status_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_status_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "37e624b74dee894a8446442a9fa851bc07deef221d6c724cb49d2906f203ae00";
   };

--- a/distros/dashing/marti-visualization-msgs/default.nix
+++ b/distros/dashing/marti-visualization-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/dashing/marti_visualization_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/dashing/marti_visualization_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "9bd90ef6bdbe6053858d9177e5f89e483192ee800194f64d5de7b3a6d309bc01";
   };

--- a/distros/dashing/ros2trace-analysis/default.nix
+++ b/distros/dashing/ros2trace-analysis/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/tracetools_analysis-release/-/archive/release/dashing/ros2trace_analysis/0.2.1-1/tracetools_analysis-release-release-dashing-ros2trace_analysis-0.2.1-1.tar.gz";
     name = "tracetools_analysis-release-release-dashing-ros2trace_analysis-0.2.1-1.tar.gz";
-    sha256 = "85a6703cc16e45e71e1d55c7192d86bf2789280f9da1ea3eda478a18264ca769";
+    sha256 = "4e91a60d803ae6ac786d6a364ecee60d67a75deb3bdd0272785286aacc2b0ba1";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/ros2trace/0.2.8-1/ros2_tracing-release-release-dashing-ros2trace-0.2.8-1.tar.gz";
     name = "ros2_tracing-release-release-dashing-ros2trace-0.2.8-1.tar.gz";
-    sha256 = "be0044a3cd8924c54627d963ea29c6987aec28afa21b3d875f0ea34bed8ad7ff";
+    sha256 = "4bcc78d1660a369807ba81094fe5879ae4c719d8d4ccb0ad92dae052ad33e083";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/slam-toolbox/default.nix
+++ b/distros/dashing/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, builtin-interfaces, ceres-solver, eigen, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-dashing-slam-toolbox";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/dashing/slam_toolbox/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "756cda804b1dcf1e0a9a3f659f841fa45a899a19152c6c2b8ca49893099c115f";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/dashing/slam_toolbox/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "c97aaa2b994959e22347d0307bc2dbca5750ea9f4ee2e7239ea0eb1b7a02d532";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/test-apex-test-tools/default.nix
+++ b/distros/dashing/test-apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/dashing/test_apex_test_tools/0.0.1-1/apex_test_tools-release-release-dashing-test_apex_test_tools-0.0.1-1.tar.gz";
     name = "apex_test_tools-release-release-dashing-test_apex_test_tools-0.0.1-1.tar.gz";
-    sha256 = "006c6431dda12ec1af3791f8cea08a963e537219e1cdc2f2942f57829dcd93f8";
+    sha256 = "6aac93a88a3991fee613b6c89aa46d83316eb878ad5478bd4f6f6ffa16c6b645";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/tracetools-analysis/default.nix
+++ b/distros/dashing/tracetools-analysis/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/tracetools_analysis-release/-/archive/release/dashing/tracetools_analysis/0.2.1-1/tracetools_analysis-release-release-dashing-tracetools_analysis-0.2.1-1.tar.gz";
     name = "tracetools_analysis-release-release-dashing-tracetools_analysis-0.2.1-1.tar.gz";
-    sha256 = "9136f5999555452ed1960996a6d725c3859665d907cc03568b882f97aa02c53c";
+    sha256 = "08617ad7569327399412dd3eaa8c7a8f81ed55625bab3a2c689d018ba160e2bb";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools_launch/0.2.8-1/ros2_tracing-release-release-dashing-tracetools_launch-0.2.8-1.tar.gz";
     name = "ros2_tracing-release-release-dashing-tracetools_launch-0.2.8-1.tar.gz";
-    sha256 = "79e8f22eefe5b15423eb3d57822ef407a03b0bd4a9cca40bae1eeeddc7acac4e";
+    sha256 = "770aaef848ded3f7e5e2d51a54d4f5547ebf664698350fad1b1ab6d0b82b4034";
   };
 
   buildType = "ament_python";

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools_test/0.2.8-1/ros2_tracing-release-release-dashing-tracetools_test-0.2.8-1.tar.gz";
     name = "ros2_tracing-release-release-dashing-tracetools_test-0.2.8-1.tar.gz";
-    sha256 = "f1664d011b343bcae3be8cd5e5fbe26f56cdaaf403cef05ca5ce4ce6171e035d";
+    sha256 = "d5f81534775be316ee7c6ca86c804719da8d146021a0da36a1539cbb56954598";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/tracetools/default.nix
+++ b/distros/dashing/tracetools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools/0.2.8-1/ros2_tracing-release-release-dashing-tracetools-0.2.8-1.tar.gz";
     name = "ros2_tracing-release-release-dashing-tracetools-0.2.8-1.tar.gz";
-    sha256 = "41d143bfa711fd0099511994140865377d0951df75711d5a22e409d5427c2ecf";
+    sha256 = "e3ea4ca3c544e46a26a4a2befc7c16439e7b477cedea5d7cba840a53e70cc577";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/actionlib-msgs/default.nix
+++ b/distros/foxy/actionlib-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-actionlib-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "f4f3e0b24772bbdde05690d3541d2f90669a3e6099db046a7ec1f6dda201c51f";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/actionlib_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "8f4f77ee69cffa1b9cf0aade27448e44ee649a6107b08a6e298b62f366fbc3d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/apex-test-tools/default.nix
+++ b/distros/foxy/apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "892bad4ede47e5e159b2d8ced4a6381f116176ecc5469783003c5cdf350ed661";
+    sha256 = "5397b4f6725e6f7a8ade5832dd802bbe9b9506fa69f2ab7402c6ebb840c3a260";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/class-loader/default.nix
+++ b/distros/foxy/class-loader/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, console-bridge, console-bridge-vendor, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-class-loader";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/foxy/class_loader/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "fce5634db80750c334ac74f517280b45625c7dad5d38c07953f6060fc1463926";
+    url = "https://github.com/ros2-gbp/class_loader-release/archive/release/foxy/class_loader/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "c75955459e9ad5f60755571d3a8018dfe27ef9204544d7346c1d04fe1a71f1d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/common-interfaces/default.nix
+++ b/distros/foxy/common-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, diagnostic-msgs, geometry-msgs, nav-msgs, sensor-msgs, shape-msgs, std-msgs, std-srvs, stereo-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-common-interfaces";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "7b98e9226c90afe4013f99df7fb403b93714cb92ac008926563cfa292c8a89a3";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/common_interfaces/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "d2e8668f3ad1bbab33ae9da3034df8c4a45dac95f1e92c92bcb8622688c7fa17";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/connext-cmake-module/default.nix
+++ b/distros/foxy/connext-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-connext-cmake-module";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/connext_cmake_module/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "5d21dc88136532ebea26f10a0ac982838a0d675169c87e3cb3f333fbcdb1111d";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/connext_cmake_module/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "4c8566c74019f306622852c0938afe3158f286f324e3d53da9b56ee06617fe91";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/console-bridge-vendor/default.nix
+++ b/distros/foxy/console-bridge-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, console-bridge, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-foxy-console-bridge-vendor";
-  version = "1.2.3-r1";
+  version = "1.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/console_bridge_vendor-release/archive/release/foxy/console_bridge_vendor/1.2.3-1.tar.gz";
-    name = "1.2.3-1.tar.gz";
-    sha256 = "b646b4771e320242ad7d2abeec85f2c11a242a903137e7113f600c26dfc9d08f";
+    url = "https://github.com/ros2-gbp/console_bridge_vendor-release/archive/release/foxy/console_bridge_vendor/1.2.4-1.tar.gz";
+    name = "1.2.4-1.tar.gz";
+    sha256 = "5a391dd9a9b92bb9777ae5d6ce9533e0ed9d637ff18f80ce205d677427f9ee8e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-msgs/default.nix
+++ b/distros/foxy/diagnostic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "98f41a5c64c85082936161088aa03021099d5937411f570e73dd31fefba81d5a";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/diagnostic_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "73736979b129074674c16914794c51923ba37aaa0cdc07176d845e8e2d953e43";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/foxy/dynamixel-sdk-custom-interfaces/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-dynamixel-sdk-custom-interfaces";
+  version = "3.7.40-r3";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_custom_interfaces/3.7.40-3.tar.gz";
+    name = "3.7.40-3.tar.gz";
+    sha256 = "e8c452ce95561229e9c8f99e7e78ee344a67d2be42d10b3cf682cc513303266d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS2 custom interface examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dynamixel-sdk-examples/default.nix
+++ b/distros/foxy/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+buildRosPackage {
+  pname = "ros-foxy-dynamixel-sdk-examples";
+  version = "3.7.40-r3";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_examples/3.7.40-3.tar.gz";
+    name = "3.7.40-3.tar.gz";
+    sha256 = "5e82d978e5f4d62d95ac24010d90512e6d3c1ebed7da064545f68c116b60fc2b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dynamixel-sdk/default.nix
+++ b/distros/foxy/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-dynamixel-sdk";
-  version = "3.7.30-r1";
+  version = "3.7.40-r3";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk/3.7.30-1.tar.gz";
-    name = "3.7.30-1.tar.gz";
-    sha256 = "935d40973ca7c2e940db3deaa27921a1810a9d47ca356269b2eb8b0fd9fe0556";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk/3.7.40-3.tar.gz";
+    name = "3.7.40-3.tar.gz";
+    sha256 = "63485d65ef4d98ef89fd488cab1168077e38ec26ec3449b91c32a22505201a3b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/examples-tf2-py/default.nix
+++ b/distros/foxy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-examples-tf2-py";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "e0109a67e5704548c7114842edae11ded6dd3f246bf8d8059409ca9ed4e2b064";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "908d0f40c9183ab68eba90170e76ec5d57d26df862f41b363cacf33e30c14661";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/fastrtps-cmake-module/default.nix
+++ b/distros/foxy/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps-cmake-module";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/fastrtps_cmake_module/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "59be189937c73c7d6bd1c4b2cb46746ea7241776fe9485ff574a95e40aa179ae";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/fastrtps_cmake_module/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "3e86c20176a31390dfdd24ebf0edaf5fec2cbab6b7ed81bd2e11e14579c3f883";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-dev/default.nix
+++ b/distros/foxy/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo_11 }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-dev";
-  version = "3.5.0-r2";
+  version = "3.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_dev/3.5.0-2.tar.gz";
-    name = "3.5.0-2.tar.gz";
-    sha256 = "3bdecff7db5745ca647ecf6279fe07a18f42366130618a19c19d38f5e615601a";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_dev/3.5.3-1.tar.gz";
+    name = "3.5.3-1.tar.gz";
+    sha256 = "36aae42a263db7463a3179bed9b352a35ac7ca573986857a99467932b9e1c589";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-msgs/default.nix
+++ b/distros/foxy/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-msgs";
-  version = "3.5.0-r2";
+  version = "3.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_msgs/3.5.0-2.tar.gz";
-    name = "3.5.0-2.tar.gz";
-    sha256 = "fe98b39c011ecea31f4ccc6c29f32b052d3db10beb7f7f97dcd39d15843bf29f";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_msgs/3.5.3-1.tar.gz";
+    name = "3.5.3-1.tar.gz";
+    sha256 = "1fafbcae164048e2c9cb475c6ac907efde4fea957531f872ece4e5894cf65b7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-plugins/default.nix
+++ b/distros/foxy/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, camera-info-manager, cv-bridge, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, nav-msgs, rclcpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-plugins";
-  version = "3.5.0-r2";
+  version = "3.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_plugins/3.5.0-2.tar.gz";
-    name = "3.5.0-2.tar.gz";
-    sha256 = "0befc30d6a8c54b0c9321172af8e4dfeee31b39050cb96ede3fd9c6b58e1a8e8";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_plugins/3.5.3-1.tar.gz";
+    name = "3.5.3-1.tar.gz";
+    sha256 = "911a05d3960d322bdc85e60dae32a166e6b424adee0e71471e3a5907bc53ddcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros-pkgs/default.nix
+++ b/distros/foxy/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros-pkgs";
-  version = "3.5.0-r2";
+  version = "3.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros_pkgs/3.5.0-2.tar.gz";
-    name = "3.5.0-2.tar.gz";
-    sha256 = "5196df0bb0229e704c1745f927fa83d628326f5348189bb33af6bfcb3eccee49";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros_pkgs/3.5.3-1.tar.gz";
+    name = "3.5.3-1.tar.gz";
+    sha256 = "8083ac447d2182c6b51ddae54b56a039d525bb0c067bcf7b5f6aa2f710494ebf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros/default.nix
+++ b/distros/foxy/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, gazebo-dev, gazebo-msgs, geometry-msgs, launch-ros, launch-testing-ament-cmake, rcl, rclcpp, rclpy, rmw, ros2run, sensor-msgs, std-msgs, std-srvs, tinyxml-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros";
-  version = "3.5.0-r2";
+  version = "3.5.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros/3.5.0-2.tar.gz";
-    name = "3.5.0-2.tar.gz";
-    sha256 = "a552e1cfd0ba2ad5908a390c2819554a03c4c3061ab41b1e0a7b1a81eb93c3b4";
+    url = "https://github.com/ros2-gbp/gazebo_ros_pkgs-release/archive/release/foxy/gazebo_ros/3.5.3-1.tar.gz";
+    name = "3.5.3-1.tar.gz";
+    sha256 = "a06b21a7abac1bf297791be915d52e5240aaed15c40a347c32dca71a64ad99a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -276,6 +276,10 @@ self: super: {
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
+ dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
+
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  ecl-build = self.callPackage ./ecl-build {};
 
  ecl-command-line = self.callPackage ./ecl-command-line {};
@@ -614,6 +618,8 @@ self: super: {
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
+ moveit = self.callPackage ./moveit {};
+
  moveit-common = self.callPackage ./moveit-common {};
 
  moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
@@ -621,6 +627,10 @@ self: super: {
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-planners = self.callPackage ./moveit-planners {};
+
+ moveit-plugins = self.callPackage ./moveit-plugins {};
 
  moveit-resources = self.callPackage ./moveit-resources {};
 
@@ -633,6 +643,8 @@ self: super: {
  moveit-resources-panda-moveit-config = self.callPackage ./moveit-resources-panda-moveit-config {};
 
  moveit-resources-pr2-description = self.callPackage ./moveit-resources-pr2-description {};
+
+ moveit-ros = self.callPackage ./moveit-ros {};
 
  moveit-ros-benchmarks = self.callPackage ./moveit-ros-benchmarks {};
 
@@ -649,6 +661,8 @@ self: super: {
  moveit-ros-visualization = self.callPackage ./moveit-ros-visualization {};
 
  moveit-ros-warehouse = self.callPackage ./moveit-ros-warehouse {};
+
+ moveit-runtime = self.callPackage ./moveit-runtime {};
 
  moveit-servo = self.callPackage ./moveit-servo {};
 
@@ -1188,6 +1202,8 @@ self: super: {
 
  run-moveit-cpp = self.callPackage ./run-moveit-cpp {};
 
+ run-ompl-constrained-planning = self.callPackage ./run-ompl-constrained-planning {};
+
  rviz2 = self.callPackage ./rviz2 {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
@@ -1204,6 +1220,8 @@ self: super: {
 
  rviz-visual-testing-framework = self.callPackage ./rviz-visual-testing-framework {};
 
+ rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
+
  sbg-driver = self.callPackage ./sbg-driver {};
 
  sdl2-vendor = self.callPackage ./sdl2-vendor {};
@@ -1211,6 +1229,8 @@ self: super: {
  self-test = self.callPackage ./self-test {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
+
+ sensor-msgs-py = self.callPackage ./sensor-msgs-py {};
 
  serial-driver = self.callPackage ./serial-driver {};
 
@@ -1305,6 +1325,8 @@ self: super: {
  test-msgs = self.callPackage ./test-msgs {};
 
  test-osrf-testing-tools-cpp = self.callPackage ./test-osrf-testing-tools-cpp {};
+
+ test-rmw-implementation = self.callPackage ./test-rmw-implementation {};
 
  tf2 = self.callPackage ./tf2 {};
 
@@ -1451,6 +1473,8 @@ self: super: {
  webots-ros2-examples = self.callPackage ./webots-ros2-examples {};
 
  webots-ros2-msgs = self.callPackage ./webots-ros2-msgs {};
+
+ webots-ros2-tesla = self.callPackage ./webots-ros2-tesla {};
 
  webots-ros2-tiago = self.callPackage ./webots-ros2-tiago {};
 

--- a/distros/foxy/geometric-shapes/default.nix
+++ b/distros/foxy/geometric-shapes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometric-shapes";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "7e532328b8d3c07fc2c3132b84a0c5cddc70e5d34a518330f48a3ee4eb64fc17";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "e340ba7fb38b9c0d2422fb725e59fa7bf3efc26e1b4dc8708eec2f8bd70b34ff";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 

--- a/distros/foxy/geometry-msgs/default.nix
+++ b/distros/foxy/geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometry-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "676cee383b07509d255a046fdb3abaffe2313d4eb71633bfc14605d58d54e4ad";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/geometry_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "ec35c19b3029f878e4b6670f033d96943510cdd5d909c6eb88d4d1de0b35914c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/geometry2/default.nix
+++ b/distros/foxy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-foxy-geometry2";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "e17434edf3b1e1ead04a1a3a963a79a301b56935296061b8992e8f91f00345d5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "e25dab04c5f0b7e0205e66765fae470d5f0c4317e87f2ada01b29ee38617a4d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-ros/default.nix
+++ b/distros/foxy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-launch-ros";
-  version = "0.11.1-r1";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "ccbf607bc324ae6ab3e910bfa72673315470f5ad9d0ca5b4726241aaa2b6ab44";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "87fbe5e6f24cc2b2793ef71c9d8d80bb79afdbf510cbb3e5b4077fd378bcd9c8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing-ament-cmake/default.nix
+++ b/distros/foxy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ament-cmake";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "12edef2a3132398513062cda359cf1a7849871dfcc933eef0724fc381ef00960";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "fe621632b2cca00ace5d3691c1aa73b86205b5764a69736088df3c341f900ea2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing-ros/default.nix
+++ b/distros/foxy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ros";
-  version = "0.11.1-r1";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "f867a370bd03c72849a7b888720dde563ee520fd7ea84c1bb64239eba2665104";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "ce429e005b42234305be336353f51f307ccc19550a74a706b6694faffcf0fe07";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing/default.nix
+++ b/distros/foxy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "66a2605cdf539192c33d6eff10d619661d76d653f0c579d8341cadae90ac824b";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "85ee1e719974059ea7bbc9988cf5da810a6909486e75972896e4888658eccdf9";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-xml/default.nix
+++ b/distros/foxy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-xml";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "b44b78fe71cdffbc4ac444dfd14a33afa90842fe0e43467e57525ef2bf39a508";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "4b22ec6c77f13ceb6e81dd7e53b03adbee1c99b1e52b1a9628da1b5992a63c3c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-yaml/default.nix
+++ b/distros/foxy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-yaml";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "6548dfef2783854a197aaa864439f42ae393389d1cb208346dfecd4a030fce6a";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "c167189cd118da6736fe7aab39ee8c886032e1f834886cdddcc584d70d4c0c42";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch/default.nix
+++ b/distros/foxy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch";
-  version = "0.10.4-r1";
+  version = "0.10.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.4-1.tar.gz";
-    name = "0.10.4-1.tar.gz";
-    sha256 = "d686bde5c4e3efa4d0580d0819c68ded9e9438f04c68d200b7ad1031fb20f790";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.5-1.tar.gz";
+    name = "0.10.5-1.tar.gz";
+    sha256 = "f4552e5a161ee5bb6a83c6fb554a012f79ad05ea3f27fe4ef967124bdbdeef95";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/libyaml-vendor/default.nix
+++ b/distros/foxy/libyaml-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils }:
 buildRosPackage {
   pname = "ros-foxy-libyaml-vendor";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/foxy/libyaml_vendor/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "f16180e3aded15087e9e41e9f7acb34062ab01439f0e3f7b298a4cd5e4559040";
+    url = "https://github.com/ros2-gbp/libyaml_vendor-release/archive/release/foxy/libyaml_vendor/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d708f94e913702062a24568fa0589bdc36de45fffb7423a7155de544b81066f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/marti-can-msgs/default.nix
+++ b/distros/foxy/marti-can-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_can_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "e4a3a9871888963ce96e4dd7a31bab93c90aa6456a0b8d12d8880a40f1e0a049";
   };

--- a/distros/foxy/marti-common-msgs/default.nix
+++ b/distros/foxy/marti-common-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_common_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "92c19118cbe50cf76047f1ebf2543952f4cb0584f45a5da58ad90b930b3b118c";
   };

--- a/distros/foxy/marti-dbw-msgs/default.nix
+++ b/distros/foxy/marti-dbw-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_dbw_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "a92839b609b425d4ac56f9904630f74ac48ee8b4ba63f16c3d4d69b9c219e119";
   };

--- a/distros/foxy/marti-nav-msgs/default.nix
+++ b/distros/foxy/marti-nav-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_nav_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "5f1d3b0d852da6735c561b7a6886e1aa412a65592a8b40d1054f19217a3c141f";
   };

--- a/distros/foxy/marti-perception-msgs/default.nix
+++ b/distros/foxy/marti-perception-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_perception_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "fe2e9840b60079964bd83c07bd5bb9e01bbd3b0b33095301510c06e609f030cb";
   };

--- a/distros/foxy/marti-sensor-msgs/default.nix
+++ b/distros/foxy/marti-sensor-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_sensor_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "83f60894f864fc337c8062b43dd8882b8c6049633820048a1cad35988eb0d682";
   };

--- a/distros/foxy/marti-status-msgs/default.nix
+++ b/distros/foxy/marti-status-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_status_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "ce0887450594257488da2c152d966dbdc97e3cb65181f036ccd9e91140d2efa0";
   };

--- a/distros/foxy/marti-visualization-msgs/default.nix
+++ b/distros/foxy/marti-visualization-msgs/default.nix
@@ -8,7 +8,7 @@ buildRosPackage {
   version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.2.0-1.tar.gz";
+    url = "https://github.com/ros2-gbp/marti_messages-release/archive/release/foxy/marti_visualization_msgs/1.2.0-1.tar.gz";
     name = "1.2.0-1.tar.gz";
     sha256 = "bd7e870ac87fe110ff8dadafd2da2e4de67c89da2f1c036755d603a8070fee53";
   };

--- a/distros/foxy/mimick-vendor/default.nix
+++ b/distros/foxy/mimick-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, git }:
 buildRosPackage {
   pname = "ros-foxy-mimick-vendor";
-  version = "0.2.3-r1";
+  version = "0.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/foxy/mimick_vendor/0.2.3-1.tar.gz";
-    name = "0.2.3-1.tar.gz";
-    sha256 = "897ffd022d2ac3b64d27b5f8c476ff593b3d5221e4c839af712136392205a277";
+    url = "https://github.com/ros2-gbp/mimick_vendor-release/archive/release/foxy/mimick_vendor/0.2.6-1.tar.gz";
+    name = "0.2.6-1.tar.gz";
+    sha256 = "4dfca00a3bd3b7f4674dfed4db0604857bfe982207f6b9165ad02992afb64a60";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake git ];
 
   meta = {
     description = ''Wrapper around mimick, it provides an ExternalProject build of mimick.'';

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "0b01eb17e3c4bc1ad9ab2735e0cffe17bae5ace132592a55a139b47de7855eb1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "cbedd518662aff3acc2bdeddb2fdcf2388c3005d11f8c04cc07b1d04c7c767c6";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/moveit-fake-controller-manager/default.nix
+++ b/distros/foxy/moveit-fake-controller-manager/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-core, moveit-ros-planning, pluginlib, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-ros-planning, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-moveit-fake-controller-manager";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_fake_controller_manager/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "050862b739034b35d9e7dee7fcee97b21fb4765ac0d597e67dbd1c85759fd3f3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_fake_controller_manager/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "efa24081b3098a2ac423a880448fb3d7c8d2afd7b05ddcec5303d4cad884e430";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ moveit-core moveit-ros-planning pluginlib rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, tf2, tf2-kdl, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "6f7becad5c0c6d923f72d58bff6e62bb4f2713705d658a6083bf7cb0c25434b4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "f331e13f93ecb2a3fa851d3495441c522cdea200c81423aa4f4de6e47aeb1a57";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ];
   propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-planners";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "b343ad606e88866a5899d9f6bc1219c3295fab52ba44f33ab5ef6c1efc8e06c1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-planners-ompl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that installs all available planners for MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-fake-controller-manager, moveit-simple-controller-manager }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-plugins";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "698825d3526cf60d07ba62169e51089220c9483e6218087066967bffe76c5d08";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-fake-controller-manager moveit-simple-controller-manager ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for MoveIt plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-resources-fanuc-description/default.nix
+++ b/distros/foxy/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources-fanuc-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_fanuc_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "80d9e0a3c4310e83fec5627dd99461de805aa533a5d60e4d04cdb7580ed93600";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_fanuc_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2798bca1c0563ae75d1200deaacfeb7fb97da1313ce685d66fcb153209e6dbc5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/foxy/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources-fanuc-moveit-config";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_fanuc_moveit_config/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "91d28067d791d441b778c56e4670fcbcae1be01e3824b48832a7b42e77cd51c0";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_fanuc_moveit_config/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "430d6df6c4302fc8456d116cef411b9345b9a174aac742c25ad52ebdccaa2dbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-resources-panda-description/default.nix
+++ b/distros/foxy/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources-panda-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_panda_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "bf684593e26721a573ddf7a68fbbe6f59b8e5fc6fe9badbb907ac1cf41c097c3";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_panda_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "218bc2f12ebcb4090666e55994c5bc994c297e6d501b206f4d115735092a78f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/foxy/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources-panda-moveit-config";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_panda_moveit_config/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1cb766154f53adc871b83e143a84d39fbf3745ae7f8724161ec8e4e9aa10be71";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_panda_moveit_config/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "9299f9e933f779e6da18daf7020e84f5aa8979acc0015a3a5d4d1bc81e548218";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-resources-pr2-description/default.nix
+++ b/distros/foxy/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources-pr2-description";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_pr2_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "44ba9b95331ba1f4660aa8e9babe36cf12c04c57406cb130b1b400b2eb2cb69b";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources_pr2_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "cf66c71e927f45029be79860bbdae663a77dab9c60164cc41c08592351de8663";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-resources/default.nix
+++ b/distros/foxy/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-foxy-moveit-resources";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "aaf2f2431e536be29d3747476f9a5603b0e62cf89456516611f67d35cf72b0a9";
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/foxy/moveit_resources/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "a3063cafb4d3c4210ee74b6554ffef1ffc965fe1dfd4df8ec91ffb605f3e4e0c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5a8393a377f1627afe335059ddeedaf1c4896e82609f9be6d00ea1b95b5380ba";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "811235eb021e3920849257f17d133423633e85c1aa86c988470c392945d6daf8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ boost moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "84f624c35381df288e325285618376b35cc37b9effb8d24c3013c535e5bd7f67";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "360051e6ab72f002925e38f03c058eda88bf4ff7acf28953d545ad88e3044b99";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ moveit-resources-fanuc-moveit-config ];
+  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-fanuc-moveit-config ];
   propagatedBuildInputs = [ moveit-core moveit-kinematics moveit-ros-occupancy-map-monitor moveit-ros-planning pluginlib rclcpp rclcpp-action std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "c3dffd1fae40294032b0060d830b2ab828c815d39d1a422b1f60e60813140f50";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d66e79a419b6146906fd7afb38ebb1e2536a0951106b50c8fa84ebed72e4a666";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-core moveit-msgs octomap pluginlib rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, python3, rclcpp, rclcpp-action, rclpy, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "1c98afb1ecdfe3041b42cfd2a92e09367a05d58b02b0cece5dc1e91e60f5abf0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "546ecb1a08062ee5d68be862037f6f014be323740492883a05338bd681ce1340";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config ];
+  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 warehouse-ros-mongo ];
   propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8501570b9033f5d57c9a022760a5880d5ca740329a7b7272ae2f0a4fd3a8f84d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "c9a38c71b903bbac5caf74f09b168a5cc3f3d19aa6ead52d471be56a9b6eee8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e3fcfc5f9cb35440ba1ea841f36e08259c3b630e6a0c0f9831848cfe83812914";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "2908129f2016bd7b6a50a206a8bb4442eda78a8aab5f4a617401a0d98f29473a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ interactive-markers moveit-ros-planning rclcpp tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "634623377ab1f8fbf19a1bf49106825a9d31d27901ea0faf12dc4d061ea46fad";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "63e51a2b8f63b89f707f461bc8803e339345892900100bc438e1de04f62aac11";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ class-loader eigen moveit-common ogre1_9 qt5.qtbase ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ geometric-shapes interactive-markers moveit-ros-planning-interface moveit-ros-robot-interaction moveit-ros-warehouse object-recognition-msgs pluginlib rclcpp rclpy rviz2 tf2-eigen ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "8acd49a110b3830a0a8687e85b502c813248e307a1542bf0ae119820a92ad5b5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "a5c8764143db3f929c505dfbdcf1dffcc7d831593e2640df21f77d29424a513f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ moveit-core moveit-ros-planning rclcpp tf2-eigen tf2-ros warehouse-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-ros";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "291754cf475bb9aea7da7b3bfbbae7de481350fe477e6bb10884570db1092c20";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-benchmarks moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-robot-interaction moveit-ros-visualization moveit-ros-warehouse ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components of MoveIt that use ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-runtime";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "650b62973891dce0e81b251a259ce519340f13212fef5e504e44cdb3454d6903";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-warehouse ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''moveit_runtime meta package contains MoveIt packages that are essential for its runtime (e.g. running MoveIt on robots).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "e18708a956942a1434ce38df56f019d9bdf67c63f4cdc58a6ba2b266e53b9543";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "0688f57db257ebd99f3e0547b890b3bff2e80cfc492a63a7811ee81d2ef75abc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ moveit-resources-panda-moveit-config ros-testing ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
   propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "11e9f010619631b9e85ad007ff209ef28a357693f02d1de597d63fc0f3937d52";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "82732040fe73b23d25655ee5ec246ad419b9033e2eb0d139a355a85cc36e4212";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ control-msgs moveit-core pluginlib rclcpp rclcpp-action ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
+buildRosPackage {
+  pname = "ros-foxy-moveit";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "1d5939a4c3d4117a29289466e9029ed3aee0af3a91933087d411f6713b0379f1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of MoveIt 2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/nav-msgs/default.nix
+++ b/distros/foxy/nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-nav-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "39cbba7119d3968c187cf0e87fcab96d44d49a7c37ecbe043d80b25b6ec9a5f5";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/nav_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "224e5e6b76099ce55b66253ace982ac95f1bb39bbbab680b78aba022060bcc00";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/osqp-vendor/default.nix
+++ b/distros/foxy/osqp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-osqp-vendor";
-  version = "0.0.2-r1";
+  version = "0.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "3b2a5e43a76c801a4709775861a65858de2141916dcef28804affad39b58b89b";
+    url = "https://github.com/tier4/osqp_vendor-release/archive/release/foxy/osqp_vendor/0.0.3-2.tar.gz";
+    name = "0.0.3-2.tar.gz";
+    sha256 = "4263861260987867d44a7ed7925220a96a38247a355045f567cd721378d49950";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "e45c6bfaaf2feb2cd5fdad1a85efc2219d7621db4adaaf8344ab69e9f292b8b3";
+    sha256 = "32179f190ed329ba1a47ba412c2762f047973a85a4baa25d69d1d530a8bdbafa";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rcl-action/default.nix
+++ b/distros/foxy/rcl-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcl, rcutils, rmw, rmw-implementation-cmake, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rcl-action";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "a842cfb8b57e66e20cc0b3e44a1a111efdbb2472f3cc3dcac81fdde34936f190";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_action/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "9d3dcef5bce4fb81a03a6e50fa4d5de7fa443716376a7a0b5485275837b2a264";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-lifecycle/default.nix
+++ b/distros/foxy/rcl-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl, rcutils, rmw, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rcl-lifecycle";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "c163f9bee4d44de7473a9d07fc86f16636d7d95b91e3fd6d9573aadc52bc4099";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_lifecycle/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "331f4102757bc0666e09929fb26469e95f410295d261cbc04159d72f7003e027";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-logging-log4cxx/default.nix
+++ b/distros/foxy/rcl-logging-log4cxx/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, log4cxx, python3Packages, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-log4cxx";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_log4cxx/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "d38f5cbaefeb0c3649ee51ceacbf9a87096adfb8f14657668bf9e46c5a8602b4";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_log4cxx/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "55d0928eff4e7e573a3fcb13b49319c6321fed83319a720d7dd21e228d641a18";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-logging-noop/default.nix
+++ b/distros/foxy/rcl-logging-noop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch-testing, python3Packages, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-noop";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_noop/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4648dd4e8d556c603d1b32b7f06f035ab25ab9773c7e08012772a2ad8432d155";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_noop/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "3fd52f9aea77dd82b1578d71bad2957664c4924d6546658f6b91d9d2153b41eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl-logging-spdlog/default.nix
+++ b/distros/foxy/rcl-logging-spdlog/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils, spdlog, spdlog-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, spdlog, spdlog-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rcl-logging-spdlog";
-  version = "1.0.1-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_spdlog/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "7399d2d8559620f9b27942a23d2bf7b005c67250bb7c443ed0cfecbba65c0c4d";
+    url = "https://github.com/ros2-gbp/rcl_logging-release/archive/release/foxy/rcl_logging_spdlog/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "cd2d87435ef1c30ab82e5ef29d52b20f840efb3978baf1dccfc92dc68aeaa5f6";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ rcutils spdlog spdlog-vendor ];
+  checkInputs = [ ament-lint-auto ament-lint-common performance-test-fixture ];
+  propagatedBuildInputs = [ rcpputils rcutils spdlog spdlog-vendor ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/foxy/rcl-yaml-param-parser/default.nix
+++ b/distros/foxy/rcl-yaml-param-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, libyaml, libyaml-vendor, mimick-vendor, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcl-yaml-param-parser";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "bc50b4fb4bae96ea137a4f840139df97858550ff2dba8117c3b24280ddbafe2a";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl_yaml_param_parser/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "edab70c9ee338e5e3353d32505b46ea5bf8ec9a4ff0b203054dda9c1a2358651";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcl/default.nix
+++ b/distros/foxy/rcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, rcl-interfaces, rcl-logging-spdlog, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation, rmw-implementation-cmake, rosidl-runtime-c, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rcl";
-  version = "1.1.10-r1";
+  version = "1.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.10-1.tar.gz";
-    name = "1.1.10-1.tar.gz";
-    sha256 = "0a038a5ef5afff33de525f9c617086474e472c20a839f08660d68c0e3894116f";
+    url = "https://github.com/ros2-gbp/rcl-release/archive/release/foxy/rcl/1.1.11-1.tar.gz";
+    name = "1.1.11-1.tar.gz";
+    sha256 = "e6e9ab8c106642697bd5c39488874c93aa8a0bf800e942f9d092b15e3a3f1f91";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-action/default.nix
+++ b/distros/foxy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-action";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "875c1ba1eecb34f4abc3363a6a3815fc263615474bbe7bf7d313dbb7e3b9357e";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "fffc7762093deeaa711ce610155b516a6e3f498235d3e0db9e7687707eadadc9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-components/default.nix
+++ b/distros/foxy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-components";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "34322237a3f9960f9c9114bf1d7b04054b970f9f1e875bdf61946d9b46cca898";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "690b1547c67e01ec5381f41d6efc76bc45e6cf5ff00d2f4dfdc4f08ef7aca095";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-lifecycle";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f3644806f8276a1b76dd9ec2288dd0a0b99e774c6a61764c3990c390b01c9644";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "08f33994e0819f75486eae532048ff4da11b9ded9223780bb847b38c4d7b6c87";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp/default.nix
+++ b/distros/foxy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "3870d5db08ad214a20dc9eaf63ce62dd0fe9168567fb7d0c15229d67afb0d8f9";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "50e96b8a3d90f8fffabb4337bbca8207fcb30525b25960a7e6169902c748a898";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcutils/default.nix
+++ b/distros/foxy/rcutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, launch, launch-testing, launch-testing-ament-cmake, mimick-vendor, osrf-testing-tools-cpp, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-rcutils";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/foxy/rcutils/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "aa0aa0db3d9da246566aa551e2eb147659db72c3a3a15e7da6435246ef2c3fb3";
+    url = "https://github.com/ros2-gbp/rcutils-release/archive/release/foxy/rcutils/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "4c6206bfebf5686a888d7fc0adcfb7aa863f9d9eb7fbca9849dc2954d833adef";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-dds-common/default.nix
+++ b/distros/foxy/rmw-dds-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, performance-test-fixture, rcpputils, rcutils, rmw, rosidl-default-generators, rosidl-default-runtime, rosidl-runtime-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-dds-common";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "654496e63a60cb583415a80dc5858e885d371ed8c0f15f7a90c38f18bdf0a6e8";
+    url = "https://github.com/ros2-gbp/rmw_dds_common-release/archive/release/foxy/rmw_dds_common/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "96d728be0c1a0a4253d95c8db028523adf8754476e51e353ea005f8c409e0cc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "0078aee5feff05738d73aa47fe6125f86871820e40c039f143cc109171d4f601";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "e89f29899cb5e39410dcb683b8420494a3e691aaeb87b7d1ffe25ddf15640739";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "6cd93f953464019e6ecfcd7d3bb0c3fd711257a767190e193cd6020af174bfbb";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "3991d382c4195f3761aeee745a15a5d7b74eaac777833e6c4a20c48d4d482d36";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.2.4-r1";
+  version = "1.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.4-1.tar.gz";
-    name = "1.2.4-1.tar.gz";
-    sha256 = "15bb1f98973966f50dec63695f17dfd80b047915b3bee0e958462d16d989f3b1";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.5-1.tar.gz";
+    name = "1.2.5-1.tar.gz";
+    sha256 = "96dea9e2e38c8b78b2a0b872384346e78a4cede5708d49f80f405cf151772d95";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-implementation-cmake/default.nix
+++ b/distros/foxy/rmw-implementation-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-implementation-cmake";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/foxy/rmw_implementation_cmake/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "ce4ff804bb7a9f35d597464bd2808c20ac5a48d34d414af1e67b5abaa00236cb";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/foxy/rmw_implementation_cmake/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "e04fd128652b0627abeb64c7057ab0bcb938135c9aa3f27f03ee17eed14cb8a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-implementation/default.nix
+++ b/distros/foxy/rmw-implementation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rcpputils, rcutils, rmw, rmw-connext-cpp, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rcutils, rmw, rmw-connext-cpp, rmw-cyclonedds-cpp, rmw-fastrtps-cpp, rmw-implementation-cmake }:
 buildRosPackage {
   pname = "ros-foxy-rmw-implementation";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/foxy/rmw_implementation/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "dd5165ddb35d4ed682b1e2a1a8a21016cba16b16b411cf3cbb53dee5af66690f";
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/foxy/rmw_implementation/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ba4680bb07ea1d1692ed34c4c28eddc20b8becb4f6e0800c1d22dd6d335cb74c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rmw rmw-connext-cpp rmw-cyclonedds-cpp rmw-fastrtps-cpp ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common performance-test-fixture ];
   propagatedBuildInputs = [ rcpputils rcutils rmw-implementation-cmake ];
   nativeBuildInputs = [ ament-cmake rmw-implementation-cmake ];
 

--- a/distros/foxy/rmw/default.nix
+++ b/distros/foxy/rmw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-cmake-version, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rmw";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw-release/archive/release/foxy/rmw/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "bc6da3dc433d76b48ca42fa16d64b541b37216d50a4e0ca218ec9fc98a313776";
+    url = "https://github.com/ros2-gbp/rmw-release/archive/release/foxy/rmw/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1adbf739200ea200e3a9ddb44378055f752c898a4e0579e4010948f684ee6a3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2launch/default.nix
+++ b/distros/foxy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2launch";
-  version = "0.11.1-r1";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "afc47cf471029a53e164532e769e83382d6f01f6137f9a050a50bd1dfa56b4fc";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "af1257292a0c82ee726c04df777fa618fef6c9a6ef3641053be8ac06735afb95";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosidl-adapter/default.nix
+++ b/distros/foxy/rosidl-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-adapter";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_adapter/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "0ac3eddab0ed88e6deade5c8b61355cb970bdb64fe40704c4c79dce3c835e44a";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_adapter/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "e11ed374bf87969b9c72b550209c6b5688a03ccc68aba8017beaf3e54b018c07";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-cmake/default.nix
+++ b/distros/foxy/rosidl-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, python3Packages, rosidl-adapter, rosidl-parser }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-cmake";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_cmake/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a91671b7a9013508b1e0fc6c0d6a704b9299c89ae9ee0fc66e10e66dd9eae419";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_cmake/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "5e0989550aa8dc4739d98713e4d34ac8086c3faa6708ef1fe2adff3d64fe2b15";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-default-generators/default.nix
+++ b/distros/foxy/rosidl-default-generators/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-generator-py, rosidl-typesupport-c, rosidl-typesupport-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-default-generators";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/foxy/rosidl_default_generators/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "47f5ff3537463be5131d61b9681c377a5ec1b74373ce261da8c6e443a6cb9ec7";
+    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/foxy/rosidl_default_generators/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7d4f2be5e2751c8dbe70344468a104f061879cf1d4759d2117d946659431600d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-default-runtime/default.nix
+++ b/distros/foxy/rosidl-default-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-generator-py, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-default-runtime";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/foxy/rosidl_default_runtime/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "a07e6cd3af3774f42684afec9c3465872ea37a32f3747f457414d470a5a142a8";
+    url = "https://github.com/ros2-gbp/rosidl_defaults-release/archive/release/foxy/rosidl_default_runtime/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4608ee420c651b7deb3d13923c61b5610b6f2c0a58c3edaf2f9650ffc34833bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-generator-c/default.nix
+++ b/distros/foxy/rosidl-generator-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-interface, test-interface-files }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-generator-c";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_generator_c/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "24cd7a26955145af3519b67d30db78129cc1de3c0281de29e6efbf26ccfcea97";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_generator_c/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "541f816199fd7bcfcf0dda7d58145b942d3060d62994c7e50085b3773b3813fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-generator-cpp/default.nix
+++ b/distros/foxy/rosidl-generator-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-core, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-generator-c, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, test-interface-files }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-generator-cpp";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_generator_cpp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ff74991b7db3304c85ec224dafd6dde97ed1c8f11201a87516decd898151a1bf";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_generator_cpp/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "7f636710ef535747a82bd207e608b0aedf8f6fb4278e6973c0dac5869b4ae44e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-parser/default.nix
+++ b/distros/foxy/rosidl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python3Packages, pythonPackages, rosidl-adapter }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-parser";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_parser/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "1a8ad9a2881f2a1b3a1067e30b0497546685d5dd218b26470dd80094ef24f508";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_parser/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "c077cfa6b9b30cef0544accbea1d1bfb2c67dacb5b79bf7e64af784f48527981";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-runtime-c/default.nix
+++ b/distros/foxy/rosidl-runtime-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcutils, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-runtime-c";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_runtime_c/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a84ecea1bce10b3876878fccae1419ba6d55bc3bd40804c68fc0df45232d0eea";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_runtime_c/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ad58225d2e216bca2a564dcc330c3c98f8e0d7c459bf66faa4bad682e3bc2197";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-runtime-cpp/default.nix
+++ b/distros/foxy/rosidl-runtime-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, performance-test-fixture }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-runtime-cpp";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_runtime_cpp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ff1956166e8ce2435f4a2b85c9c6ff090aefaa789c666565ed00af1c4978372b";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_runtime_cpp/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "94a421dd87f22d594b929bedb40cb85107160a8b6ebcda596e7f6a666f67ab7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-c/default.nix
+++ b/distros/foxy/rosidl-typesupport-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcpputils, rcutils, rosidl-runtime-c, rosidl-typesupport-connext-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-c";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/foxy/rosidl_typesupport_c/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "ff13cb2599dc285927870f823c20076e37e0e272c1f8610ddd4f344b960f43f5";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/foxy/rosidl_typesupport_c/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "bada063b080ae58f96a7eb8d1b422500f47c1403afdf10ca2c0d42c1bf07bdbc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-connext-c/default.nix
+++ b/distros/foxy/rosidl-typesupport-connext-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rosidl-cmake, rosidl-generator-c, rosidl-generator-dds-idl, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-connext-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-connext-c";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/rosidl_typesupport_connext_c/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0890657b5828a45d86b026f5f4c6a83234fc634ddac4408d5b47fe1874e3faed";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/rosidl_typesupport_connext_c/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "60b24753c51030c08d9cce34541a2ce02d528759da2eb0006fdf8ceff243a204";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-connext-cpp/default.nix
+++ b/distros/foxy/rosidl-typesupport-connext-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, connext-cmake-module, rcutils, rmw, rosidl-cmake, rosidl-generator-dds-idl, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-connext-cpp";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/rosidl_typesupport_connext_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "60b72b970f3e02b0d8f69901aae8f24f80764be776a86245c2d35fa27d2fdfb5";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_connext-release/archive/release/foxy/rosidl_typesupport_connext_cpp/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "8edd59200934ec40dc9a1ff0b1b4e543c550f69efa8b5332735b686caede6ba7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-cpp/default.nix
+++ b/distros/foxy/rosidl-typesupport-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcpputils, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-connext-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-cpp";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/foxy/rosidl_typesupport_cpp/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "97f937673852d38c13355ccdfcb85236e86a7936dce48e81b8ffd2d9a973b86e";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport-release/archive/release/foxy/rosidl_typesupport_cpp/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "51c964f33694c022a803cbffef9f2d2f3e864540436f15014485f449e730017c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/foxy/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, rmw, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-fastrtps-c";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_c/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "41538ec9ae5b269e30fc5e9a50eb24f1ca51d65d40f4c87ae3eda4c042723d2e";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_c/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9e9cecdbb898ea74136ec98146004c0e12c418430b3dfcfbe699fc403513609c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/foxy/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, rmw, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-fastrtps-cpp";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0cae1aa4816696ba449d48a1a3c107fcffc07130b52fdcfa260a8138f2d5ad01";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_cpp/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "1a79f13180b8ca50e74537721f868326c51aa2d4e31117ac85ef61421a7fe671";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-interface/default.nix
+++ b/distros/foxy/rosidl-typesupport-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-interface";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_interface/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "13a45d71970dbb3091378ecc610a786124a47a8c4ad76ac9b5339bcdeaaed469";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_interface/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "161ec09df1a53d1fb94eb2f556c4f568663335d93da2869f2437c8af813d19fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-introspection-c/default.nix
+++ b/distros/foxy/rosidl-typesupport-introspection-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-parser, rosidl-runtime-c }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-introspection-c";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_introspection_c/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "a18bb82c6d3b6352a492f49795c88f1febcd0d5ab9dd79f8b0f4e3c7fc411fd0";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_introspection_c/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "dd644a71827f50f356c63a590db0d6a13a663d9f8f5cdb0b5a76a501aed275a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-introspection-cpp/default.nix
+++ b/distros/foxy/rosidl-typesupport-introspection-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface, rosidl-typesupport-introspection-c }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-introspection-cpp";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_introspection_cpp/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "22b5289e9be9190c6cd09a5610b56e0d5a424bfb53e5ec45947462f819cb0d02";
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/foxy/rosidl_typesupport_introspection_cpp/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "51683222628f7491028ec8f9d2b8b44e802ff3d83dba9d0812c55c6680809f06";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-graph/default.nix
+++ b/distros/foxy/rqt-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-dotgraph, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-graph";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/foxy/rqt_graph/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "ac3a1a37740445b2a0a015adf773bc2806cfeccf8adc8f673e877023e80b79bf";
+    url = "https://github.com/ros2-gbp/rqt_graph-release/archive/release/foxy/rqt_graph/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0000b50704a4466515b46717fc7b267e2538bdf3213cfef7026395f3a316d7ef";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-gui-cpp/default.nix
+++ b/distros/foxy/rqt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-cpp";
-  version = "1.0.7-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "3b1d267733147a33e3a689144f64d42c4482449b544fabaec96702466e8885e0";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4a822b3483a082a53a52a7f071f861d370dedf5274b86eede42603c12f4b7600";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-gui-py/default.nix
+++ b/distros/foxy/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-py";
-  version = "1.0.7-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "7f8b0c9f6678b5f9f7f20bca1a8e1763fef35394981baeb1a98d8c9f760a8da2";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "24676fd2cd84cbcf850d3bf5daf9a6ac42e1e388a5abf8d390cab695b9ba4008";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-gui/default.nix
+++ b/distros/foxy/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui";
-  version = "1.0.7-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "143c2a4dbda33155814440abbc40a7cdd12bcee169ead22a56bfe9e085d52f11";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "595fa107266592c4b0b4b56ab31920eff4b5fdfb6f31ed5b8ad018692fbb8fea";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-msg/default.nix
+++ b/distros/foxy/rqt-msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-msg";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "318e4d9399ea181fe996338f30b06b41abf6bb72b6e66417b64d759122f9ff70";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "6ce023ae638defd6ed5f9e1253f4d15db896e96b139f08114d73e4af1cfb2a42";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-py-common/default.nix
+++ b/distros/foxy/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rqt-py-common";
-  version = "1.0.7-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "134b115263c4f4559512c8c09db423d59276ae89bb32e08c1305b4f68729907b";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d87c479605e5ce7e1e322e21cc8c94333ac81800c9394dc488e77f961a6e2d12";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt/default.nix
+++ b/distros/foxy/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt";
-  version = "1.0.7-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2b6a2e58eb6e48209b2703a6f1c35c6a8ad109935a9bf6bba980cdcfbf88682f";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "432bfb597a8a54fc435d51906a4d3e3c9f5153857a5da5be60d98eeffe5d1df2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "060dd719e52878cd3f424493cab1f9bd37e05036c4f5f97052398e7143c518af";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "af84ec6768b2bd6e28b9cc6a2f92e98f09ca87e84b53583dfdfff61dd0528182";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "27d646efd3bbb7965c7f0d7baa789997f3a212b61964d4bcad371a2c6dc6027a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "066098a94c6903a98a9fe087fe651349e30f27a65755aa3d064a045d863bb74b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
+buildRosPackage {
+  pname = "ros-foxy-run-ompl-constrained-planning";
+  version = "2.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "aec3e638945d1dff4eaa20ac5c989d16e7e2da3f26463fd77478efc8b822b712";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-planning-interface warehouse-ros-mongo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo ompl constrained planning capabilities'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rviz-visual-tools/default.nix
+++ b/distros/foxy/rviz-visual-tools/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-rviz-visual-tools";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/foxy/rviz_visual_tools/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "3765050a7325d945d5865c7c55a65b785973d6c7c3da4da3e186aed95adcc187";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Utility functions for displaying and debugging data in Rviz via published markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/sensor-msgs-py/default.nix
+++ b/distros/foxy/sensor-msgs-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-sensor-msgs-py";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs_py/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "4397d375a6d0708b78b99c4dbd3e8287e2379c97c3e39b107a3e8c919558a45d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ sensor-msgs ];
+
+  meta = {
+    description = ''A package for easy creation and reading of PointCloud2 messages in Python.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/sensor-msgs/default.nix
+++ b/distros/foxy/sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-sensor-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "085d2a034281e03cb734361535a40c207275a52670598ce49b60f26c1fd6f3a3";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/sensor_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "54b4f653eff8e160fc15b643105f0b6ee8d5e555298f334e237dd9fe3f7d7e84";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shape-msgs/default.nix
+++ b/distros/foxy/shape-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-shape-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "3f347fe010c14636023e45890aa10be3653d5bc477feb663d70a555b4b379695";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/shape_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "b69e0218aa85cb169e8604dbb5993c75914f44a0a3df57e0878270457ca985c8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/slam-toolbox/default.nix
+++ b/distros/foxy/slam-toolbox/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-uncrustify, ament-lint-auto, boost, builtin-interfaces, ceres-solver, eigen, interactive-markers, launch, launch-testing, liblapack, message-filters, nav-msgs, nav2-common, nav2-map-server, pluginlib, qt5, rclcpp, rosidl-default-generators, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, std-srvs, suitesparse, tbb, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-slam-toolbox";
-  version = "2.3.0-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/foxy/slam_toolbox/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2343c9c190b4a6f2bb32b0067b40b7db64b8287e56db52a62fb19ebe6a5aebb0";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/foxy/slam_toolbox/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "da182aca6d39a22ab7da8d9be582394cef57c45e170e322171ec6ba55abc2bda";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gtest ament-cmake-uncrustify ament-lint-auto launch launch-testing ];
-  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen liblapack message-filters nav-msgs nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
+  propagatedBuildInputs = [ boost builtin-interfaces ceres-solver eigen interactive-markers liblapack message-filters nav-msgs nav2-common nav2-map-server pluginlib qt5.qtbase rclcpp rosidl-default-generators rviz-common rviz-default-plugins rviz-ogre-vendor rviz-rendering sensor-msgs std-msgs std-srvs suitesparse tbb tf2 tf2-geometry-msgs tf2-ros tf2-sensor-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/spdlog-vendor/default.nix
+++ b/distros/foxy/spdlog-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, spdlog }:
 buildRosPackage {
   pname = "ros-foxy-spdlog-vendor";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/spdlog_vendor-release/archive/release/foxy/spdlog_vendor/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "59d56c44263c161b784d9cf8d1d19d4f1e99c9b0efd5266cc81b5dd893c68724";
+    url = "https://github.com/ros2-gbp/spdlog_vendor-release/archive/release/foxy/spdlog_vendor/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "9cb16123ea0cd28d9405e155011697577c1aca151b898d9a28afa63d53ce8442";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/srdfdom/default.nix
+++ b/distros/foxy/srdfdom/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-foxy-srdfdom";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/srdfdom-release/archive/release/foxy/srdfdom/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d2b1e382c6119373ddbffbd39e0ca88a7f93d2e546c08cc81b9cfa22b6ff0ddb";
+    url = "https://github.com/moveit/srdfdom-release/archive/release/foxy/srdfdom/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5b37fb645c38a5791a0519a8df56875c0111254f808cdeda6cced47b2f36f669";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ boost urdfdom-headers ];
-  checkInputs = [ ament-cmake-gtest ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ console-bridge console-bridge-vendor tinyxml2-vendor urdf urdfdom-py ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/std-msgs/default.nix
+++ b/distros/foxy/std-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "ede1a545c01d4cd0538ef34594688f082d7b77695e7f76ae2052a95ff6f1aa3d";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "e3d77b3118285557c544893b84ddac21d8c490ac1098fa21c0f509c025066184";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/std-srvs/default.nix
+++ b/distros/foxy/std-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-std-srvs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "3f9f8cc2e1882b0a4bb008dbee489d73b1bf6c63436f6a53b210d888906c49de";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/std_srvs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "a7b2e324ece1e54527f5acdcf1cd455cd7018af07d8ab6cfeb75de4840bd8218";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/stereo-msgs/default.nix
+++ b/distros/foxy/stereo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-stereo-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "a46baa7a4675c795665f1312cdc9ebc2172aa76df7da2209e294a4931d427ab8";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/stereo_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "ea4f6e7fc77c02aec34c7422c14a0cf2b13da7f921e79382eb4fa4072a30f261";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-apex-test-tools/default.nix
+++ b/distros/foxy/test-apex-test-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/ApexAI/apex_test_tools-release/-/archive/release/foxy/test_apex_test_tools/0.0.2-1/apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
     name = "apex_test_tools-release-release-foxy-test_apex_test_tools-0.0.2-1.tar.gz";
-    sha256 = "8f2a8281836a6ef61d778b7196cd77998aa4557285574064931e62e925832e5e";
+    sha256 = "275623d9706e2f131b95b40c5f3b082069078ece9a0bb76f2dfc3e4359cf763d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/test-osrf-testing-tools-cpp/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/ros2-gbp/osrf_testings_tools_cpp-release/archive/release/foxy/test_osrf_testing_tools_cpp/1.3.2-1.tar.gz";
     name = "1.3.2-1.tar.gz";
-    sha256 = "5a63a3c96ca015cc0ac3e9ba54d83320cd014fb0f67105a114c69a22b22f9bf3";
+    sha256 = "c4305d66ab841ea1a44618a15187e7d54fb4b3c6beb695f5c312e0f35dc8ed99";
   };
 
   buildType = "cmake";

--- a/distros/foxy/test-rmw-implementation/default.nix
+++ b/distros/foxy/test-rmw-implementation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, osrf-testing-tools-cpp, rcutils, rmw, rmw-dds-common, rmw-implementation, rmw-implementation-cmake, test-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-test-rmw-implementation";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmw_implementation-release/archive/release/foxy/test_rmw_implementation/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ac1267ff6e3b4dbc7796d45cd3cb4ba22417e5ea97ca33acb6c3dc09baef66e6";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp rcutils rmw rmw-dds-common rmw-implementation rmw-implementation-cmake test-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Test suite for ROS middleware API.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/tf2-bullet/default.nix
+++ b/distros/foxy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-bullet";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "c80bbdedd1b4615f3ba57c0fadcc9a77f4e7bce88e8988c7323602a86318313e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "f9476cd779c9400f5c4328700e9056083694e9082f5a628ed8e0b684ee2c0336";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen-kdl/default.nix
+++ b/distros/foxy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen-kdl";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "48af65a3b1769c162079430b3d652e7a4118a3b631e58cd151809bceb55b6cab";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "69f77e45befb6174aee8fdac68c918321803dbeaf31784e7d502e10611c19eb4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen/default.nix
+++ b/distros/foxy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "18a947c0894fb4bd0f0d8d3af6c258da155dba0dbfd8880bd8e518038297cf30";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "4eaf920a4265a55b7989c7faed6ef4206b18fed70d07823d022262b8b6e85854";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-geometry-msgs/default.nix
+++ b/distros/foxy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-geometry-msgs";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "33934bb3ca9915e19706dd72d198f485b53edf784f55c5863960915342335cfd";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "35a6e52aa3ffc7c4e01ff9f30d927cdab374a2dc92783b31c2dff33d97fabd59";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-kdl/default.nix
+++ b/distros/foxy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-kdl";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "04a5fd763367edbde2ace899ec055336e04ea456f0907a147f1e656ddc058c73";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "5f98099398d98fde8bdc7c8071ab3510701611a81eb9a81c46efd723364d6bb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-msgs/default.nix
+++ b/distros/foxy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-tf2-msgs";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "d368c218ef4b18fe52b71f4b975e6bb6332c8a1d8c98ba541b71fb86507e6e32";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "8c1872ddaf254a36a6ba3fe36a975fc4cc9853c46f4f568a6cb615820edf0404";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-py/default.nix
+++ b/distros/foxy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-py";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "20dbc77b480f934002fc87630dd992438540b91d73f407452fdc8a814e90c826";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "2478d0aca7ecbc34ad07c2a06f9efc5606cbe7212fcfc39cbffdeb6d4545bf06";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-ros/default.nix
+++ b/distros/foxy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, message-filters, python-cmake-module, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-foxy-tf2-ros";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "36edaf18b5d4312c8eb8f167e4e778ba652bdc6363451aa5d0389891a2eec901";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "601e1056ec032863b9d848022531425ebb0ea7c5e67748d19403f34237c6db01";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-sensor-msgs/default.nix
+++ b/distros/foxy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-sensor-msgs";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "c058b5b7b254acae09ac5535866eca032f4e562e2ab30f96e9aa3c437a5598ce";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "31537c5a0d00ef9150b409bd85bcb5c11464ed7e353474cd81ba8d3686533113";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-tools/default.nix
+++ b/distros/foxy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-tools";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "c2d7586b3c9cdb4f99c4d87071b4655acebc9b6a16d89764952f9beddeac29b2";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "0b50013b49888fc36b1803ee539411348f99b257cbec5dcc2896607a536a764d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2/default.nix
+++ b/distros/foxy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-tf2";
-  version = "0.13.9-r1";
+  version = "0.13.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.9-1.tar.gz";
-    name = "0.13.9-1.tar.gz";
-    sha256 = "3463ad96f3313c7db5e47451925ba352ca7917c640446fb0976134eeba92dc07";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.10-1.tar.gz";
+    name = "0.13.10-1.tar.gz";
+    sha256 = "f1914c963cd4a14f833824d17bd44f120bbc0d216b69d51a4ce18a1b01b5d945";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/trajectory-msgs/default.nix
+++ b/distros/foxy/trajectory-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-trajectory-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "ba09a09927ca906c2efce8234306601bf90197fe7033877cd62e05940b68649b";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/trajectory_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "fbcac90876b0a34e24cd0d2df189c7057e336518e94cfdc6a61259b982a9e5c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/unique-identifier-msgs/default.nix
+++ b/distros/foxy/unique-identifier-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-unique-identifier-msgs";
-  version = "2.1.2-r1";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/foxy/unique_identifier_msgs/2.1.2-1.tar.gz";
-    name = "2.1.2-1.tar.gz";
-    sha256 = "b5e65148ee26691d08ce194f65c0416bbce0b96d768c4849ee5012e4b7d0b6c9";
+    url = "https://github.com/ros2-gbp/unique_identifier_msgs-release/archive/release/foxy/unique_identifier_msgs/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "7390b7af2ebe08a8f9f6d4f844ee36a7de0bdda6394abb636970e26d930d2ed5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/visualization-msgs/default.nix
+++ b/distros/foxy/visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-visualization-msgs";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "39a5ff0d5643414e842a16a7d9f0abf97e60f84d27db6e532080b4789d3ca397";
+    url = "https://github.com/ros2-gbp/common_interfaces-release/archive/release/foxy/visualization_msgs/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "d87b2b0738336686b05d34f205c65a425951003572793b65f03a433aae66ed8f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-abb/default.nix
+++ b/distros/foxy/webots-ros2-abb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-abb";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "75289c295df3716da927e2b4188fa040598b5b295b02a11f039b2b2ba9e56472";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "e22314d520c51d584175334ca2cdfc1b28203dca43c2abc4c0a461a543849640";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "6465bcd2f0720f50fd510c9699fc3d4d65bcaafc0ca284d3f2c7811d0c81627d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "fc0e2e0ea1887ebf46ee6bde6bc478c9fc2a69c3c7da0ec69e0e0d6c59810175";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces python3Packages.tkinter rclpy std-msgs webots-ros2-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces python3Packages.tkinter rclpy std-msgs vision-msgs webots-ros2-msgs ];
 
   meta = {
     description = ''Core interface between Webots and ROS2'';

--- a/distros/foxy/webots-ros2-demos/default.nix
+++ b/distros/foxy/webots-ros2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-demos";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c816ae7efc7c08936ccd2bc8cecdacda3812ca8d2abf39d2c407dfecd37eb77f";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "15e7d5de283aebca8c07a9e8eac11eead02db6c97a1eabb0b863845be6217d79";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9d8b1548a6fac099e3851d2e1641a9df40d7f54db0b21f4ccc785d81abdde6a2";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "4a9279a3a5cf7805f067bde7d9a03c9a07359d1008d50ae3e369dfe28a82308d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-examples/default.nix
+++ b/distros/foxy/webots-ros2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-examples";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "68913359f8957b4cdf13f94f2658a0421c9a0bf8d340bef52cf76c786d02eb91";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "cccba5cfdffd2a8629dd90ac70ea7cfc271568754124587fcd667e3a49bad0b5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "443a0deb9b5e25c44480a12c916b7c2721c3e162d7331bf4e36e8892a08b64de";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "17253b5b61585f5f10236278c32e2c57df54ec41ad54425fd866db6f52e13154";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs vision-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-tesla";
+  version = "1.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "07382ffb899d4f4d495d9e626031e7c8c069223072bd4cbce004b1068e618d40";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ackermann-msgs builtin-interfaces rclpy webots-ros2-core ];
+
+  meta = {
+    description = ''Tesla ROS2 interface for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c2f4aeabe2e97b6b16b4598b99e74d412a1211c1e55e45d08b976eea64d626a4";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "ae5537db12cc491ced97b3edcd7a704baa0267b51c4386dbc92d2bacd8e12700";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "dcdb6025383811a384bd14200b5a751b122c0e830dbbe05d4b2c7081dc11d816";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "d9db73b50f52c6539e22f007d6e9937e2915d9ac75f7a714d48eb8ac55faa690";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tutorials/default.nix
+++ b/distros/foxy/webots-ros2-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, std-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tutorials";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "a2f07eb5081eb1eb7b0a52f24cbd68f7996c1c579f98ad42775c66ae01be34e6";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "82525e7e5094857e6008e3171c292fa55632ab0c93abaeaae067e5defc51ad7c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "60be666e8f9271a4f2b0ad7c6cc7139a75d91b006daac686e45ceb130009706f";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "c41d298bdd75040f38155519eddbb3047de1e78381865f4ac7488da507060790";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-ur-e-description/default.nix
+++ b/distros/foxy/webots-ros2-ur-e-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, urdf }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-ur-e-description";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9a978ad9ec233053ede854a98ef4e1848ddc31fa8b9d478f5a70d8e0169176f3";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "cc98e500bb007ee224c8ae03b4fe5547ef8e42a788de7da4dae950d044484e12";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-msgs, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "b7c9fe129d00ee40b82fd87a0f977d7249b5f689b8fa9c2e00b4eea938618511";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "45cf583827a91c1a26a970443b56dbe6841d709ad6c60c98494db0d8e274d518";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-demos webots-ros2-epuck webots-ros2-examples webots-ros2-importer webots-ros2-msgs webots-ros2-tiago webots-ros2-turtlebot webots-ros2-tutorials webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-demos webots-ros2-epuck webots-ros2-examples webots-ros2-importer webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-tutorials webots-ros2-universal-robot ];
 
   meta = {
     description = ''Interface between Webots and ROS2'';

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -308,8 +308,6 @@ self: super: {
 
  care-o-bot = self.callPackage ./care-o-bot {};
 
- care-o-bot-robot = self.callPackage ./care-o-bot-robot {};
-
  care-o-bot-simulation = self.callPackage ./care-o-bot-simulation {};
 
  carla-msgs = self.callPackage ./carla-msgs {};
@@ -1395,8 +1393,6 @@ self: super: {
  grizzly-viz = self.callPackage ./grizzly-viz {};
 
  grpc = self.callPackage ./grpc {};
-
- gscam = self.callPackage ./gscam {};
 
  gundam-robot = self.callPackage ./gundam-robot {};
 

--- a/distros/kinetic/genpy/default.nix
+++ b/distros/kinetic/genpy/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-genpy";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/kinetic/genpy/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "bec9eda88be0295d62db2d846af960fae57dac5a6b384c0f5e4011a97181e448";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/kinetic/genpy/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "79dd12c91d49d7b9aceeded88935965a91ef59db2ecc589b17bcee4d1090b598";
   };
 
   buildType = "catkin";
+  checkInputs = [ pythonPackages.numpy ];
   propagatedBuildInputs = [ genmsg pythonPackages.pyyaml ];
   nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 

--- a/distros/kinetic/homer-map-manager/default.nix
+++ b/distros/kinetic/homer-map-manager/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_map_manager-release/-/archive/release/kinetic/homer_map_manager/0.1.54-0/homer_map_manager-release-release-kinetic-homer_map_manager-0.1.54-0.tar.gz";
     name = "homer_map_manager-release-release-kinetic-homer_map_manager-0.1.54-0.tar.gz";
-    sha256 = "27440ab6119c544c875eb802466e0a7155e68e2c5bd3892b14985c76cd9423b9";
+    sha256 = "d29b4fd5a2ef833014bfe9b4ef884206840602e330df0715c53560574b03f27a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-mapnav-msgs/default.nix
+++ b/distros/kinetic/homer-mapnav-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_mapnav_msgs-release/-/archive/release/kinetic/homer_mapnav_msgs/0.1.53-0/homer_mapnav_msgs-release-release-kinetic-homer_mapnav_msgs-0.1.53-0.tar.gz";
     name = "homer_mapnav_msgs-release-release-kinetic-homer_mapnav_msgs-0.1.53-0.tar.gz";
-    sha256 = "12038984195da143f1d65ed613d1a28b8614fa57f0490feb74fe2fa994cdbf53";
+    sha256 = "e932a8d3c526d1ef820a73bdfb75d244802153e2eaccae357803a8c773a82e7e";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-mapping/default.nix
+++ b/distros/kinetic/homer-mapping/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_mapping-release/-/archive/release/kinetic/homer_mapping/0.1.53-0/homer_mapping-release-release-kinetic-homer_mapping-0.1.53-0.tar.gz";
     name = "homer_mapping-release-release-kinetic-homer_mapping-0.1.53-0.tar.gz";
-    sha256 = "e654ffefc17fd17fb005adbe83c437c1c9e41c617d61971146ae1136014d9c2b";
+    sha256 = "b2b9f3fcc049e042504ce6c0fe69ee61bab985ee3239afa853fc684f5ea01185";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-mary-tts/default.nix
+++ b/distros/kinetic/homer-mary-tts/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_robot_face-release/-/archive/release/kinetic/homer_mary_tts/1.0.18-1/homer_robot_face-release-release-kinetic-homer_mary_tts-1.0.18-1.tar.gz";
     name = "homer_robot_face-release-release-kinetic-homer_mary_tts-1.0.18-1.tar.gz";
-    sha256 = "25077804fdec7a71ac9677c2952107c514ae41d2994e568d08578e36a90d8ed8";
+    sha256 = "cd1a4bf1d7f483af3bbb8461edddb259415fe55b668a7f00df259a6df5a67bb4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-msgs/default.nix
+++ b/distros/kinetic/homer-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_msgs-release/-/archive/release/kinetic/homer_msgs/0.1.6-1/homer_msgs-release-release-kinetic-homer_msgs-0.1.6-1.tar.gz";
     name = "homer_msgs-release-release-kinetic-homer_msgs-0.1.6-1.tar.gz";
-    sha256 = "b6e7861f84afa4caf9094f2c48005f74e996ac5d1a6e31085d38246053f7a9cf";
+    sha256 = "e9f91137552c0a4f07d7fd970b053f75d8ca45a9e6957a6cc0ebdc756715e1ee";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-nav-libs/default.nix
+++ b/distros/kinetic/homer-nav-libs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_nav_libs-release/-/archive/release/kinetic/homer_nav_libs/0.1.53-0/homer_nav_libs-release-release-kinetic-homer_nav_libs-0.1.53-0.tar.gz";
     name = "homer_nav_libs-release-release-kinetic-homer_nav_libs-0.1.53-0.tar.gz";
-    sha256 = "875763c5d69764aa9dca369f7e743e1c45c59fc52df48915892afdbf22af0cb5";
+    sha256 = "afad76b9900cd46ebe3143e79af881632ca4069a3ddae67314fe6a352aebcb92";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-navigation/default.nix
+++ b/distros/kinetic/homer-navigation/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_navigation-release/-/archive/release/kinetic/homer_navigation/0.1.53-0/homer_navigation-release-release-kinetic-homer_navigation-0.1.53-0.tar.gz";
     name = "homer_navigation-release-release-kinetic-homer_navigation-0.1.53-0.tar.gz";
-    sha256 = "9ef7d2074a73e51a04324c7bb58c2f5eb0ec9e8c2bd6ed3938e039f66895c7b1";
+    sha256 = "8ede179b298b747fddb5c68cab7dfc133a32bcb59513290d62242fbfe17ad457";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-ptu-msgs/default.nix
+++ b/distros/kinetic/homer-ptu-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_ptu_msgs-release/-/archive/release/kinetic/homer_ptu_msgs/0.1.7-2/homer_ptu_msgs-release-release-kinetic-homer_ptu_msgs-0.1.7-2.tar.gz";
     name = "homer_ptu_msgs-release-release-kinetic-homer_ptu_msgs-0.1.7-2.tar.gz";
-    sha256 = "38139dbce8bcc522358ee39dd3d4be7e65e79654dcea7b8ae584e260b474fb96";
+    sha256 = "221eace54a5cc14502e93453dce3f86276df86d1173f9f9310cb735bd38a8d5d";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-robbie-architecture/default.nix
+++ b/distros/kinetic/homer-robbie-architecture/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_robbie_architecture/-/archive/release/kinetic/homer_robbie_architecture/1.0.2-3/homer_robbie_architecture-release-kinetic-homer_robbie_architecture-1.0.2-3.tar.gz";
     name = "homer_robbie_architecture-release-kinetic-homer_robbie_architecture-1.0.2-3.tar.gz";
-    sha256 = "46d28885ce35f865ff4408dc116e7f244723b584f60a0f36ff4f66564b294d23";
+    sha256 = "7907d6f5820b9edd8ecaadcb2cdf2b6fe29db77f260139d3f1203a0a2224dffa";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/homer-tts/default.nix
+++ b/distros/kinetic/homer-tts/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.uni-koblenz.de/robbie/homer_tts-release/-/archive/release/kinetic/homer_tts/1.0.29-0/homer_tts-release-release-kinetic-homer_tts-1.0.29-0.tar.gz";
     name = "homer_tts-release-release-kinetic-homer_tts-1.0.29-0.tar.gz";
-    sha256 = "29c653c5625de780c20cf3e416c9211b0bac19f3ece308604a6fc0eae64ac555";
+    sha256 = "e8141568b40781c5e7ae02a50a28a66e5c51c9d9f8b360d5820a78efdf8d7361";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/ira-laser-tools/default.nix
+++ b/distros/kinetic/ira-laser-tools/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-kinetic-ira-laser-tools";
   version = "1.0.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt4 ];
+  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/libphidget21/default.nix
+++ b/distros/kinetic/libphidget21/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-kinetic-libphidget21";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/libphidget21/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "cb19859d7275598b9bf33f5cdf35397ef394275a7f427f30f94f7ff324ab33ac";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/libphidget21/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "eb03636911fbe6dbaf54623e6480a92ecbc8e1900e8f4761d47a1acbee0cad22";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/nerian-stereo/default.nix
+++ b/distros/kinetic/nerian-stereo/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-kinetic-nerian-stereo";
-  version = "3.8.0-r1";
+  version = "3.9.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/kinetic/nerian_stereo/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "c9ce06b847666fd037db00269984af8626260e2c0e45517d8b6961d99c708b73";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/kinetic/nerian_stereo/3.9.0-3.tar.gz";
+    name = "3.9.0-3.tar.gz";
+    sha256 = "694b8b6be5e0ff0c4497ce88a901d5ba3a078cad83d69d3a8241bb66239fbd71";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs ];
+  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Driver node for SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    description = ''Driver node for Scarlet and SceneScan stereo vision sensors by Nerian Vision GmbH'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/kinetic/opencv3/default.nix
+++ b/distros/kinetic/opencv3/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, ffmpeg, libjpeg, libpng, libtiff, libv4l, libwebp, protobuf, python, pythonPackages, vtkWithQt4, zlib }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, ffmpeg, libjpeg, libpng, libtiff, libv4l, libwebp, protobuf, python, pythonPackages, vtkWithQt5, zlib }:
 buildRosPackage {
   pname = "ros-kinetic-opencv3";
   version = "3.3.1-r5";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ libtiff libv4l ];
-  propagatedBuildInputs = [ catkin ffmpeg libjpeg libpng libwebp protobuf python pythonPackages.numpy vtkWithQt4 zlib ];
+  propagatedBuildInputs = [ catkin ffmpeg libjpeg libpng libwebp protobuf python pythonPackages.numpy vtkWithQt5 zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/kinetic/phidgets-api/default.nix
+++ b/distros/kinetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget21 }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-api";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_api/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "ed886454294daed65b07f850a23c9c6c74a9141bb47216e5f3e159ba140cd411";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_api/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "b189952ec9aefde4b7dc9df251f0d26c251fbf2c18b4894aab728d748d664eef";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phidgets-drivers/default.nix
+++ b/distros/kinetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-ik, phidgets-imu, phidgets-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-drivers";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_drivers/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "6145d09441e835743fd3bee6a61aac26c1eea54f930a982b1f07ffd7316b4028";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_drivers/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "ba834481f43f71fa41178b142482e0c7630a800f1dce8fc3b00cf9a63b967ca7";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/kinetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-high-speed-encoder";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_high_speed_encoder/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "3e35b666024fe2b84ea72090ece93da72c88b3d5d75bc41e5c030a46b0af1c85";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_high_speed_encoder/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "b57a77cb394d28385ff64506fb088a6b5ac92f1f56353e5d8181988e002e2d4c";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phidgets-ik/default.nix
+++ b/distros/kinetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-ik";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_ik/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1d2d1441024d5dd1df4c5eaed1572809dd9637d74200f3fbb804f3c47d5a5c80";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_ik/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "8702d4c17785de93d1e91a099d58b87876c507d7fd696af99b460f515f28ea0a";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phidgets-imu/default.nix
+++ b/distros/kinetic/phidgets-imu/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-imu";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_imu/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "e9e92853b8863c01a6786cf26872f2d251e2f20ddef21ac511c38138b2eaea79";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_imu/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "4a5304ecf500bd166c5a097edfb02d608599cac6cc12db11caede5e74d359864";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/phidgets-msgs/default.nix
+++ b/distros/kinetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-phidgets-msgs";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_msgs/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "1f29e1a7cd91a7fb43ce1fd496d3096bd05aa4c9676b24e2ded69bafc9c5d4dd";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/kinetic/phidgets_msgs/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "09a7742d6897fbb79e5ccc7887f8ee8b8b7dbe43ef50c70ca994f00409db6f4b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/python-qt-binding/default.nix
+++ b/distros/kinetic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-kinetic-python-qt-binding";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/kinetic/python_qt_binding/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "e4060d7a7505e6c017d93215d6a27df94d1fdf0767b57e80b07be39f296af07b";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/kinetic/python_qt_binding/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "48f29ea9818a2dae8344eb2c3d2b5c3ffe4d89fddeb8e90a3ec699cdf6e97d46";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-dotgraph/default.nix
+++ b/distros/kinetic/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-qt-dotgraph";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_dotgraph/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "687e7f72d0b227075eb7ad40f178ff3b925b439c0252c62e1847fe19950dc39b";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_dotgraph/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "ea49dc2a3db0e9a7d58cd40b118c06841d38863272d0a217243f3b528ba56cd8";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-gui-app/default.nix
+++ b/distros/kinetic/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-gui }:
 buildRosPackage {
   pname = "ros-kinetic-qt-gui-app";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_app/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "ea14ae686d0c5a700b02b2043f353879e05abec636344615b53941bbce326a88";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_app/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "9cd9d0a028cb5b3c831f37c89b68ff62f8b69246552626540c8317a3d4a8215f";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-gui-core/default.nix
+++ b/distros/kinetic/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-kinetic-qt-gui-core";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_core/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "7efbafad8cab624542f91de8b400c85fb7960921f3606d55d136a4f3bcc7c981";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_core/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "e5c7e6b755b230b91e40561932a9de53f93aac2ba4db7ccb1415c2e69ed7f964";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-gui-cpp/default.nix
+++ b/distros/kinetic/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml }:
 buildRosPackage {
   pname = "ros-kinetic-qt-gui-cpp";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_cpp/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "9ad6c29dd7b32ce7937f6a13026a875f17395a75bf00459f057809cda032fbd3";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_cpp/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "ad415dc711b3759d9959d160512ce6512fe8f54146b0884783e819db0cc1880b";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-gui-py-common/default.nix
+++ b/distros/kinetic/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-qt-gui-py-common";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_py_common/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "56476af4ba02b03e923041aac3e463210ebb85177daacb38bcfc17bd95a61cae";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui_py_common/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "2b6b9d5ac2c7ac7a8f7b7c87aa7c5f74d1d07467b15d1a87b5146d37f133f282";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/qt-gui/default.nix
+++ b/distros/kinetic/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, pythonPackages, qt5, tango-icon-theme }:
 buildRosPackage {
   pname = "ros-kinetic-qt-gui";
-  version = "0.3.17-r1";
+  version = "0.3.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui/0.3.17-1.tar.gz";
-    name = "0.3.17-1.tar.gz";
-    sha256 = "5fc655e7739a03accac34205366f3d76cc8f4e1ff62c197dd335815435099450";
+    url = "https://github.com/ros-gbp/qt_gui_core-release/archive/release/kinetic/qt_gui/0.3.18-1.tar.gz";
+    name = "0.3.18-1.tar.gz";
+    sha256 = "a9357239aa091a3b32ce0cd8332d49859e0830f05d2c1112bf9fb117acf744e5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/razor-imu-9dof/default.nix
+++ b/distros/kinetic/razor-imu-9dof/default.nix
@@ -5,25 +5,21 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, pythonPackages, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-razor-imu-9dof";
-  version = "1.2.0";
+  version = "1.3.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/KristofRobot/razor_imu_9dof-release/archive/release/kinetic/razor_imu_9dof/1.2.0-0.tar.gz";
-    name = "1.2.0-0.tar.gz";
-    sha256 = "1ea328c3cd8dcc84de220e721fe4eeac184951c18167ebbeb4fd6702872b224f";
+    url = "https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release/archive/release/kinetic/razor_imu_9dof/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "6907cd7a264709109ea7b4f8e9ae5f66d764f1391863194e8997e8c658fc88aa";
   };
 
   buildType = "catkin";
+  buildInputs = [ pythonPackages.catkin-pkg ];
   propagatedBuildInputs = [ dynamic-reconfigure pythonPackages.pyserial rospy sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''razor_imu_9dof is a package that provides a ROS driver
-     for the Sparkfun Razor IMU 9DOF. It also provides Arduino
-     firmware that runs on the Razor board, and which must be
-     installed on the Razor board for the system to work. A node
-     which displays the attitude (roll, pitch and yaw) of the Razor board 
-     (or any IMU) is provided for testing.'';
-    license = with lib.licenses; [ bsdOriginal ];
+    description = ''razor_imu_9dof is a package that provides a ROS driver for the Sparkfun OpenLog Artemis, 9DoF Razor IMU M0, 9DOF Razor IMU and 9DOF Sensor Stick. It also provides Arduino firmware that runs on the board, and which must be installed on it for the system to work. A node which displays the attitude (roll, pitch and yaw) of the board (or any IMU) is provided for testing.'';
+    license = with lib.licenses; [ bsdOriginal gpl3 ];
   };
 }

--- a/distros/kinetic/rc-cloud-accumulator/default.nix
+++ b/distros/kinetic/rc-cloud-accumulator/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pcl, pcl-ros, roscpp, std-srvs, tf2, tf2-msgs, tf2-ros, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pcl, pcl-ros, roscpp, std-srvs, tf2, tf2-msgs, tf2-ros, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-kinetic-rc-cloud-accumulator";
   version = "1.0.4";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs nav-msgs pcl pcl-ros roscpp std-srvs tf2 tf2-msgs tf2-ros vtkWithQt4 ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs pcl pcl-ros roscpp std-srvs tf2 tf2-msgs tf2-ros vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/kinetic/rdl-benchmark/default.nix
+++ b/distros/kinetic/rdl-benchmark/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_benchmark/1.1.0-0/rdl_release-release-kinetic-rdl_benchmark-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_benchmark-1.1.0-0.tar.gz";
-    sha256 = "2fd90df67337deadde23ca02ecf0f683c26c8547fc268d5b9794d784a34c37b4";
+    sha256 = "944352a11d327120539fa85abf5df6181b688162f5ea144d034be3a8114d7ac4";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl-cmake/default.nix
+++ b/distros/kinetic/rdl-cmake/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_cmake/1.1.0-0/rdl_release-release-kinetic-rdl_cmake-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_cmake-1.1.0-0.tar.gz";
-    sha256 = "d7973d56abb99d31251154588af5694865301492b6eaf2fd743d8f9fda76cf3a";
+    sha256 = "a74329b5e992686e8c42fe73ec706f11446431470012ea8b8d3389d2083a2208";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl-dynamics/default.nix
+++ b/distros/kinetic/rdl-dynamics/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_dynamics/1.1.0-0/rdl_release-release-kinetic-rdl_dynamics-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_dynamics-1.1.0-0.tar.gz";
-    sha256 = "65b04cf2a3b86031f11f44bbb8f02db4f237a3a6a5aef4086fe32e67ce789ec7";
+    sha256 = "b26380fe4310ddd34286e20652d1bd8b49e6f76ee1e23864c4466d336afb4cd0";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl-msgs/default.nix
+++ b/distros/kinetic/rdl-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_msgs/1.1.0-0/rdl_release-release-kinetic-rdl_msgs-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_msgs-1.1.0-0.tar.gz";
-    sha256 = "79db3bb1a9162e6d39b83c3c2ce1101d65ec77fa2fa4260e0b72faf42a577bcc";
+    sha256 = "055beffc8f5d462e86684e672b4fa5d81972d548d62ce6ec2c9f3ac315828cc5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl-ros-tools/default.nix
+++ b/distros/kinetic/rdl-ros-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_ros_tools/1.1.0-0/rdl_release-release-kinetic-rdl_ros_tools-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_ros_tools-1.1.0-0.tar.gz";
-    sha256 = "f5855c1044dd86dfaab57dace95580d1838d7e0330a8a21eb0ec2d93d850216f";
+    sha256 = "ce08c88be96e91d43c99d78662d459c16c09d4a92f96739b9d35cc409c0e0cf3";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl-urdfreader/default.nix
+++ b/distros/kinetic/rdl-urdfreader/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl_urdfreader/1.1.0-0/rdl_release-release-kinetic-rdl_urdfreader-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl_urdfreader-1.1.0-0.tar.gz";
-    sha256 = "44a776b10b02d4faef56d3f77df5eb31ad2f4f9424255247823ab4499d3442c5";
+    sha256 = "56c2b84e35909fa309d7a5167864bf978a22554a26b0311d6c30d35589b9b7f5";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/rdl/default.nix
+++ b/distros/kinetic/rdl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/kinetic/rdl/1.1.0-0/rdl_release-release-kinetic-rdl-1.1.0-0.tar.gz";
     name = "rdl_release-release-kinetic-rdl-1.1.0-0.tar.gz";
-    sha256 = "c582bf84e03b65888829f3883e3dc0d820b71a5ae01aa492169e9763357c1b99";
+    sha256 = "013d88610b9486e2895b3fdea15200f55a7033cac956582b7d343dd4d38144e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-assets/default.nix
+++ b/distros/melodic/drone-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-drone-assets";
-  version = "1.3.7-r3";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.7-3.tar.gz";
-    name = "1.3.7-3.tar.gz";
-    sha256 = "ac97d1219300c698c4ee91347f65f3f452f21b40cf9e49cb95e088e440db62c0";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "78de68ca2619e7015c587d3e930b31883ad12eb22d840960e36681fb5e25b77d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.3.7-r3";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.7-3.tar.gz";
-    name = "1.3.7-3.tar.gz";
-    sha256 = "77d3e15f0fa014cbe4d437a9a12845908c7d03ca9292801b16903d77139610ae";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "3f57d28446b812c2ac8222fa15e39d7ccf03a1ed7e4da881803549b5cd0038f3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2064,6 +2064,8 @@ self: super: {
 
  move-base-sequence = self.callPackage ./move-base-sequence {};
 
+ move-basic = self.callPackage ./move-basic {};
+
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
  moveback-recovery = self.callPackage ./moveback-recovery {};
@@ -2965,6 +2967,8 @@ self: super: {
  range-sensor-layer = self.callPackage ./range-sensor-layer {};
 
  raw-description = self.callPackage ./raw-description {};
+
+ razor-imu-9dof = self.callPackage ./razor-imu-9dof {};
 
  rc-cloud-accumulator = self.callPackage ./rc-cloud-accumulator {};
 

--- a/distros/melodic/genpy/default.nix
+++ b/distros/melodic/genpy/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genpy";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "5b57fb2edba204a8799a619648107ac44a857bf5f94c65a5505a4beca54716f7";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "4085c1c3c0798218f15ba925883c2e02faadce969e4179b30593e6f69a9aaacd";
   };
 
   buildType = "catkin";
+  checkInputs = [ pythonPackages.numpy ];
   propagatedBuildInputs = [ genmsg pythonPackages.pyyaml ];
   nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 

--- a/distros/melodic/imu-complementary-filter/default.nix
+++ b/distros/melodic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-imu-complementary-filter";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "5a0386e57b5a89f5c6e0c4dd93ee25dddd8a80a8477c869e912cb37cdf35af6d";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_complementary_filter/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "c77dc4623d5940a2df13eaf732e6b46fde54392efdcf7b53bca5cd1c941b9498";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-filter-madgwick/default.nix
+++ b/distros/melodic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-imu-filter-madgwick";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "698aeeefd73cade364967525d9d3199ff8397f72581a6dff89db000b2c735a78";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_filter_madgwick/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "6bca1c317388c21f816acbb6427c104400d24a35926726724e56b25fc914ebc7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/imu-tools/default.nix
+++ b/distros/melodic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-imu-tools";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "4ee66ea61a29712ddfcafb76dade45b7d90d83093255fcdec12e7f68f3c5abe9";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/imu_tools/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "29b4c0968c742e6bef6092ed35e1ec1d4c8bdbe1d65c4bf5a759ee972bfb3859";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ira-laser-tools/default.nix
+++ b/distros/melodic/ira-laser-tools/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-melodic-ira-laser-tools";
   version = "1.0.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt4 ];
+  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/iris-lama-ros/default.nix
+++ b/distros/melodic/iris-lama-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-iris-lama-ros";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/melodic/iris_lama_ros/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2a0b18ea41dd4dcc3e9664c2040fd4c7bfddf1f87b853b685e3a7ea9c4232187";
+    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/melodic/iris_lama_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2107bf075df0ee097ce884a08d919b5bf659d293ac4b5409025f8d3931655b2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/iris-lama/default.nix
+++ b/distros/melodic/iris-lama/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen }:
 buildRosPackage {
   pname = "ros-melodic-iris-lama";
-  version = "1.1.0-r2";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/melodic/iris_lama/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "819d1176a2b631109337b9309d86a1cb3b277daa7307c33b2f658ea110f97b4b";
+    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/melodic/iris_lama/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "50395fa0959650024b0ff00692fb86b9d37b7aea8d330cd82a63a9ee917c121a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-drones";
-  version = "1.3.7-r3";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.7-3.tar.gz";
-    name = "1.3.7-3.tar.gz";
-    sha256 = "7261c3ca84fec7223d490cd7a882cd42bfcce72effdc04b1c3eb4fadbb91bb6c";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "08cf45db506da549d05fc5797096eaf30e9abc5ce5afebbb41729b48cf62f35e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libphidget21/default.nix
+++ b/distros/melodic/libphidget21/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-libphidget21";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/libphidget21/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "b493f61274d99ad205a18a6c841f140e54789361fdaccb2cc59f79ef2cfde9e1";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/libphidget21/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "498fe200b0df6350e73931592f8e7b1d9971f24f22f8f8328c6d4e64548d9b92";
   };
 
   buildType = "catkin";

--- a/distros/melodic/move-basic/default.nix
+++ b/distros/melodic/move-basic/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-core, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-move-basic";
+  version = "0.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/move_basic-release/archive/release/melodic/move_basic/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "e7aa6c6ce08b3a9f4fd248dfa9a8763cbd58f5f11ea6fca68e631b6a5c41b372";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs message-generation message-runtime move-base-msgs nav-core roscpp rostest sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/nerian-stereo/default.nix
+++ b/distros/melodic/nerian-stereo/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-nerian-stereo";
-  version = "3.8.0-r1";
+  version = "3.9.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.8.0-1.tar.gz";
-    name = "3.8.0-1.tar.gz";
-    sha256 = "bf374d4a67100c50798ea75dfc4233b15be533a085a901be23ee80354734a46d";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/melodic/nerian_stereo/3.9.0-3.tar.gz";
+    name = "3.9.0-3.tar.gz";
+    sha256 = "76e540e8302dc7084e49c711a0b0ca0a6c0bbef6f14a9e808cfcab7079b2dac8";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs ];
+  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Driver node for SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    description = ''Driver node for Scarlet and SceneScan stereo vision sensors by Nerian Vision GmbH'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/phidgets-api/default.nix
+++ b/distros/melodic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget21 }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-api";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_api/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "4fc49e7bad1c3bf5a165f144a18d0c3a2af76ec27a2d1cf70eb6ce98b0281ee3";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_api/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "9d4a754230661ad607e621d6cfc94ef56549e1b9e3f0772937b1ba023195e189";
   };
 
   buildType = "catkin";

--- a/distros/melodic/phidgets-drivers/default.nix
+++ b/distros/melodic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget21, phidgets-api, phidgets-high-speed-encoder, phidgets-ik, phidgets-imu, phidgets-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-drivers";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_drivers/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "6f72628611a85e25175c1ae86266adbf5dec38e276c1ca2f19602f30dc8837f8";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_drivers/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "76ba15fc6d2c454eb9f3682958cba17cc221c2c26d3b22628b4417570a3b6c8d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/phidgets-high-speed-encoder/default.nix
+++ b/distros/melodic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-high-speed-encoder";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_high_speed_encoder/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "5878e35c9e46f6be29b4b9d3641fc308b1c8fb50b3ce6d36b48ab8fdc0b374b8";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_high_speed_encoder/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "c80996cd598e2d92710bfc0a78436e790f682495072557be049b80d418054da5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/phidgets-ik/default.nix
+++ b/distros/melodic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-ik";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_ik/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "efde9126efa41df2e088958b1047afa402bc04dff2bc8e0cfe07aeeb7e8c698f";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_ik/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "1e115c59cf1c38b6a74820fe419fe520e6807930c7b8c1cb493c7a8e2a5e21e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/phidgets-imu/default.nix
+++ b/distros/melodic/phidgets-imu/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-imu";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_imu/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "03325987c440379ef8e1d00656aff251eff1a7ba10da092948c131fb06c26014";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_imu/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "734bc239351695bffac0addd1ebbc93fa75d9c6d4f291c05e6cff41fcb4155ae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/phidgets-msgs/default.nix
+++ b/distros/melodic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-phidgets-msgs";
-  version = "0.7.10-r1";
+  version = "0.7.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_msgs/0.7.10-1.tar.gz";
-    name = "0.7.10-1.tar.gz";
-    sha256 = "e05ec181840e85efc5a58351b799ab9cb9143901070c3542c750b5dbb45c316a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/melodic/phidgets_msgs/0.7.11-1.tar.gz";
+    name = "0.7.11-1.tar.gz";
+    sha256 = "3a93c937d43ab6f4a715931ffb7bee9bd32cb5ab9d6e934536b89ef5e6620ece";
   };
 
   buildType = "catkin";

--- a/distros/melodic/razor-imu-9dof/default.nix
+++ b/distros/melodic/razor-imu-9dof/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, pythonPackages, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-razor-imu-9dof";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release/archive/release/melodic/razor_imu_9dof/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "7b9cf9527dede1fa4eecc2da794eee2ce4acfdff994b5f3416b7870e6751a224";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pythonPackages.catkin-pkg ];
+  propagatedBuildInputs = [ dynamic-reconfigure pythonPackages.pyserial rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''razor_imu_9dof is a package that provides a ROS driver for the Sparkfun OpenLog Artemis, 9DoF Razor IMU M0, 9DOF Razor IMU and 9DOF Sensor Stick. It also provides Arduino firmware that runs on the board, and which must be installed on it for the system to work. A node which displays the attitude (roll, pitch and yaw) of the board (or any IMU) is provided for testing.'';
+    license = with lib.licenses; [ bsdOriginal gpl3 ];
+  };
+}

--- a/distros/melodic/rc-cloud-accumulator/default.nix
+++ b/distros/melodic/rc-cloud-accumulator/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pcl, pcl-ros, roscpp, std-srvs, tf2, tf2-msgs, tf2-ros, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pcl, pcl-ros, roscpp, std-srvs, tf2, tf2-msgs, tf2-ros, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-melodic-rc-cloud-accumulator";
   version = "1.0.4";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs nav-msgs pcl pcl-ros roscpp std-srvs tf2 tf2-msgs tf2-ros vtkWithQt4 ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs pcl pcl-ros roscpp std-srvs tf2 tf2-msgs tf2-ros vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rdl-benchmark/default.nix
+++ b/distros/melodic/rdl-benchmark/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_benchmark/3.2.0-1/rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_benchmark-3.2.0-1.tar.gz";
-    sha256 = "b3764041b76d8541b11d5acdb176bed3be086ec1b953a41aa2b56b42898d34aa";
+    sha256 = "d351794b18247cd31330fe3a9d7a84cd41c5bd8b65b3f9ed11a9abae582fed82";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-cmake/default.nix
+++ b/distros/melodic/rdl-cmake/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_cmake/3.2.0-1/rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_cmake-3.2.0-1.tar.gz";
-    sha256 = "dd87bce11db76a5bd23cb7919bd886b93bb97b99df3396b824b6132619dacb7e";
+    sha256 = "30c5695aa0bb0847d991d05020be78e50d5795c51b832eeb17990da8c0488bc2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-dynamics/default.nix
+++ b/distros/melodic/rdl-dynamics/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_dynamics/3.2.0-1/rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_dynamics-3.2.0-1.tar.gz";
-    sha256 = "02996f90bf325b1c47f8b436761468a0af9662aa937ec90250cf10ecd7107fa0";
+    sha256 = "85053786c16693de1bd832d6f81307d41d63b593e2f2b54cd32d8adca0a03bf1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-msgs/default.nix
+++ b/distros/melodic/rdl-msgs/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_msgs/3.2.0-1/rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_msgs-3.2.0-1.tar.gz";
-    sha256 = "338e4d203d43511f7232d2528f44364d36c739eb86f5de1b791e68ea2e9273d2";
+    sha256 = "e51406d626a0114ed044ee5e90462bc10737ed057a5abf50f808fdea52cd6ddf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-ros-tools/default.nix
+++ b/distros/melodic/rdl-ros-tools/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_ros_tools/3.2.0-1/rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_ros_tools-3.2.0-1.tar.gz";
-    sha256 = "3d535dc2d58a675a64d78d2b30820586f00b16e350008e146e9ac19415e0c926";
+    sha256 = "36c236da8fa738216e65211f173f73a203d2b99a582e396aabf170e26d841483";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl-urdfreader/default.nix
+++ b/distros/melodic/rdl-urdfreader/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl_urdfreader/3.2.0-1/rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl_urdfreader-3.2.0-1.tar.gz";
-    sha256 = "acf08d42afc98a4ffb76a16dfc67124f19f3adeb56167f886322019cb3fc83ee";
+    sha256 = "21e9d728f57fa66aa13948bb25fd1900aa5926410fe533b6e92da0f8acf00ffa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rdl/default.nix
+++ b/distros/melodic/rdl/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://gitlab.com/jlack/rdl_release/-/archive/release/melodic/rdl/3.2.0-1/rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
     name = "rdl_release-release-melodic-rdl-3.2.0-1.tar.gz";
-    sha256 = "697a892941f85b37eb08270936b94605ef7745c4aa2f7788f64b1a4974b5bf46";
+    sha256 = "402f1c9db58df28b9506bff1ae06cafb299e6a076cb46a1bc44f8bfc9019436e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.3.7-r3";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.7-3.tar.gz";
-    name = "1.3.7-3.tar.gz";
-    sha256 = "2ce82e22304f925b0cfb0f520560d6ecef1af1552a3ff2a270e29db6fc8d9df8";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "87489e35b416d29a2012f318da05b9090e02589ca580c98e6d4a287fb4150486";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.3.7-r3";
+  version = "1.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.7-3.tar.gz";
-    name = "1.3.7-3.tar.gz";
-    sha256 = "1513c291a25a66ab29560861223d934a3b9fc05e2f1782fe95936170e9d81c35";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.8-1.tar.gz";
+    name = "1.3.8-1.tar.gz";
+    sha256 = "889e5838ef66a6a37cf69424708b51bdbe3ce73e1407d6d41d7dcfde40ddfcbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz-imu-plugin/default.nix
+++ b/distros/melodic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-rviz-imu-plugin";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "8d9af7ecde2407f571f97f6d3fd6f89d67b6cd0c3cb7732f5be3c6979b570db5";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/melodic/rviz_imu_plugin/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "1adab782a4bc97d91ec714b841e9761f4349ecbfc08434d3ca00b9f8783033f2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.16-r1";
+  version = "1.13.17-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.16-1.tar.gz";
-    name = "1.13.16-1.tar.gz";
-    sha256 = "1addd391a6fc14528987b99bab69b59b99d22140d9c4ba90b3c925ca6ab80da2";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.17-1.tar.gz";
+    name = "1.13.17-1.tar.gz";
+    sha256 = "b06a1273a338d4e849ce9b59d4f5da5a2b203a22accb8f7968e029781c0a458a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/simple-grasping/default.nix
+++ b/distros/melodic/simple-grasping/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-melodic-simple-grasping";
   version = "0.3.1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation ];
-  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt4 ];
+  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/volta-simulation/default.nix
+++ b/distros/melodic/volta-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, roslaunch, rostopic, volta-control, volta-description }:
 buildRosPackage {
   pname = "ros-melodic-volta-simulation";
-  version = "1.1.1-r1";
+  version = "1.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/botsync-gbp/volta_simulation-release/archive/release/melodic/volta_simulation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "8c63736709099eadd7f623a54b726fe8df936d39179d4121c255b70f6fdc389d";
+    url = "https://github.com/botsync-gbp/volta_simulation-release/archive/release/melodic/volta_simulation/1.1.0-2.tar.gz";
+    name = "1.1.0-2.tar.gz";
+    sha256 = "8819262427c6cb04c561d9148ddd31788a6ec2da49c21972c58b5f9403270e09";
   };
 
   buildType = "catkin";

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "437c49664504a107f5939e51c5bdc9f8e0de176ccc0af6acdf0d89f3e6790bd6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "a4ec926f15003c57d5d23fe4d1511223e630dc7f1a8d30e6e5327804aa3a307d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1642,6 +1642,10 @@ self: super: {
 
  pid = self.callPackage ./pid {};
 
+ pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
+
+ pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
+
  pilz-industrial-motion-testutils = self.callPackage ./pilz-industrial-motion-testutils {};
 
  pilz-msgs = self.callPackage ./pilz-msgs {};
@@ -1773,6 +1777,8 @@ self: super: {
  random-numbers = self.callPackage ./random-numbers {};
 
  raw-description = self.callPackage ./raw-description {};
+
+ razor-imu-9dof = self.callPackage ./razor-imu-9dof {};
 
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
@@ -2333,6 +2339,20 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
+
+ tesseract-common = self.callPackage ./tesseract-common {};
+
+ tesseract-geometry = self.callPackage ./tesseract-geometry {};
+
+ tesseract-kinematics = self.callPackage ./tesseract-kinematics {};
+
+ tesseract-scene-graph = self.callPackage ./tesseract-scene-graph {};
+
+ tesseract-support = self.callPackage ./tesseract-support {};
+
+ tesseract-urdf = self.callPackage ./tesseract-urdf {};
+
+ tesseract-visualization = self.callPackage ./tesseract-visualization {};
 
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 

--- a/distros/noetic/genpy/default.nix
+++ b/distros/noetic/genpy/default.nix
@@ -5,15 +5,16 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genpy";
-  version = "0.6.14-r1";
+  version = "0.6.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.14-1.tar.gz";
-    name = "0.6.14-1.tar.gz";
-    sha256 = "a32c58646815ef69c971f8370d80a03f925e5fa85fbdc607ab262f5ecc41d2f2";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/noetic/genpy/0.6.15-1.tar.gz";
+    name = "0.6.15-1.tar.gz";
+    sha256 = "6ff427b4dba67d28eb6c39e3c43c3ab5a011e9fc0d3b5c4c39828476f5ea2746";
   };
 
   buildType = "catkin";
+  checkInputs = [ python3Packages.numpy ];
   propagatedBuildInputs = [ genmsg python3Packages.pyyaml ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 

--- a/distros/noetic/hector-compressed-map-transport/default.nix
+++ b/distros/noetic/hector-compressed-map-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, eigen, geometry-msgs, hector-map-tools, image-transport, nav-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-compressed-map-transport";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_compressed_map_transport/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "3741cf10b494678719665e84216a3a3242df28c385f53576420786b830b651f1";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_compressed_map_transport/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "13434ed757d7aa27414ba2495d0a296b6c4100cd21c4f513be3d6ca93cbbad9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-geotiff-launch/default.nix
+++ b/distros/noetic/hector-geotiff-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-geotiff, hector-geotiff-plugins, hector-trajectory-server }:
 buildRosPackage {
   pname = "ros-noetic-hector-geotiff-launch";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff_launch/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d2880f784da28859e9c435ad5a2993cfa2889b3ca1d575ae49b44708523b3266";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff_launch/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "3e8f605d905a45743d07dfc38895f2e5e8163be71dfb3856ac4332c581cf1821";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-geotiff-plugins/default.nix
+++ b/distros/noetic/hector-geotiff-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-geotiff, hector-nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-geotiff-plugins";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff_plugins/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "459611623a7d99d6d089fbc3709186cc824a47a3e057dc3d0f3bd6bcd9e2025d";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff_plugins/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "a262122d12d80b717963890bb8ab61813e503c46152d9c170c665af49e230f1e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-geotiff/default.nix
+++ b/distros/noetic/hector-geotiff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-nav-msgs, nav-msgs, pluginlib, qt5, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-geotiff";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "b95664c752e8832726ef80928a1794da031f20d7a62871392dc6cb37d29a6505";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_geotiff/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "000385fc14d0a1f11099f71934902f311881bacf2c53aeb50a7f9c9042d69753";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-imu-attitude-to-tf/default.nix
+++ b/distros/noetic/hector-imu-attitude-to-tf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-hector-imu-attitude-to-tf";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_imu_attitude_to_tf/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "ef7b01ee4e41b8929813fb34fe31b543b82205194e3b96ec9adc3e382a5ae0fe";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_imu_attitude_to_tf/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "10731ab0d6e13ee76b8dca754ed32049e2a7ea518a9474d119996ea8c87373ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-imu-tools/default.nix
+++ b/distros/noetic/hector-imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-hector-imu-tools";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_imu_tools/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "d86151fc628ce031cdf17872cc156a40fc99d7035cab67845ed996b68258674d";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_imu_tools/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "a4e67b8a5f662733075aa076acc1fc18f5eed4b34e7c87f611524207efb65326";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-map-server/default.nix
+++ b/distros/noetic/hector-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-marker-drawing, hector-nav-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-hector-map-server";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_map_server/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "9e60b83b6786e6b552ae1f6e6d44b8e510d180a6517d834b28dc6a1167fbc4d3";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_map_server/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "0fc4cf934248651db1cda8878bffde6608a9c65d2d890cad44855ee753346fec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-map-tools/default.nix
+++ b/distros/noetic/hector-map-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-map-tools";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_map_tools/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a0b0cf4118a38dda18d1d6e263a0065e18c01ca412523191326ed4c7cbff8576";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_map_tools/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "2d6643594c4f64a75becf83dde3da61f65cc34cbbdfe0e1153ca9436f6764cc3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-mapping/default.nix
+++ b/distros/noetic/hector-mapping/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, eigen, laser-geometry, message-filters, message-generation, message-runtime, nav-msgs, roscpp, tf, tf-conversions, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, eigen, laser-geometry, message-filters, message-generation, message-runtime, nav-msgs, roscpp, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-mapping";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_mapping/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "50637b90420532e5fdbd2136eba6ebd2dcf492fb172c7929d05bb7f0d5641f1c";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_mapping/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "ecceebe2a85de049572d9362d99760a92a22acbfedf55e27f219fb590c3b5a75";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost eigen laser-geometry message-filters message-runtime nav-msgs roscpp tf tf-conversions visualization-msgs ];
+  propagatedBuildInputs = [ boost eigen laser-geometry message-filters message-runtime nav-msgs roscpp tf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/hector-marker-drawing/default.nix
+++ b/distros/noetic/hector-marker-drawing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-marker-drawing";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_marker_drawing/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "16158a1dd69bb1abc0ee73348febddda0d802d6be2630e38356931f1b1abba8b";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_marker_drawing/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "3859c57d91000a3fe44b89821cabcec52857a70a72639c0d6f94dc216b764d55";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-nav-msgs/default.nix
+++ b/distros/noetic/hector-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hector-nav-msgs";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_nav_msgs/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "7e70c68c630259704f00ad681625e1b7ff94d90753cb01947d23399a022f2848";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_nav_msgs/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "e4d5333e218e78929a4f1da4e468c2876507dd9a3e0fd51bec0a1a544874f45b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-slam-launch/default.nix
+++ b/distros/noetic/hector-slam-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-geotiff, hector-geotiff-plugins, hector-map-server, hector-mapping, hector-trajectory-server, rviz, tf, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-hector-slam-launch";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_slam_launch/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "3dce44d3e6f34f737775a61fbea21b85b6a7375d2882abe83450ad77fdb6811f";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_slam_launch/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "7942ad6c108ead0b1146131ae0b039a8512c229e45fb40bec6620acf2e1a3105";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-slam/default.nix
+++ b/distros/noetic/hector-slam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-compressed-map-transport, hector-geotiff, hector-geotiff-launch, hector-geotiff-plugins, hector-imu-attitude-to-tf, hector-map-server, hector-map-tools, hector-mapping, hector-marker-drawing, hector-nav-msgs, hector-slam-launch, hector-trajectory-server }:
 buildRosPackage {
   pname = "ros-noetic-hector-slam";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_slam/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "30fb9aa259bc9ee0c7bd466098c612cb2e72a75ae6383207bff985b2c30e901d";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_slam/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "d2d894897f630824f2ea1638608e99badafff6aa0a4b1940c1fc59b6b0e5eb64";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-trajectory-server/default.nix
+++ b/distros/noetic/hector-trajectory-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-map-tools, hector-nav-msgs, nav-msgs, roscpp, tf }:
 buildRosPackage {
   pname = "ros-noetic-hector-trajectory-server";
-  version = "0.5.1-r1";
+  version = "0.5.2-r4";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_trajectory_server/0.5.1-1.tar.gz";
-    name = "0.5.1-1.tar.gz";
-    sha256 = "a20848163a5e938922f81393692d51bb726f5d8a454f00d3c394838fc6651b3f";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_slam-release/archive/release/noetic/hector_trajectory_server/0.5.2-4.tar.gz";
+    name = "0.5.2-4.tar.gz";
+    sha256 = "44921895097d9e11f05cc3055f6574fab40062b082c9e9db6f4b7d30936b3430";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-complementary-filter/default.nix
+++ b/distros/noetic/imu-complementary-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-filters, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-imu-complementary-filter";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "765a085424e8c978c3731e7ccd0a604cbfe2180313ad9022fc81b499f480895f";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_complementary_filter/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "e4fb380b8e4d8aee751f8c42882a8a4ebe6cab0c8403622b9aedae1c156b43e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-filter-madgwick/default.nix
+++ b/distros/noetic/imu-filter-madgwick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, message-filters, nodelet, pluginlib, roscpp, rosunit, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-imu-filter-madgwick";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "1aaed50ea8d450c79d6a1d5ee821f2d0c907702ceb33d243dbc142df24528194";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_filter_madgwick/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "0382ec399bdcb8c01e15ab9bd84347f69e8c0292379af84472c1aa83ae99b8a1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-tools/default.nix
+++ b/distros/noetic/imu-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-complementary-filter, imu-filter-madgwick, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-noetic-imu-tools";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "ffbb383013e7396a60c056533ec89c69ddf3b61577bb8e9bee0b059678d083f9";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/imu_tools/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "904844b49082ed7b5171294492843ce842d6e9aa67965a512b5077eb11a592e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/iris-lama-ros/default.nix
+++ b/distros/noetic/iris-lama-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, iris-lama, message-filters, nav-msgs, rosbag, rosbag-storage, roscpp, std-srvs, tf, tf-conversions, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama-ros";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/noetic/iris_lama_ros/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2eb84cbb775047aabfb9ead468443b3b290d77059bf6f688ba010df52f83f00d";
+    url = "https://github.com/eupedrosa/iris_lama_ros-release/archive/release/noetic/iris_lama_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d53c2064d66d9ed37d41db740666304d55caed042ea225f5a4baf57cb935ec95";
   };
 
   buildType = "catkin";

--- a/distros/noetic/iris-lama/default.nix
+++ b/distros/noetic/iris-lama/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen }:
 buildRosPackage {
   pname = "ros-noetic-iris-lama";
-  version = "1.1.0-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2bf9cd1fbcdfbd21d7bdcd2951d12f60badb8cc54c5007ef703be7ab1bd993ce";
+    url = "https://github.com/eupedrosa/iris_lama-release/archive/release/noetic/iris_lama/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e44735c6be4270290423282d6dcb8240c750373bcc2e2ce1e3adacff6c0be378";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "811dede6f9a51f3ea2843521ba0ca495847cd8f7067abdac38aaab515e6503f4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "795d0d384b749bbcfc4179a26240784d8ad189f29fa44c8d7013951c0b8e298e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-conversions, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "c04dc536858fcc83fa175042bdeb8aef2d8e078ebe6871e4a37cfa940c0c5b4c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0892744400e6c37e5659cd2d041b9d1da3bc4143a5f4843eed0e5da97f1eb647";
   };
 
   buildType = "catkin";
   checkInputs = [ angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl rosunit tf2-kdl ];
-  propagatedBuildInputs = [ assimp boost bullet console-bridge eigen eigen-conversions eigen-stl-containers fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs random-numbers rosconsole roslib rostime sensor-msgs shape-msgs srdfdom std-msgs tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs xmlrpcpp ];
+  propagatedBuildInputs = [ assimp boost bullet console-bridge eigen eigen-stl-containers fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pybind11-catkin random-numbers rosconsole roslib rostime sensor-msgs shape-msgs srdfdom std-msgs tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs xmlrpcpp ];
   nativeBuildInputs = [ catkin pkg-config ];
 
   meta = {

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4f69e71740f055c9d61709224ad2d032ffac9d3f219003dffdeb6bb7c816e775";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c6230757746f6802a8fccc50212e90b134dbb5f078c6480cac9874423a55735b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a0a0c40fbf2cb6760683c8c3a725d68c26dd4f1d221c732f617b4604a4d3347d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "457f10a9b07db26c4f99bbf30df468cc2027316855c4431ed62ba88302a24718";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-msgs/default.nix
+++ b/distros/noetic/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, object-recognition-msgs, octomap-msgs, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-msgs";
-  version = "0.11.1-r1";
+  version = "0.11.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_msgs-release/archive/release/noetic/moveit_msgs/0.11.1-1.tar.gz";
-    name = "0.11.1-1.tar.gz";
-    sha256 = "66809976ac82cf8a3cc92091416497ab86ce48bfba5c8511c60e05c0ef1cb0cc";
+    url = "https://github.com/ros-gbp/moveit_msgs-release/archive/release/noetic/moveit_msgs/0.11.2-1.tar.gz";
+    name = "0.11.2-1.tar.gz";
+    sha256 = "414a42e930bc0d2c047ff02c631a251455df053e1cce140166208c96f5a33a9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "aea0947d42ba0b4c4967ee8739effdd1331dd878f68ff42ae514fdde6022d960";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "617d73b0a713ff48e15442adbd4eca561273c0b914cdded4abca324be9a214d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rosunit, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b3c4ca77f8d50bf4dbd1f6444b10d5a86fb0e4ae5b4abf37aad31a39ef898a9a";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "5ed08d714296e7f164454f410b13a05d65c7b6ac5478770dc02bfffba07324f0";
   };
 
   buildType = "catkin";
-  checkInputs = [ moveit-resources-pr2-description rosunit ];
-  propagatedBuildInputs = [ dynamic-reconfigure moveit-core moveit-ros-planning ompl pluginlib rosconsole roscpp tf2-ros ];
+  checkInputs = [ moveit-resources-fanuc-description moveit-resources-panda-description moveit-resources-pr2-description rostest rosunit tf2-eigen ];
+  propagatedBuildInputs = [ dynamic-reconfigure moveit-core moveit-ros-planning ompl pluginlib rosconsole roscpp tf2 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4279138b98f2d6232454b240c3e573ae46b23216fe266727859bbace664d1bf9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "1bf82c8f095d9083698a0e897b53ab9c78d777625f23652ccb3f9f1e4f264d79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bd66730e8026d8f85c35bde79fe46e068d11bc2b678aa2a75598cbdaad9c8a57";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "94a1859de3edf53c2d9d1bfded7d20befd3753743a11659e6921e3a7a1b81650";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "383ef555d28f94cba4d59314f51c1399923abd538a25a1c99a392520adfb2cf0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "de07baff7c8f0c3ed34a11b6acef2bae5a6622bbfe824730fd5aafc34036e439";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "84fff910fb63a269901a775e1e74e04f61d0dd193f888288abe15e93fb51dbec";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "5356c844a4ccb93c414a84e619b818ad586f68109b018ebc9c7f3a019d213969";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "61ec02da3362e899b7f707b792359395ed9dfab775db2a7ea5cd9c232c569969";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "83f01c01c5d59f564c885472e009e71d3d3b60911bbfbf00b4691afd058d51c5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "56de3f06cbf7ce4d255f720fb26969e802c42944bc503feaaa5a7c5e7b56b580";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "de6aa943e2cf5428f964b57a4abf172b95149f89e35df198c12e9333f976d9d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "e84763fc2105e6121d901f62b96eff5dd5eb0c89e9e07ba101ad797708fd3263";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "e79d5459aa36502856e2a5e3b91993aecb286506eb62d9e741c53cc3004bfb3e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigen-conversions, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bcdcb8ee509881e37085fd4571f1e88871a66961d51cdf801cced618f9bc3b73";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "81c8526a7051af7dcaf4174dd759ea150a2823f89520d2c1536872b274d8e321";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen ];
-  checkInputs = [ eigen-conversions moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config rostest ];
+  checkInputs = [ moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config rostest ];
   propagatedBuildInputs = [ actionlib eigenpy geometry-msgs moveit-msgs moveit-ros-manipulation moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rosconsole roscpp rospy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
 

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "80b2752d63d6e5c7b241c027f24916f2a4b75091e2ffa7167505c40e6d7f7ef6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "d868a024f1e397d5c9297ff7389f5a9a97b4cea6e1cf4a6d326111d904f2a4e9";
   };
 
   buildType = "catkin";
   buildInputs = [ eigen ];
+  checkInputs = [ moveit-resources-panda-moveit-config rostest ];
   propagatedBuildInputs = [ actionlib dynamic-reconfigure message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rosconsole roscpp srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d7ea752b78b3e866f9ae395fc68b9964d1b93c3a70dc7755c33a03ba6bbaca57";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b043f658cf15c6c56baa89365860b19a9f1cead5aecf294df8061139fc8d7c9f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a2b72044b775ec9d6d5c5a204d034bed0cdf056e8d4b1473023d33d21d0c4fac";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "668c0e9ebf19e1fa485772489f8841acbda0e92ffcb5ee35b401109669083ec5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "20aaddd5a34ba135f1dc2af1c81fd6bca86d7e7edd2d9a884da576fa6cb4419d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ad296a830ae24e3773efe42c2d114283b424fcc6171ade4fb2a63a2141c434bf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "e47ec035b19bfa156470ac51a6ce5462fab6ebb6f3ff0769a818c7d0d25a0cb1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "8be3653f01465f430fcb4f532ee698366d7792596c00413469b7bdc71523be33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "5ad31e65b766fab2f072548ee4bfd272c4bd87e535867a5a8b66ed7dc28ee54d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b025f7a2ca3fb38b74410ff8be6780d1b2dd32a7c3f447d15d5f4bfe28655f94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "dd0e3ca93621aeb77306e70435cead2f8996a47b352ea408a2a980470ec9c5ef";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "4d71320736f8f4ca1c7c8f53299977728acee302c5cef1180a24223a19e0b49b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "8e518f0ecc87da513c02428b2aef364deb42cbb9f3fca4e58cc140e1c181d7b3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ec827b3112bd67fcd76566564f158d51ff03e2f925d00e39bf25929abb4289e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6cff401a3627510d535eef507401580d770883d8a43eaa9b27ac4e93ecf7f27c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "6ddcfe6febe6d19be02f286d67098d174d33d9ae7e834b632e3bf947b221778f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "db7f1f41fbed3931afe64539575878a326819471572d08b6cbde0b04b6446ff4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3652f82c79a59bd346ca9b8127c2559a7aec796227716ae75b0fe30cb7ad289b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nerian-stereo/default.nix
+++ b/distros/noetic/nerian-stereo/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, curl, cv-bridge, dynamic-reconfigure, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-nerian-stereo";
-  version = "3.8.1-r1";
+  version = "3.9.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.8.1-1.tar.gz";
-    name = "3.8.1-1.tar.gz";
-    sha256 = "8f11a621aa83524b23965991bd4937589a91c0c07ff44db1e281136c1b4a23a7";
+    url = "https://github.com/nerian-vision/nerian_stereo-release/archive/release/noetic/nerian_stereo/3.9.0-5.tar.gz";
+    name = "3.9.0-5.tar.gz";
+    sha256 = "0f8b2dd99bcbb9052a4363ca0a69fd51c932ac9c0866326c12287b40e6346d44";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs ];
+  propagatedBuildInputs = [ boost curl cv-bridge dynamic-reconfigure message-runtime nodelet roscpp sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Driver node for SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    description = ''Driver node for Scarlet and SceneScan stereo vision sensors by Nerian Vision GmbH'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-opw-kinematics";
-  version = "0.4.0-r1";
+  version = "0.4.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "22a484c86d5a90211d3f76f4ce7c77da3820c4810b7b95568ec89daaec7e54af";
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.1-2.tar.gz";
+    name = "0.4.1-2.tar.gz";
+    sha256 = "c0519833d8b0565a70af7b7deff9aadb734ec782a719a3b0e73811a4d6c64b49";
   };
 
   buildType = "cmake";

--- a/distros/noetic/picovoice-driver/default.nix
+++ b/distros/noetic/picovoice-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, ddynamic-reconfigure, libsndfile, picovoice-msgs, portaudio, roscpp, roslib }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-driver";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "ac192c9f2989d15e9aae2fad6ae471c9ded28d7f31641e305ca04ede5d673501";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_driver/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "7fde59976511d7247a0558dc5ff1c040a381aa1923f8b0279a7cbd94d772d22d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/picovoice-msgs/default.nix
+++ b/distros/noetic/picovoice-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-picovoice-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "edc1f8fc1d0319948bc317df7e0e58490970d3760dc91fdf69ba3a3a418372ab";
+    url = "https://github.com/reinzor/picovoice_ros-release/archive/release/noetic/picovoice_msgs/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "029e8ce3645694b964d6405c19286ff2b9cd24c249d0877ca2a6bde6c416d2b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "bd6938bd65e4ce7089f891af48c54137c07416865b7320460db4e8be56a3f71f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ tf2-eigen ];
+  propagatedBuildInputs = [ moveit-commander moveit-core moveit-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Helper scripts and functionality to test industrial motion generation'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-industrial-motion-planner";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "0ad05c18eb63b71bb5cd37fe73c594f183dc407ab3bb154ae75a599344a105b0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ cmake-modules code-coverage moveit-resources-panda-moveit-config moveit-resources-prbt-moveit-config moveit-resources-prbt-pg70-support moveit-resources-prbt-support pilz-industrial-motion-planner-testutils rostest rosunit ];
+  propagatedBuildInputs = [ joint-limits-interface moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface orocos-kdl pluginlib roscpp tf2 tf2-eigen tf2-geometry-msgs tf2-kdl tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''MoveIt plugin to generate industrial trajectories PTP, LIN, CIRC and sequences thereof.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/razor-imu-9dof/default.nix
+++ b/distros/noetic/razor-imu-9dof/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, python3Packages, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-razor-imu-9dof";
+  version = "1.3.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ENSTABretagneRobotics/razor_imu_9dof-release/archive/release/noetic/razor_imu_9dof/1.3.0-2.tar.gz";
+    name = "1.3.0-2.tar.gz";
+    sha256 = "96b9ff366ac1665105c8473acaf18fc2e6741c2454364150e9160d200560fe25";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.catkin-pkg ];
+  propagatedBuildInputs = [ dynamic-reconfigure python3Packages.pyserial rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''razor_imu_9dof is a package that provides a ROS driver for the Sparkfun OpenLog Artemis, 9DoF Razor IMU M0, 9DOF Razor IMU and 9DOF Sensor Stick. It also provides Arduino firmware that runs on the board, and which must be installed on it for the system to work. A node which displays the attitude (roll, pitch and yaw) of the board (or any IMU) is provided for testing.'';
+    license = with lib.licenses; [ bsdOriginal gpl3 ];
+  };
+}

--- a/distros/noetic/rqt-dep/default.nix
+++ b/distros/noetic/rqt-dep/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-dep";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "a6da024e6e8455f588ec1ea3622db81a0d49c6c57592a6a0b896f353a1931715";
+    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "ae71c5531c73809ccf544bba2899cbd2d916deccd75e03689479d2b1d0d0b72d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-imu-plugin/default.nix
+++ b/distros/noetic/rviz-imu-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, roscpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rviz-imu-plugin";
-  version = "1.2.2-r1";
+  version = "1.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.2-1.tar.gz";
-    name = "1.2.2-1.tar.gz";
-    sha256 = "8541afeb218d867cff4f3ab02461a87006333db6913ae74b642dabebd6f11d7f";
+    url = "https://github.com/uos-gbp/imu_tools-release/archive/release/noetic/rviz_imu_plugin/1.2.3-1.tar.gz";
+    name = "1.2.3-1.tar.gz";
+    sha256 = "9126da97631404722996aaec8fde11f96a3e4d897839e8be62304130fdba8555";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.6-r1";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.6-1.tar.gz";
-    name = "1.14.6-1.tar.gz";
-    sha256 = "d32a1a35764906a7cc12782d0cf5d057e23ddd337380ea8a6cb372de80184d51";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "8a5af0440229aba171490192afffc54085630f9a8aabb93f2ea52a4fa69c001b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/simple-grasping/default.nix
+++ b/distros/noetic/simple-grasping/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt4 }:
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, cmake-modules, geometry-msgs, grasping-msgs, message-generation, message-runtime, moveit-msgs, moveit-python, pcl-ros, roscpp, sensor-msgs, shape-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-noetic-simple-grasping";
   version = "0.4.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation ];
-  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt4 ];
+  propagatedBuildInputs = [ actionlib geometry-msgs grasping-msgs message-runtime moveit-msgs moveit-python pcl-ros roscpp sensor-msgs shape-msgs tf vtkWithQt5 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/slam-toolbox-msgs/default.nix
+++ b/distros/noetic/slam-toolbox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-msgs";
-  version = "1.5.4-r1";
+  version = "1.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.4-1.tar.gz";
-    name = "1.5.4-1.tar.gz";
-    sha256 = "80f5a3a302f97f8ee2fea7811f2219aa0133a6fc380889e7c01ee544a4036fe8";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_msgs/1.5.5-1.tar.gz";
+    name = "1.5.5-1.tar.gz";
+    sha256 = "31803abdc1cfc3b09410c3a9297261c30b43f484c3aab05f91e168f3a11c9ef9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox-rviz/default.nix
+++ b/distros/noetic/slam-toolbox-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qt5, rviz, slam-toolbox-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox-rviz";
-  version = "1.5.4-r1";
+  version = "1.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.4-1.tar.gz";
-    name = "1.5.4-1.tar.gz";
-    sha256 = "cba8368f4f81024e58df96e1056aa2999da330e97e7afd0e5dee95b6475675df";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox_rviz/1.5.5-1.tar.gz";
+    name = "1.5.5-1.tar.gz";
+    sha256 = "547300395d1b6983a62705d3611ec7f7c5f5892e49f026b5ce105f7dd47d3a95";
   };
 
   buildType = "catkin";

--- a/distros/noetic/slam-toolbox/default.nix
+++ b/distros/noetic/slam-toolbox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ceres-solver, cmake-modules, eigen, gtest, interactive-markers, libg2o, liblapack, map-server, message-filters, message-runtime, nav-msgs, pluginlib, qt5, rosconsole, roscpp, sensor-msgs, slam-toolbox-msgs, sparse-bundle-adjustment, std-msgs, std-srvs, suitesparse, tbb, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-slam-toolbox";
-  version = "1.5.4-r1";
+  version = "1.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.4-1.tar.gz";
-    name = "1.5.4-1.tar.gz";
-    sha256 = "b83aaf537b11a2a9db36fb12fe720bd2868e91f0da6202f7de12360d3758d02a";
+    url = "https://github.com/SteveMacenski/slam_toolbox-release/archive/release/noetic/slam_toolbox/1.5.5-1.tar.gz";
+    name = "1.5.5-1.tar.gz";
+    sha256 = "549b5ea6ce1834562da8b90f288ac6f3b0d50b97e00ce5a70c4e282efe1d40ec";
   };
 
   buildType = "catkin";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, ros-industrial-cmake-boilerplate, tinyxml-2 }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-common";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "2fdefdd90889c18262674dd77f35cae10d060925fa735a062563f33b60de8bd1";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ clang gtest lcov ];
+  propagatedBuildInputs = [ boost console-bridge eigen tinyxml-2 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Contains common macros, utils and types used throughout'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-geometry";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "67bdb418c137fe3d7cf4c96aac1d81251c66da77de513c33b76515479d728905";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest tesseract-support ];
+  propagatedBuildInputs = [ assimp console-bridge eigen octomap tesseract-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_geometry package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-kinematics";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "315c370363569719db8f2ce0804467294cc20877d757bb7c7386ebd1ec8f71c0";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest tesseract-support tesseract-urdf ];
+  propagatedBuildInputs = [ console-bridge eigen opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_kinematics package contains kinematics related libraries.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-scene-graph";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "f420f16550dd7765b740c9cf3d0b6da28bfbd0f584d79c1d3df46ae7823adf96";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest tesseract-support ];
+  propagatedBuildInputs = [ boost console-bridge eigen orocos-kdl tesseract-common tesseract-geometry ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_scene_graph package'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-support";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "d5a8fb78a67a451407c0a140d7ed5850b520c300802517bc72fef3f6a86ef85c";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  propagatedBuildInputs = [ tesseract-common ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_support package containing files for test and examples'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-urdf";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "36ac730980015be09d6f8e1d201dca295a6459d4a777b9bac005924c8d49af93";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest tesseract-support ];
+  propagatedBuildInputs = [ console-bridge eigen tesseract-collision tesseract-common tesseract-geometry tesseract-scene-graph ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_urdf package for parsing tesseract specific urdf'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-visualization";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "c7e1ef6833a06ed49a573b20dce540915c5c7f78b7822f49f25a72d679fd10d5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  propagatedBuildInputs = [ console-bridge eigen tesseract-collision tesseract-common tesseract-environment tesseract-scene-graph ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_visualization package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 0d3aca6651c13bca684339a40f6f13d3f90066aa.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *dynamixel-sdk 3.7.30-r1 --> 3.7.40-r10*
* *dynamixel-sdk-custom-interfaces 3.7.40-r10*
* *dynamixel-sdk-examples 3.7.40-r10*
* *slam-toolbox 2.0.3-r1 --> 2.0.4-r1*

Foxy Changes:
-------------
* *actionlib-msgs 2.0.3-r1 --> 2.0.4-r1*
* *class-loader 2.0.1-r1 --> 2.0.2-r1*
* *common-interfaces 2.0.3-r1 --> 2.0.4-r1*
* *connext-cmake-module 1.0.2-r1 --> 1.0.3-r1*
* *console-bridge-vendor 1.2.3-r1 --> 1.2.4-r1*
* *diagnostic-msgs 2.0.3-r1 --> 2.0.4-r1*
* *dynamixel-sdk 3.7.30-r1 --> 3.7.40-r3*
* *dynamixel-sdk-custom-interfaces 3.7.40-r3*
* *dynamixel-sdk-examples 3.7.40-r3*
* *examples-tf2-py 0.13.9-r1 --> 0.13.10-r1*
* *fastrtps-cmake-module 1.0.2-r1 --> 1.0.3-r1*
* *gazebo-dev 3.5.0-r2 --> 3.5.3-r1*
* *gazebo-msgs 3.5.0-r2 --> 3.5.3-r1*
* *gazebo-plugins 3.5.0-r2 --> 3.5.3-r1*
* *gazebo-ros 3.5.0-r2 --> 3.5.3-r1*
* *gazebo-ros-pkgs 3.5.0-r2 --> 3.5.3-r1*
* *geometric-shapes 2.0.0-r1 --> 2.0.1-r1*
* *geometry-msgs 2.0.3-r1 --> 2.0.4-r1*
* *geometry2 0.13.9-r1 --> 0.13.10-r1*
* *launch 0.10.4-r1 --> 0.10.5-r1*
* *launch-ros 0.11.1-r1 --> 0.11.2-r1*
* *launch-testing 0.10.4-r1 --> 0.10.5-r1*
* *launch-testing-ament-cmake 0.10.4-r1 --> 0.10.5-r1*
* *launch-testing-ros 0.11.1-r1 --> 0.11.2-r1*
* *launch-xml 0.10.4-r1 --> 0.10.5-r1*
* *launch-yaml 0.10.4-r1 --> 0.10.5-r1*
* *libyaml-vendor 1.0.3-r1 --> 1.0.4-r1*
* *mimick-vendor 0.2.3-r1 --> 0.2.6-r1*
* *moveit 2.1.1-r1*
* *moveit-common 2.1.0-r1 --> 2.1.1-r1*
* *moveit-fake-controller-manager 2.1.0-r1 --> 2.1.1-r1*
* *moveit-kinematics 2.1.0-r1 --> 2.1.1-r1*
* *moveit-planners 2.1.1-r1*
* *moveit-plugins 2.1.1-r1*
* *moveit-resources 2.0.0-r1 --> 2.0.1-r1*
* *moveit-resources-fanuc-description 2.0.0-r1 --> 2.0.1-r1*
* *moveit-resources-fanuc-moveit-config 2.0.0-r1 --> 2.0.1-r1*
* *moveit-resources-panda-description 2.0.0-r1 --> 2.0.1-r1*
* *moveit-resources-panda-moveit-config 2.0.0-r1 --> 2.0.1-r1*
* *moveit-resources-pr2-description 2.0.0-r1 --> 2.0.1-r1*
* *moveit-ros 2.1.1-r1*
* *moveit-ros-benchmarks 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-move-group 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-occupancy-map-monitor 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-planning 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-planning-interface 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-robot-interaction 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-visualization 2.1.0-r1 --> 2.1.1-r1*
* *moveit-ros-warehouse 2.1.0-r1 --> 2.1.1-r1*
* *moveit-runtime 2.1.1-r1*
* *moveit-servo 2.1.0-r1 --> 2.1.1-r1*
* *moveit-simple-controller-manager 2.1.0-r1 --> 2.1.1-r1*
* *nav-msgs 2.0.3-r1 --> 2.0.4-r1*
* *osqp-vendor 0.0.2-r1 --> 0.0.3-r2*
* *rcl 1.1.10-r1 --> 1.1.11-r1*
* *rcl-action 1.1.10-r1 --> 1.1.11-r1*
* *rcl-lifecycle 1.1.10-r1 --> 1.1.11-r1*
* *rcl-logging-log4cxx 1.0.1-r1 --> 1.1.0-r1*
* *rcl-logging-noop 1.0.1-r1 --> 1.1.0-r1*
* *rcl-logging-spdlog 1.0.1-r1 --> 1.1.0-r1*
* *rcl-yaml-param-parser 1.1.10-r1 --> 1.1.11-r1*
* *rclcpp 2.3.0-r1 --> 2.3.1-r1*
* *rclcpp-action 2.3.0-r1 --> 2.3.1-r1*
* *rclcpp-components 2.3.0-r1 --> 2.3.1-r1*
* *rclcpp-lifecycle 2.3.0-r1 --> 2.3.1-r1*
* *rcutils 1.1.2-r1 --> 1.1.3-r1*
* *rmw 1.0.2-r1 --> 1.0.3-r1*
* *rmw-dds-common 1.0.2-r1 --> 1.0.3-r1*
* *rmw-fastrtps-cpp 1.2.4-r1 --> 1.2.5-r1*
* *rmw-fastrtps-dynamic-cpp 1.2.4-r1 --> 1.2.5-r1*
* *rmw-fastrtps-shared-cpp 1.2.4-r1 --> 1.2.5-r1*
* *rmw-implementation 1.0.1-r1 --> 1.0.2-r1*
* *rmw-implementation-cmake 1.0.2-r1 --> 1.0.3-r1*
* *ros2launch 0.11.1-r1 --> 0.11.2-r1*
* *rosidl-adapter 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-cmake 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-default-generators 1.0.0-r1 --> 1.0.1-r1*
* *rosidl-default-runtime 1.0.0-r1 --> 1.0.1-r1*
* *rosidl-generator-c 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-generator-cpp 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-parser 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-runtime-c 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-runtime-cpp 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-typesupport-c 1.0.1-r1 --> 1.0.2-r1*
* *rosidl-typesupport-connext-c 1.0.2-r1 --> 1.0.3-r1*
* *rosidl-typesupport-connext-cpp 1.0.2-r1 --> 1.0.3-r1*
* *rosidl-typesupport-cpp 1.0.1-r1 --> 1.0.2-r1*
* *rosidl-typesupport-fastrtps-c 1.0.2-r1 --> 1.0.3-r1*
* *rosidl-typesupport-fastrtps-cpp 1.0.2-r1 --> 1.0.3-r1*
* *rosidl-typesupport-interface 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-typesupport-introspection-c 1.2.0-r1 --> 1.2.1-r1*
* *rosidl-typesupport-introspection-cpp 1.2.0-r1 --> 1.2.1-r1*
* *rqt 1.0.7-r1 --> 1.1.1-r1*
* *rqt-graph 1.1.1-r1 --> 1.1.2-r1*
* *rqt-gui 1.0.7-r1 --> 1.1.1-r1*
* *rqt-gui-cpp 1.0.7-r1 --> 1.1.1-r1*
* *rqt-gui-py 1.0.7-r1 --> 1.1.1-r1*
* *rqt-msg 1.0.2-r1 --> 1.0.3-r1*
* *rqt-py-common 1.0.7-r1 --> 1.1.1-r1*
* *run-move-group 2.1.0-r1 --> 2.1.1-r1*
* *run-moveit-cpp 2.1.0-r1 --> 2.1.1-r1*
* *run-ompl-constrained-planning 2.1.1-r1*
* *rviz-visual-tools 4.0.0-r1*
* *sensor-msgs 2.0.3-r1 --> 2.0.4-r1*
* *sensor-msgs-py 2.0.4-r1*
* *shape-msgs 2.0.3-r1 --> 2.0.4-r1*
* *slam-toolbox 2.3.0-r1 --> 2.4.0-r1*
* *spdlog-vendor 1.1.2-r1 --> 1.1.3-r1*
* *srdfdom 2.0.0-r1 --> 2.0.1-r1*
* *std-msgs 2.0.3-r1 --> 2.0.4-r1*
* *std-srvs 2.0.3-r1 --> 2.0.4-r1*
* *stereo-msgs 2.0.3-r1 --> 2.0.4-r1*
* *test-rmw-implementation 1.0.2-r1*
* *tf2 0.13.9-r1 --> 0.13.10-r1*
* *tf2-bullet 0.13.9-r1 --> 0.13.10-r1*
* *tf2-eigen 0.13.9-r1 --> 0.13.10-r1*
* *tf2-eigen-kdl 0.13.9-r1 --> 0.13.10-r1*
* *tf2-geometry-msgs 0.13.9-r1 --> 0.13.10-r1*
* *tf2-kdl 0.13.9-r1 --> 0.13.10-r1*
* *tf2-msgs 0.13.9-r1 --> 0.13.10-r1*
* *tf2-py 0.13.9-r1 --> 0.13.10-r1*
* *tf2-ros 0.13.9-r1 --> 0.13.10-r1*
* *tf2-sensor-msgs 0.13.9-r1 --> 0.13.10-r1*
* *tf2-tools 0.13.9-r1 --> 0.13.10-r1*
* *trajectory-msgs 2.0.3-r1 --> 2.0.4-r1*
* *unique-identifier-msgs 2.1.2-r1 --> 2.1.3-r1*
* *visualization-msgs 2.0.3-r1 --> 2.0.4-r1*
* *webots-ros2 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-abb 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-core 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-demos 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-epuck 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-examples 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-msgs 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-tesla 1.0.6-r1*
* *webots-ros2-tiago 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-turtlebot 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-tutorials 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-universal-robot 1.0.5-r1 --> 1.0.6-r1*
* *webots-ros2-ur-e-description 1.0.5-r1 --> 1.0.6-r1*

Kinetic Changes:
----------------
* *genpy 0.6.14-r1 --> 0.6.15-r1*
* *libphidget21 0.7.10-r1 --> 0.7.11-r1*
* *nerian-stereo 3.8.0-r1 --> 3.9.0-r3*
* *phidgets-api 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-drivers 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-high-speed-encoder 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-ik 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-imu 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-msgs 0.7.10-r1 --> 0.7.11-r1*
* *python-qt-binding 0.3.7-r1 --> 0.3.8-r1*
* *qt-dotgraph 0.3.17-r1 --> 0.3.18-r1*
* *qt-gui 0.3.17-r1 --> 0.3.18-r1*
* *qt-gui-app 0.3.17-r1 --> 0.3.18-r1*
* *qt-gui-core 0.3.17-r1 --> 0.3.18-r1*
* *qt-gui-cpp 0.3.17-r1 --> 0.3.18-r1*
* *qt-gui-py-common 0.3.17-r1 --> 0.3.18-r1*
* *razor-imu-9dof 1.2.0 --> 1.3.0-r2*

Melodic Changes:
----------------
* *drone-assets 1.3.7-r3 --> 1.3.8-r1*
* *drone-wrapper 1.3.7-r3 --> 1.3.8-r1*
* *genpy 0.6.14-r1 --> 0.6.15-r1*
* *imu-complementary-filter 1.2.2-r1 --> 1.2.3-r1*
* *imu-filter-madgwick 1.2.2-r1 --> 1.2.3-r1*
* *imu-tools 1.2.2-r1 --> 1.2.3-r1*
* *iris-lama 1.1.0-r2 --> 1.2.0-r1*
* *iris-lama-ros 1.1.0-r1 --> 1.2.0-r1*
* *jderobot-drones 1.3.7-r3 --> 1.3.8-r1*
* *libphidget21 0.7.10-r1 --> 0.7.11-r1*
* *move-basic 0.4.1-r1*
* *nerian-stereo 3.8.0-r1 --> 3.9.0-r3*
* *phidgets-api 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-drivers 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-high-speed-encoder 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-ik 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-imu 0.7.10-r1 --> 0.7.11-r1*
* *phidgets-msgs 0.7.10-r1 --> 0.7.11-r1*
* *razor-imu-9dof 1.3.0-r2*
* *rqt-drone-teleop 1.3.7-r3 --> 1.3.8-r1*
* *rqt-ground-robot-teleop 1.3.7-r3 --> 1.3.8-r1*
* *rviz 1.13.16-r1 --> 1.13.17-r1*
* *rviz-imu-plugin 1.2.2-r1 --> 1.2.3-r1*
* *volta-simulation 1.1.1-r1 --> 1.1.0-r2*

Noetic Changes:
---------------
* *chomp-motion-planner 1.1.1-r1 --> 1.1.2-r1*
* *genpy 0.6.14-r1 --> 0.6.15-r1*
* *hector-compressed-map-transport 0.5.1-r1 --> 0.5.2-r4*
* *hector-geotiff 0.5.1-r1 --> 0.5.2-r4*
* *hector-geotiff-launch 0.5.1-r1 --> 0.5.2-r4*
* *hector-geotiff-plugins 0.5.1-r1 --> 0.5.2-r4*
* *hector-imu-attitude-to-tf 0.5.1-r1 --> 0.5.2-r4*
* *hector-imu-tools 0.5.1-r1 --> 0.5.2-r4*
* *hector-map-server 0.5.1-r1 --> 0.5.2-r4*
* *hector-map-tools 0.5.1-r1 --> 0.5.2-r4*
* *hector-mapping 0.5.1-r1 --> 0.5.2-r4*
* *hector-marker-drawing 0.5.1-r1 --> 0.5.2-r4*
* *hector-nav-msgs 0.5.1-r1 --> 0.5.2-r4*
* *hector-slam 0.5.1-r1 --> 0.5.2-r4*
* *hector-slam-launch 0.5.1-r1 --> 0.5.2-r4*
* *hector-trajectory-server 0.5.1-r1 --> 0.5.2-r4*
* *imu-complementary-filter 1.2.2-r1 --> 1.2.3-r1*
* *imu-filter-madgwick 1.2.2-r1 --> 1.2.3-r1*
* *imu-tools 1.2.2-r1 --> 1.2.3-r1*
* *iris-lama 1.1.0-r1 --> 1.2.0-r1*
* *iris-lama-ros 1.1.0-r1 --> 1.2.0-r1*
* *moveit 1.1.1-r1 --> 1.1.2-r1*
* *moveit-chomp-optimizer-adapter 1.1.1-r1 --> 1.1.2-r1*
* *moveit-core 1.1.1-r1 --> 1.1.2-r1*
* *moveit-fake-controller-manager 1.1.1-r1 --> 1.1.2-r1*
* *moveit-kinematics 1.1.1-r1 --> 1.1.2-r1*
* *moveit-msgs 0.11.1-r1 --> 0.11.2-r1*
* *moveit-planners 1.1.1-r1 --> 1.1.2-r1*
* *moveit-planners-chomp 1.1.1-r1 --> 1.1.2-r1*
* *moveit-planners-ompl 1.1.1-r1 --> 1.1.2-r1*
* *moveit-plugins 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-benchmarks 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-control-interface 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-manipulation 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-move-group 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-occupancy-map-monitor 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-planning 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-planning-interface 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-robot-interaction 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-visualization 1.1.1-r1 --> 1.1.2-r1*
* *moveit-ros-warehouse 1.1.1-r1 --> 1.1.2-r1*
* *moveit-runtime 1.1.1-r1 --> 1.1.2-r1*
* *moveit-servo 1.1.1-r1 --> 1.1.2-r1*
* *moveit-setup-assistant 1.1.1-r1 --> 1.1.2-r1*
* *moveit-simple-controller-manager 1.1.1-r1 --> 1.1.2-r1*
* *nerian-stereo 3.8.1-r1 --> 3.9.0-r5*
* *opw-kinematics 0.4.0-r1 --> 0.4.1-r2*
* *picovoice-driver 0.0.3-r1 --> 0.0.4-r1*
* *picovoice-msgs 0.0.3-r1 --> 0.0.4-r1*
* *pilz-industrial-motion-planner 1.1.2-r1*
* *pilz-industrial-motion-planner-testutils 1.1.2-r1*
* *razor-imu-9dof 1.3.0-r2*
* *rqt-dep 0.4.10-r1 --> 0.4.11-r1*
* *rviz 1.14.6-r1 --> 1.14.7-r1*
* *rviz-imu-plugin 1.2.2-r1 --> 1.2.3-r1*
* *slam-toolbox 1.5.4-r1 --> 1.5.5-r1*
* *slam-toolbox-msgs 1.5.4-r1 --> 1.5.5-r1*
* *slam-toolbox-rviz 1.5.4-r1 --> 1.5.5-r1*
* *tesseract-common 0.3.0-r1*
* *tesseract-geometry 0.3.0-r1*
* *tesseract-kinematics 0.3.0-r1*
* *tesseract-scene-graph 0.3.0-r1*
* *tesseract-support 0.3.0-r1*
* *tesseract-urdf 0.3.0-r1*
* *tesseract-visualization 0.3.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] iwyu
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libgstreamer-plugins-base0.10-dev
 * [ ] libgstreamer0.10-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libsoqt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] message_generation
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rosinstall
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rostime
 * [ ] rviz
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

