### PR TITLE
rosdistro sync, Fri Apr 30 12:50:24 2021

### DIFF
--- a/distros/dashing/hls-lfcd-lds-driver/default.nix
+++ b/distros/dashing/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-hls-lfcd-lds-driver";
-  version = "2.0.1-r1";
+  version = "2.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "a70559ce1e1a78ad3e8578781acdd151065e0067faa2292127cd811d1d7ba1f8";
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "a8a86f9afe5bffd509761a72a4491e030d78800164fccb7234f96da212f6c0c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-package/default.nix
+++ b/distros/foxy/ament-package/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-package";
-  version = "0.9.4-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/foxy/ament_package/0.9.4-1.tar.gz";
-    name = "0.9.4-1.tar.gz";
-    sha256 = "84219be6b42aeb1888041a18448ec08fbe176658419241d6c71576bc95e89772";
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/foxy/ament_package/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "7bee9d1107c1e922899d7883be41672051bf34383daca36bb53628bf26f73830";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/gazebo-ros2-control-demos/default.nix
+++ b/distros/foxy/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, std-msgs, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control-demos";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "0aa94bfccea3be2f45b9b8a26f1dc128b8986ef9ebab7ebdbe321b5ce64438c3";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "387fb517b9ba623dc78b893317eeae84f7e78d90d1871fc3b803f7b43fee636d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher std-msgs velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-controllers std-msgs velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/gazebo-ros2-control/default.nix
+++ b/distros/foxy/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "3df932b76645e5c35d33a915baa5f445f85aa8108245a544da89377f2312c9ca";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "bccf46c151e93760cf2da7db4bb899aba9df87133ee49e7268e07ef56a18cbd1";
   };
 
   buildType = "ament_cmake";
@@ -20,6 +20,6 @@ buildRosPackage {
 
   meta = {
     description = ''gazebo_ros2_control'';
-    license = with lib.licenses; [ bsdOriginal ];
+    license = with lib.licenses; [ bsdOriginal asl20 ];
   };
 }

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -726,6 +726,8 @@ self: super: {
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
+ nerian-stereo = self.callPackage ./nerian-stereo {};
+
  nmea-msgs = self.callPackage ./nmea-msgs {};
 
  nodl-python = self.callPackage ./nodl-python {};
@@ -749,6 +751,8 @@ self: super: {
  ompl = self.callPackage ./ompl {};
 
  openvslam = self.callPackage ./openvslam {};
+
+ openzen-driver = self.callPackage ./openzen-driver {};
 
  oroca-rqt-command = self.callPackage ./oroca-rqt-command {};
 
@@ -1250,6 +1254,8 @@ self: super: {
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
+ slider-publisher = self.callPackage ./slider-publisher {};
+
  smac-planner = self.callPackage ./smac-planner {};
 
  smclib = self.callPackage ./smclib {};
@@ -1305,6 +1311,8 @@ self: super: {
  system-modes = self.callPackage ./system-modes {};
 
  system-modes-examples = self.callPackage ./system-modes-examples {};
+
+ system-modes-msgs = self.callPackage ./system-modes-msgs {};
 
  tango-icons-vendor = self.callPackage ./tango-icons-vendor {};
 

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "cbedd518662aff3acc2bdeddb2fdcf2388c3005d11f8c04cc07b1d04c7c767c6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "76472d0dde04cd11ea7b7ee33c07aa0620250209d5ffd8c7045997e3c6774819";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-fake-controller-manager/default.nix
+++ b/distros/foxy/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-ros-planning, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-moveit-fake-controller-manager";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_fake_controller_manager/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "efa24081b3098a2ac423a880448fb3d7c8d2afd7b05ddcec5303d4cad884e430";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_fake_controller_manager/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "2cb09e897652224670653411411e86186082e6d5f325584b1e441b74c7ce6487";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "f331e13f93ecb2a3fa851d3495441c522cdea200c81423aa4f4de6e47aeb1a57";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "ea0a13337d89a78ef4b909de27404c3ad463477453c01f1d53f0e9abb8e580ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "b343ad606e88866a5899d9f6bc1219c3295fab52ba44f33ab5ef6c1efc8e06c1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b43fdebbf0e15048f39d5087ca323390707a0a179e215bf111903a00c3a27b59";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-fake-controller-manager, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "698825d3526cf60d07ba62169e51089220c9483e6218087066967bffe76c5d08";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "065f5496118fe825db90972d427806ced28fd1f67b97d38df249487caa8ab9f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "811235eb021e3920849257f17d133423633e85c1aa86c988470c392945d6daf8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "3f2b80b699fe0b92d92976f7d433c11367345a59155536350b75a02604e4fd06";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "360051e6ab72f002925e38f03c058eda88bf4ff7acf28953d545ad88e3044b99";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b0ed2ec65f41a605bedbd2d023f661382ddf2409f7f2d294baee2d12f7f63312";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "d66e79a419b6146906fd7afb38ebb1e2536a0951106b50c8fa84ebed72e4a666";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b7eb40b64d471d42402fa17cae84df0611fcc9edc84dc6efadc72566932a6b2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, warehouse-ros-mongo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "546ecb1a08062ee5d68be862037f6f014be323740492883a05338bd681ce1340";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "18db69841648f6790db4e9232cbcc7a046d3ad73000c41829060cd1975f4b832";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 warehouse-ros-mongo ];
-  propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "c9a38c71b903bbac5caf74f09b168a5cc3f3d19aa6ead52d471be56a9b6eee8f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "b10de68bbe7f35378ac8b15a5f5b9a2e62881df1b02cf809211a3abbe0f476eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "2908129f2016bd7b6a50a206a8bb4442eda78a8aab5f4a617401a0d98f29473a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "5636e2770296b937f08c98f820d775316e1380f30e65825aed8799f819ba9d9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "63e51a2b8f63b89f707f461bc8803e339345892900100bc438e1de04f62aac11";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "6f62f1872faedf1263c7f4f91de5942eb74600d6f1b90e6db1e101eba11fc744";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "a5c8764143db3f929c505dfbdcf1dffcc7d831593e2640df21f77d29424a513f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "de7788c67778b661101c1469730d4eec1512bd75366a9d36c1a8bdb2debb30a6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "291754cf475bb9aea7da7b3bfbbae7de481350fe477e6bb10884570db1092c20";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "5c9cec1db1b9e25d5ef854b359f3353096c4dd5946f231d78388d3404d3d349c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "650b62973891dce0e81b251a259ce519340f13212fef5e504e44cdb3454d6903";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "3232e69df937211a308f717ba78d388c76d78bc9b20b9ba786d885faf12ac8f7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "0688f57db257ebd99f3e0547b890b3bff2e80cfc492a63a7811ee81d2ef75abc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "c14e7b9c0bcbd43011b4ee1ab45a46d766469fb3839576d72f4b8aae5ab51c5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "82732040fe73b23d25655ee5ec246ad419b9033e2eb0d139a355a85cc36e4212";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "3a6748bf949fb11aebadeee0d41f2a9a1bd1c2531bda0773f5a68456426dc6ad";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "1d5939a4c3d4117a29289466e9029ed3aee0af3a91933087d411f6713b0379f1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "4472e96b86b4afe5de7a81f6374d432450c58814ef553019328250568d21839e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-nerian-stereo";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4ceb088ea3090011cc5de3eb335197491d99860d238f8fcb1c0d269aaffa7e9b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/openzen-driver/default.nix
+++ b/distros/foxy/openzen-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-testing, rclcpp, rqt-plot, sensor-msgs, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-foxy-openzen-driver";
+  version = "1.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/lp-research/openzen_sensor_ros2-release/archive/release/foxy/openzen_driver/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "13508ba2db05e446942b792dc0539e06546470a9071cb24c3543db431e3035f0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ launch launch-testing ];
+  propagatedBuildInputs = [ rclcpp rqt-plot sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 Driver for LP-Research inertial measurement units and satellite navigation senors'';
+    license = with lib.licenses; [ mit boost lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/foxy/rqt-msg/default.nix
+++ b/distros/foxy/rqt-msg/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-msg";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "6ce023ae638defd6ed5f9e1253f4d15db896e96b139f08114d73e4af1cfb2a42";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "cb2fc6d9c49fc2db31e3c28615d994fcbf3eb896682577abbf7ab7d1f3fa4a54";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg rclpy rqt-console rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''A Python GUI plugin for introspecting available ROS message types.

--- a/distros/foxy/rqt-plot/default.nix
+++ b/distros/foxy/rqt-plot/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rqt-plot";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "956100cd548a6540b7311f68d0da39e3d5c22588ae1ef93ee769e69c0388916c";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "975d869e369a098157b3a097780d951c1e9e6732beda66c9444acee9a1d20e87";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg python3Packages.matplotlib python3Packages.numpy qt-gui-py-common rclpy rqt-gui rqt-gui-py rqt-py-common std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_plot provides a GUI plugin visualizing numeric values in a 2D plot using different plotting backends.'';

--- a/distros/foxy/rqt-publisher/default.nix
+++ b/distros/foxy/rqt-publisher/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-publisher";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "2c7b4a8994f7e70d35404c550a69a0e77d6bef71c666797b145c72cf96628cf8";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "9001466e4057b2cb174aab4a7e41916b6d15f53ba1f8a351b17d8cdf080a0117";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg qt-gui-py-common rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_publisher provides a GUI plugin for publishing arbitrary messages with fixed or computed field values.'';

--- a/distros/foxy/rqt-py-console/default.nix
+++ b/distros/foxy/rqt-py-console/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-py-console";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/foxy/rqt_py_console/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "538d88a7424dcdd3266aee56e2dc0b8e94433287e56ba902f8b953a8cf1e806e";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/foxy/rqt_py_console/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1f8ca426804703dce0530abddfa66a3ec9fff96a7038a953793c8ba6f6df81ef";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ ament-index-python python-qt-binding qt-gui qt-gui-py-common rclpy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_py_console is a Python GUI plugin providing an interactive Python console.'';

--- a/distros/foxy/rqt-service-caller/default.nix
+++ b/distros/foxy/rqt-service-caller/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rqt-gui, rqt-gui-py, rqt-py-common }:
+{ lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-service-caller";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/foxy/rqt_service_caller/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d2a4f3faacd84fabf25ae3e83193880fd3d8918c02b6727eadad513a18284afe";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/foxy/rqt_service_caller/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9dc34d9e41b2ceed4825eefc80c45e3c8e691a35abce7aef02bf85ba9259c38d";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ rqt-gui rqt-gui-py rqt-py-common ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_service_caller provides a GUI plugin for calling arbitrary services.'';

--- a/distros/foxy/rqt-shell/default.nix
+++ b/distros/foxy/rqt-shell/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-shell";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/foxy/rqt_shell/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "cb484c1f639838bed4404c98d8ad4950d2276705d55f34c03d4b3c87772fc98f";
+    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/foxy/rqt_shell/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c442c88a2ab6b2599b18253df950b86398a0b790fe2fe52133890b6f38863e2f";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ python-qt-binding python3Packages.catkin-pkg qt-gui qt-gui-py-common rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''rqt_shell is a Python GUI plugin providing an interactive shell.'';

--- a/distros/foxy/rqt-srv/default.nix
+++ b/distros/foxy/rqt-srv/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, rclpy, rqt-gui, rqt-gui-py, rqt-msg }:
+{ lib, buildRosPackage, fetchurl, rclpy, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-foxy-rqt-srv";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/foxy/rqt_srv/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "5c4fb97379ed52db252a1d5cdeb059fe45c495b6f312459a85cbe1d3964b55b6";
+    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/foxy/rqt_srv/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "1c5dcfcc4583b81a4525ee5451701d0cb7c0e271a5b472b4cea8674c78747b9f";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ rclpy rqt-gui rqt-gui-py rqt-msg ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''A Python GUI plugin for introspecting available ROS message types.

--- a/distros/foxy/rqt-top/default.nix
+++ b/distros/foxy/rqt-top/default.nix
@@ -2,20 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
+{ lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-top";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/foxy/rqt_top/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f5eeca2a342a2275facc5e35a5099840ad99cb28b26c694afe3fac67dfa49289";
+    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/foxy/rqt_top/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "cfd078a9e077da41da7f379b523a9a282a36c88304ed1397df746f3a5af4abd4";
   };
 
-  buildType = "ament_cmake";
+  buildType = "ament_python";
   propagatedBuildInputs = [ python-qt-binding python3Packages.psutil rclpy rqt-gui rqt-gui-py ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''RQT plugin for monitoring ROS processes.'';

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "af84ec6768b2bd6e28b9cc6a2f92e98f09ca87e84b53583dfdfff61dd0528182";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "453800a49b924ceb2fbfd7b49965b45e76614e4277f3fefafaecfb3d6193fb84";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "066098a94c6903a98a9fe087fe651349e30f27a65755aa3d064a045d863bb74b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "43a5b275045c23620d0e92ebf2d2d15faee9b2218a931729781a2c46387ed4ae";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.1.1-r1";
+  version = "2.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.1-1.tar.gz";
-    name = "2.1.1-1.tar.gz";
-    sha256 = "aec3e638945d1dff4eaa20ac5c989d16e7e2da3f26463fd77478efc8b822b712";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "36792a10043df1d68cd25acb71cb7984d6416d1854ea293166353ae5442ab6ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.0.2-r1";
+  version = "1.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "22079e33c9597f1fdd2da1f08db2f4073cffe4fa55f5083b3b0bcf325cbe22da";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.3-2.tar.gz";
+    name = "1.0.3-2.tar.gz";
+    sha256 = "5c005f945b9c18437a4f9ba844e2a0ca4e19c43f7b51df69a18279599b78f0ea";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/slider-publisher/default.nix
+++ b/distros/foxy/slider-publisher/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-foxy-slider-publisher";
+  version = "1.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/foxy/slider_publisher/1.0.2-2.tar.gz";
+    name = "1.0.2-2.tar.gz";
+    sha256 = "32cd644d8107e3573bc68eaa103ce05de211dab7532f9350b77fbfe9e0465bd8";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ rqt-gui-py ];
+
+  meta = {
+    description = ''This packages proposes a slider-based publisher node similar to the joint_state_publisher, but that can publish any type of message.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.6.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "c3226911ead17f5c2395832fbb08ab2f0740665ed5465f0d7cf29193a543d605";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "ebc8c82e6fc12ee28422be3e70baa2e8759582e5783ab906705b883a9b21d891";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
-  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ros2launch system-modes ];
+  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/system-modes-msgs/default.nix
+++ b/distros/foxy/system-modes-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, builtin-interfaces, rosidl-default-generators }:
+buildRosPackage {
+  pname = "ros-foxy-system-modes-msgs";
+  version = "0.7.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "4ff87f11a757b85a17a27a8f129f6aa14749005e6a197a2154e5c1155ea3ca66";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-lint-auto ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Interface package, containing message definitions and service definitions
+    for the system modes package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, rosidl-default-generators, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.6.0-r1";
+  version = "0.7.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "0f100d44cce9d7043cab8b5d1241a506e11b5a30eb2eca9087f85e0a1086b0a9";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-2.tar.gz";
+    name = "0.7.1-2.tar.gz";
+    sha256 = "4ed0d952b61b9ae5e077f88be6cc2188ff6d0d8bb2dc95f5412a4bd14d225b61";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-index-python ament-lint-auto launch-testing-ament-cmake launch-testing-ros ros2run ];
-  propagatedBuildInputs = [ builtin-interfaces launch-ros rclcpp rclcpp-lifecycle rosidl-default-generators std-msgs ];
+  propagatedBuildInputs = [ builtin-interfaces launch-ros rclcpp rclcpp-lifecycle system-modes-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/kinetic/bagger/default.nix
+++ b/distros/kinetic/bagger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, rosbag, roscpp, roslint, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-bagger";
-  version = "0.1.3-r2";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/squarerobot/bagger-release/archive/release/kinetic/bagger/0.1.3-2.tar.gz";
-    name = "0.1.3-2.tar.gz";
-    sha256 = "aba96b75ed79895ac7af81d1865b4e0e4b124ae136dff617eeb237a3a6936c1d";
+    url = "https://github.com/squarerobot/bagger-release/archive/release/kinetic/bagger/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "02067fdb76fe28e090caec3f192e2ad3c1301329d193dfb8d20cc95bd8273d29";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/dynamixel-sdk-examples/default.nix
+++ b/distros/kinetic/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-dynamixel-sdk-examples";
+  version = "3.7.51-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/kinetic/dynamixel_sdk_examples/3.7.51-2.tar.gz";
+    name = "3.7.51-2.tar.gz";
+    sha256 = "bb462f9a9eb1e9ce355325b1b5730c817a7a63e344adc4c95ef48a9da45adc3e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ dynamixel-sdk message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The DYNAMIXEL SDK ROS example package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/dynamixel-sdk/default.nix
+++ b/distros/kinetic/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-kinetic-dynamixel-sdk";
-  version = "3.7.31-r1";
+  version = "3.7.51-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/kinetic/dynamixel_sdk/3.7.31-1.tar.gz";
-    name = "3.7.31-1.tar.gz";
-    sha256 = "b999544df975f9e0e0df3719c6fd0f6b7cbb6d91347461f725055f5bb0a0f289";
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/kinetic/dynamixel_sdk/3.7.51-2.tar.gz";
+    name = "3.7.51-2.tar.gz";
+    sha256 = "677f490dc75c9a0f40842df4447b2964df695360b222399052a06bcea4fdac82";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -868,6 +868,8 @@ self: super: {
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  dynamixel-tutorials = self.callPackage ./dynamixel-tutorials {};
 
  dynamixel-workbench = self.callPackage ./dynamixel-workbench {};

--- a/distros/kinetic/hls-lfcd-lds-driver/default.nix
+++ b/distros/kinetic/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-hls-lfcd-lds-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/kinetic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "3a61d95dd976fbfbd0f54cbe17fb9be35c6da6a3726b18cbdd8270598e56920e";
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/kinetic/hls_lfcd_lds_driver/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "4d56c99373c25d7e334c27992f21f21baa29b9772e907beaa59b60c7f2ab8460";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.22-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.22-1.tar.gz";
-    name = "2.2.22-1.tar.gz";
-    sha256 = "4f0c18a8294c6c617c41081d87cf4a9d41eaee84049d08d1d97ab27618ef2cfe";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "53ccfacfd82f3d90b923cd835037a715c9aa5fb05eef28fcf1fb109e46c20698";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.22-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.22-1.tar.gz";
-    name = "2.2.22-1.tar.gz";
-    sha256 = "d60211f7fd3a04701a3073798ebbccda87e9b3fa378ec26ea6ee850a48dd0f91";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "2f9fe1e0cdb9f96f8395f9238f23717c815635831257a508ed3359c28ab27734";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/urg-stamped/default.nix
+++ b/distros/kinetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-kinetic-urg-stamped";
-  version = "0.0.10-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.10-1.tar.gz";
-    name = "0.0.10-1.tar.gz";
-    sha256 = "44db2631d76488767a46c62dadc198f0990c1449cab5a1ace46309675305043e";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/kinetic/urg_stamped/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "53868b9bb2f65b74538888da88bce813c9e8e2b6019c3e3daf039ad4c1efd669";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bagger/default.nix
+++ b/distros/melodic/bagger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, rosbag, roscpp, roslint, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-bagger";
-  version = "0.1.3";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/squarerobot/bagger-release/archive/release/melodic/bagger/0.1.3-0.tar.gz";
-    name = "0.1.3-0.tar.gz";
-    sha256 = "e8275de0f4ad29f758472ae12d8ce534b53705ec57066e8611498b6077188226";
+    url = "https://github.com/squarerobot/bagger-release/archive/release/melodic/bagger/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "417cbd4e7a43e72355430d0608a328aa14091eb94650d4f28910ada5e68c664f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/boost-sml/default.nix
+++ b/distros/melodic/boost-sml/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, roscpp, roslint, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-boost-sml";
-  version = "0.1.0-r3";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/melodic/boost_sml/0.1.0-3.tar.gz";
-    name = "0.1.0-3.tar.gz";
-    sha256 = "5684c6e8c9430035a4b172f16ba480cb9cc2fd7db95f72253b291dd35e660f57";
+    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/melodic/boost_sml/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "e98ea8d0a8064f30a76842a435fc4b87a5547fe2f28001582173a21ebca65326";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ roscpp roslint ];
+  propagatedBuildInputs = [ boost roscpp roslint ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dynamixel-sdk-examples/default.nix
+++ b/distros/melodic/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-dynamixel-sdk-examples";
+  version = "3.7.51-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/melodic/dynamixel_sdk_examples/3.7.51-4.tar.gz";
+    name = "3.7.51-4.tar.gz";
+    sha256 = "3a0fe8ed9053aaa5d2eae92dd76596a5d9d2917d8296733f5a3c4a842112ece2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ dynamixel-sdk message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The DYNAMIXEL SDK ROS example package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/dynamixel-sdk/default.nix
+++ b/distros/melodic/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-melodic-dynamixel-sdk";
-  version = "3.7.31-r1";
+  version = "3.7.51-r4";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/melodic/dynamixel_sdk/3.7.31-1.tar.gz";
-    name = "3.7.31-1.tar.gz";
-    sha256 = "949d7eca39b060ec04eb87a2d52e892b4eee48a6e90bcbb204cb2fd935f7771d";
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/melodic/dynamixel_sdk/3.7.51-4.tar.gz";
+    name = "3.7.51-4.tar.gz";
+    sha256 = "9acbf98d3e733be9a321c31816c0beddd5bacff6dc266775c35fb455a31c6a3b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.2-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.2-1.tar.gz";
-    name = "2.6.2-1.tar.gz";
-    sha256 = "d5de3cd6e1dc21ba4c27335fc6de5878f68ebc20bada11af1d5babbd1a79a89b";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "90db8a2e6a5d647aa64c3aee80fc3a6204137b037e8417557ba241b8252dfe4c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/fadecandy-driver/default.nix
+++ b/distros/melodic/fadecandy-driver/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, pythonPackages, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, libusb1, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-driver";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "b9d68a934b7729c3b519eb66126eda7e61b6237a1f96cec651b983f8e9bd4e93";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "0deab9f6d9db619017f140288d2a31bcc6b462126440f2098340e2ec19882298";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs pythonPackages.pyusb rospy ];
+  checkInputs = [ rospy ];
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs libusb1 roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/fadecandy-msgs/default.nix
+++ b/distros/melodic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-fadecandy-msgs";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "b765c7e0ec121d981ac2f6a9b91599cad5db173b9d8ad6d64b50f1a53f559d59";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/melodic/fadecandy_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "54ef7969941c0a92984356491a4c929fb510a158f771a35d82b2a398547d0f71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -774,6 +774,8 @@ self: super: {
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  dynamixel-workbench = self.callPackage ./dynamixel-workbench {};
 
  dynamixel-workbench-controllers = self.callPackage ./dynamixel-workbench-controllers {};
@@ -1171,6 +1173,8 @@ self: super: {
  gmapping = self.callPackage ./gmapping {};
 
  goal-passer = self.callPackage ./goal-passer {};
+
+ gpio-control = self.callPackage ./gpio-control {};
 
  gps-common = self.callPackage ./gps-common {};
 
@@ -1736,13 +1740,21 @@ self: super: {
 
  laser-joint-projector = self.callPackage ./laser-joint-projector {};
 
+ laser-ortho-projector = self.callPackage ./laser-ortho-projector {};
+
  laser-pipeline = self.callPackage ./laser-pipeline {};
 
  laser-proc = self.callPackage ./laser-proc {};
 
  laser-scan-densifier = self.callPackage ./laser-scan-densifier {};
 
+ laser-scan-matcher = self.callPackage ./laser-scan-matcher {};
+
  laser-scan-publisher-tutorial = self.callPackage ./laser-scan-publisher-tutorial {};
+
+ laser-scan-sparsifier = self.callPackage ./laser-scan-sparsifier {};
+
+ laser-scan-splitter = self.callPackage ./laser-scan-splitter {};
 
  laser-tilt-controller-filter = self.callPackage ./laser-tilt-controller-filter {};
 
@@ -2312,6 +2324,8 @@ self: super: {
 
  navigation-tutorials = self.callPackage ./navigation-tutorials {};
 
+ ncd-parser = self.callPackage ./ncd-parser {};
+
  neo-local-planner = self.callPackage ./neo-local-planner {};
 
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
@@ -2663,6 +2677,8 @@ self: super: {
  pointgrey-camera-driver = self.callPackage ./pointgrey-camera-driver {};
 
  points-preprocessor = self.callPackage ./points-preprocessor {};
+
+ polar-scan-matcher = self.callPackage ./polar-scan-matcher {};
 
  polled-camera = self.callPackage ./polled-camera {};
 
@@ -3631,6 +3647,10 @@ self: super: {
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
+
+ scan-to-cloud-converter = self.callPackage ./scan-to-cloud-converter {};
+
+ scan-tools = self.callPackage ./scan-tools {};
 
  scenario-test-tools = self.callPackage ./scenario-test-tools {};
 

--- a/distros/melodic/gpio-control/default.nix
+++ b/distros/melodic/gpio-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-gpio-control";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cst0/gpio_control-release/archive/release/melodic/gpio_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "36bb27fdd2f6a914db67bdd646795874b37a3f3a2b8def950ac1719b5bd0dbca";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Control GPIO pins on Raspberry Pi, Nvidia Jetson, and other Linux devices with GPIO pins'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/hls-lfcd-lds-driver/default.nix
+++ b/distros/melodic/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-hls-lfcd-lds-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/melodic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d178dcdb4efd0c7550eaa85e02e59e874221e0fb3a34e2c1c21b136fbcfc16d5";
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/melodic/hls_lfcd_lds_driver/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "818186f69f514fea41023eefdeef1721c8817b0a57a7f113c4f8ae887f1147a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-ortho-projector/default.nix
+++ b/distros/melodic/laser-ortho-projector/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-filters, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-laser-ortho-projector";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/laser_ortho_projector/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "c5f80e123b12083739cd83a6f96d06d073ff4d904463ca7bfb6f196f35a2ac97";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs message-filters nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_ortho_projector package calculates orthogonal projections of LaserScan messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/laser-scan-matcher/default.nix
+++ b/distros/melodic/laser-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, csm, geometry-msgs, nav-msgs, nodelet, pcl, pcl-conversions, pcl-ros, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-laser-scan-matcher";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/laser_scan_matcher/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "00b14d69b87fb6da8dbfd290beddf7c8f2b92adcce22fed066a5883adfe825c4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ csm geometry-msgs nav-msgs nodelet pcl pcl-conversions pcl-ros roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+     An incremental laser scan matcher, using Andrea Censi's Canonical Scan Matcher (CSM) implementation. See <a href="http://censi.mit.edu/software/csm/">the web site</a> for more about CSM. NOTE the CSM library is licensed under the GNU Lesser General Public License v3, whereas the rest of the code is released under the BSD license.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/melodic/laser-scan-sparsifier/default.nix
+++ b/distros/melodic/laser-scan-sparsifier/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-laser-scan-sparsifier";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/laser_scan_sparsifier/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "43fa615c88414d204c326f4bb56f75fd887dcba367211d0b00ebbd17ff2cdab9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_sparsifier takes in a LaserScan message and sparsifies it.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/laser-scan-splitter/default.nix
+++ b/distros/melodic/laser-scan-splitter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-laser-scan-splitter";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/laser_scan_splitter/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "9cc0f57c8712d129c8181e2a03c950c39d0199cc8838dd98493815d5b430ce2e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The laser_scan_splitter takes in a LaserScan message and splits it into a number of other LaserScan messages. Each of the resulting laser scans can be assigned an arbitrary coordinate frame, and is published on a separate topic.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/leo-bringup/default.nix
+++ b/distros/melodic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-melodic-leo-bringup";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "25bfc72cfae951ef08d764c3cf0ebd524de5dfdbd026ed1ceea543d24acb9039";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "514b122fc75f96603bc2815f4119ccd879bb1e88c6872390232792f09a29f505";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-fw/default.nix
+++ b/distros/melodic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-leo-fw";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "670b9fb62599c7f02cdf4b10e0a98aafc0da1231a6da823e8d5e80df22aad563";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "42c12033819e86cda2a5050f76d739ec7fdcc17e9d6de5e545c275bffc7ede41";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-robot/default.nix
+++ b/distros/melodic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-melodic-leo-robot";
-  version = "1.1.3-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "2ef847a9938d847fbd72260cf952df16216243b548c2037706fca600c89a1bbb";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2938d90306d1433d772c494bb527f88b02d654f41e482d0d3743471fdea326e5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.43.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.43.0-1.tar.gz";
-    name = "2.43.0-1.tar.gz";
-    sha256 = "4c3242c4fcd2c4e46f9c315fca1fb897263a0c438dbec7fb6258ba8f511ab4e2";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "b98ed069209d2ccc6dd358e5290150d64289b08281e13f7b2f3a35a1c832588b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/message-filters/default.nix
+++ b/distros/melodic/message-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosconsole, roscpp, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-message-filters";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "dc3838cfe3975721cc0d82d8c1865d5dd5250f0f168c29a34514c58bacb85e74";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/message_filters/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "3c6b60f9944985cfd4a8898bea6f2a94d8a392015ece2993d8559fbb88d88acb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/movie-publisher/default.nix
+++ b/distros/melodic/movie-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ffmpeg, pythonPackages, rosbash-params, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-movie-publisher";
-  version = "1.3.0-r1";
+  version = "1.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/movie_publisher-release/archive/release/melodic/movie_publisher/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "d25ff36cadc9c0e22259a1e55b9e761efcc0e9ed0f4c1fcd30c1f919dfb90f4b";
+    url = "https://github.com/peci1/movie_publisher-release/archive/release/melodic/movie_publisher/1.3.1-1.tar.gz";
+    name = "1.3.1-1.tar.gz";
+    sha256 = "917662a10f791fb87c5a3e7d42433f0c0a83365c5e9eba6aa3c05642e6df1f71";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ncd-parser/default.nix
+++ b/distros/melodic/ncd-parser/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-ncd-parser";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/ncd_parser/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "d9450f71b29650cdf242e1a50b4489d5dc6cb66bd1b01f6798e6eee82d0829d8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ncd_parser package reads in .alog data files from the New College Dataset and broadcasts scan and odometry messages to ROS.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/points-preprocessor/default.nix
+++ b/distros/melodic/points-preprocessor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-points-preprocessor";
-  version = "1.14.13-r2";
+  version = "1.14.15-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/core_perception-release/archive/release/melodic/points_preprocessor/1.14.13-2.tar.gz";
-    name = "1.14.13-2.tar.gz";
-    sha256 = "96180eb61847e299023fe29e03a1856c806fb152b57b670c6a50ba1cfcc6d48f";
+    url = "https://github.com/nobleo/core_perception-release/archive/release/melodic/points_preprocessor/1.14.15-1.tar.gz";
+    name = "1.14.15-1.tar.gz";
+    sha256 = "ee99435ac069adf5eec07434497732d6206558dcde942241b331d44cd478c17b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/polar-scan-matcher/default.nix
+++ b/distros/melodic/polar-scan-matcher/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-melodic-polar-scan-matcher";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/polar_scan_matcher/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "20762e0309884c1cfc3cc2370939cbb4493238a13ba62af0c6a6748c9ee4d19a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+    A wrapper around Polar Scan Matcher by Albert Diosi and Lindsay Kleeman, used for laser scan registration.
+    </p>'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.1.6-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.1.6-1.tar.gz";
-    name = "0.1.6-1.tar.gz";
-    sha256 = "99386b052806fadf59655b324e2b3069fbad7b6c6855bd8b2863c17c7edd1b9f";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2c8b2835cc189797eac002438990ad47080e21f22556da3d5efb600b7677134c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.23-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.23-1.tar.gz";
-    name = "2.2.23-1.tar.gz";
-    sha256 = "07e2f53a1f507495631ada20faad2fc198e0b1b25e405734559d531351ad5a6f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "7e67a9cf5290584e7ebcb47df474ed6e05bfadf36c2bb7dd936a43a5dfdb951e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.23-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.23-1.tar.gz";
-    name = "2.2.23-1.tar.gz";
-    sha256 = "2388970b8db1c1b6eb334cd598f98a4906095c9c388a4c2093e3fc084d4f16ad";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "d7def3715aacbe10d673cd070dbfd7b7bb6998f73ba1a5370d273695441b782f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-comm/default.nix
+++ b/distros/melodic/ros-comm/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-filters, ros, rosbag, rosconsole, roscpp, rosgraph, rosgraph-msgs, roslaunch, roslisp, rosmaster, rosmsg, rosnode, rosout, rosparam, rospy, rosservice, rostest, rostopic, roswtf, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-ros-comm";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "5b35d02244f71e41e342408baabe29ed8697b3c7e5506b13c7dd88fc2ee2230a";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/ros_comm/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "808f2d3441ea5c7633691fa7bc5caa380635e0b98242a177eb0fd2864fc2d32f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag-storage/default.nix
+++ b/distros/melodic/rosbag-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, bzip2, catkin, console-bridge, cpp-common, gpgme, openssl, pluginlib, roscpp-serialization, roscpp-traits, roslz4, rostest, rostime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-storage";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "cff71a92895548f688d37c9592c7cc4fbb7dabd9c958a2f0cbb3668f2e4707f8";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag_storage/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "f9daa22e3e6723fa36aa0d396493db01c57e8b2912d597ce434cfe36e46072fd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosbag/default.nix
+++ b/distros/melodic/rosbag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, genmsg, genpy, pythonPackages, rosbag-storage, rosconsole, roscpp, roscpp-serialization, roslib, rospy, std-srvs, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "cf787728793a54adddb8cc479d8ae31d9e3e952fea6b7950a3f3b487991d1929";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosbag/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "a5aa5b1b7d69d31969e738f929fa5a6bc4c66026bbdeb0536c1bea1e67b9e978";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roscpp/default.nix
+++ b/distros/melodic/roscpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, pkg-config, rosconsole, roscpp-serialization, roscpp-traits, rosgraph-msgs, roslang, rostime, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-roscpp";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "1d195e27879effecc7bc19596f5f95e52b24d17d97062491acd91739f9fb5eac";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roscpp/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "91a20fa2dec45369c7f47b30f66743d597164ae095d671b540b2c2acc971841f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosgraph/default.nix
+++ b/distros/melodic/rosgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-rosgraph";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "22de461f4beafbf3d72da8b2b28b2deb0ae051c8bf85eb296c3451e12c0b4f8d";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosgraph/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "f83a0339ceaa523d031f9a08017d1ce5cfee484beac739d7a5d7f76909067a21";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslaunch/default.nix
+++ b/distros/melodic/roslaunch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosbuild, rosclean, rosgraph-msgs, roslib, rosmaster, rosout, rosparam, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslaunch";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "fc7ca4bc451cafbac669b7c92c39778efa654299863aaa3813bea2b35638dc50";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslaunch/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "fb35c33f82ba1944751ba808b5bbd404a2f578f703c96bec312d5d81a4e5fcb8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roslz4/default.nix
+++ b/distros/melodic/roslz4/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, lz4, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-roslz4";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "018ed275a26779866834319ccc54904d16c510a4080d69f0160b6d036e0caed7";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roslz4/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "a3f329a4f31f60caf63ffcb8d00253f8542e6781d494243f1642d0200a9cc36b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmaster/default.nix
+++ b/distros/melodic/rosmaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosmaster";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "712d5a88dbcd1354ec6ade9d7e7d6a08f8d416e98e24183fd60bc0accfd136b1";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmaster/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "8fb2e05f9124468709d989f06288ce91636136cf522cec340a907d5bc0abdb78";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosmsg/default.nix
+++ b/distros/melodic/rosmsg/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages, rosbag, roslib, std-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, genmsg, genpy, pythonPackages, rosbag, roslib, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rosmsg";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "829f8bed2a2c606adfc03b1d40dd6d21df654dbcd052e1d6fa26d7ce0185063b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosmsg/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "9a24f62640b88f80f4c3cec76cf250e1c86a07fbc53625204ae1ab06aea660ac";
   };
 
   buildType = "catkin";
-  checkInputs = [ std-msgs ];
+  checkInputs = [ diagnostic-msgs rostest std-msgs std-srvs ];
   propagatedBuildInputs = [ catkin genmsg genpy pythonPackages.rospkg rosbag roslib ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rosnode/default.nix
+++ b/distros/melodic/rosnode/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosgraph, rostest, rostopic }:
 buildRosPackage {
   pname = "ros-melodic-rosnode";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "e38d9daad53041e61ec0458f4b534e3cb2f8d8eda544af7446c0d330a0e4c2c8";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosnode/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "b8f02747bbfb123068fbf289474f113d373303c7d4b0c03243c9e96ac1e0d2b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosout/default.nix
+++ b/distros/melodic/rosout/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosgraph-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosout";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "4c009ccd76ea6f4d16dfc5e8e3c660d5a3e49b5983350a26a2b999b44c2687a0";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosout/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "5208714afbd40fb2ef7bea4a521042af6df02929b149003c0b73c180b4595463";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosparam/default.nix
+++ b/distros/melodic/rosparam/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph }:
 buildRosPackage {
   pname = "ros-melodic-rosparam";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "48649ee91f921cac5503822b924b19fb27a6a92c27d0b4a7512512513d563987";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosparam/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "820bcc97f09854b834c6b9228b0c65734c74b9fadde44b616ad247c98e9572e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospy/default.nix
+++ b/distros/melodic/rospy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, pythonPackages, roscpp, rosgraph, rosgraph-msgs, roslib, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospy";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "d1de035b543e183d1f6bbb89aaff4f96fce54d27920b527e4cbbbcf0d1318ab1";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rospy/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "802d8567ffc1084e436cf4f7aa2f1c649409441384d089d8353b6ee7346d0e3c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosservice/default.nix
+++ b/distros/melodic/rosservice/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosgraph, roslib, rosmsg, rospy }:
 buildRosPackage {
   pname = "ros-melodic-rosservice";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "daa71fc4d4c843397e20262b71d6e81f3b39f5a40eb9c07b3ee17262cd4304bb";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rosservice/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "bcf4c35d0219ad769aea84bbcf707d635ceeac74e62216aa7f3ae7a308c42cd1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostest/default.nix
+++ b/distros/melodic/rostest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, rosgraph, roslaunch, rosmaster, rospy, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-rostest";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "ec68d2014fca46fc3e95ea2ab6fa543f664da2b602b910ce60611d679ad0f074";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostest/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "9a8d4607901e4110612b5ffb4af87432c8b936cd3c1fdce476279f0a6525aabe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rostopic/default.nix
+++ b/distros/melodic/rostopic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genpy, rosbag, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-rostopic";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "1ba7c973718aedd89cd023759e1c53a39b67265f5798fb60a4fab00a4a9b76f2";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/rostopic/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "479ce44dad57f7cc9fd107d9036817ab82b4bf95d22bc71671f5c431b1ccebc5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswtf/default.nix
+++ b/distros/melodic/roswtf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, pythonPackages, rosbag, rosbuild, rosgraph, roslang, roslaunch, roslib, rosnode, rosservice, rostest, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-roswtf";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "59e6d2b684b32f5765a628fd442fcc11160acaac409ab3b837941fc671df4ce6";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/roswtf/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "43c9fa813abb06f8a639918c2eaa102a02952638c3513bd43c960f1d61d1a330";
   };
 
   buildType = "catkin";

--- a/distros/melodic/scan-to-cloud-converter/default.nix
+++ b/distros/melodic/scan-to-cloud-converter/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl, pcl-conversions, pcl-ros, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-scan-to-cloud-converter";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/scan_to_cloud_converter/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "3ec240f339589c404db018ccf98fda92f2dc33e740678a6246ffa248f2dab533";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pcl pcl-conversions pcl-ros roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts LaserScan to PointCloud messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/scan-tools/default.nix
+++ b/distros/melodic/scan-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-ortho-projector, laser-scan-matcher, laser-scan-sparsifier, laser-scan-splitter, ncd-parser, polar-scan-matcher, scan-to-cloud-converter }:
+buildRosPackage {
+  pname = "ros-melodic-scan-tools";
+  version = "0.3.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/scan_tools-release/archive/release/melodic/scan_tools/0.3.3-2.tar.gz";
+    name = "0.3.3-2.tar.gz";
+    sha256 = "b2848d7623a75866185fa47d415fbcb05bbabcfdbfc7bc11f40fdfd704c698f6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laser-ortho-projector laser-scan-matcher laser-scan-sparsifier laser-scan-splitter ncd-parser polar-scan-matcher scan-to-cloud-converter ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Laser scan processing tools.'';
+    license = with lib.licenses; [ bsdOriginal lgpl2 ];
+  };
+}

--- a/distros/melodic/sot-core/default.nix
+++ b/distros/melodic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-melodic-sot-core";
-  version = "4.11.5-r2";
+  version = "4.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.5-2.tar.gz";
-    name = "4.11.5-2.tar.gz";
-    sha256 = "cd97257236edad1d9299d1c9e26ac664760ecee65a28dcf4fc6af301ca5910d4";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/melodic/sot-core/4.11.6-1.tar.gz";
+    name = "4.11.6-1.tar.gz";
+    sha256 = "83bae069452c9010919d4cc4395bdd999fbc7aa34a186dcc49b057828a5e9f41";
   };
 
   buildType = "cmake";

--- a/distros/melodic/topic-tools/default.nix
+++ b/distros/melodic/topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cpp-common, message-generation, message-runtime, rosbash, rosconsole, roscpp, rostest, rostime, rosunit, std-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-topic-tools";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "1f3498d53b9b013ac9a6d6d85864f6646ebb3538f1658ea2cdf36ebc03e00e2b";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/topic_tools/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "508515c4be04d35a37c6be12e600284dd0dc5b590f626f0eae901ffe4a0b8f60";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.10-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.10-1.tar.gz";
-    name = "0.0.10-1.tar.gz";
-    sha256 = "22e1aa2efeb41c16ecb09cfabb80b419f66e50a6b6d59e7afa529fd8b88a9685";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "f8009574969c5c35909be73d0fb7730c597be54ef02d9d511e9586dc2aa409df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xmlrpcpp/default.nix
+++ b/distros/melodic/xmlrpcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cpp-common, rostime }:
 buildRosPackage {
   pname = "ros-melodic-xmlrpcpp";
-  version = "1.14.10-r1";
+  version = "1.14.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.10-1.tar.gz";
-    name = "1.14.10-1.tar.gz";
-    sha256 = "ad3365cd74300bb02ce79735f5c5536df3a87b99e601dff3ab4922ea98474404";
+    url = "https://github.com/ros-gbp/ros_comm-release/archive/release/melodic/xmlrpcpp/1.14.11-1.tar.gz";
+    name = "1.14.11-1.tar.gz";
+    sha256 = "118e05e22780e149753b5d2cb4b09a462631e6f83a1132d0c7c6b909bcd4d612";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bagger/default.nix
+++ b/distros/noetic/bagger/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, rosbag, roscpp, roslint, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-bagger";
-  version = "0.1.3-r4";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/squarerobot/bagger-release/archive/release/noetic/bagger/0.1.3-4.tar.gz";
-    name = "0.1.3-4.tar.gz";
-    sha256 = "acd129c677edeac531445ce4b48eb37e89e0f94e67ad2b45e7705a305a167ed3";
+    url = "https://github.com/squarerobot/bagger-release/archive/release/noetic/bagger/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "781c7b23f9e302fabb4b9067e62e3ef8158a8ea4f3a2276fe5ce03530884eed3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/boost-sml/default.nix
+++ b/distros/noetic/boost-sml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, roslint, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-boost-sml";
-  version = "0.1.1-r1";
+  version = "0.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/noetic/boost_sml/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "f711e5bed75fd7d931b4db94f59f73e57b3af679f6525b01d4b0e1869f72f045";
+    url = "https://github.com/PickNikRobotics/boost_sml-release/archive/release/noetic/boost_sml/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "9c30d429372d194d44eefd350ff8d03df8b7cada5b4bedba2c6a0a0628760830";
   };
 
   buildType = "catkin";

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
-  version = "0.8.9-r1";
+  version = "0.8.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.9-1.tar.gz";
-    name = "0.8.9-1.tar.gz";
-    sha256 = "0d1ebc94098ff620d521540d37c97891d5d33b9fc2e1b2cda266394cbe4f0702";
+    url = "https://github.com/ros-gbp/catkin-release/archive/release/noetic/catkin/0.8.10-1.tar.gz";
+    name = "0.8.10-1.tar.gz";
+    sha256 = "08401b37f85d0a6b153e00408b6e51fdf7b0fd0d485da6ccb808aba401a5518f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamixel-sdk-examples/default.nix
+++ b/distros/noetic/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, message-generation, message-runtime, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-sdk-examples";
+  version = "3.7.51-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/noetic/dynamixel_sdk_examples/3.7.51-4.tar.gz";
+    name = "3.7.51-4.tar.gz";
+    sha256 = "cdf263c504bef8621da2c23fb2aef0255eebe0c8966a29cd6169d0f3ac78223d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ dynamixel-sdk message-runtime roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The DYNAMIXEL SDK ROS example package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/dynamixel-sdk/default.nix
+++ b/distros/noetic/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-noetic-dynamixel-sdk";
-  version = "3.7.31-r1";
+  version = "3.7.51-r4";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/noetic/dynamixel_sdk/3.7.31-1.tar.gz";
-    name = "3.7.31-1.tar.gz";
-    sha256 = "258090ab7b333982492ec6361b98b49850837cab53d11a7860918078e4f075c0";
+    url = "https://github.com/ROBOTIS-GIT-release/DynamixelSDK-release/archive/release/noetic/dynamixel_sdk/3.7.51-4.tar.gz";
+    name = "3.7.51-4.tar.gz";
+    sha256 = "2af181d5c4a9fbadfaf2b4d52e26836aa038c22dcc233c85487712b7300a8c8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.2-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.2-1.tar.gz";
-    name = "2.6.2-1.tar.gz";
-    sha256 = "3d93aa9cf279245b8c9508715c7c18a6b88eaa8362a56e2bbc2ef54e6f6c41f5";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "637bf87817af74b2f8d6236836bc8599742354552c16b96b0147a6addc22e9eb";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ethercat-grant/default.nix
+++ b/distros/noetic/ethercat-grant/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/shadow-robot/ethercat_grant-release/archive/release/noetic/ethercat_grant/0.2.5-3.tar.gz";
     name = "0.2.5-3.tar.gz";
-    sha256 = "0bbcfe78e74ff116fb9bc41abd18224702b61d89a2e0bd0ec5f4b10918cd2d02";
+    sha256 = "5038c00d18399930e6b88a67b0472a4b89ee3ad5c97e2110f5872975caf60cbb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, python3Packages, rospy }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, libusb1, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "8127adc92c19930bb41d8e332f94febe5256a04402970b18f20f10e6c7155874";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "0b54a26391d8f1a2c8ef375a254cac0a97f4f39eb0cd01b1fc7f52a7e4f75a37";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs python3Packages.pyusb rospy ];
+  checkInputs = [ rospy ];
+  propagatedBuildInputs = [ diagnostic-updater fadecandy-msgs libusb1 roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.1.3-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "28181b950a206e9a148f5ca518685914dea85e236395da30472890925c973efb";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "402372d8c17569423ea2bb5ceb95c12472b45f53e3ea4982a4015e93d62b3ff8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-bringup/default.nix
+++ b/distros/noetic/fetch-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, depth-image-proc, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-moveit-config, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, image-proc, joy, openni2-launch, robot-state-publisher, sensor-msgs, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-fetch-bringup";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_bringup/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "fdb2a6fbcfc4a9a5f8c06a5f037002ae252e34de6897e4adbfdedcb4f27a314a";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_bringup/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "2aefed0cb404f41fd0729945bff58a05784f6ff4872faf781fd673933b7d9bb1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fetch-drivers/default.nix
+++ b/distros/noetic/fetch-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, catkin, curl, diagnostic-msgs, fetch-auto-dock-msgs, fetch-driver-msgs, libyamlcpp, mk, nav-msgs, power-msgs, python3, robot-calibration-msgs, robot-controllers, robot-controllers-interface, rosconsole, roscpp, roscpp-serialization, rospack, rostime, sensor-msgs, urdf, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-fetch-drivers";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_drivers/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "d504e7ef63e54745253de09244b81b3fb22b518de815de094924f773893c7647";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/fetch_drivers/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "0c76111986c9801ed8e104c00cfc952a7891b156355347ec00b86b36e0e3822c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/freight-bringup/default.nix
+++ b/distros/noetic/freight-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, fetch-description, fetch-drivers, fetch-navigation, fetch-open-auto-dock, fetch-teleop, graft, joy, robot-state-publisher, sick-tim, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-freight-bringup";
-  version = "0.9.2-r1";
+  version = "0.9.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/freight_bringup/0.9.2-1.tar.gz";
-    name = "0.9.2-1.tar.gz";
-    sha256 = "086782f7b8b80bb9bc94daf0d93bdc6f39bab06369ea872ae3f83c086a98f1ae";
+    url = "https://github.com/fetchrobotics-gbp/fetch_robots-release/archive/release/noetic/freight_bringup/0.9.3-1.tar.gz";
+    name = "0.9.3-1.tar.gz";
+    sha256 = "430799bc6412c9f30e6c53f1ae003e6469930241bf846d5a901f520873db2ff8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-dev/default.nix
+++ b/distros/noetic/gazebo-dev/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo_11 }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-dev";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_dev/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "ea57ba4d3f0209c6d4912ef9476b9761e272ae14f55b7e588585458cb9e9f2df";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_dev/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "a594abb4b5f4da4c29c18f676ea9ade011da49794613788f1ddbe5c4273689bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-msgs/default.nix
+++ b/distros/noetic/gazebo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, std-srvs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-msgs";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_msgs/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "b4264ae694da21a28ae0a65addaf091d754c51665ba9083c0fccf19b7a7cfebf";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_msgs/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "45114343951b0c49c73cc33840dc3c8a1d83e169d4c6e7798da9dfaa048a079b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-plugins/default.nix
+++ b/distros/noetic/gazebo-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, camera-info-manager, catkin, cv-bridge, diagnostic-updater, dynamic-reconfigure, gazebo-dev, gazebo-msgs, gazebo-ros, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, polled-camera, rosconsole, roscpp, rosgraph-msgs, rospy, rostest, sensor-msgs, std-msgs, std-srvs, tf, tf2-ros, trajectory-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-plugins";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_plugins/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "9a73b433fa3bc5f8ac318654c9b519f814bf5fee600d6ba582d343aedfabc477";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_plugins/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "0c7aba61f1e6f811387bc63b6d5a1679758754af6784d93a7efd3045fe6a7a43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros-control/default.nix
+++ b/distros/noetic/gazebo-ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, joint-limits-interface, pluginlib, roscpp, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros-control";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_control/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "56344eb183068671724e79f226fd0f867e1ef32cf0c5854bf45a2bff1a3d34da";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_control/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "0e862d58508c1bf22aaf47c26aae4f7233863ea8da4e6d1e9ac1e21bb527501d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros-pkgs/default.nix
+++ b/distros/noetic/gazebo-ros-pkgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-dev, gazebo-msgs, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros-pkgs";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_pkgs/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "c42fd67588c6bad6f17db1ee79cc08027f0006db3bb3c36615df1f0e0938f632";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros_pkgs/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "b76529d93b6990c44f07168651fa5c355b3e1377fec10ba07189f387dfd3dff4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gazebo-ros/default.nix
+++ b/distros/noetic/gazebo-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, gazebo-dev, gazebo-msgs, geometry-msgs, python, roscpp, rosgraph-msgs, roslib, std-msgs, std-srvs, tf, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-gazebo-ros";
-  version = "2.9.1-r1";
+  version = "2.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros/2.9.1-1.tar.gz";
-    name = "2.9.1-1.tar.gz";
-    sha256 = "e11f96ea6b51f1869770a141e130245d88a166f608935966083044859ffe1d6a";
+    url = "https://github.com/ros-gbp/gazebo_ros_pkgs-release/archive/release/noetic/gazebo_ros/2.9.2-1.tar.gz";
+    name = "2.9.2-1.tar.gz";
+    sha256 = "24232fe990ef4d5802f18b33b0a0dcf527595adfa9ed5fe16f4b4e55d73be5b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -542,6 +542,8 @@ self: super: {
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  easy-markers = self.callPackage ./easy-markers {};
 
  ecl-build = self.callPackage ./ecl-build {};
@@ -1642,6 +1644,8 @@ self: super: {
 
  pid = self.callPackage ./pid {};
 
+ pilz-control = self.callPackage ./pilz-control {};
+
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
@@ -1649,6 +1653,10 @@ self: super: {
  pilz-industrial-motion-testutils = self.callPackage ./pilz-industrial-motion-testutils {};
 
  pilz-msgs = self.callPackage ./pilz-msgs {};
+
+ pilz-robots = self.callPackage ./pilz-robots {};
+
+ pilz-status-indicator-rqt = self.callPackage ./pilz-status-indicator-rqt {};
 
  pilz-testutils = self.callPackage ./pilz-testutils {};
 
@@ -1735,6 +1743,20 @@ self: super: {
  pr2-power-board = self.callPackage ./pr2-power-board {};
 
  pr2-power-drivers = self.callPackage ./pr2-power-drivers {};
+
+ prbt-gazebo = self.callPackage ./prbt-gazebo {};
+
+ prbt-grippers = self.callPackage ./prbt-grippers {};
+
+ prbt-hardware-support = self.callPackage ./prbt-hardware-support {};
+
+ prbt-ikfast-manipulator-plugin = self.callPackage ./prbt-ikfast-manipulator-plugin {};
+
+ prbt-moveit-config = self.callPackage ./prbt-moveit-config {};
+
+ prbt-pg70-support = self.callPackage ./prbt-pg70-support {};
+
+ prbt-support = self.callPackage ./prbt-support {};
 
  prosilica-camera = self.callPackage ./prosilica-camera {};
 
@@ -1824,6 +1846,8 @@ self: super: {
 
  robot = self.callPackage ./robot {};
 
+ robot-body-filter = self.callPackage ./robot-body-filter {};
+
  robot-calibration = self.callPackage ./robot-calibration {};
 
  robot-calibration-msgs = self.callPackage ./robot-calibration-msgs {};
@@ -1899,6 +1923,8 @@ self: super: {
  ros-ign-bridge = self.callPackage ./ros-ign-bridge {};
 
  ros-ign-image = self.callPackage ./ros-ign-image {};
+
+ ros-industrial-cmake-boilerplate = self.callPackage ./ros-industrial-cmake-boilerplate {};
 
  ros-introspection = self.callPackage ./ros-introspection {};
 
@@ -2348,6 +2374,8 @@ self: super: {
 
  tesseract-scene-graph = self.callPackage ./tesseract-scene-graph {};
 
+ tesseract-srdf = self.callPackage ./tesseract-srdf {};
+
  tesseract-support = self.callPackage ./tesseract-support {};
 
  tesseract-urdf = self.callPackage ./tesseract-urdf {};
@@ -2535,6 +2563,18 @@ self: super: {
  vision-msgs = self.callPackage ./vision-msgs {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
+
+ vision-visp = self.callPackage ./vision-visp {};
+
+ visp-auto-tracker = self.callPackage ./visp-auto-tracker {};
+
+ visp-bridge = self.callPackage ./visp-bridge {};
+
+ visp-camera-calibration = self.callPackage ./visp-camera-calibration {};
+
+ visp-hand2eye-calibration = self.callPackage ./visp-hand2eye-calibration {};
+
+ visp-tracker = self.callPackage ./visp-tracker {};
 
  visualization-marker-tutorials = self.callPackage ./visualization-marker-tutorials {};
 

--- a/distros/noetic/hls-lfcd-lds-driver/default.nix
+++ b/distros/noetic/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, roscpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-hls-lfcd-lds-driver";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/noetic/hls_lfcd_lds_driver/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "5ec411d7393221815e2c31f2a850fafea7fd2defb6874cfa660ba913fa39bd8c";
+    url = "https://github.com/ROBOTIS-GIT-release/hls-lfcd-lds-driver-release/archive/release/noetic/hls_lfcd_lds_driver/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "220169c149322ff80704155057c73c31d36bd80a9ffc98a75040061c1c4e5b1c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.42.0-r1";
+  version = "2.44.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "850d0729ca79fa340f020894279f3474f80b7476c349cbafde239a25f1fb2b1d";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.44.0-1.tar.gz";
+    name = "2.44.0-1.tar.gz";
+    sha256 = "fd51f0159a2559c744903fb27c08e9ad2165dabf06ad16b8129dcb9181b9a201";
   };
 
   buildType = "cmake";

--- a/distros/noetic/opw-kinematics/default.nix
+++ b/distros/noetic/opw-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, eigen, gtest, ros-industrial-cmake-boilerplate }:
 buildRosPackage {
   pname = "ros-noetic-opw-kinematics";
-  version = "0.4.1-r2";
+  version = "0.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.1-2.tar.gz";
-    name = "0.4.1-2.tar.gz";
-    sha256 = "c0519833d8b0565a70af7b7deff9aadb734ec782a719a3b0e73811a4d6c64b49";
+    url = "https://github.com/ros-industrial-release/opw_kinematics-release/archive/release/noetic/opw_kinematics/0.4.3-1.tar.gz";
+    name = "0.4.3-1.tar.gz";
+    sha256 = "a52ca47f208e4c261c6764ef6f66119ce36151d600783c3023a3e8d3188866c5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/pilz-control/default.nix
+++ b/distros/noetic/pilz-control/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, geometry-msgs, joint-trajectory-controller, moveit-core, moveit-ros-planning, pilz-msgs, pilz-testutils, pilz-utils, roscpp, roslint, rostest, rosunit, std-srvs, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-control";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/pilz_control/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "8b6f39bf772fff9f2a7a3335923ffb990133968611c9ced7b02f82c77fe51f88";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules roslint ];
+  checkInputs = [ code-coverage geometry-msgs pilz-testutils pilz-utils rostest rosunit tf2 tf2-geometry-msgs ];
+  propagatedBuildInputs = [ controller-interface controller-manager joint-trajectory-controller moveit-core moveit-ros-planning pilz-msgs roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a specialized joint_trajectory_controller that can be moved into holding state via service call.
+  No further trajectories will be accepted/followed in this state.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pilz-robots/default.nix
+++ b/distros/noetic/pilz-robots/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pilz-control, pilz-status-indicator-rqt, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-robots";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/pilz_robots/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fcc2acb4d679e4c28ca857adbbe15548f9430af9f16fa98e9c258d902eed0d80";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pilz-control pilz-status-indicator-rqt prbt-hardware-support prbt-ikfast-manipulator-plugin prbt-moveit-config prbt-support ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pilz-status-indicator-rqt/default.nix
+++ b/distros/noetic/pilz-status-indicator-rqt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pilz-msgs, python3Packages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-status-indicator-rqt";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/pilz_status_indicator_rqt/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "6a3b1821bf4b38214ed38d73e69d379432f322554df9cb79de991023c0848f90";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ python3Packages.mock rostest rosunit ];
+  propagatedBuildInputs = [ pilz-msgs rospy rqt-gui rqt-gui-py std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Showing information about operation mode, status and speed override of the robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.5.6-r1";
+  version = "2.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.5.6-1.tar.gz";
-    name = "2.5.6-1.tar.gz";
-    sha256 = "8445464c30a254293a4f35edae134d3b0293fdc32403b85cc839d5abef6af5d8";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.0-1.tar.gz";
+    name = "2.6.0-1.tar.gz";
+    sha256 = "175fc2605fdaa47ae3fbd22a9048e0c07a83f7ea0d2f4ca4063a7a76c98b16a4";
   };
 
   buildType = "cmake";

--- a/distros/noetic/points-preprocessor/default.nix
+++ b/distros/noetic/points-preprocessor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, autoware-config-msgs, catkin, cv-bridge, gtest, libyamlcpp, message-filters, pcl-conversions, pcl-ros, qt5, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-eigen, tf2-ros, velodyne-pcl }:
 buildRosPackage {
   pname = "ros-noetic-points-preprocessor";
-  version = "1.14.11-r3";
+  version = "1.14.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/core_perception-release/archive/release/noetic/points_preprocessor/1.14.11-3.tar.gz";
-    name = "1.14.11-3.tar.gz";
-    sha256 = "e1ea291c2914b45a251ccca9b998510276a3c94c310cda00d98a270e9fa5d746";
+    url = "https://github.com/nobleo/core_perception-release/archive/release/noetic/points_preprocessor/1.14.14-1.tar.gz";
+    name = "1.14.14-1.tar.gz";
+    sha256 = "a67d1b1fc406637f36230faaf9618b6d2db69e7c08c24cab555c587265cf4264";
   };
 
   buildType = "catkin";

--- a/distros/noetic/prbt-gazebo/default.nix
+++ b/distros/noetic/prbt-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-gazebo";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/prbt_gazebo/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "280c0ed66eb1a3da2af1948f312fce548ed54c929502b32b1f340de8f351a2b1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib roscpp rostest trajectory-msgs ];
+  propagatedBuildInputs = [ gazebo-ros gazebo-ros-control prbt-moveit-config prbt-support roslaunch xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch prbt robot in an empty Gazebo world.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/prbt-grippers/default.nix
+++ b/distros/noetic/prbt-grippers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, prbt-pg70-support }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-grippers";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/prbt_grippers-release/archive/release/noetic/prbt_grippers/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "247d2f120856a583416b03754784fae60810ad9855c85b7681db9364547a44e7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ prbt-pg70-support ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The package provides gripper support for the pilz_robots package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/prbt-hardware-support/default.nix
+++ b/distros/noetic/prbt-hardware-support/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rosservice, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-hardware-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/prbt_hardware_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "e52a0dd1a3c31542f3c232f31b7daff8a3edb0073b690d72cd1f0494daad37e2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ canopen-chain-node dynamic-reconfigure libmodbus message-filters message-generation pilz-utils tf2 tf2-geometry-msgs tf2-ros urdf ];
+  checkInputs = [ cmake-modules code-coverage pilz-testutils rostest rosunit ];
+  propagatedBuildInputs = [ message-runtime pilz-msgs roscpp rosservice sensor-msgs std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Control hardware functions of the PRBT manipulator like RUN_PERMITTED for Stop1 functionality.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/noetic/prbt-ikfast-manipulator-plugin/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-ikfast-manipulator-plugin";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/prbt_ikfast_manipulator_plugin/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "9597d21902753ce2451b608d2c16bc6647a38a6070e6e4873fc860a6fc285061";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ tf2-eigen ];
+  propagatedBuildInputs = [ eigen-conversions moveit-core pluginlib roscpp tf2-kdl ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The prbt_ikfast_manipulator_plugin package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/prbt-moveit-config/default.nix
+++ b/distros/noetic/prbt-moveit-config/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-core, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-planning, moveit-ros-visualization, moveit-simple-controller-manager, pluginlib, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roscpp, roslaunch, rostest, rosunit, rviz, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-moveit-config";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/prbt_moveit_config/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "430c360df9a9c17698dd9c114f73ff1b4aa200027bbd8f01cbf6211b0b41d13a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ moveit-core moveit-ros-planning pluginlib roscpp roslaunch rostest rosunit ];
+  propagatedBuildInputs = [ joint-state-publisher moveit-fake-controller-manager moveit-kinematics moveit-planners-ompl moveit-ros-move-group moveit-ros-visualization moveit-simple-controller-manager prbt-hardware-support prbt-ikfast-manipulator-plugin prbt-support robot-state-publisher rviz xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An automatically generated package with all the configuration and launch files for using the prbt with the MoveIt! Motion Planning Framework'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/prbt-pg70-support/default.nix
+++ b/distros/noetic/prbt-pg70-support/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support, schunk-description, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-pg70-support";
+  version = "0.0.5-r2";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/prbt_grippers-release/archive/release/noetic/prbt_pg70_support/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "9b31e3222c15a3ef66fcbab83046465d7884e253ed7e827ac3a99f8690cdccd5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ prbt-ikfast-manipulator-plugin prbt-moveit-config prbt-support schunk-description xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''PRBT support for Schunk pg70 gripper.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/prbt-support/default.nix
+++ b/distros/noetic/prbt-support/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, pilz-status-indicator-rqt, pilz-testutils, pilz-utils, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-prbt-support";
+  version = "0.6.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/noetic/prbt_support/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "66bdbbe527721dce392d9fa8449f0f857377f3a5b3f7e298595c478c9240444d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ canopen-chain-node pilz-utils roslint sensor-msgs ];
+  checkInputs = [ cmake-modules code-coverage eigen joint-state-publisher moveit-core moveit-ros-planning pilz-testutils prbt-hardware-support roslaunch rostest rosunit rviz ];
+  propagatedBuildInputs = [ canopen-motor-node controller-manager joint-state-controller pilz-control pilz-status-indicator-rqt prbt-hardware-support robot-state-publisher roscpp rosservice topic-tools xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Mechanical, kinematic and visual description
+  of the Pilz light weight arm PRBT.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "eb9d3e916308707e49ef65431d31605a91043d1bef26885df0fe85c2418d4c57";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "343b3172dc3f13850934ccc30ce81e0e7d71c6d4466346f822df87f1856a3026";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.2.22-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.22-1.tar.gz";
-    name = "2.2.22-1.tar.gz";
-    sha256 = "08c5d55e48d1152bcf20bdad3b6b0ff77c72e3cd79ddce93bc4f5c078b03409f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "56f3bdd1e20981fd57a58a048ba8c6047b74b78d65345db7a16f35e06bddf58e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.2.22-r1";
+  version = "2.2.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.22-1.tar.gz";
-    name = "2.2.22-1.tar.gz";
-    sha256 = "641098008e6d40aaee4fd97dfc77164cbb4b074b48d615cebf6319a854253494";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.24-1.tar.gz";
+    name = "2.2.24-1.tar.gz";
+    sha256 = "75c0d55590b06849a95533b9b3e2c440d5ded76b8aa2e94cff6596ececfd13d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-body-filter/default.nix
+++ b/distros/noetic/robot-body-filter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-body-filter";
+  version = "1.1.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/noetic/robot_body_filter/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "420340eb7e8b30ccec09e505208cb31e3e305ddb8bc06b18b43412f0289dc9f5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation pkg-config tf2-eigen tf2-sensor-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure fcl filters geometric-shapes geometry-msgs laser-geometry message-runtime moveit-core moveit-ros-perception pcl pcl-conversions roscpp sensor-msgs std-msgs tf2 tf2-ros urdf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filters the robot's body out of laser scans or point clouds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
+buildRosPackage {
+  pname = "ros-noetic-ros-industrial-cmake-boilerplate";
+  version = "0.2.9-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.9-2.tar.gz";
+    name = "0.2.9-2.tar.gz";
+    sha256 = "52b25332e4bd2139fadeb6c89f6a2d385f8f49a765d841c0486a6580965941a5";
+  };
+
+  buildType = "cmake";
+  checkInputs = [ clang cppcheck gtest include-what-you-use lcov ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Contains boilerplate cmake script, macros and utils'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/noetic/rqt-msg/default.nix
+++ b/distros/noetic/rqt-msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, roslib, rosmsg, rospy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-msg";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_msg-release/archive/release/noetic/rqt_msg/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "8eef9fa2b0c7f26ef82d6d6d3a832d486cd5af4ab095e4c84b2568194673abb8";
+    url = "https://github.com/ros-gbp/rqt_msg-release/archive/release/noetic/rqt_msg/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "a9afbaff68d9f0ffa209152355c1511010b312e04d7c8244068f460f165b9f9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-pose-view/default.nix
+++ b/distros/noetic/rqt-pose-view/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gl-dependency, python-qt-binding, python3Packages, rospy, rostopic, rqt-gui, rqt-gui-py, rqt-py-common, tf }:
 buildRosPackage {
   pname = "ros-noetic-rqt-pose-view";
-  version = "0.5.10-r1";
+  version = "0.5.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_pose_view-release/archive/release/noetic/rqt_pose_view/0.5.10-1.tar.gz";
-    name = "0.5.10-1.tar.gz";
-    sha256 = "951223055a1d471928cc9509d91eeed6abe8633de993f414ec3e352edaff716f";
+    url = "https://github.com/ros-gbp/rqt_pose_view-release/archive/release/noetic/rqt_pose_view/0.5.11-1.tar.gz";
+    name = "0.5.11-1.tar.gz";
+    sha256 = "cf7dbeba319b1a3b934ea9e89457dbe292d07e7fb7a01946adb802eb232acb61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-publisher/default.nix
+++ b/distros/noetic/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui-py-common, roslib, rosmsg, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-publisher";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_publisher-release/archive/release/noetic/rqt_publisher/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "5d6f4d72eb217abcc8e739cadda1f69a644dfcb08a28cfcdc9726b01487dd498";
+    url = "https://github.com/ros-gbp/rqt_publisher-release/archive/release/noetic/rqt_publisher/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "5cbe23d13ab2d2c4286bb3e6d6b2e56396845732c3bf6574e6a129cedc642c07";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-py-console/default.nix
+++ b/distros/noetic/rqt-py-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-console";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_py_console-release/archive/release/noetic/rqt_py_console/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "b3930d768041631bbb758340d2f0ae62212ec875dfd31bafbd41f28dd0bb4d52";
+    url = "https://github.com/ros-gbp/rqt_py_console-release/archive/release/noetic/rqt_py_console/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "daf9be587966164b916b8a33de9d10d4e78db010228c6fc50ee63f511190874c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-runtime-monitor/default.nix
+++ b/distros/noetic/rqt-runtime-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-runtime-monitor";
-  version = "0.5.8-r1";
+  version = "0.5.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_runtime_monitor-release/archive/release/noetic/rqt_runtime_monitor/0.5.8-1.tar.gz";
-    name = "0.5.8-1.tar.gz";
-    sha256 = "814f84fe0bdc566a9ad9e8b133384468c8f70423da1616bb20b58aa983f37626";
+    url = "https://github.com/ros-gbp/rqt_runtime_monitor-release/archive/release/noetic/rqt_runtime_monitor/0.5.9-1.tar.gz";
+    name = "0.5.9-1.tar.gz";
+    sha256 = "237206b6bdd8850ce375e7900125b5864646556a68acb107989624cefc5c0d33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-service-caller/default.nix
+++ b/distros/noetic/rqt-service-caller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rosservice, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-noetic-rqt-service-caller";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_service_caller-release/archive/release/noetic/rqt_service_caller/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "42275c8b360494f911db00704bab8e2a33d27c31773c71618746db37c329a7e0";
+    url = "https://github.com/ros-gbp/rqt_service_caller-release/archive/release/noetic/rqt_service_caller/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "dbf87bc996e161a0512b4f0627caa1d66ae00bfcbf28ef8ab6fa58de2fa4d9f5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-shell/default.nix
+++ b/distros/noetic/rqt-shell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-shell";
-  version = "0.4.10-r1";
+  version = "0.4.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_shell-release/archive/release/noetic/rqt_shell/0.4.10-1.tar.gz";
-    name = "0.4.10-1.tar.gz";
-    sha256 = "1efdc24496c86ae5f56e66517821bc13dbab53c9484465265cf512d4953a24da";
+    url = "https://github.com/ros-gbp/rqt_shell-release/archive/release/noetic/rqt_shell/0.4.11-1.tar.gz";
+    name = "0.4.11-1.tar.gz";
+    sha256 = "b61beef13cb61b57d09f257d91316a884927a9fba44ac4c8b156f54d91e280c4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-srv/default.nix
+++ b/distros/noetic/rqt-srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosmsg, rospy, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-noetic-rqt-srv";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_srv-release/archive/release/noetic/rqt_srv/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "a920e60e6ed33e1c017689e7807d8aa43517a50a290c41c8855ddeb78453f6fe";
+    url = "https://github.com/ros-gbp/rqt_srv-release/archive/release/noetic/rqt_srv/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "a6bf6dba3326ed7d75d4f4ac1cedb2e162714721b7bba6141bf27dea2086ebcb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-top/default.nix
+++ b/distros/noetic/rqt-top/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-top";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_top-release/archive/release/noetic/rqt_top/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "3abfefb43d7f3eacaeebfa74aa118a4638bdc765a71359d232310a79286656f8";
+    url = "https://github.com/ros-gbp/rqt_top-release/archive/release/noetic/rqt_top/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "4bc9f4bfb79ee30f00faf53fc48c2914c179c51782dab97d625a07d5834d7a2b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-web/default.nix
+++ b/distros/noetic/rqt-web/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, webkit-dependency }:
 buildRosPackage {
   pname = "ros-noetic-rqt-web";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_web-release/archive/release/noetic/rqt_web/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "3caa18816f329aba8ffd2e262e8aca9c6488aa139be2d5d06ba5fe3526471a13";
+    url = "https://github.com/ros-gbp/rqt_web-release/archive/release/noetic/rqt_web/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "ab966db5d643bc5912b5f915bd2849ea8d4563b59f44bff9cd25c42ecba61e8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sot-core/default.nix
+++ b/distros/noetic/sot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, dynamic-graph, dynamic-graph-python, pinocchio }:
 buildRosPackage {
   pname = "ros-noetic-sot-core";
-  version = "4.11.5-r2";
+  version = "4.11.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.5-2.tar.gz";
-    name = "4.11.5-2.tar.gz";
-    sha256 = "cbf16687c4ebb2226500c8fba4ffe6ffbea2bf15c5d09cf3fba151ba57d8327f";
+    url = "https://github.com/stack-of-tasks/sot-core-ros-release/archive/release/noetic/sot-core/4.11.6-1.tar.gz";
+    name = "4.11.6-1.tar.gz";
+    sha256 = "4b462e9c1a17017e791dc38799c91049ca30373bfd36cf49e202e13a0a43eb59";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "2fdefdd90889c18262674dd77f35cae10d060925fa735a062563f33b60de8bd1";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "12589f5eb9062c63c204e4f84aec7b60bfb0053fa572f122584da80093306d0a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "67bdb418c137fe3d7cf4c96aac1d81251c66da77de513c33b76515479d728905";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "1e8f31eb932060813644a450d0d0a9ca79c2d2486799232b7c478adaee7a2c55";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-srdf, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "315c370363569719db8f2ce0804467294cc20877d757bb7c7386ebd1ec8f71c0";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "894c1ac51131eff63bc7f00cd7ce10d8dbd8915a6b6daccd442d53cc8e67732a";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
   checkInputs = [ gtest tesseract-support tesseract-urdf ];
-  propagatedBuildInputs = [ console-bridge eigen opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph ];
+  propagatedBuildInputs = [ console-bridge eigen opw-kinematics orocos-kdl tesseract-common tesseract-scene-graph tesseract-srdf ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "f420f16550dd7765b740c9cf3d0b6da28bfbd0f584d79c1d3df46ae7823adf96";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "a7a541a6ce27b49ddcf204c7f20d69ad5715f6ccc174abaae4f2468038ab5e7a";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
+buildRosPackage {
+  pname = "ros-noetic-tesseract-srdf";
+  version = "0.4.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "cf57cada98437d0d63ca98423ea8f224063f1bd918272b782e9011f673a8ae00";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ ros-industrial-cmake-boilerplate ];
+  checkInputs = [ gtest tesseract-support ];
+  propagatedBuildInputs = [ console-bridge eigen tesseract-common tesseract-scene-graph ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''The tesseract_srdf package for parsing Tesseract specific srdf'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,17 +5,16 @@
 { lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "d5a8fb78a67a451407c0a140d7ed5850b520c300802517bc72fef3f6a86ef85c";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "5879c2ed8ca4cd121fc6bd12f7c77f0627671bc1a20aa0638dae541637700075";
   };
 
   buildType = "cmake";
-  buildInputs = [ ros-industrial-cmake-boilerplate ];
-  propagatedBuildInputs = [ tesseract-common ];
+  buildInputs = [ ros-industrial-cmake-boilerplate tesseract-common ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
+{ lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "36ac730980015be09d6f8e1d201dca295a6459d4a777b9bac005924c8d49af93";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "03b865ec55cc9b8313a3d39836c6cbc71de226467139681013fa563638dd3501";
   };
 
   buildType = "cmake";
   buildInputs = [ ros-industrial-cmake-boilerplate ];
   checkInputs = [ gtest tesseract-support ];
-  propagatedBuildInputs = [ console-bridge eigen tesseract-collision tesseract-common tesseract-geometry tesseract-scene-graph ];
+  propagatedBuildInputs = [ console-bridge eigen pcl tesseract-collision tesseract-common tesseract-geometry tesseract-scene-graph ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.3.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "c7e1ef6833a06ed49a573b20dce540915c5c7f78b7822f49f25a72d679fd10d5";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "74d9c636fc34d36cd104069989ed084953d8a15d7e9abe10d9b560ed623e52d5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.10-r1";
+  version = "0.0.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.10-1.tar.gz";
-    name = "0.0.10-1.tar.gz";
-    sha256 = "1d30951aadfb3edb33d5208b55b8f9000fead533ae234dfc208f337f59a2c4be";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.11-1.tar.gz";
+    name = "0.0.11-1.tar.gz";
+    sha256 = "598bb427682aea7eecfb4199526685dbebe5bd4a6ddb958614c51667f42d2a86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/vision-visp/default.nix
+++ b/distros/noetic/vision-visp/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, visp-auto-tracker, visp-bridge, visp-camera-calibration, visp-hand2eye-calibration, visp-tracker }:
+buildRosPackage {
+  pname = "ros-noetic-vision-visp";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/vision_visp/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "28e44cc1fa6ce206e0f09ab8528665508bd9aa363bb4adde97ba9b2e0c29ce8b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ visp-auto-tracker visp-bridge visp-camera-calibration visp-hand2eye-calibration visp-tracker ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Virtual package providing ViSP related packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/visp-auto-tracker/default.nix
+++ b/distros/noetic/visp-auto-tracker/default.nix
@@ -1,0 +1,35 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, libdmtx, message-filters, resource-retriever, roscpp, sensor-msgs, std-msgs, usb-cam, visp, visp-bridge, visp-tracker, zbar }:
+buildRosPackage {
+  pname = "ros-noetic-visp-auto-tracker";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_auto_tracker/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "9c7f711b183dab46d36a7de358e24e878fb681762930f94789dd6d44d8a249bb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs libdmtx message-filters resource-retriever roscpp sensor-msgs std-msgs usb-cam visp visp-bridge visp-tracker zbar ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Online automated pattern-based object tracker relying on visual servoing.
+
+    visp_auto_tracker wraps model-based trackers provided by ViSP visual
+    servoing library into a ROS package. The tracked object should have a
+    QRcode of Flash code pattern. Based on the pattern, the object is
+    automaticaly detected. The detection allows then to initialise the
+    model-based trackers. When lost of tracking achieves a new detection
+    is performed that will be used to re-initialize the tracker.
+
+    This computer vision algorithm computes the pose (i.e. position and
+    orientation) of an object in an image. It is fast enough to allow
+    object online tracking using a camera.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/noetic/visp-bridge/default.nix
+++ b/distros/noetic/visp-bridge/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, roscpp, sensor-msgs, std-msgs, visp }:
+buildRosPackage {
+  pname = "ros-noetic-visp-bridge";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_bridge/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "a81134c3961592a9433960ed40a3d6a534cf1488bf9ca27164027eba9c58050c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs roscpp sensor-msgs std-msgs visp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Converts between ROS structures and ViSP structures.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/noetic/visp-camera-calibration/default.nix
+++ b/distros/noetic/visp-camera-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, geometry-msgs, message-generation, message-runtime, roscpp, rqt-console, sensor-msgs, std-msgs, visp, visp-bridge }:
+buildRosPackage {
+  pname = "ros-noetic-visp-camera-calibration";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_camera_calibration/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "3b1049c3cb0dca52fa13b3b211f1ccc055f58db595f282b219fb98e7771b5790";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-calibration-parsers geometry-msgs message-generation message-runtime roscpp rqt-console sensor-msgs std-msgs visp visp-bridge ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''visp_camera_calibration allows easy calibration of
+     cameras using a customizable pattern and ViSP library.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/noetic/visp-hand2eye-calibration/default.nix
+++ b/distros/noetic/visp-hand2eye-calibration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, image-proc, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, visp, visp-bridge }:
+buildRosPackage {
+  pname = "ros-noetic-visp-hand2eye-calibration";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_hand2eye_calibration/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "c35a9ce9f4cd7d0e2ed71726e48e26a621163858b25fe21d115d670dd4e7391e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs image-proc message-generation message-runtime roscpp sensor-msgs std-msgs visp visp-bridge ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''visp_hand2eye_calibration estimates the camera position with respect
+     to its effector using the ViSP library.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/noetic/visp-tracker/default.nix
+++ b/distros/noetic/visp-tracker/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, image-proc, image-transport, message-generation, message-runtime, nodelet, resource-retriever, roscpp, rospy, sensor-msgs, std-msgs, tf, visp }:
+buildRosPackage {
+  pname = "ros-noetic-visp-tracker";
+  version = "0.12.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/lagadic/vision_visp-release/archive/release/noetic/visp_tracker/0.12.1-1.tar.gz";
+    name = "0.12.1-1.tar.gz";
+    sha256 = "b5642e82a21c8dae985149f9dca3b9044bea1d40fe8a669b3a9a2e5569b9d971";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamic-reconfigure geometry-msgs image-proc image-transport message-generation message-runtime nodelet resource-retriever roscpp rospy sensor-msgs std-msgs tf visp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Wraps the ViSP moving edge tracker provided by the ViSP visual
+    servoing library into a ROS package.
+
+    This computer vision algorithm computes the pose (i.e. position
+    and orientation) of an object in an image. It is fast enough to
+    allow object online tracking using a camera.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 880145cbb8712014e3bfbf95736a79401e318773.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *hls-lfcd-lds-driver 2.0.1-r1 --> 2.0.2-r2*

Foxy Changes:
-------------
* *ament-package 0.9.4-r1 --> 0.9.5-r1*
* *gazebo-ros2-control 0.0.1-r1 --> 0.0.2-r1*
* *gazebo-ros2-control-demos 0.0.1-r1 --> 0.0.2-r1*
* *moveit 2.1.1-r1 --> 2.1.2-r1*
* *moveit-common 2.1.1-r1 --> 2.1.2-r1*
* *moveit-fake-controller-manager 2.1.1-r1 --> 2.1.2-r1*
* *moveit-kinematics 2.1.1-r1 --> 2.1.2-r1*
* *moveit-planners 2.1.1-r1 --> 2.1.2-r1*
* *moveit-plugins 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-benchmarks 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-move-group 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-occupancy-map-monitor 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-planning 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-planning-interface 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-robot-interaction 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-visualization 2.1.1-r1 --> 2.1.2-r1*
* *moveit-ros-warehouse 2.1.1-r1 --> 2.1.2-r1*
* *moveit-runtime 2.1.1-r1 --> 2.1.2-r1*
* *moveit-servo 2.1.1-r1 --> 2.1.2-r1*
* *moveit-simple-controller-manager 2.1.1-r1 --> 2.1.2-r1*
* *nerian-stereo 1.0.1-r1*
* *openzen-driver 1.2.0-r2*
* *rqt-msg 1.0.3-r1 --> 1.0.4-r1*
* *rqt-plot 1.0.9-r1 --> 1.0.10-r1*
* *rqt-publisher 1.1.1-r1 --> 1.1.2-r1*
* *rqt-py-console 1.0.0-r1 --> 1.0.1-r1*
* *rqt-service-caller 1.0.3-r1 --> 1.0.4-r1*
* *rqt-shell 1.0.0-r1 --> 1.0.1-r1*
* *rqt-srv 1.0.1-r1 --> 1.0.2-r1*
* *rqt-top 1.0.0-r1 --> 1.0.1-r1*
* *run-move-group 2.1.1-r1 --> 2.1.2-r1*
* *run-moveit-cpp 2.1.1-r1 --> 2.1.2-r1*
* *run-ompl-constrained-planning 2.1.1-r1 --> 2.1.2-r1*
* *simple-launch 1.0.2-r1 --> 1.0.3-r2*
* *slider-publisher 1.0.2-r2*
* *system-modes 0.6.0-r1 --> 0.7.1-r2*
* *system-modes-examples 0.6.0-r1 --> 0.7.1-r2*
* *system-modes-msgs 0.7.1-r2*

Kinetic Changes:
----------------
* *bagger 0.1.3-r2 --> 0.1.4-r1*
* *dynamixel-sdk 3.7.31-r1 --> 3.7.51-r2*
* *dynamixel-sdk-examples 3.7.51-r2*
* *hls-lfcd-lds-driver 1.1.1-r1 --> 1.1.2-r1*
* *realsense2-camera 2.2.22-r1 --> 2.2.24-r1*
* *realsense2-description 2.2.22-r1 --> 2.2.24-r1*
* *urg-stamped 0.0.10-r1 --> 0.0.11-r1*

Melodic Changes:
----------------
* *bagger 0.1.3 --> 0.1.4-r1*
* *boost-sml 0.1.0-r3 --> 0.1.2-r1*
* *dynamixel-sdk 3.7.31-r1 --> 3.7.51-r4*
* *dynamixel-sdk-examples 3.7.51-r4*
* *eigenpy 2.6.2-r1 --> 2.6.3-r1*
* *fadecandy-driver 0.1.3-r1 --> 0.2.1-r1*
* *fadecandy-msgs 0.1.3-r1 --> 0.2.1-r1*
* *gpio-control 1.0.0-r1*
* *hls-lfcd-lds-driver 1.1.1-r1 --> 1.1.2-r1*
* *laser-ortho-projector 0.3.3-r2*
* *laser-scan-matcher 0.3.3-r2*
* *laser-scan-sparsifier 0.3.3-r2*
* *laser-scan-splitter 0.3.3-r2*
* *leo-bringup 1.1.3-r1 --> 1.2.0-r1*
* *leo-fw 1.1.3-r1 --> 1.2.0-r1*
* *leo-robot 1.1.3-r1 --> 1.2.0-r1*
* *librealsense2 2.43.0-r1 --> 2.44.0-r1*
* *message-filters 1.14.10-r1 --> 1.14.11-r1*
* *movie-publisher 1.3.0-r1 --> 1.3.1-r1*
* *ncd-parser 0.3.3-r2*
* *points-preprocessor 1.14.13-r2 --> 1.14.15-r1*
* *polar-scan-matcher 0.3.3-r2*
* *psen-scan-v2 0.1.6-r1 --> 0.2.1-r1*
* *realsense2-camera 2.2.23-r1 --> 2.2.24-r1*
* *realsense2-description 2.2.23-r1 --> 2.2.24-r1*
* *ros-comm 1.14.10-r1 --> 1.14.11-r1*
* *rosbag 1.14.10-r1 --> 1.14.11-r1*
* *rosbag-storage 1.14.10-r1 --> 1.14.11-r1*
* *roscpp 1.14.10-r1 --> 1.14.11-r1*
* *rosgraph 1.14.10-r1 --> 1.14.11-r1*
* *roslaunch 1.14.10-r1 --> 1.14.11-r1*
* *roslz4 1.14.10-r1 --> 1.14.11-r1*
* *rosmaster 1.14.10-r1 --> 1.14.11-r1*
* *rosmsg 1.14.10-r1 --> 1.14.11-r1*
* *rosnode 1.14.10-r1 --> 1.14.11-r1*
* *rosout 1.14.10-r1 --> 1.14.11-r1*
* *rosparam 1.14.10-r1 --> 1.14.11-r1*
* *rospy 1.14.10-r1 --> 1.14.11-r1*
* *rosservice 1.14.10-r1 --> 1.14.11-r1*
* *rostest 1.14.10-r1 --> 1.14.11-r1*
* *rostopic 1.14.10-r1 --> 1.14.11-r1*
* *roswtf 1.14.10-r1 --> 1.14.11-r1*
* *scan-to-cloud-converter 0.3.3-r2*
* *scan-tools 0.3.3-r2*
* *sot-core 4.11.5-r2 --> 4.11.6-r1*
* *topic-tools 1.14.10-r1 --> 1.14.11-r1*
* *urg-stamped 0.0.10-r1 --> 0.0.11-r1*
* *xmlrpcpp 1.14.10-r1 --> 1.14.11-r1*

Noetic Changes:
---------------
* *bagger 0.1.3-r4 --> 0.1.4-r1*
* *boost-sml 0.1.1-r1 --> 0.1.2-r1*
* *catkin 0.8.9-r1 --> 0.8.10-r1*
* *dynamixel-sdk 3.7.31-r1 --> 3.7.51-r4*
* *dynamixel-sdk-examples 3.7.51-r4*
* *eigenpy 2.6.2-r1 --> 2.6.3-r1*
* *fadecandy-driver 0.1.3-r1 --> 0.2.1-r1*
* *fadecandy-msgs 0.1.3-r1 --> 0.2.1-r1*
* *fetch-bringup 0.9.2-r1 --> 0.9.3-r1*
* *fetch-drivers 0.9.2-r1 --> 0.9.3-r1*
* *freight-bringup 0.9.2-r1 --> 0.9.3-r1*
* *gazebo-dev 2.9.1-r1 --> 2.9.2-r1*
* *gazebo-msgs 2.9.1-r1 --> 2.9.2-r1*
* *gazebo-plugins 2.9.1-r1 --> 2.9.2-r1*
* *gazebo-ros 2.9.1-r1 --> 2.9.2-r1*
* *gazebo-ros-control 2.9.1-r1 --> 2.9.2-r1*
* *gazebo-ros-pkgs 2.9.1-r1 --> 2.9.2-r1*
* *hls-lfcd-lds-driver 1.1.1-r1 --> 1.1.2-r1*
* *librealsense2 2.42.0-r1 --> 2.44.0-r1*
* *opw-kinematics 0.4.1-r2 --> 0.4.3-r1*
* *pilz-control 0.6.0-r1*
* *pilz-robots 0.6.0-r1*
* *pilz-status-indicator-rqt 0.6.0-r1*
* *pinocchio 2.5.6-r1 --> 2.6.0-r1*
* *points-preprocessor 1.14.11-r3 --> 1.14.14-r1*
* *prbt-gazebo 0.6.0-r1*
* *prbt-grippers 0.0.5-r2*
* *prbt-hardware-support 0.6.0-r1*
* *prbt-ikfast-manipulator-plugin 0.6.0-r1*
* *prbt-moveit-config 0.6.0-r1*
* *prbt-pg70-support 0.0.5-r2*
* *prbt-support 0.6.0-r1*
* *psen-scan-v2 0.2.0-r1 --> 0.2.1-r1*
* *realsense2-camera 2.2.22-r1 --> 2.2.24-r1*
* *realsense2-description 2.2.22-r1 --> 2.2.24-r1*
* *robot-body-filter 1.1.9-r1*
* *ros-industrial-cmake-boilerplate 0.2.9-r2*
* *rqt-msg 0.4.9-r1 --> 0.4.10-r1*
* *rqt-pose-view 0.5.10-r1 --> 0.5.11-r1*
* *rqt-publisher 0.4.9-r1 --> 0.4.10-r1*
* *rqt-py-console 0.4.9-r1 --> 0.4.10-r1*
* *rqt-runtime-monitor 0.5.8-r1 --> 0.5.9-r1*
* *rqt-service-caller 0.4.9-r1 --> 0.4.10-r1*
* *rqt-shell 0.4.10-r1 --> 0.4.11-r1*
* *rqt-srv 0.4.8-r1 --> 0.4.9-r1*
* *rqt-top 0.4.9-r1 --> 0.4.10-r1*
* *rqt-web 0.4.9-r1 --> 0.4.10-r1*
* *sot-core 4.11.5-r2 --> 4.11.6-r1*
* *tesseract-common 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-geometry 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-kinematics 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-scene-graph 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-srdf 0.4.1-r1*
* *tesseract-support 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-urdf 0.3.0-r1 --> 0.4.1-r1*
* *tesseract-visualization 0.3.0-r1 --> 0.4.1-r1*
* *urg-stamped 0.0.10-r1 --> 0.0.11-r1*
* *vision-visp 0.12.1-r1*
* *visp-auto-tracker 0.12.1-r1*
* *visp-bridge 0.12.1-r1*
* *visp-camera-calibration 0.12.1-r1*
* *visp-hand2eye-calibration 0.12.1-r1*
* *visp-tracker 0.12.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libgstreamer-plugins-base0.10-dev
 * [ ] libgstreamer0.10-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libsoqt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rosinstall
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

