### PR TITLE
rosdistro sync, Fri May  7 13:30:57 2021

### DIFF
--- a/distros/dashing/ros2trace/default.nix
+++ b/distros/dashing/ros2trace/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "0.2.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/ros2trace/0.2.8-1/ros2_tracing-release-release-dashing-ros2trace-0.2.8-1.tar.gz";
-    name = "ros2_tracing-release-release-dashing-ros2trace-0.2.8-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/dashing/ros2trace/0.2.8-1.tar.gz";
+    name = "0.2.8-1.tar.gz";
     sha256 = "4bcc78d1660a369807ba81094fe5879ae4c719d8d4ccb0ad92dae052ad33e083";
   };
 

--- a/distros/dashing/tracetools-launch/default.nix
+++ b/distros/dashing/tracetools-launch/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "0.2.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools_launch/0.2.8-1/ros2_tracing-release-release-dashing-tracetools_launch-0.2.8-1.tar.gz";
-    name = "ros2_tracing-release-release-dashing-tracetools_launch-0.2.8-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/dashing/tracetools_launch/0.2.8-1.tar.gz";
+    name = "0.2.8-1.tar.gz";
     sha256 = "770aaef848ded3f7e5e2d51a54d4f5547ebf664698350fad1b1ab6d0b82b4034";
   };
 

--- a/distros/dashing/tracetools-test/default.nix
+++ b/distros/dashing/tracetools-test/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "0.2.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools_test/0.2.8-1/ros2_tracing-release-release-dashing-tracetools_test-0.2.8-1.tar.gz";
-    name = "ros2_tracing-release-release-dashing-tracetools_test-0.2.8-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/dashing/tracetools_test/0.2.8-1.tar.gz";
+    name = "0.2.8-1.tar.gz";
     sha256 = "d5f81534775be316ee7c6ca86c804719da8d146021a0da36a1539cbb56954598";
   };
 

--- a/distros/dashing/tracetools/default.nix
+++ b/distros/dashing/tracetools/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "0.2.8-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/dashing/tracetools/0.2.8-1/ros2_tracing-release-release-dashing-tracetools-0.2.8-1.tar.gz";
-    name = "ros2_tracing-release-release-dashing-tracetools-0.2.8-1.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/dashing/tracetools/0.2.8-1.tar.gz";
+    name = "0.2.8-1.tar.gz";
     sha256 = "e3ea4ca3c544e46a26a4a2befc7c16439e7b477cedea5d7cba840a53e70cc577";
   };
 

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1a5dd311c14074233172bd80b22d0dfac019864f09fa7c14952f6aa2d0f6a082";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "7e29e4f86033bbcf40295bf658c48397a7b08d7a7d25a5c6aa2bd6564a30260a";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "4b519e3f209df0a06d58daed59ed03be6a720232418ed774de9ce2220c0df2dc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "2978351f547d33a018eea627dc9381a01c5509e2a9f027624885bff1bb05934b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "cad0be362e44ab6e7dc4ca38644504475c0dbe43feb8a57eab18eea37adf01dc";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "2c914f98ee926d65f4bf53d5a083ca1ee10664732610c41f251f0db4c1230231";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d2b3f3ca141acf6b5c758e1f1b42bc8b4a74296852ddfe830f9b6f22df381065";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d4f42c99320ce0c061b2d7992d3deb0fa803f57bfd73e7cac109f4b3c723c0f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamic-edt-3d/default.nix
+++ b/distros/foxy/dynamic-edt-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, octomap }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, octomap }:
 buildRosPackage {
   pname = "ros-foxy-dynamic-edt-3d";
-  version = "1.9.5-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/dynamic_edt_3d/1.9.5-2.tar.gz";
-    name = "1.9.5-2.tar.gz";
-    sha256 = "54c3247c65810814e12ebae2093f4f6d18e2c98c3f9773ada68f2690d5d1eff0";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/dynamic_edt_3d/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "875f29170fcf67ae8c6cdafe91baea41b258714a4eae930eb7c4ae712d731523";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ octomap ];
+  propagatedBuildInputs = [ ament-cmake octomap ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "d6d2c02da2803afda3d0193d84c8e1dceb3fe275d8e98afe1fa1ffa14b236b8a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "0911df3b259fd90c98e4e1f3bd29e09aa1246c5ac7dabaac807ba49ab9814375";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "0995f3fb3aaa6e01080b53000f9213d5be9c98fd098ab4344ffb0b726a7bed96";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "803c0e5a55729234362df019cb02cb18182ed7fe48d04e4bcb166c29ed01b0d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -494,6 +494,8 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
+
  joint-state-controller = self.callPackage ./joint-state-controller {};
 
  joint-state-publisher = self.callPackage ./joint-state-publisher {};

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "ccb49ea0322ef662f1b8989c65989b9d8c0a301c56d2cd1eb065ea4190c3fa26";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "e0691ae6b4fa56fefb121107633353fc9e7295fc48b0ac2cb1bf07ed06a66baa";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-joint-state-broadcaster";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "67bbbe7ca4c71954dc5020b4fddce54e5706ed43651457428b71f5e8044f6f8f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager rclcpp ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Broadcaster to publish joint state'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -2,20 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "c104aed4df9e821871a8ba13a530b27acce3d6e3e086142604f1ac570747ca77";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "566e516af991cd87dc7ee6ef47f6e0921847e72e818e174a8df2d8252a790e59";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager rclcpp ros2-control-test-assets ];
-  propagatedBuildInputs = [ control-msgs controller-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface rclcpp ros2-control-test-assets ];
+  propagatedBuildInputs = [ joint-state-broadcaster ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "f82abd362220bafdc1ddb1d08c10e0193a7989b5c14a535062fb9d96aae5b397";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "b40e594dc25947eeeae48714139270761e9051796312a2ea14561afcb154cb93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.42.0-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "4bf17bb40850d0130541079431abded90c270976d6c39ad680ec821394ff22bf";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "3ac5359c3e7e21c29d588b99b729577043dfbfd48c6bea21ee25d07ea12028ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.4.5-r1";
+  version = "2021.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.4.5-1.tar.gz";
-    name = "2021.4.5-1.tar.gz";
-    sha256 = "54a4a903655c5be2e0b72d967b37cd55786c00a9f1716b532a98a75a94515173";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.5.5-1.tar.gz";
+    name = "2021.5.5-1.tar.gz";
+    sha256 = "822596ffd11e1420b2732b9b79c67be9b3ad6caf09508bf8bff53c5e2f7d4063";
   };
 
   buildType = "cmake";

--- a/distros/foxy/nerian-stereo/default.nix
+++ b/distros/foxy/nerian-stereo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, stereo-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-nerian-stereo";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "4ceb088ea3090011cc5de3eb335197491d99860d238f8fcb1c0d269aaffa7e9b";
+    url = "https://github.com/nerian-vision/nerian_stereo_ros2-release/archive/release/foxy/nerian_stereo/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "b4a0bf390da4dcb6ed8b609f29a46e2108459549c8679cd0edfb92af92482c22";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ ament-cmake cv-bridge rosidl-default-generators rosidl-default-runtime sensor-msgs std-msgs stereo-msgs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''Driver node for ROS 2 for Scarlet, SceneScan and SP1 stereo vision sensors by Nerian Vision GmbH'';

--- a/distros/foxy/octomap/default.nix
+++ b/distros/foxy/octomap/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake }:
 buildRosPackage {
   pname = "ros-foxy-octomap";
-  version = "1.9.5-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octomap/1.9.5-2.tar.gz";
-    name = "1.9.5-2.tar.gz";
-    sha256 = "3bd2efc7e386c6ac70aa0f0af2d2794ad14042d1b3fb2adf1875ad2b03869342";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octomap/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "98bf2fe150437da7c6438b4936778889dbea3400775c90195c7916f7c83d28a2";
   };
 
   buildType = "cmake";
+  propagatedBuildInputs = [ ament-cmake ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/octovis/default.nix
+++ b/distros/foxy/octovis/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-octovis";
-  version = "1.9.5-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octovis/1.9.5-2.tar.gz";
-    name = "1.9.5-2.tar.gz";
-    sha256 = "72d466eb350fd1e84b32aa8d1d3d1e87eca8735a4712cbc00de8c00846d590f3";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/foxy/octovis/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "792c48dc5943a326194f72f5efa22cd37f4dd4c8e073e659e599a09e8f4be52e";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libsForQt5.libqglviewer octomap qt5.qtbase ];
+  propagatedBuildInputs = [ ament-cmake libsForQt5.libqglviewer octomap qt5.qtbase ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "b3b5422f74c918c62806445e94b3e78086ee95305eb1e96a258264295c366421";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "da6e26ecd8831c1d9833cfb69592e6fd744203b06513f8a5fa2c77e1e867b449";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.1.5-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "e5f4216f5db39bd0dad24e97fe4315224e644948efbad3a807c1b98ee81d6869";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c8b803c1f94d74a6a43379184ccb903f9d890cd452fd8ecec4468f439b7ed74d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.1.5-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "1de0248d83afddd9c710e1adb74e6c3b21f0b9473617079279b3925984835e3a";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c6b1e27024c24a334742f6acf2d6913d778500efc7de3edab5c936dd04286600";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
-  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs tf2 tf2-ros ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.1.5-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.1.5-1.tar.gz";
-    name = "3.1.5-1.tar.gz";
-    sha256 = "bcf9982981e6edb8d437180e1c9cc2196c9a0d114a2e216e6f90110f10b041d9";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "f6f69004cad342ce6d47981efc2104b28c2e498cc1b1b33506274bbe5bff39e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "2d3dc8e216b093772e45cce03db8b23f068fdfd398133ba940dd79c8463507e7";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "81e4745afcba5e4af2616d154d178ba80c8bead3ed7f5dce4d221cfe2ef570dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "06181c07d3ead1dd1583c935d9808bd3ea4df6873a1d4eded91a5d8569afc92e";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ba71fa8f899a6ab80908d575eab5b53e2afc2524153d952d766d8e46abe31cf8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, forward-command-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, forward-command-controller, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "5890b99f3d442576cb8960a82f2ca6078480df0a192dd97c7126b98a1545327b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "61fe8300e897a39cfcb778988028ba5ed7bc14cc38f6e16733c986dbc8925bc6";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ diff-drive-controller effort-controllers forward-command-controller joint-state-controller joint-trajectory-controller position-controllers velocity-controllers ];
+  propagatedBuildInputs = [ diff-drive-controller effort-controllers forward-command-controller joint-state-broadcaster joint-state-controller joint-trajectory-controller position-controllers velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "827bb83cd8db2195b8be2cf4372606e8f699651ed6da1f83186c3accae00e839";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "6e55ffd098128fd63a6fbf45a6e4276cdba13a83710e050a9c61fd54c1dbf150";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2trace/default.nix
+++ b/distros/foxy/ros2trace/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/foxy/ros2trace/1.0.5-2/ros2_tracing-release-release-foxy-ros2trace-1.0.5-2.tar.gz";
-    name = "ros2_tracing-release-release-foxy-ros2trace-1.0.5-2.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/foxy/ros2trace/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
     sha256 = "9cd998d905f4d740bf63d06a6713efb94e58344f75eaafea34a604c8becf6904";
   };
 

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.7.1-r2";
+  version = "0.7.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "ebc8c82e6fc12ee28422be3e70baa2e8759582e5783ab906705b883a9b21d891";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-3.tar.gz";
+    name = "0.7.1-3.tar.gz";
+    sha256 = "28926ff2f3994d256a0e7d2d7c6a3774f4d98be66cf05c96d23bcab1550f9219";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-msgs/default.nix
+++ b/distros/foxy/system-modes-msgs/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-lint-auto, builtin-interfaces, rosidl-default-generators }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-msgs";
-  version = "0.7.1-r2";
+  version = "0.7.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "4ff87f11a757b85a17a27a8f129f6aa14749005e6a197a2154e5c1155ea3ca66";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-3.tar.gz";
+    name = "0.7.1-3.tar.gz";
+    sha256 = "9993f0bd62647006dfe60e6708cbfb6e66b62d889dde8365779d862158cbe168";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-cppcheck ament-lint-auto ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators ];
-  nativeBuildInputs = [ ament-cmake ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-cmake-cppcheck ament-cmake-cpplint rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {
     description = ''Interface package, containing message definitions and service definitions

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.7.1-r2";
+  version = "0.7.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "4ed0d952b61b9ae5e077f88be6cc2188ff6d0d8bb2dc95f5412a4bd14d225b61";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-3.tar.gz";
+    name = "0.7.1-3.tar.gz";
+    sha256 = "7117fc6f467a6ec92295ad0b49b67bd3fb0c55020051f6b2a7ec513fd88840fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tracetools-launch/default.nix
+++ b/distros/foxy/tracetools-launch/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/foxy/tracetools_launch/1.0.5-2/ros2_tracing-release-release-foxy-tracetools_launch-1.0.5-2.tar.gz";
-    name = "ros2_tracing-release-release-foxy-tracetools_launch-1.0.5-2.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/foxy/tracetools_launch/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
     sha256 = "7789d923e675d776aea16b103bf20e4bb8ca38534ac3f0712b59985e7190dfee";
   };
 

--- a/distros/foxy/tracetools-test/default.nix
+++ b/distros/foxy/tracetools-test/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/foxy/tracetools_test/1.0.5-2/ros2_tracing-release-release-foxy-tracetools_test-1.0.5-2.tar.gz";
-    name = "ros2_tracing-release-release-foxy-tracetools_test-1.0.5-2.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/foxy/tracetools_test/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
     sha256 = "066770fa01463a384c5118c2a6c3ce86bc8a5807da57eea8c6b82fe13a1d58a4";
   };
 

--- a/distros/foxy/tracetools/default.nix
+++ b/distros/foxy/tracetools/default.nix
@@ -8,8 +8,8 @@ buildRosPackage {
   version = "1.0.5-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/ros-tracing/ros2_tracing-release/-/archive/release/foxy/tracetools/1.0.5-2/ros2_tracing-release-release-foxy-tracetools-1.0.5-2.tar.gz";
-    name = "ros2_tracing-release-release-foxy-tracetools-1.0.5-2.tar.gz";
+    url = "https://github.com/ros2-gbp/ros2_tracing-release/archive/release/foxy/tracetools/1.0.5-2.tar.gz";
+    name = "1.0.5-2.tar.gz";
     sha256 = "82e89315144b486b23e26cc59add26084f5d06173f2adcc04d7369e8b3a2eef3";
   };
 

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.4.0-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "0b27c5bc5e90fd263b2e0328ded512035d583999d171d767ef955311176c51f0";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "3a7bc953f373f229c9c9d63f3d12ea037f45a54ad76027d9adb039e7e364fb9b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.2.0-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "afaf2efa81937138d3622c4ad54998986514bba8ba47bfe95efeb057c2f9a713";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "da0f2ed79d649b5f203fbcd8c1cc13e51ebbf71af9b6d7368a6682a87c5f9cbb";
   };
 
   buildType = "ament_cmake";

--- a/distros/kinetic/generated.nix
+++ b/distros/kinetic/generated.nix
@@ -1334,6 +1334,8 @@ self: super: {
 
  goal-passer = self.callPackage ./goal-passer {};
 
+ gpio-control = self.callPackage ./gpio-control {};
+
  gps-common = self.callPackage ./gps-common {};
 
  gps-goal = self.callPackage ./gps-goal {};

--- a/distros/kinetic/genpy/default.nix
+++ b/distros/kinetic/genpy/default.nix
@@ -5,16 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-kinetic-genpy";
-  version = "0.6.15-r1";
+  version = "0.6.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/kinetic/genpy/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "79dd12c91d49d7b9aceeded88935965a91ef59db2ecc589b17bcee4d1090b598";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/kinetic/genpy/0.6.14-1.tar.gz";
+    name = "0.6.14-1.tar.gz";
+    sha256 = "bec9eda88be0295d62db2d846af960fae57dac5a6b384c0f5e4011a97181e448";
   };
 
   buildType = "catkin";
-  checkInputs = [ pythonPackages.numpy ];
   propagatedBuildInputs = [ genmsg pythonPackages.pyyaml ];
   nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 

--- a/distros/kinetic/gpio-control/default.nix
+++ b/distros/kinetic/gpio-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-kinetic-gpio-control";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cst0/gpio_control-release/archive/release/kinetic/gpio_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f7b5a3a99b94cf5c7e9710c54dd7491991942a3ff835e87e70a15e1afa78bdaf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Control GPIO pins on Raspberry Pi, Nvidia Jetson, and other Linux devices with GPIO pins'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/kinetic/librealsense/default.nix
+++ b/distros/kinetic/librealsense/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, linuxHeaders, openssl, pkg-config }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense";
-  version = "1.12.1";
+  version = "1.12.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/intel-ros/librealsense-release/archive/release/kinetic/librealsense/1.12.1-0.tar.gz";
-    name = "1.12.1-0.tar.gz";
-    sha256 = "5a25f39bc13940211cec4fae8d377da4117fa07033d73226a588bce4a9e34129";
+    url = "https://github.com/intel-ros/librealsense-release/archive/release/kinetic/librealsense/1.12.2-1.tar.gz";
+    name = "1.12.2-1.tar.gz";
+    sha256 = "c704a8070489b4b4fbc3f23f514b284155731fc101391a8a5601b42c895c49ff";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/librealsense2/default.nix
+++ b/distros/kinetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-kinetic-librealsense2";
-  version = "2.42.0-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.42.0-1.tar.gz";
-    name = "2.42.0-1.tar.gz";
-    sha256 = "b6e5e80de9dbc2a4d6221d9e231514520da68d72219f1019d004c30e02c26b4f";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/kinetic/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "92ef7437fec6e782458a05363ad333ef670b93281273d1d49790c18c4fddc838";
   };
 
   buildType = "cmake";

--- a/distros/kinetic/realsense2-camera/default.nix
+++ b/distros/kinetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-camera";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "53ccfacfd82f3d90b923cd835037a715c9aa5fb05eef28fcf1fb109e46c20698";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_camera/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "948cfca6c2fb1343daffc7e5c3591b122438b6ce5c0d5e289157a426bdeb9698";
   };
 
   buildType = "catkin";

--- a/distros/kinetic/realsense2-description/default.nix
+++ b/distros/kinetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-kinetic-realsense2-description";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "2f9fe1e0cdb9f96f8395f9238f23717c815635831257a508ed3359c28ab27734";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/kinetic/realsense2_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "09a67e648efba504ec4daf005539a9cffd40056780c70962aaa60b326059d708";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dynamic-edt-3d/default.nix
+++ b/distros/melodic/dynamic-edt-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, octomap }:
 buildRosPackage {
   pname = "ros-melodic-dynamic-edt-3d";
-  version = "1.9.0-r1";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "b3da422d3baebaea5aa422558b878f02058f7695617e5b116ee7bdf1723c12cc";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/dynamic_edt_3d/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "b716b393f7a79fbcf653cb96ed7ce995ef0d02f29653db7ecf7087259a31322d";
   };
 
   buildType = "cmake";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1142,6 +1142,8 @@ self: super: {
 
  genmsg = self.callPackage ./genmsg {};
 
+ genmypy = self.callPackage ./genmypy {};
+
  gennodejs = self.callPackage ./gennodejs {};
 
  genpy = self.callPackage ./genpy {};
@@ -2419,6 +2421,8 @@ self: super: {
  octomap-rviz-plugins = self.callPackage ./octomap-rviz-plugins {};
 
  octomap-server = self.callPackage ./octomap-server {};
+
+ octovis = self.callPackage ./octovis {};
 
  odom-frame-publisher = self.callPackage ./odom-frame-publisher {};
 

--- a/distros/melodic/genmypy/default.nix
+++ b/distros/melodic/genmypy/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages }:
+buildRosPackage {
+  pname = "ros-melodic-genmypy";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rospypi/genmypy-release/archive/release/melodic/genmypy/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "6ffd972d47af70880c895da63f5c266d79454bde61e9c55a2cae7cba31249bf7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ genmsg genpy ];
+  nativeBuildInputs = [ catkin pythonPackages.setuptools ];
+
+  meta = {
+    description = ''Python stub generator from genmsg specs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/genpy/default.nix
+++ b/distros/melodic/genpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genpy";
-  version = "0.6.15-r1";
+  version = "0.6.16-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.15-1.tar.gz";
-    name = "0.6.15-1.tar.gz";
-    sha256 = "4085c1c3c0798218f15ba925883c2e02faadce969e4179b30593e6f69a9aaacd";
+    url = "https://github.com/ros-gbp/genpy-release/archive/release/melodic/genpy/0.6.16-1.tar.gz";
+    name = "0.6.16-1.tar.gz";
+    sha256 = "1b1e9c10f9bc7976395bc7d966d6ec895f1a5d5d4c161a11c3f38c8a2e614f7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libmavconn/default.nix
+++ b/distros/melodic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-libmavconn";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "01db158bb922e2c4164a6ac10d9cfb82a83aa8ef01eb1f553c447dfd487615f5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/libmavconn/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "75e920879ec83e3d97fced433b3ef8cbd90794e3430bdc87af5f1e9705c68f09";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.44.0-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.44.0-1.tar.gz";
-    name = "2.44.0-1.tar.gz";
-    sha256 = "b98ed069209d2ccc6dd358e5290150d64289b08281e13f7b2f3a35a1c832588b";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "381766c25440e4b4e241110fbbcedfc89139dc47802251e548f3b3f79b8fbce9";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.4.5-r1";
+  version = "2021.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.4.5-1.tar.gz";
-    name = "2021.4.5-1.tar.gz";
-    sha256 = "5c8763c08dad8f10140a09a5ba3a2265280b5491f8e62b4fa5f54d946ab6879d";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.5.5-1.tar.gz";
+    name = "2021.5.5-1.tar.gz";
+    sha256 = "c18788153874f44a16720fbf7216b6dcc1c7817d269d7188e4aa1b934e788fdb";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavros-extras/default.nix
+++ b/distros/melodic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-extras";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "35288baf807030765024fac4ffd82bc96bf37904b797ea747b1bab706199c3a5";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_extras/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "d724a42f120b98c766fe6386353bfb1df885f73109bad2e4b95a0c7a25d71f35";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros-msgs/default.nix
+++ b/distros/melodic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros-msgs";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "5952f361bd61e1e5d2782026fee357f6e80a1fda93284aa3b02bdf338bc9a0cb";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros_msgs/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "c3cc214ca1c9759518aac85b1f5941e67528a3c3beaa437ac34b5c529b7ca626";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavros/default.nix
+++ b/distros/melodic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mavros";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "21dc2d76fff5ebfa705651ce66adfdedb5e91cab409a234bb6a9089889e66f63";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/mavros/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "68ce1c7220ee095a1d8652973f4f0d2aa3c241bec5438ed660cde1bb3744653c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-description/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "65805fec2f5b7f969070d1f9d366552a7e2dc35d00caeba2b983554df795164e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "0a5d9ecb8548374826711eff22823fb86e6ca1b26e37d4f39a24874d7f541a11";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-fanuc-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "1c4222c33fc3e445798ac8bab17f1272f2a05c6b6568a12ffc7a64c7b7a2b601";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_fanuc_moveit_config/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "d11bce419df56d78db8a13f39aa93a31e9cec6d320b018238e3e2f0cd7eaf4e3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-description/default.nix
+++ b/distros/melodic/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "2ea454f18275d032d3840a98a7c73c8875fd79d6bd6ef30792d715b6e2e9eee1";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "11ab71e36ddcaa98661635dc5c4adc03de3efd20564106387d2f330a161fad93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-panda-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "64287aa29d93df7a1c96ea81a22b3d9453a7be3d3d2be92f8631cbaad9a71911";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_panda_moveit_config/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "baaf3eaeedb341f01100349341646c2c5ded56936e214d5ea991b0807b97fe11";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-pr2-description/default.nix
+++ b/distros/melodic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-pr2-description";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "46c51309d28c77c56ae164068cc6df87847f971be48b5adcac4a0eba0e46ea77";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_pr2_description/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "01a026146163de2a0f08186c0cbe623f69ddfa0c86b0a258d877a5a9d15a4bd3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "8f5a09a6be8183fcf3f66f1ebbeee2c8ed0c6b47dacfcab658e9136f88e1ff3e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_ikfast_manipulator_plugin/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "84e7a9be6e81953ad3b003e2d4bde971bc0e4345c46dc89497c17713a193d4df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/melodic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "83f5e7a7d9e779b40f53a6904100bb088af35387c47d3bf293be93eafab12350";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_moveit_config/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "cc1e2a2f1fef9e0a366b65158d0687aa47e40d4e24c50a1f19be9fd5b5c46dc1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-pg70-support";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "c23e3715408a66a81c5cd8e282281c61bca3885f725322568325c8c79efc7925";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_pg70_support/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "e0828621bbed5c1cb24ce616f46987b8c58ae65facac5f7fa1869fc21e00e220";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources-prbt-support/default.nix
+++ b/distros/melodic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources-prbt-support";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "bff9692e8580aaa8b83a30630eea0fca5883505ce69781f95d0ecb9014870d14";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources_prbt_support/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "9b377b7cdf7a37161b3c8700a69afa66c3fcfaf29da2d666cec1d96eb6584655";
   };
 
   buildType = "catkin";

--- a/distros/melodic/moveit-resources/default.nix
+++ b/distros/melodic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-melodic-moveit-resources";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "e8125019593326ed19a34f45a006a418324bbf8de0af29aebab71ca010c490a4";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/melodic/moveit_resources/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "80247c1d9562e45f7c10e0fb3c01074c70199e712ff6c124e6322e31ddedf52c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/octomap/default.nix
+++ b/distros/melodic/octomap/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-melodic-octomap";
-  version = "1.9.0-r1";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.0-1.tar.gz";
-    name = "1.9.0-1.tar.gz";
-    sha256 = "20a5bb7d159129053c2b25f7c02a76ad4ffec83c31e2fb4486753c88115caee6";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octomap/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "4e0637858158938f744a53cbbfaa410f5d67d103cdd78cfc759d86321877a8fd";
   };
 
   buildType = "cmake";

--- a/distros/melodic/octovis/default.nix
+++ b/distros/melodic/octovis/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, libsForQt5, octomap, qt5 }:
+buildRosPackage {
+  pname = "ros-melodic-octovis";
+  version = "1.9.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/melodic/octovis/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "5b0d576647416126ae201c21e66e734bc9587766dfff31de44bca12bd5a024fc";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ catkin libsForQt5.libqglviewer octomap qt5.qtbase ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''octovis is visualization tool for the OctoMap library based on Qt and libQGLViewer. See
+  http://octomap.github.io for details.'';
+    license = with lib.licenses; [ gpl2 ];
+  };
+}

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "7e67a9cf5290584e7ebcb47df474ed6e05bfadf36c2bb7dd936a43a5dfdb951e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a54563887751fe230e7f4fd9b1f5d62e641f48fb395afcdc2150d4273aad97c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "d7def3715aacbe10d673cd070dbfd7b7bb6998f73ba1a5370d273695441b782f";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e3b1935e077bd1906236929a21f9f2fbd59cc005f8648dc7cd613ca4cd0ba718";
   };
 
   buildType = "catkin";

--- a/distros/melodic/stag-ros/default.nix
+++ b/distros/melodic/stag-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, geometry-msgs, image-transport, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-stag-ros";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/usrl-uofsc/stag_ros-release/archive/release/melodic/stag_ros/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "8e4352d89fd773c91a4451293ff45f21c1055d9c21795f99854a86e84ec1d7b4";
+    url = "https://github.com/usrl-uofsc/stag_ros-release/archive/release/melodic/stag_ros/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "e0ad126a2ffbeacc996a39f3dc98b53401462a21d0aa46ba4873233f8c9b90ba";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager cv-bridge geometry-msgs image-transport nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge geometry-msgs image-transport message-generation message-runtime nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/test-mavros/default.nix
+++ b/distros/melodic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-test-mavros";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "67dac20e5c401b6dab696ad115a3717c7ad477cbbe8080f8072d1e9350b81289";
+    url = "https://github.com/mavlink/mavros-release/archive/release/melodic/test_mavros/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "c061b35c785758828eb7057c297be5656c8aa83520fabfa36a67f3f9f1dcb4a5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ur-client-library/default.nix
+++ b/distros/melodic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ur-client-library";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "73799aade33baff806b0ce765299351fcdebb9e35f7d12f73024de65f108517f";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "94dca774fb8043d00cbc81d8662388b19c31a2b9d7ac20cc29c5b2ea976069e5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, utillinux }:
+buildRosPackage {
+  pname = "ros-noetic-azure-iot-sdk-c";
+  version = "1.7.0-r3";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-3.tar.gz";
+    name = "1.7.0-3.tar.gz";
+    sha256 = "f3f2075567737c0e23e919dfc043654d8bf3fb2125cc90ba83c06545f4e70bf7";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ catkin curl utillinux ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Azure IoT C SDKs and Libraries'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "a4ec926f15003c57d5d23fe4d1511223e630dc7f1a8d30e6e5327804aa3a307d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "40a235087ac33569da3347dc37e333ae46cea50dab95cbc9d971b7bcbd12c58b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/darknet-ros-msgs/default.nix
+++ b/distros/noetic/darknet-ros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-darknet-ros-msgs";
+  version = "1.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/leggedrobotics/darknet_ros-release/archive/release/noetic/darknet_ros_msgs/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "ffb4a63ef48a67dc35cf7887b0c120951ad3b293bf4e0f259660ff7e3d26e29d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Darknet is an open source neural network framework that runs on CPU and GPU. You only look once (YOLO) is a state-of-the-art, real-time object detection system.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/darknet-ros/default.nix
+++ b/distros/noetic/darknet-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cv-bridge, darknet-ros-msgs, image-transport, message-generation, nodelet, opencv3, roscpp, rospy, rostest, sensor-msgs, std-msgs, wget, xorg }:
+buildRosPackage {
+  pname = "ros-noetic-darknet-ros";
+  version = "1.1.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/leggedrobotics/darknet_ros-release/archive/release/noetic/darknet_ros/1.1.5-1.tar.gz";
+    name = "1.1.5-1.tar.gz";
+    sha256 = "1ab3b50195ea9537bf73b5c9e756bece85da94e0f77792314699e8ed9c607bd1";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest wget ];
+  propagatedBuildInputs = [ actionlib boost cv-bridge darknet-ros-msgs image-transport message-generation nodelet opencv3 roscpp rospy sensor-msgs std-msgs xorg.libX11 xorg.libXext xorg.libXtst ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Darknet is an open source neural network framework that runs on CPU and GPU. You only look once (YOLO) is a state-of-the-art, real-time object detection system.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/drone-assets/default.nix
+++ b/distros/noetic/drone-assets/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-drone-assets";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_assets/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "fe6c1d0b77977a27226148598d70eb902bb833ed24fd59cb6f32c80322489399";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The drone_assets package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/drone-wrapper/default.nix
+++ b/distros/noetic/drone-wrapper/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-drone-wrapper";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_wrapper/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "a08c33118fc65b516e994a1c0d433256fd4e3a9b2a2f686726dcb6915e234b8e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The drone_wrapper package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/dynamic-edt-3d/default.nix
+++ b/distros/noetic/dynamic-edt-3d/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, octomap }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, octomap }:
 buildRosPackage {
   pname = "ros-noetic-dynamic-edt-3d";
-  version = "1.9.6-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.6-2.tar.gz";
-    name = "1.9.6-2.tar.gz";
-    sha256 = "a520fefda72b7919a8d500bbf94dc0ad88c4388e3c6a29df74e621b71785e88a";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/dynamic_edt_3d/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "233899b5ed9f3422daa94d4fbd8ab3069ed7dc18a4d16504daccac0eb240bda4";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ octomap ];
+  propagatedBuildInputs = [ catkin octomap ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/ethercat-grant/default.nix
+++ b/distros/noetic/ethercat-grant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libcap, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-ethercat-grant";
-  version = "0.2.5-r3";
+  version = "0.2.5-r5";
 
   src = fetchurl {
-    url = "https://github.com/shadow-robot/ethercat_grant-release/archive/release/noetic/ethercat_grant/0.2.5-3.tar.gz";
-    name = "0.2.5-3.tar.gz";
-    sha256 = "5038c00d18399930e6b88a67b0472a4b89ee3ad5c97e2110f5872975caf60cbb";
+    url = "https://github.com/shadow-robot/ethercat_grant-release/archive/release/noetic/ethercat_grant/0.2.5-5.tar.gz";
+    name = "0.2.5-5.tar.gz";
+    sha256 = "9ad306c1bb8772ccb1ec19c4baae841715a3e16e3d36116a57ab21486d596c60";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -94,6 +94,8 @@ self: super: {
 
  avt-vimba-camera = self.callPackage ./avt-vimba-camera {};
 
+ azure-iot-sdk-c = self.callPackage ./azure-iot-sdk-c {};
+
  backward-ros = self.callPackage ./backward-ros {};
 
  bagger = self.callPackage ./bagger {};
@@ -412,6 +414,10 @@ self: super: {
 
  cv-camera = self.callPackage ./cv-camera {};
 
+ darknet-ros = self.callPackage ./darknet-ros {};
+
+ darknet-ros-msgs = self.callPackage ./darknet-ros-msgs {};
+
  dataspeed-can = self.callPackage ./dataspeed-can {};
 
  dataspeed-can-msg-filters = self.callPackage ./dataspeed-can-msg-filters {};
@@ -513,6 +519,10 @@ self: super: {
  driver-base = self.callPackage ./driver-base {};
 
  driver-common = self.callPackage ./driver-common {};
+
+ drone-assets = self.callPackage ./drone-assets {};
+
+ drone-wrapper = self.callPackage ./drone-wrapper {};
 
  dual-quaternions = self.callPackage ./dual-quaternions {};
 
@@ -824,6 +834,8 @@ self: super: {
 
  genmsg = self.callPackage ./genmsg {};
 
+ genmypy = self.callPackage ./genmypy {};
+
  gennodejs = self.callPackage ./gennodejs {};
 
  genpy = self.callPackage ./genpy {};
@@ -1045,6 +1057,8 @@ self: super: {
  ixblue-stdbin-decoder = self.callPackage ./ixblue-stdbin-decoder {};
 
  jderobot-assets = self.callPackage ./jderobot-assets {};
+
+ jderobot-drones = self.callPackage ./jderobot-drones {};
 
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
 
@@ -1530,6 +1544,8 @@ self: super: {
 
  novatel-oem7-msgs = self.callPackage ./novatel-oem7-msgs {};
 
+ ntpd-driver = self.callPackage ./ntpd-driver {};
+
  obj-to-pointcloud = self.callPackage ./obj-to-pointcloud {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -1646,6 +1662,8 @@ self: super: {
 
  pilz-control = self.callPackage ./pilz-control {};
 
+ pilz-industrial-motion = self.callPackage ./pilz-industrial-motion {};
+
  pilz-industrial-motion-planner = self.callPackage ./pilz-industrial-motion-planner {};
 
  pilz-industrial-motion-planner-testutils = self.callPackage ./pilz-industrial-motion-planner-testutils {};
@@ -1653,6 +1671,8 @@ self: super: {
  pilz-industrial-motion-testutils = self.callPackage ./pilz-industrial-motion-testutils {};
 
  pilz-msgs = self.callPackage ./pilz-msgs {};
+
+ pilz-robot-programming = self.callPackage ./pilz-robot-programming {};
 
  pilz-robots = self.callPackage ./pilz-robots {};
 
@@ -2104,9 +2124,13 @@ self: super: {
 
  rqt-dep = self.callPackage ./rqt-dep {};
 
+ rqt-drone-teleop = self.callPackage ./rqt-drone-teleop {};
+
  rqt-ez-publisher = self.callPackage ./rqt-ez-publisher {};
 
  rqt-graph = self.callPackage ./rqt-graph {};
+
+ rqt-ground-robot-teleop = self.callPackage ./rqt-ground-robot-teleop {};
 
  rqt-gui = self.callPackage ./rqt-gui {};
 
@@ -2257,6 +2281,8 @@ self: super: {
  slam-toolbox-rviz = self.callPackage ./slam-toolbox-rviz {};
 
  slic = self.callPackage ./slic {};
+
+ slider-publisher = self.callPackage ./slider-publisher {};
 
  slime-ros = self.callPackage ./slime-ros {};
 

--- a/distros/noetic/genmypy/default.nix
+++ b/distros/noetic/genmypy/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-genmypy";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rospypi/genmypy-release/archive/release/noetic/genmypy/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "888f8ec42b8f6664e3b75acaa8493f213e6c7fea16f6b80a095ea48a6d879de5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ genmsg genpy ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Python stub generator from genmsg specs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/jderobot-drones/default.nix
+++ b/distros/noetic/jderobot-drones/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
+buildRosPackage {
+  pname = "ros-noetic-jderobot-drones";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/jderobot_drones/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "77b06ac7a019f69390e1c3ec7f63fda32f2611bbd2bcc646aad9e0dd97062008";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ drone-assets drone-wrapper rqt-drone-teleop rqt-ground-robot-teleop ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The jderobot_drones stack'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/libmavconn/default.nix
+++ b/distros/noetic/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, console-bridge, gtest, mavlink, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-libmavconn";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "3ba84d67006f63959cfeee2d01bbaebd6055b1b2009cc493bd1e0894923dd333";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/libmavconn/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "bb9ad71810b538612d38db3494e3f41728fbf4a5365e8f438ac260030717dc51";
   };
 
   buildType = "catkin";

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.44.0-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.44.0-1.tar.gz";
-    name = "2.44.0-1.tar.gz";
-    sha256 = "fd51f0159a2559c744903fb27c08e9ad2165dabf06ad16b8129dcb9181b9a201";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "431ba3109e26e9fcf8ea32d2fe7b302e59a42304783dfa8dd29eb5c394e1bbf9";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.4.5-r1";
+  version = "2021.5.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.4.5-1.tar.gz";
-    name = "2021.4.5-1.tar.gz";
-    sha256 = "01a831cd36fed4504000cb36b06b11efa5f53d5ea2926d5eeb11beedbb555a2c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.5.5-1.tar.gz";
+    name = "2021.5.5-1.tar.gz";
+    sha256 = "5e0034dab7c4867b4e2dd8719d2db56eea004c021c996e6d9615c88f7960c37e";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mavros-extras/default.nix
+++ b/distros/noetic/mavros-extras/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, mavros, mavros-msgs, roscpp, sensor-msgs, std-msgs, tf, tf2-eigen, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-extras";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "57f5d92d6f7358ec94f72f12cfe59720e960a9322c090556d9056f57b9d45a01";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_extras/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "c51cc0bde07f5f41a710f5d85fa1dfa566cea4cd636f06ee0e557dde5e79738e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros-msgs/default.nix
+++ b/distros/noetic/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros-msgs";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "850964bc8c11eff51b1afd3bc449eb0ba44f442d8628c87050a5350403c98fda";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros_msgs/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "eca08ade9653f00896f84977c95654541ca8674d42e35bab83432c956b249685";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavros/default.nix
+++ b/distros/noetic/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, boost, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-runtime, nav-msgs, pluginlib, rosconsole-bridge, roscpp, rospy, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mavros";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "8c72a97c5b071ab343dae98c047cee261739c12243decdb2557129619c2ac930";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/mavros/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "e534ff47963abc6e938db0e36754cb32dad610f6c662f9fd6910f77eaa86be13";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "795d0d384b749bbcfc4179a26240784d8ad189f29fa44c8d7013951c0b8e298e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "dc3837435a7e86ee4d89fea33cc2d81d6484f299cd3e7143a26ef2e6537193e8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "0892744400e6c37e5659cd2d041b9d1da3bc4143a5f4843eed0e5da97f1eb647";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "e4e4a349f5604a01f56541e3f899a37ec257e83e1ff66d352f0137c3fcad10e2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "c6230757746f6802a8fccc50212e90b134dbb5f078c6480cac9874423a55735b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "05bedb5272e8382adf359f67f753f6910bddad13a79802c6b02b09b12f86f173";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "457f10a9b07db26c4f99bbf30df468cc2027316855c4431ed62ba88302a24718";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "2c2e4b2098eeec79d6f43f48394136ff9445ac0d41c37e2af9b7f3e907f0fb85";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "617d73b0a713ff48e15442adbd4eca561273c0b914cdded4abca324be9a214d6";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "9fedafd54cde4a54adbf92c6b6e7579a99bb71b406864787afc762d92cca832b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "5ed08d714296e7f164454f410b13a05d65c7b6ac5478770dc02bfffba07324f0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "97e8073177b88339e04093c31836d56ab1eab521a6bec01841cfe3ddbb08b959";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "1bf82c8f095d9083698a0e897b53ab9c78d777625f23652ccb3f9f1e4f264d79";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "ce340abcc49d65758ebf52ffa642986af1fbe773e184815a05cb0aab4e2413b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "94a1859de3edf53c2d9d1bfded7d20befd3753743a11659e6921e3a7a1b81650";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "084587749d27de3a91c8a256a8b5cfe610f0644c6e0804a41b8b1cdee6a5bce4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-fanuc-description/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-description";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "ac31453192d462730e5bc2db03cdf110672c017d76a366bf017c75497a8857cd";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_description/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e96e572ca7e9e2c3f4f33f879adf0b9656c0f3b72735e214af1693e687d771c2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-fanuc-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-fanuc-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "98d01c59b11310f98c0c4c6fc9a9dc465256296978b5f27663d079dfa47c47cc";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_fanuc_moveit_config/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "29cd4e85a6cef4f7f8b1c3bb7c79527a23dce9affd8d53c7c63049656d0145f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-panda-description/default.nix
+++ b/distros/noetic/moveit-resources-panda-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-description";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "faabfd7c5117051cefc3e47d8c240b839889b85e6f51d09bb2976bd1aa1c9eee";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_description/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "5cf0960a451c173bb6a66db6f1f7963249065d6307b8a7904626490aaf833a6f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-panda-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-panda-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "a0cda146285e31b0abc036bcf6bbb92f6a37442fcdbd8d6e04aa799b0baffd35";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_panda_moveit_config/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "4d855537b5ec93a7a9f9ad0326ea1d44734c02b8a7bcc98efd1a288d3a8b84b8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-pr2-description/default.nix
+++ b/distros/noetic/moveit-resources-pr2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-pr2-description";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "3d91786544c7a867c69e209374a8cab067b980efbd2aa0e99cdc34b59332418e";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_pr2_description/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "9d004fa8beee829a196ad0cbacabd5cc3df0dadeed7d3ec18e129b0e53155492";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/noetic/moveit-resources-prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-ikfast-manipulator-plugin";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "79b5862b188c5bb31a4acdb32243d80cc72a9d3ac6fc7759b679ce740f859426";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_ikfast_manipulator_plugin/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "4ab4c28fc8320c55f6d9fbdfeb0c8392b88dfb444adcc3e38dffb6d09515f659";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
+++ b/distros/noetic/moveit-resources-prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-support, robot-state-publisher, rviz, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-moveit-config";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "27f3307a7a2094a317c7b08bc91c9034e7e5dcb2ce207c8b61c5fa80e968a810";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_moveit_config/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "1377e3cf0ad2d10f52d8806535737b239890a4a5d43533df6afd5f7448cbbaf1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-pg70-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-resources-prbt-ikfast-manipulator-plugin, moveit-resources-prbt-moveit-config, moveit-resources-prbt-support, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-pg70-support";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "d0af752779a06226aa4efe26884e1cd7c2351977c21c2bac873907577263d197";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_pg70_support/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e45858c99bb4fdb924ad2260b960cd843114c4f394d62493f84ba11bef7f5748";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources-prbt-support/default.nix
+++ b/distros/noetic/moveit-resources-prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources-prbt-support";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "03bd797f0ee3d71990586f630ddead1330259299c753bedf5c43adf8f66bc2e1";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources_prbt_support/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e18673001b74ec83b9a3417f45e9bc7f86018b6a79b600be669eb800c4cd37fd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-resources/default.nix
+++ b/distros/noetic/moveit-resources/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
 buildRosPackage {
   pname = "ros-noetic-moveit-resources";
-  version = "0.7.2-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "fc73c68d1e04feab8807f938ad690f9537d24e00fc5cbda913a42ef0edebff2a";
+    url = "https://github.com/ros-gbp/moveit_resources-release/archive/release/noetic/moveit_resources/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "291ca0f0b0b28c74a3eb2d82df027e96f6214b4a3d4ea8ac9d6f44688351f9b5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "de07baff7c8f0c3ed34a11b6acef2bae5a6622bbfe824730fd5aafc34036e439";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "e98a41e04f33e23fd9d5a621c301a2636851ecb4bbeaaf8cae69a5c934b27292";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "5356c844a4ccb93c414a84e619b818ad586f68109b018ebc9c7f3a019d213969";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "11b2642a6866855e57552add90147401e299e210d63ddc867e2b6e03ab68ea29";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "83f01c01c5d59f564c885472e009e71d3d3b60911bbfbf00b4691afd058d51c5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "b6261c98a42580ac0fb430f7eeca9172753fc13a1755563cffe7f76e3247ae37";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "de6aa943e2cf5428f964b57a4abf172b95149f89e35df198c12e9333f976d9d1";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "617bf760fa919debf0c4f6d791268bd7dd3daeaff6996b85b59f6cf147b8ac83";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "e79d5459aa36502856e2a5e3b91993aecb286506eb62d9e741c53cc3004bfb3e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "c987857a989027bf70ad96ee60aaa6e36d217b8e3078b39084797bbee481af7f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "81c8526a7051af7dcaf4174dd759ea150a2823f89520d2c1536872b274d8e321";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "617c150d1b81fe7fffb05963b33eb0b08448c484ba049c3bedbd69b677f87553";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "d868a024f1e397d5c9297ff7389f5a9a97b4cea6e1cf4a6d326111d904f2a4e9";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "b4a4e20c4203194b568b10eea06fdb57a4679188b402300e7ceea60598214bbe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "b043f658cf15c6c56baa89365860b19a9f1cead5aecf294df8061139fc8d7c9f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "34d80354ac2d33c044e56334a06b27758ba5d5547a557a7339824ea6f78b89cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "668c0e9ebf19e1fa485772489f8841acbda0e92ffcb5ee35b401109669083ec5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "68877ee1daaf5347d467a6177b15b64a03f9b637bcfa1e1852fd4f6d4c218c5b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "ad296a830ae24e3773efe42c2d114283b424fcc6171ade4fb2a63a2141c434bf";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "8d6da5bbf389916e3b057df713461f094c5d6e91103cb9b4ed6e1d521b72f378";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "8be3653f01465f430fcb4f532ee698366d7792596c00413469b7bdc71523be33";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "131bb5a6e90fdb26576ad1c1d5aa7ea01d75f6bfe7fd4d278c983c607eef6d6c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "b025f7a2ca3fb38b74410ff8be6780d1b2dd32a7c3f447d15d5f4bfe28655f94";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "51ff138e5495f94027275ca45a5af4e80d9fefb60e9f679bc7e2a2d542ab03e3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "4d71320736f8f4ca1c7c8f53299977728acee302c5cef1180a24223a19e0b49b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "438f16835e2d7cc679407cee998a639669d74691b78853a58695d5ff84f02390";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "ec827b3112bd67fcd76566564f158d51ff03e2f925d00e39bf25929abb4289e2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "76e58a570436f5bdf36add482f84cbac92d8c111485d041486e43e78b3460754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "6ddcfe6febe6d19be02f286d67098d174d33d9ae7e834b632e3bf947b221778f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "338d54d1fc03e3596ac9c88d33ca25015027a9996849220b89f008d92e2d7d6e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "3652f82c79a59bd346ca9b8127c2559a7aec796227716ae75b0fe30cb7ad289b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "922477480dbdc31f24c4916ae07f567519e7d8b13adcf2af7a679f4e4ffa13a5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ntpd-driver/default.nix
+++ b/distros/noetic/ntpd-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, message-generation, message-runtime, poco, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ntpd-driver";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/vooon/ntpd_driver-release/archive/release/noetic/ntpd_driver/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "79f1971ba1b4652a10b7d1cad9354a1219da68b86b4a8321911efd2621fe0fe7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules message-generation message-runtime poco roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ntpd_driver sends TimeReference message time to ntpd server'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/octomap/default.nix
+++ b/distros/noetic/octomap/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake }:
 buildRosPackage {
   pname = "ros-noetic-octomap";
-  version = "1.9.6-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.6-2.tar.gz";
-    name = "1.9.6-2.tar.gz";
-    sha256 = "8c374f5ef014c9d5496aa7bccb496dba458a5ce2c4d3ace2d6f4c4104cda3296";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octomap/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "070c0eb719b120814c7ab76ec0f38ba46e924bac8b5415080bc080fa3aeb404f";
   };
 
   buildType = "cmake";
+  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/octovis/default.nix
+++ b/distros/noetic/octovis/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libsForQt5, octomap, qt5 }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, libsForQt5, octomap, qt5 }:
 buildRosPackage {
   pname = "ros-noetic-octovis";
-  version = "1.9.6-r2";
+  version = "1.9.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.6-2.tar.gz";
-    name = "1.9.6-2.tar.gz";
-    sha256 = "6fb47ca3b08da643c13d00d9a7c0ecd5454ddb05ab30247bd9bf753d69701713";
+    url = "https://github.com/ros-gbp/octomap-release/archive/release/noetic/octovis/1.9.7-1.tar.gz";
+    name = "1.9.7-1.tar.gz";
+    sha256 = "c04e15284a47d6e952f0d9ab9670cad38ee45287d200fbe3a7c50149126f3d1c";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libsForQt5.libqglviewer octomap qt5.qtbase ];
+  propagatedBuildInputs = [ catkin libsForQt5.libqglviewer octomap qt5.qtbase ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "bd6938bd65e4ce7089f891af48c54137c07416865b7320460db4e8be56a3f71f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "cd694ae7119ec753265e4827744208f2ff950e285a3006a00e8c6cddcad5933d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "0ad05c18eb63b71bb5cd37fe73c594f183dc407ab3bb154ae75a599344a105b0";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "c0eb5b2339672ffd06696cc03daf0dec9cd3224e79cbd860ae1f97c58278d211";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion/default.nix
+++ b/distros/noetic/pilz-industrial-motion/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pilz-industrial-motion-planner, pilz-msgs, pilz-robot-programming }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-industrial-motion";
+  version = "0.5.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/noetic/pilz_industrial_motion/0.5.0-4.tar.gz";
+    name = "0.5.0-4.tar.gz";
+    sha256 = "722c0b449c3c1f60769edd5ce16c2833c781d389d26b49a56a455aaaf5289641";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pilz-industrial-motion-planner pilz-msgs pilz-robot-programming ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pilz_industrial_motion package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pilz-robot-programming/default.nix
+++ b/distros/noetic/pilz-robot-programming/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, moveit-commander, pilz-industrial-motion-planner, pilz-industrial-motion-testutils, pilz-msgs, prbt-hardware-support, prbt-moveit-config, prbt-pg70-support, python3Packages, roslint, rospy, rostest, rosunit, tf-conversions, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-pilz-robot-programming";
+  version = "0.5.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/noetic/pilz_robot_programming/0.5.0-4.tar.gz";
+    name = "0.5.0-4.tar.gz";
+    sha256 = "4b094349fefd046eb81afc7c233cd56e763c5a7ba91bc13fcead1bf7bf598d62";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ code-coverage pilz-industrial-motion-testutils prbt-hardware-support prbt-moveit-config prbt-pg70-support python3Packages.coverage python3Packages.docopt python3Packages.mock rostest rosunit ];
+  propagatedBuildInputs = [ moveit-commander pilz-industrial-motion-planner pilz-msgs python3Packages.psutil rospy tf-conversions tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''An Easy to use API to execute standard industrial robot commands like Ptp, Lin, Circ and Sequence using Moveit.'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "56f3bdd1e20981fd57a58a048ba8c6047b74b78d65345db7a16f35e06bddf58e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2653644627753fb74647c9b6a48ff9f59690e63a709fdffcde1acb97c8c88155";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.2.24-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.2.24-1.tar.gz";
-    name = "2.2.24-1.tar.gz";
-    sha256 = "75c0d55590b06849a95533b9b3e2c440d5ded76b8aa2e94cff6596ececfd13d1";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "eae4d4966849bb5cae78b4fa802085e514a399ffb8232fed5f7cebb17788a4e5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-pytest/default.nix
+++ b/distros/noetic/ros-pytest/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, pythonPackages, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-ros-pytest";
-  version = "0.2.0";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/machinekoder/ros_pytest-release/archive/release/melodic/ros_pytest/0.2.0-0.tar.gz";
-    name = "0.2.0-0.tar.gz";
-    sha256 = "ba602e2fda979ab6f3097bfdad4c9cc589a7f0781f784cd46a1462de3636dc84";
+    url = "https://github.com/machinekoder/ros_pytest-release/archive/release/noetic/ros_pytest/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3a2e581bb9e205709f0613e58d93c6b0400f29e2359f058e81d1f18be5e5f643";
   };
 
   buildType = "catkin";
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ pythonPackages.pytest rospy ];
+  propagatedBuildInputs = [ python3Packages.pytestcov pythonPackages.pytest rospy ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-drone-teleop/default.nix
+++ b/distros/noetic/rqt-drone-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-drone-teleop";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_drone_teleop/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "296fdabffa7365e21fb7ab133efc32756463f189bf49a349e5ea6d1d511b6155";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ drone-wrapper geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A common drone teleop interface for all drone exercises in the JdeRobot Robotics Academy'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/rqt-ground-robot-teleop/default.nix
+++ b/distros/noetic/rqt-ground-robot-teleop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-ground-robot-teleop";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_ground_robot_teleop/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "3bb3ec22c82992e457654fa2bbca60688ae872e5dba98701d2f749d9d12d9f8c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A common ground robot teleop interface for all ground robot exercises in the JdeRobot Robotics Academy'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/slider-publisher/default.nix
+++ b/distros/noetic/slider-publisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rospy, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-noetic-slider-publisher";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/noetic/slider_publisher/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "82a79a0a9cac662cf81c61dd3efffacee06847054bf5c5f3c0de5e9f59be9dbe";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rospy rqt-gui-py ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The slider_publisher package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/stag-ros/default.nix
+++ b/distros/noetic/stag-ros/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, geometry-msgs, image-transport, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, roscpp, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-stag-ros";
-  version = "0.3.7-r1";
+  version = "0.3.9-r3";
 
   src = fetchurl {
-    url = "https://github.com/usrl-uofsc/stag_ros-release/archive/release/noetic/stag_ros/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "b39b8bed22738a18b760d55ec40a904efbd9ac2818b19ed559f57cde58b76c0c";
+    url = "https://github.com/usrl-uofsc/stag_ros-release/archive/release/noetic/stag_ros/0.3.9-3.tar.gz";
+    name = "0.3.9-3.tar.gz";
+    sha256 = "5829fb232d80c8e092afc90f5ec25b6d912bf08674703e6288cbd59d58eb39b3";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager cv-bridge geometry-msgs image-transport nodelet roscpp sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ camera-info-manager cv-bridge geometry-msgs image-transport message-generation message-runtime nodelet roscpp sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/test-mavros/default.nix
+++ b/distros/noetic/test-mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, control-toolbox, eigen, eigen-conversions, geometry-msgs, mavros, mavros-extras, roscpp, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-test-mavros";
-  version = "1.7.1-r1";
+  version = "1.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.7.1-1.tar.gz";
-    name = "1.7.1-1.tar.gz";
-    sha256 = "14ba833f527d4180f818bbafcfbb02cace92d2b51715d2ee0a2df65125539858";
+    url = "https://github.com/mavlink/mavros-release/archive/release/noetic/test_mavros/1.8.0-1.tar.gz";
+    name = "1.8.0-1.tar.gz";
+    sha256 = "ce1a93c95a6a1a466a96140eceb01dc187c2a98515e18926b38f475966b05dfe";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trac-ik-examples/default.nix
+++ b/distros/noetic/trac-ik-examples/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, orocos-kdl, trac-ik-lib, xacro }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, nlopt, orocos-kdl, trac-ik-lib, xacro }:
 buildRosPackage {
   pname = "ros-noetic-trac-ik-examples";
-  version = "1.6.1-r6";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_examples/1.6.1-6.tar.gz";
-    name = "1.6.1-6.tar.gz";
-    sha256 = "c9821e136f5ad6139c4cc10166baf5316cf360e20dc31d390133098843d54a7b";
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_examples/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "7e165764159a0cd77fa86d802a164a901bb79057257d9e3183782dd350f624ca";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ boost orocos-kdl trac-ik-lib xacro ];
+  propagatedBuildInputs = [ boost nlopt orocos-kdl trac-ik-lib xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/trac-ik-kinematics-plugin/default.nix
+++ b/distros/noetic/trac-ik-kinematics-plugin/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, moveit-core, pluginlib, roscpp, tf-conversions, trac-ik-lib }:
+{ lib, buildRosPackage, fetchurl, catkin, moveit-core, nlopt, pluginlib, roscpp, tf-conversions, trac-ik-lib }:
 buildRosPackage {
   pname = "ros-noetic-trac-ik-kinematics-plugin";
-  version = "1.6.1-r6";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_kinematics_plugin/1.6.1-6.tar.gz";
-    name = "1.6.1-6.tar.gz";
-    sha256 = "75a3e0da9b5cc99b5abdedcca241111b48354971b5faeb258f07d18bc56c748d";
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_kinematics_plugin/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "5edc36fd48484fee5af8fc5d54a089505d17d1dbd9e20cbfbaa76a62afbf22f1";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ moveit-core pluginlib roscpp tf-conversions trac-ik-lib ];
+  propagatedBuildInputs = [ moveit-core nlopt pluginlib roscpp tf-conversions trac-ik-lib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/trac-ik-lib/default.nix
+++ b/distros/noetic/trac-ik-lib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake-modules, eigen, kdl-parser, nlopt, pkg-config, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-trac-ik-lib";
-  version = "1.6.1-r6";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_lib/1.6.1-6.tar.gz";
-    name = "1.6.1-6.tar.gz";
-    sha256 = "1e3cf96735799225f4674ccd134181aa284168b7520c4a620c458e6027b1d1e7";
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_lib/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "3fc21184382c87e093b56e09b23d7683e216ed6fac1e807a6ce118712916ef04";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trac-ik-python/default.nix
+++ b/distros/noetic/trac-ik-python/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rospy, swig, tf, tf-conversions, trac-ik-lib }:
+{ lib, buildRosPackage, fetchurl, catkin, nlopt, rospy, swig, tf, tf-conversions, trac-ik-lib }:
 buildRosPackage {
   pname = "ros-noetic-trac-ik-python";
-  version = "1.6.1-r6";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_python/1.6.1-6.tar.gz";
-    name = "1.6.1-6.tar.gz";
-    sha256 = "83bd0dfb591bc4d63f8a3f3f4539ac0aa8a58c157689b715413f4d3f95a50733";
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik_python/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "fc8d13dfbc13c7b9513a9edd3f4b552c75e5b72d702d4a8b9475af6617719773";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rospy swig tf tf-conversions trac-ik-lib ];
+  propagatedBuildInputs = [ nlopt rospy swig tf tf-conversions trac-ik-lib ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/trac-ik/default.nix
+++ b/distros/noetic/trac-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, trac-ik-examples, trac-ik-kinematics-plugin, trac-ik-lib, trac-ik-python }:
 buildRosPackage {
   pname = "ros-noetic-trac-ik";
-  version = "1.6.1-r6";
+  version = "1.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik/1.6.1-6.tar.gz";
-    name = "1.6.1-6.tar.gz";
-    sha256 = "042fe38815ad645a4c75974238ef30c8da3cc4b13a4e1217d4a2e71aa55c956b";
+    url = "https://github.com/traclabs/trac_ik-release/archive/release/noetic/trac_ik/1.6.6-1.tar.gz";
+    name = "1.6.6-1.tar.gz";
+    sha256 = "14bc7e8cc907b126ef1c5aadf458709569f07d2f3a9831a75f47ced763996e52";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "0.1.1-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "2a4619d46de76b3543ee0a198ee735c1e669ca1676b7f5f094e7a5aba2bfdd31";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "e7eec06de67fc92fe275b5ac7b55e030acde82e40b683c8b9a9b7d51f7f76cc3";
   };
 
   buildType = "cmake";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 99e01d578a875f6a9930ef7d3833290af9296f4b.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *controller-interface 0.4.0-r1 --> 0.5.0-r1*
* *controller-manager 0.4.0-r1 --> 0.5.0-r1*
* *controller-manager-msgs 0.4.0-r1 --> 0.5.0-r1*
* *diff-drive-controller 0.2.0-r1 --> 0.2.1-r1*
* *dynamic-edt-3d 1.9.5-r2 --> 1.9.7-r1*
* *effort-controllers 0.2.0-r1 --> 0.2.1-r1*
* *forward-command-controller 0.2.0-r1 --> 0.2.1-r1*
* *hardware-interface 0.4.0-r1 --> 0.5.0-r1*
* *joint-state-broadcaster 0.2.1-r1*
* *joint-state-controller 0.2.0-r1 --> 0.2.1-r1*
* *joint-trajectory-controller 0.2.0-r1 --> 0.2.1-r1*
* *librealsense2 2.42.0-r1 --> 2.45.0-r1*
* *mavlink 2021.4.5-r1 --> 2021.5.5-r1*
* *nerian-stereo 1.0.1-r1 --> 1.0.2-r1*
* *octomap 1.9.5-r2 --> 1.9.7-r1*
* *octovis 1.9.5-r2 --> 1.9.7-r1*
* *position-controllers 0.2.0-r1 --> 0.2.1-r1*
* *realsense2-camera 3.1.5-r1 --> 3.2.0-r1*
* *realsense2-camera-msgs 3.1.5-r1 --> 3.2.0-r1*
* *realsense2-description 3.1.5-r1 --> 3.2.0-r1*
* *ros2-control 0.4.0-r1 --> 0.5.0-r1*
* *ros2-control-test-assets 0.4.0-r1 --> 0.5.0-r1*
* *ros2-controllers 0.2.0-r1 --> 0.2.1-r1*
* *ros2controlcli 0.4.0-r1 --> 0.5.0-r1*
* *system-modes 0.7.1-r2 --> 0.7.1-r3*
* *system-modes-examples 0.7.1-r2 --> 0.7.1-r3*
* *system-modes-msgs 0.7.1-r2 --> 0.7.1-r3*
* *transmission-interface 0.4.0-r1 --> 0.5.0-r1*
* *velocity-controllers 0.2.0-r1 --> 0.2.1-r1*

Kinetic Changes:
----------------
* *genpy 0.6.15-r1 --> 0.6.14-r1*
* *gpio-control 1.0.0-r1*
* *librealsense 1.12.1 --> 1.12.2-r1*
* *librealsense2 2.42.0-r1 --> 2.45.0-r1*
* *realsense2-camera 2.2.24-r1 --> 2.3.0-r1*
* *realsense2-description 2.2.24-r1 --> 2.3.0-r1*

Melodic Changes:
----------------
* *dynamic-edt-3d 1.9.0-r1 --> 1.9.7-r1*
* *genmypy 0.3.0-r1*
* *genpy 0.6.15-r1 --> 0.6.16-r1*
* *libmavconn 1.7.1-r1 --> 1.8.0-r1*
* *librealsense2 2.44.0-r1 --> 2.45.0-r1*
* *mavlink 2021.4.5-r1 --> 2021.5.5-r1*
* *mavros 1.7.1-r1 --> 1.8.0-r1*
* *mavros-extras 1.7.1-r1 --> 1.8.0-r1*
* *mavros-msgs 1.7.1-r1 --> 1.8.0-r1*
* *moveit-resources 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-fanuc-description 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-fanuc-moveit-config 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-panda-description 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-panda-moveit-config 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-pr2-description 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-prbt-moveit-config 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-prbt-pg70-support 0.7.2-r1 --> 0.7.3-r1*
* *moveit-resources-prbt-support 0.7.2-r1 --> 0.7.3-r1*
* *octomap 1.9.0-r1 --> 1.9.7-r1*
* *octovis 1.9.7-r1*
* *realsense2-camera 2.2.24-r1 --> 2.3.0-r1*
* *realsense2-description 2.2.24-r1 --> 2.3.0-r1*
* *stag-ros 0.2.1-r1 --> 0.2.2-r1*
* *test-mavros 1.7.1-r1 --> 1.8.0-r1*
* *ur-client-library 0.1.1-r1 --> 0.2.0-r1*

Noetic Changes:
---------------
* *azure-iot-sdk-c 1.7.0-r3*
* *chomp-motion-planner 1.1.2-r1 --> 1.1.3-r1*
* *darknet-ros 1.1.5-r1*
* *darknet-ros-msgs 1.1.5-r1*
* *drone-assets 1.4.0-r1*
* *drone-wrapper 1.4.0-r1*
* *dynamic-edt-3d 1.9.6-r2 --> 1.9.7-r1*
* *ethercat-grant 0.2.5-r3 --> 0.2.5-r5*
* *genmypy 0.3.0-r1*
* *jderobot-drones 1.4.0-r1*
* *libmavconn 1.7.1-r1 --> 1.8.0-r1*
* *librealsense2 2.44.0-r1 --> 2.45.0-r1*
* *mavlink 2021.4.5-r1 --> 2021.5.5-r1*
* *mavros 1.7.1-r1 --> 1.8.0-r1*
* *mavros-extras 1.7.1-r1 --> 1.8.0-r1*
* *mavros-msgs 1.7.1-r1 --> 1.8.0-r1*
* *moveit 1.1.2-r1 --> 1.1.3-r1*
* *moveit-chomp-optimizer-adapter 1.1.2-r1 --> 1.1.3-r1*
* *moveit-core 1.1.2-r1 --> 1.1.3-r1*
* *moveit-fake-controller-manager 1.1.2-r1 --> 1.1.3-r1*
* *moveit-kinematics 1.1.2-r1 --> 1.1.3-r1*
* *moveit-planners 1.1.2-r1 --> 1.1.3-r1*
* *moveit-planners-chomp 1.1.2-r1 --> 1.1.3-r1*
* *moveit-planners-ompl 1.1.2-r1 --> 1.1.3-r1*
* *moveit-plugins 1.1.2-r1 --> 1.1.3-r1*
* *moveit-resources 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-fanuc-description 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-fanuc-moveit-config 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-panda-description 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-panda-moveit-config 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-pr2-description 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-prbt-ikfast-manipulator-plugin 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-prbt-moveit-config 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-prbt-pg70-support 0.7.2-r1 --> 0.8.0-r1*
* *moveit-resources-prbt-support 0.7.2-r1 --> 0.8.0-r1*
* *moveit-ros 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-benchmarks 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-control-interface 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-manipulation 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-move-group 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-occupancy-map-monitor 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-planning 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-planning-interface 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-robot-interaction 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-visualization 1.1.2-r1 --> 1.1.3-r1*
* *moveit-ros-warehouse 1.1.2-r1 --> 1.1.3-r1*
* *moveit-runtime 1.1.2-r1 --> 1.1.3-r1*
* *moveit-servo 1.1.2-r1 --> 1.1.3-r1*
* *moveit-setup-assistant 1.1.2-r1 --> 1.1.3-r1*
* *moveit-simple-controller-manager 1.1.2-r1 --> 1.1.3-r1*
* *ntpd-driver 1.2.0-r1*
* *octomap 1.9.6-r2 --> 1.9.7-r1*
* *octovis 1.9.6-r2 --> 1.9.7-r1*
* *pilz-industrial-motion 0.5.0-r4*
* *pilz-industrial-motion-planner 1.1.2-r1 --> 1.1.3-r1*
* *pilz-industrial-motion-planner-testutils 1.1.2-r1 --> 1.1.3-r1*
* *pilz-robot-programming 0.5.0-r4*
* *realsense2-camera 2.2.24-r1 --> 2.3.0-r1*
* *realsense2-description 2.2.24-r1 --> 2.3.0-r1*
* *ros-pytest 0.2.0 --> 0.2.1-r1*
* *rqt-drone-teleop 1.4.0-r1*
* *rqt-ground-robot-teleop 1.4.0-r1*
* *slider-publisher 1.0.0-r1*
* *stag-ros 0.3.7-r1 --> 0.3.9-r3*
* *test-mavros 1.7.1-r1 --> 1.8.0-r1*
* *trac-ik 1.6.1-r6 --> 1.6.6-r1*
* *trac-ik-examples 1.6.1-r6 --> 1.6.6-r1*
* *trac-ik-kinematics-plugin 1.6.1-r6 --> 1.6.6-r1*
* *trac-ik-lib 1.6.1-r6 --> 1.6.6-r1*
* *trac-ik-python 1.6.1-r6 --> 1.6.6-r1*
* *ur-client-library 0.1.1-r1 --> 0.2.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] g++-multilib
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libgstreamer-plugins-base0.10-dev
 * [ ] libgstreamer0.10-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libsoqt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rosinstall
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

