### PR TITLE
melodic/franka-ros: add missing dependencies

### DIFF
--- a/distros/melodic/overrides.nix
+++ b/distros/melodic/overrides.nix
@@ -16,6 +16,29 @@ rosSelf: rosSuper: with rosSelf.lib; {
 
   gazebo = self.gazebo_9;
 
+  image-view = rosSuper.image-view.overrideAttrs (old: with self; {
+    # the problem is very similar to this:
+    # https://github.com/ros/ros-overlay/issues/607
+    cmakeFlags = [
+      "-DGTK2_GLIBCONFIG_INCLUDE_DIR:PATH=${glib.out}/lib/glib-2.0/include"
+      "-DGTK2_GDKCONFIG_INCLUDE_DIR:PATH=${gtk2.out}/lib/gtk-2.0/include"
+    ];
+  });
+
+  libfranka = rosSuper.libfranka.overrideAttrs (old: {
+    propagatedBuildInputs = with self; [ zlib pcre ] ++ old.propagatedBuildInputs;
+  });
+
+  moveit-core = (rosSelf.callPackage ../noetic/moveit-core {}).overrideAttrs (old: {
+    pname = "ros-melodic-moveit-core";
+    src = fetchTarball {
+      url = "https://github.com/ros-gbp/moveit-release/archive/refs/tags/release/melodic/moveit_core/1.0.7-1.tar.gz";
+      sha256 = "1b41dwdfwpywkf706403pk5ak810ijr46gri0phhi0wbnr071mqn";
+    };
+  });
+
+  moveit-ros-perception = (rosSelf.callPackage ./moveit-ros-perception {});
+
   pcl-ros = rosSuper.pcl-ros.overrideAttrs ({
     patches ? [], ...
   }: {


### PR DESCRIPTION
Unfortunately this does not build because of `defusedxml`. For the project where the patches were needed I used `nixpkgs-20.09`. There `defusedxml` is still at 0.6.0 and compatible with Python2.7.

I don't get why `overridePythonAttrs` does not apply properly. Can anyone help out?

```log
while evaluating the attribute 'defusedxml' at /home/vg/src/nix-ros-overlay/pkgs/default.nix:45:7:
while evaluating the attribute 'defusedxml.overridePythonAttrs' at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/top-level/python-packages.nix:1788:3:
while evaluating 'callPackageWith' at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:117:35, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/top-level/python-packages.nix:1788:16:
while evaluating 'makeOverridable' at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:67:24, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:121:8:
while evaluating anonymous function at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/development/python-modules/defusedxml/default.nix:1:1, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:69:16:
while evaluating 'makeOverridablePythonPackage' at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/top-level/python-packages.nix:32:37, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/development/python-modules/defusedxml/default.nix:8:1:
while evaluating 'makeOverridable' at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:67:24, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/top-level/python-packages.nix:34:12:
while evaluating anonymous function at /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/pkgs/development/interpreters/python/mk-python-derivation.nix:30:1, called from /nix/store/dxy4zxqgs0jdf4zswj0j9frbqy21qli7-source/lib/customisation.nix:69:16:
defusedxml-0.7.0 not supported for interpreter python2.7
```

Tested with

```nix
with (import ./. {});
mkShell {
  nativeBuildInputs = [
    (with rosPackages.melodic; buildEnv {
      paths = [
        desktop-full
        franka-ros
      ];
    })
  ];
}
```