### PR TITLE
rosdistro sync, Fri May 14 13:49:44 2021

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -794,6 +794,12 @@ self: super: {
 
  rcutils = self.callPackage ./rcutils {};
 
+ realsense2-camera = self.callPackage ./realsense2-camera {};
+
+ realsense2-camera-msgs = self.callPackage ./realsense2-camera-msgs {};
+
+ realsense2-description = self.callPackage ./realsense2-description {};
+
  realsense-camera-msgs = self.callPackage ./realsense-camera-msgs {};
 
  realsense-ros2-camera = self.callPackage ./realsense-ros2-camera {};

--- a/distros/dashing/librealsense2/default.nix
+++ b/distros/dashing/librealsense2/default.nix
@@ -2,24 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, gtk3, libGL, libGLU, libusb1, linuxHeaders, openssl, pkg-config, udev }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-dashing-librealsense2";
-  version = "2.16.5-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/dashing/librealsense2/2.16.5-1.tar.gz";
-    name = "2.16.5-1.tar.gz";
-    sha256 = "8200ccf50818a19a4dcd625f099e960c38285c2181cef249da10fae25206ee07";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/dashing/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "525cb4c6d9c249e14402fa204abae875bd06308872a088751e20a461e0722862";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ glfw3 gtk3 libGL libGLU libusb1 linuxHeaders openssl udev ];
+  buildInputs = [ libusb1 openssl pkg-config udev ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/dashing/realsense2-camera-msgs/default.nix
+++ b/distros/dashing/realsense2-camera-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-camera-msgs";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_camera_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "88ad2af34aa78f98d787ed0bea856323d2763e23db5edec62d6043884e2d4009";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing realsense camera messages definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/realsense2-camera/default.nix
+++ b/distros/dashing/realsense2-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-camera";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_camera/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ad46182ff3c4d50654ccebe7df56ffdf5ada0ca470e1b7af9876f9d5ced15245";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera package allowing access to Intel SR300, D400 and L500 3D cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/realsense2-description/default.nix
+++ b/distros/dashing/realsense2-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-description";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "05e681ef40cc31ba2353bc536fc96a764416a3e00609de45dfab6d33cba5b4fe";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-ros rclcpp rclcpp-components realsense2-camera-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera description package for Intel 3D D400 cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ament-cmake-ros/default.nix
+++ b/distros/foxy/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-ros";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "9fc0c46e7be8f40ddf5938ed7cf3657b8f591111b9134ece9d1a703a2666961f";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "c3799ed35c6541e8f0143c483206c770b037fd4c30fe9e46f10c6179ee8a164d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/domain-coordinator/default.nix
+++ b/distros/foxy/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-domain-coordinator";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "af7d7476efae55600ff613e1899a5ec47687ab7922e5bf0a7182bb0df3834344";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "515283f770b058bacaad143ba983c1e560ab22a601779b6e97c84facca818d5e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -1430,6 +1430,8 @@ self: super: {
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
 
+ ur-client-library = self.callPackage ./ur-client-library {};
+
  urdf = self.callPackage ./urdf {};
 
  urdfdom = self.callPackage ./urdfdom {};

--- a/distros/foxy/py-trees-ros/default.nix
+++ b/distros/foxy/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-py-trees-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/foxy/py_trees_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "60ce57d3f63b22e7a60e9c9672b968196474706827afa6f175a6b4fa8e3c2c04";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/foxy/py_trees_ros/2.1.1-3.tar.gz";
+    name = "2.1.1-3.tar.gz";
+    sha256 = "1c6cbab03fd44a3c03dd7e5901f4d3e9aa0cfacf756cd923d44ecc43be847c03";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c8b803c1f94d74a6a43379184ccb903f9d890cd452fd8ecec4468f439b7ed74d";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a48aec95f6ac846e3a420003773f1dc33c794c20ae76a546d5f5bde96e1cf19e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c6b1e27024c24a334742f6acf2d6913d778500efc7de3edab5c936dd04286600";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d3017f181cd72636966fadcf03e71966668353890befe77116b48c3fa91e61a5";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
   propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "f6f69004cad342ce6d47981efc2104b28c2e498cc1b1b33506274bbe5bff39e9";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "cbc3158f8c918963dab3809980c0560f0f444c5b6c2b80dc47e253bfb2a427a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-reconfigure/default.nix
+++ b/distros/foxy/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-reconfigure";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "db98b17e679c17aee40633d7fb3ff0473b9e94b925ebaf2979d6a04d9eb37858";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6b6c856a869f815c573da23e0f9bba96efc65d1a7f92153afd75f6afef8c69f2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, console-bridge }:
+buildRosPackage {
+  pname = "ros-foxy-ur-client-library";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bb15dd6655becd4f6a536a34592d2f3e9b67dbd3a23dedd81cbdc74d7891be78";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.'';
+    license = with lib.licenses; [ asl20 bsd2 "Zlib" mit ];
+  };
+}

--- a/distros/melodic/genmypy/default.nix
+++ b/distros/melodic/genmypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genmypy";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rospypi/genmypy-release/archive/release/melodic/genmypy/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "6ffd972d47af70880c895da63f5c266d79454bde61e9c55a2cae7cba31249bf7";
+    url = "https://github.com/rospypi/genmypy-release/archive/release/melodic/genmypy/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6a55a01f75fa0cb6ec6fb8eb55d3a89067016bb38f9c0a10c31427c97360573e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, utillinux }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, utillinux }:
 buildRosPackage {
   pname = "ros-noetic-azure-iot-sdk-c";
-  version = "1.7.0-r3";
+  version = "1.7.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-3.tar.gz";
-    name = "1.7.0-3.tar.gz";
-    sha256 = "f3f2075567737c0e23e919dfc043654d8bf3fb2125cc90ba83c06545f4e70bf7";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-4.tar.gz";
+    name = "1.7.0-4.tar.gz";
+    sha256 = "a15053f5d1ea349991c07839eaf8c8a8eaa33fdb2c98ad7ae0fd898c1b638aa8";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin curl utillinux ];
+  propagatedBuildInputs = [ catkin curl openssl utillinux ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "40a235087ac33569da3347dc37e333ae46cea50dab95cbc9d971b7bcbd12c58b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "809c50f56d05af23e89f7aea77c85134d1ee93e91a3e3cd47b2236fd0b0f55de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-can";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "afc3a3ba831ed4f5f5a440d7838a94466ea51e9c91e343e800837695b45f5a5c";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "255a3a8e3b4badee3e3c6fd811271da49f6d5c80038dbc2cb8ec24dbcfbabb77";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-description";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "7d9e052777ebb63e94efdaa3dca498b79327a85400bb75b7b7e1b7143ce8d4d7";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "50e0e1324da794fea40df40c29bc5906cce9b810d192b28aa36f0a8228d35097";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-joystick-demo";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "d19fdd0973443483739b5f585a0b79a29218f1fe67e7dbc623ed50844aae6050";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "19709b0b133dfa8ad5b129f3df179db18270df2ca595f0402981fc106ee71b08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-msgs";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "8f98ba7772e145a119dc4cf53b6fafa066cc970f5781082edae4793c60aa6fd9";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bef0f78b9e56648eccb2902a0e8e32c6188250cea725629bedbeda8edc231754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "64c1fcc3be602d70b046fa88fd7a08330236e66ca3e70a3d22beffbdaf315974";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d58a31fdc7345fe6dfc5906b2143444a9214b8532fa86a8d7a57d1e310459fa4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-can";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "946b620d59ee76ef68ff1ff07e839ee8f167146a7c00e96d043f1e64d559161f";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c5ce21b3888b71a5f90e714a3c2a4d1b506d37b3efce41581f6ebacd441c66a7";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-description";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "4811f7951a55569dbe480ed2b3dd54b6ad0bf17414f914fc4ea63d2f407a1563";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "7ab02ae3997621fd53c3693f9851bd6fbcdf047b98d5c20eaba770394f5d1612";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-joystick-demo";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "842a370679cdfbed6d8296726e46fbf12a848f58e20d462c79f6771f551d2872";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "37d09beac34caa8b645f7571f0a02a4073fe02b9b6eb96c7f162c0891df045dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-msgs";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "88b83dec55f5a9bf3255423a7be6310f47b9b967b4cabf7a48885c258faa064c";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "72a164dbaec7c221713652023322491fdd8d464c73304a3b3d50537002b17cbf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "3dac6cba2f74c36d7604718ee011a8f13b369ef1505d3b903987d24d7bfb7b53";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "ed47697b9e2e238a916afc22a724c6ad7038dd324e0e5b0b8708602b16b72a35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-can/default.nix
+++ b/distros/noetic/dbw-polaris-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-can";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "42125be547585ebe2cfd69f5cb5808ba8f9da93c6c1cb1ed811dd61ff2f7f707";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2515778c68b8f9cb2153e1f886b0d6d5c7b97355ac0acafadab0bcaea7aa53ee";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-polaris-description/default.nix
+++ b/distros/noetic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-description";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "65a9dbff4e56ab7633a7dc7fbf07fc559ed21d6d47888ed799209df42530d222";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9b770811e84e71eae953cb787c745152ad47dd1331ac9e1f36d0b487cedd1a02";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/noetic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-joystick-demo";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "92204a75df535577cb9b3496b11fd2ec003b74de351d336384868ff489262b5c";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dc192c68eebdf67f243944fe805cd7c25939db8b02037513169455b69f718bcd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-msgs/default.nix
+++ b/distros/noetic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "8e25dec0089e6ece276a71fae88247f0623525991484e595ae61231c396118cd";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f964d212b38b5048afe2e312c421e0ef943c9d41e0397431abeff21a73d3724b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris/default.nix
+++ b/distros/noetic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "8f32cfb10ce02b5a0a344d373aaa52c99a3e8b0555cc15044e2ee7dcd523945e";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0f40796df33956ed30974ccf12340a223fe2b06cfd2c2bca2ab7495e123e163b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ethercat-trigger-controllers/default.nix
+++ b/distros/noetic/ethercat-trigger-controllers/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, libtool, message-generation, message-runtime, pluginlib, pr2-controller-interface, realtime-tools, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ethercat-trigger-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/ethercat_trigger_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "76eadb510379a0887d67d78299cadf476fd5f4c91465b696b132a551d06ff51d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs libtool message-runtime pluginlib pr2-controller-interface realtime-tools roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers to operate the digital output of the motor controller
+    boards and the projector board. This package has not been reviewed and
+    should be considered unstable.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -646,6 +646,8 @@ self: super: {
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
 
+ ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
+
  executive-smach = self.callPackage ./executive-smach {};
 
  executive-smach-visualization = self.callPackage ./executive-smach-visualization {};
@@ -1067,6 +1069,8 @@ self: super: {
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
  joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
+ joint-trajectory-action = self.callPackage ./joint-trajectory-action {};
 
  joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
 
@@ -1734,11 +1738,19 @@ self: super: {
 
  power-msgs = self.callPackage ./power-msgs {};
 
+ pr2-arm-kinematics = self.callPackage ./pr2-arm-kinematics {};
+
+ pr2-calibration-controllers = self.callPackage ./pr2-calibration-controllers {};
+
  pr2-common = self.callPackage ./pr2-common {};
 
  pr2-controller-interface = self.callPackage ./pr2-controller-interface {};
 
  pr2-controller-manager = self.callPackage ./pr2-controller-manager {};
+
+ pr2-controllers = self.callPackage ./pr2-controllers {};
+
+ pr2-controllers-msgs = self.callPackage ./pr2-controllers-msgs {};
 
  pr2-dashboard-aggregator = self.callPackage ./pr2-dashboard-aggregator {};
 
@@ -1746,11 +1758,19 @@ self: super: {
 
  pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
 
+ pr2-gripper-action = self.callPackage ./pr2-gripper-action {};
+
  pr2-hardware-interface = self.callPackage ./pr2-hardware-interface {};
+
+ pr2-head-action = self.callPackage ./pr2-head-action {};
+
+ pr2-kinematics = self.callPackage ./pr2-kinematics {};
 
  pr2-machine = self.callPackage ./pr2-machine {};
 
  pr2-mechanism = self.callPackage ./pr2-mechanism {};
+
+ pr2-mechanism-controllers = self.callPackage ./pr2-mechanism-controllers {};
 
  pr2-mechanism-diagnostics = self.callPackage ./pr2-mechanism-diagnostics {};
 
@@ -1879,6 +1899,8 @@ self: super: {
  robot-controllers-msgs = self.callPackage ./robot-controllers-msgs {};
 
  robot-localization = self.callPackage ./robot-localization {};
+
+ robot-mechanism-controllers = self.callPackage ./robot-mechanism-controllers {};
 
  robot-nav-rviz-plugins = self.callPackage ./robot-nav-rviz-plugins {};
 
@@ -2270,6 +2292,8 @@ self: super: {
 
  simulators = self.callPackage ./simulators {};
 
+ single-joint-position-action = self.callPackage ./single-joint-position-action {};
+
  slam-gmapping = self.callPackage ./slam-gmapping {};
 
  slam-karto = self.callPackage ./slam-karto {};
@@ -2633,6 +2657,8 @@ self: super: {
  wge100-camera-firmware = self.callPackage ./wge100-camera-firmware {};
 
  wge100-driver = self.callPackage ./wge100-driver {};
+
+ wifi-ddwrt = self.callPackage ./wifi-ddwrt {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/noetic/genmypy/default.nix
+++ b/distros/noetic/genmypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genmypy";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rospypi/genmypy-release/archive/release/noetic/genmypy/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "888f8ec42b8f6664e3b75acaa8493f213e6c7fea16f6b80a095ea48a6d879de5";
+    url = "https://github.com/rospypi/genmypy-release/archive/release/noetic/genmypy/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "65630a5fe0762662abedd95c8193d9a0141e61511149f780b3d9bbfd69ef3aed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-action/default.nix
+++ b/distros/noetic/joint-trajectory-action/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pr2-controllers-msgs, roscpp, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joint-trajectory-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/joint_trajectory_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "420aea15c157faddb4abd0abda90f3b701d3549ca642c6a0435bc06d7db07136";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pr2-controllers-msgs roscpp trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The joint_trajectory_action is a node that exposes an action interface
+     to a joint trajectory controller.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/mcl-3dl-msgs/default.nix
+++ b/distros/noetic/mcl-3dl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl-msgs";
-  version = "0.2.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/noetic/mcl_3dl_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "f9798340f50b1c3731546201ba912fbe5d66c4cc0d6ff9a5d4582277b5bb3a05";
+    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/noetic/mcl_3dl_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d2ea9655c093e240f4acdd1619cb5a75aa4f73c2d0406f8250a3f5664282034b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.5.4-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "377051c7668e2ca049915362a394f6f641643d5775b88ff60d02abad163e3b48";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "307271fe5886008f3a09991dbd62142b090ff93f57eb627001baf45bbf453741";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-actions/default.nix
+++ b/distros/noetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-actions";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "1403ef21f683c48af660faa6d022f356f741a8d2195e61e70fb5866be6abb42e";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c4ec302bc2ff3f358dd583114828668781868338a7db78624b9c7099707e9892";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-description/default.nix
+++ b/distros/noetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mir-description";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bc2cd5ae680e667c6b68054f6460e16dac7db4dd360b41c5531a86936da9caf6";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "41cc4ada636750c30cfd2c5db98f32dd652f5e6397a7f9eeb3294ac59926d27a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-dwb-critics/default.nix
+++ b/distros/noetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, python3Packages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-dwb-critics";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "962d8a94037fc110a0a007caccb591594cf4c64c625d66463d31c724804cd795";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "cbbe88f045d9d35a762337a537eac300e9a226d8b64de529507a282fb55e9ec1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-gazebo/default.nix
+++ b/distros/noetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mir-gazebo";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d615cd1976c607b67855f7dc38b5d5aeec5fc1ab7b1b3afc91fbe5f5a4fdf38a";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "08be14c18ac8c0b6f75d17621b3b7d9c72638b5c43d3b0e7eea8a93d8f224c99";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-msgs/default.nix
+++ b/distros/noetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-mir-msgs";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "5be240e6ff4067ef2182a8151f36eeb0b94de347f3054538ff35d739bafd8556";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "094d5454ba5dbf2fba1ca3d2fd1e34d2345f3ad1f4c50f5a015e184824583a7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-navigation/default.nix
+++ b/distros/noetic/mir-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner }:
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner, teb-local-planner }:
 buildRosPackage {
   pname = "ros-noetic-mir-navigation";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "e81bc632ad1ef28c7181c2fbee62dacd22d2dedf008388371d835e942523fdf7";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "77c4a6ad42c5dd44b7f4493121e844421b37fcc3c7b122125cd0e68a4672dbfe";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner ];
+  propagatedBuildInputs = [ amcl base-local-planner dwa-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner teb-local-planner ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mir-robot/default.nix
+++ b/distros/noetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-noetic-mir-robot";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b44682fe2a45b73811e34f7ae350657df1aac3c0aee32a58de2c6b3ab04b6c38";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "7896887c34cc628c2b7e26fcd79aa279fa3238df2935dd4f050a9718acd23203";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "dc3837435a7e86ee4d89fea33cc2d81d6484f299cd3e7143a26ef2e6537193e8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "1aa5979c14c66b60dcd8a87ed7996ff96bfb602bdada0b6a51491f147f31ffaa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e4e4a349f5604a01f56541e3f899a37ec257e83e1ff66d352f0137c3fcad10e2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "88991813b5fcfd0789d1febe4be48816377a67c739453751596353db016bdb11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "05bedb5272e8382adf359f67f753f6910bddad13a79802c6b02b09b12f86f173";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "3e19a9820c7358de9155c09694e4b0e5887cdac02c133f6ab67f742d93681986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "2c2e4b2098eeec79d6f43f48394136ff9445ac0d41c37e2af9b7f3e907f0fb85";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "77d008587f3babd794f3b77c9c80e4b198ad3bb74d661e91ec8b97131d323a88";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9fedafd54cde4a54adbf92c6b6e7579a99bb71b406864787afc762d92cca832b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "37066e33108ec29a16479c5fd28af96ca4b81a48016ab269bdc70f8d5bb4b67c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "97e8073177b88339e04093c31836d56ab1eab521a6bec01841cfe3ddbb08b959";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "6cef139b3053cbfc87150b36edd159a78f3d3c751a4c6f431386640c8b7e873d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ce340abcc49d65758ebf52ffa642986af1fbe773e184815a05cb0aab4e2413b7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "9b087dca0031dcb94acec04091f5672947859171363ba31019cd23c3b86e00b3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "084587749d27de3a91c8a256a8b5cfe610f0644c6e0804a41b8b1cdee6a5bce4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "34118c41a54b86d6c11aa10f79c2193a979052493aae598c7ca8800a441f4659";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e98a41e04f33e23fd9d5a621c301a2636851ecb4bbeaaf8cae69a5c934b27292";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "cd6499b791c37e1ddfe1539df81554267dfe9b0571d9fe1e643e0ed3389b2432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "11b2642a6866855e57552add90147401e299e210d63ddc867e2b6e03ab68ea29";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d3d970712c101672994853643cfd4e6b97fb74d4ae38c1d7f88e089e97837d54";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b6261c98a42580ac0fb430f7eeca9172753fc13a1755563cffe7f76e3247ae37";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "aa58a3b208da3741df0c87f4a092d972d002df2020dc427e01e3b4241448f0a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "617bf760fa919debf0c4f6d791268bd7dd3daeaff6996b85b59f6cf147b8ac83";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "28b9c467c961d753b2bb078591cb4e30fb894a6eddb2b7000ed6244bc50e565d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c987857a989027bf70ad96ee60aaa6e36d217b8e3078b39084797bbee481af7f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c5bc4992a5b12dccb6e512145118e11345721e7946206ef585af6d13f43caa00";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "617c150d1b81fe7fffb05963b33eb0b08448c484ba049c3bedbd69b677f87553";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c047c517d4bd27c4ecbe18bcf8e810d69b8cfc7c283134202b71aaab97de861c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b4a4e20c4203194b568b10eea06fdb57a4679188b402300e7ceea60598214bbe";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "4cb675b389e7e3b71d956266497a294e56b4bfebc7181bb79a1caeba492346b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "34d80354ac2d33c044e56334a06b27758ba5d5547a557a7339824ea6f78b89cb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c7d3af6783d50fa69eb336f7cdb5676eebacf13a2797a54e8dc3e3bf228d9986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "68877ee1daaf5347d467a6177b15b64a03f9b637bcfa1e1852fd4f6d4c218c5b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "0f05315e600b28b35ce315dab5024252bff179d5ca3c65eb5eebddc47c83c5ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8d6da5bbf389916e3b057df713461f094c5d6e91103cb9b4ed6e1d521b72f378";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5e5545d928cba4bdc8538deb032fc0d7dc1d90367972ad3ce06e28c9a9ede2eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "131bb5a6e90fdb26576ad1c1d5aa7ea01d75f6bfe7fd4d278c983c607eef6d6c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "3c375e80042df72811e123d60c5d896eda9a1b9f73e44eb885a4efb5ff1555d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "51ff138e5495f94027275ca45a5af4e80d9fefb60e9f679bc7e2a2d542ab03e3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d4c6d65a9b0c3c372aa1372cd50fe3566267a2d21c1b6b028176d5b0ab6ff455";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "438f16835e2d7cc679407cee998a639669d74691b78853a58695d5ff84f02390";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "f22c7f5a211f2b75d1a7c0af10dc11a449c06f5d9db5eef4c3c53188ff003f6c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "76e58a570436f5bdf36add482f84cbac92d8c111485d041486e43e78b3460754";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "e3dc269c14577bda99d7fae5a1abd6500ffd23fc7a1daa7fdc10f3abe76e9578";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "338d54d1fc03e3596ac9c88d33ca25015027a9996849220b89f008d92e2d7d6e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5e9a781b28ec97a3531b66eef4027b13f1a7b3ae9a101d7cee94f34081e6eb95";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "922477480dbdc31f24c4916ae07f567519e7d8b13adcf2af7a679f4e4ffa13a5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "cfe740a2a6ed38b2016d76cf5e5d51c1abc55fcecfdbb88999aeb1f473f0545b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "cd694ae7119ec753265e4827744208f2ff950e285a3006a00e8c6cddcad5933d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "a2d2ef2d47ca47021b78fd20310a3470668c90c8683463f68d4ca4417eff59b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c0eb5b2339672ffd06696cc03daf0dec9cd3224e79cbd860ae1f97c58278d211";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "88c34f277802ca4792e4a907931ab1b3c3d895e6f371e95cb45de42f9cadebc4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-arm-kinematics/default.nix
+++ b/distros/noetic/pr2-arm-kinematics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, pluginlib, roscpp, tf-conversions, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-arm-kinematics";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_kinematics-release/archive/release/noetic/pr2_arm_kinematics/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b0ba5739fbb795b156e5c746810d1ecefe4785d7ad49a2eb5d92fa0313abf20e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ angles geometry-msgs kdl-parser moveit-core moveit-msgs pluginlib roscpp tf-conversions urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a kinematics implementation for the PR2 robot. It can be used to compute forward and inverse kinematics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-calibration-controllers/default.nix
+++ b/distros/noetic/pr2-calibration-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, pr2-controller-interface, pr2-mechanism-controllers, pr2-mechanism-model, realtime-tools, robot-mechanism-controllers, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-calibration-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_calibration_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "80da6ee89676f08f30ce5148a52d0d63aefe3db6b58f0ae0c4a0ee445761b1c9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pluginlib pr2-controller-interface pr2-mechanism-controllers pr2-mechanism-model realtime-tools robot-mechanism-controllers roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_calibration_controllers package contains the controllers
+     used to bring all the joints in the PR2 to a calibrated state.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controllers-msgs/default.nix
+++ b/distros/noetic/pr2-controllers-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controllers-msgs";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_controllers_msgs/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "f9c03a06ee60764b673fa836ba64064b5c679695c79e0471a169701af1e1605c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages, services, and actions used in the pr2_controllers stack.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controllers/default.nix
+++ b/distros/noetic/pr2-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, ethercat-trigger-controllers, joint-trajectory-action, pr2-calibration-controllers, pr2-controllers-msgs, pr2-gripper-action, pr2-head-action, pr2-mechanism-controllers, robot-mechanism-controllers, single-joint-position-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "27537dbc0e3aecc450ba1a232140e147f2a9958178ac29abdda9aa57926d2f34";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox ethercat-trigger-controllers joint-trajectory-action pr2-calibration-controllers pr2-controllers-msgs pr2-gripper-action pr2-head-action pr2-mechanism-controllers robot-mechanism-controllers single-joint-position-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains the controllers that run in realtime on the PR2 and supporting packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-gripper-action/default.nix
+++ b/distros/noetic/pr2-gripper-action/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, pr2-controllers-msgs, pr2-mechanism-controllers, pr2-mechanism-model, robot-mechanism-controllers, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-gripper-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_gripper_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "7f56e298697eca4aa4844f5aba01a82984f78cbdaf180aa269bfad3b08cfad11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs pr2-controllers-msgs pr2-mechanism-controllers pr2-mechanism-model robot-mechanism-controllers roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_action provides an action interface for using the
+  gripper. Users can specify what position to move to (while limiting the
+  force) and the action will report success when the position is reached or
+  failure when the gripper cannot move any longer.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-head-action/default.nix
+++ b/distros/noetic/pr2-head-action/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, kdl-parser, message-filters, orocos-kdl, pr2-controllers-msgs, roscpp, sensor-msgs, tf, tf-conversions, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-head-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_head_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "cecfe6fe06cc1135881c8e356de9897730ac9013ad6f160a1d5173e544791e72";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib geometry-msgs kdl-parser message-filters orocos-kdl pr2-controllers-msgs roscpp sensor-msgs tf tf-conversions trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The PR2 head action is a node that provides an action interface for
+  pointing the head of the PR2.  It passes trajectory goals to the
+  controller, and reports success when they have finished executing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-kinematics/default.nix
+++ b/distros/noetic/pr2-kinematics/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-arm-kinematics }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-kinematics";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_kinematics-release/archive/release/noetic/pr2_kinematics/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b560d5ef8d8221b354b4ffc810da347d3a47400ac080cca788c1b08de99a4a05";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-arm-kinematics ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_kinematics package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-mechanism-controllers/default.nix
+++ b/distros/noetic/pr2-mechanism-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, diagnostic-msgs, diagnostic-updater, filters, geometry-msgs, message-generation, message-runtime, nav-msgs, pluginlib, pr2-controller-interface, pr2-controllers-msgs, pr2-mechanism-model, pr2-mechanism-msgs, pr2-msgs, realtime-tools, robot-mechanism-controllers, rosconsole, roscpp, rospy, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-mechanism-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_mechanism_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "5126a1cb20e26793ed2c29a3aea466c4832fdab5cd0675cc665b20c266701ce7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ angles control-toolbox diagnostic-msgs diagnostic-updater filters geometry-msgs message-runtime nav-msgs pluginlib pr2-controller-interface pr2-controllers-msgs pr2-mechanism-model pr2-mechanism-msgs pr2-msgs realtime-tools robot-mechanism-controllers rosconsole roscpp rospy std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_mechanism_controllers package contains realtime
+    controllers that are meant for specific mechanisms of the PR2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/py-trees-msgs/default.nix
+++ b/distros/noetic/py-trees-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, dynamic-reconfigure, message-generation, message-runtime, std-msgs, uuid-msgs }:
 buildRosPackage {
   pname = "ros-noetic-py-trees-msgs";
-  version = "0.3.6-r1";
+  version = "0.3.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_msgs-release/archive/release/noetic/py_trees_msgs/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "a472c703fa0c24a837a7a12176663d4a76cda25e174c58c6b8b700cc430b723c";
+    url = "https://github.com/stonier/py_trees_msgs-release/archive/release/noetic/py_trees_msgs/0.3.7-2.tar.gz";
+    name = "0.3.7-2.tar.gz";
+    sha256 = "9c976c1ff899f72608b244e445fe3900ef0b32b2ac4d7361c3c5ccd1a6f36c4e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-mechanism-controllers/default.nix
+++ b/distros/noetic/robot-mechanism-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, control-msgs, control-toolbox, diagnostic-msgs, eigen-conversions, filters, geometry-msgs, kdl-parser, libtool, message-filters, message-generation, message-runtime, pluginlib, pr2-controller-interface, pr2-controller-manager, pr2-controllers-msgs, pr2-mechanism-model, realtime-tools, roscpp, rospy, std-msgs, tf, tf-conversions, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-mechanism-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/robot_mechanism_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "74305f5067b74273f7fd18d723134d8616b25231a2aa64db5e97cedd3582a847";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib angles control-msgs control-toolbox diagnostic-msgs eigen-conversions filters geometry-msgs kdl-parser libtool message-filters message-runtime pluginlib pr2-controller-interface pr2-controller-manager pr2-controllers-msgs pr2-mechanism-model realtime-tools roscpp rospy std-msgs tf tf-conversions trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic Mechanism Controller Library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rqt-dep/default.nix
+++ b/distros/noetic/rqt-dep/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-dep";
-  version = "0.4.11-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.11-1.tar.gz";
-    name = "0.4.11-1.tar.gz";
-    sha256 = "ae71c5531c73809ccf544bba2899cbd2d916deccd75e03689479d2b1d0d0b72d";
+    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "173543b28fd652b17aa90d4be483382b1fb6a2c7cc842fa58c3151293eccc445";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-py-trees/default.nix
+++ b/distros/noetic/rqt-py-trees/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, py-trees, py-trees-msgs, python3Packages, qt-dotgraph, rospy, rqt-bag, rqt-graph, rqt-gui, rqt-gui-py, unique-id }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-trees";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/rqt_py_trees-release/archive/release/noetic/rqt_py_trees/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "78101685d5cb8d67ab3ba9a7a263d297b64e52b0fe81bc7ab2182167a05e2408";
+    url = "https://github.com/stonier/rqt_py_trees-release/archive/release/noetic/rqt_py_trees/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "4a243cfcf715beaf4d54717872166e67638d4da8530c1eeda1d78e6046619a79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sdc21x0/default.nix
+++ b/distros/noetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sdc21x0";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a452f391d4d28527ad083caa028f55c3ab22a2ed3268741eb5254d2df3864a68";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ed315a6ec7d5a2b6700e894b9883db1dcb9f1fe7921f24b977f5da7a5a7152ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/single-joint-position-action/default.nix
+++ b/distros/noetic/single-joint-position-action/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pr2-controllers-msgs, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-single-joint-position-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/single_joint_position_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "e69860f0edc1f6aad505b4d4796f59fe477d47193b329072b1f1c80fbe6f35ec";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pr2-controllers-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The single joint position action is a node that provides an action
+  interface for commanding a trajectory to move a joint to a particular
+  position. The action reports success when the joint reaches the desired
+  position.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/wifi-ddwrt/default.nix
+++ b/distros/noetic/wifi-ddwrt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pr2-msgs, pythonPackages, rospy, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-wifi-ddwrt";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/wifi_ddwrt-release/archive/release/noetic/wifi_ddwrt/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d1bf36a65c42894d5711c7361a5eff4e391d52fa38e882a07a78be0e80dcac22";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs pr2-msgs pythonPackages.mechanize rospy std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Access to the DD-WRT wifi'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'kinetic', 'melodic', 'noetic'] from nix-ros-overlay commit 60e2d68e833a75d263d7259a2c4961476124b660.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *librealsense2 2.16.5-r1 --> 2.45.0-r1*
* *realsense2-camera 3.2.1-r1*
* *realsense2-camera-msgs 3.2.1-r1*
* *realsense2-description 3.2.1-r1*

Foxy Changes:
-------------
* *ament-cmake-ros 0.9.1-r1 --> 0.9.2-r1*
* *domain-coordinator 0.9.1-r1 --> 0.9.2-r1*
* *py-trees-ros 2.1.0-r1 --> 2.1.1-r3*
* *realsense2-camera 3.2.0-r1 --> 3.2.1-r1*
* *realsense2-camera-msgs 3.2.0-r1 --> 3.2.1-r1*
* *realsense2-description 3.2.0-r1 --> 3.2.1-r1*
* *rqt-reconfigure 1.0.7-r1 --> 1.0.8-r1*
* *ur-client-library 0.2.1-r1*

Melodic Changes:
----------------
* *genmypy 0.3.0-r1 --> 0.3.1-r1*

Noetic Changes:
---------------
* *azure-iot-sdk-c 1.7.0-r3 --> 1.7.0-r4*
* *chomp-motion-planner 1.1.3-r1 --> 1.1.4-r1*
* *dbw-fca 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-can 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-description 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-joystick-demo 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-msgs 1.0.10-r1 --> 1.2.0-r1*
* *dbw-mkz 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-can 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-description 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-joystick-demo 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-msgs 1.2.9-r1 --> 1.4.0-r1*
* *dbw-polaris 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-can 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-description 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-joystick-demo 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-msgs 0.0.4-r1 --> 1.0.0-r1*
* *ethercat-trigger-controllers 1.10.18-r1*
* *genmypy 0.3.0-r1 --> 0.3.1-r1*
* *joint-trajectory-action 1.10.18-r1*
* *mcl-3dl 0.5.4-r1 --> 0.6.0-r1*
* *mcl-3dl-msgs 0.2.0-r1 --> 0.6.0-r1*
* *mir-actions 1.1.1-r1 --> 1.1.2-r1*
* *mir-description 1.1.1-r1 --> 1.1.2-r1*
* *mir-dwb-critics 1.1.1-r1 --> 1.1.2-r1*
* *mir-gazebo 1.1.1-r1 --> 1.1.2-r1*
* *mir-msgs 1.1.1-r1 --> 1.1.2-r1*
* *mir-navigation 1.1.1-r1 --> 1.1.2-r1*
* *mir-robot 1.1.1-r1 --> 1.1.2-r1*
* *moveit 1.1.3-r1 --> 1.1.4-r1*
* *moveit-chomp-optimizer-adapter 1.1.3-r1 --> 1.1.4-r1*
* *moveit-core 1.1.3-r1 --> 1.1.4-r1*
* *moveit-fake-controller-manager 1.1.3-r1 --> 1.1.4-r1*
* *moveit-kinematics 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners-chomp 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners-ompl 1.1.3-r1 --> 1.1.4-r1*
* *moveit-plugins 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-benchmarks 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-control-interface 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-manipulation 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-move-group 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-occupancy-map-monitor 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-planning 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-planning-interface 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-robot-interaction 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-visualization 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-warehouse 1.1.3-r1 --> 1.1.4-r1*
* *moveit-runtime 1.1.3-r1 --> 1.1.4-r1*
* *moveit-servo 1.1.3-r1 --> 1.1.4-r1*
* *moveit-setup-assistant 1.1.3-r1 --> 1.1.4-r1*
* *moveit-simple-controller-manager 1.1.3-r1 --> 1.1.4-r1*
* *pilz-industrial-motion-planner 1.1.3-r1 --> 1.1.4-r1*
* *pilz-industrial-motion-planner-testutils 1.1.3-r1 --> 1.1.4-r1*
* *pr2-arm-kinematics 1.0.11-r1*
* *pr2-calibration-controllers 1.10.18-r1*
* *pr2-controllers 1.10.18-r1*
* *pr2-controllers-msgs 1.10.18-r1*
* *pr2-gripper-action 1.10.18-r1*
* *pr2-head-action 1.10.18-r1*
* *pr2-kinematics 1.0.11-r1*
* *pr2-mechanism-controllers 1.10.18-r1*
* *py-trees-msgs 0.3.6-r1 --> 0.3.7-r2*
* *robot-mechanism-controllers 1.10.18-r1*
* *rqt-dep 0.4.11-r1 --> 0.4.12-r1*
* *rqt-py-trees 0.4.0-r1 --> 0.4.1-r1*
* *sdc21x0 1.1.1-r1 --> 1.1.2-r1*
* *single-joint-position-action 1.10.18-r1*
* *wifi-ddwrt 0.2.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] app1
 * [ ] app2
 * [ ] app3
 * [ ] app_loader
 * [ ] atlas
 * [ ] avr-libc
 * [ ] bag_tools
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] festival-dev
 * [ ] gcc-avr
 * [ ] gsdf_msgs
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] language-pack-de
 * [ ] language-pack-en
 * [ ] libapache2-mod-python
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libesd0-dev
 * [ ] libestools-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] libgstreamer-plugins-base0.10-dev
 * [ ] libgstreamer0.10-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libsoqt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxtst-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] micros_swarm
 * [ ] micros_swarm_gazebo
 * [ ] micros_swarm_stage
 * [ ] ml_classifiers
 * [ ] mrpt
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] olfati_saber_flocking
 * [ ] openni_launch
 * [ ] opensplice_dds_broker
 * [ ] postgresql-9.x-postgis
 * [ ] postgresql-postgis
 * [ ] pso
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-bloom
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-expiringdict
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt-bindings
 * [ ] python-qt-bindings-gl
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-rosinstall
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python-wstool
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] ros_broker
 * [ ] roseus
 * [ ] rviz
 * [ ] spinnaker_camera_driver
 * [ ] testbb
 * [ ] testnc
 * [ ] testrth
 * [ ] testscdspso
 * [ ] testvstig
 * [ ] texlive-fonts-recommended
 * [ ] xdot
 * [ ] xpath-perl

