### PR TITLE
rosdistro sync, Fri May 21 13:26:22 2021

### DIFF
--- a/distros/dashing/generated.nix
+++ b/distros/dashing/generated.nix
@@ -794,6 +794,12 @@ self: super: {
 
  rcutils = self.callPackage ./rcutils {};
 
+ realsense2-camera = self.callPackage ./realsense2-camera {};
+
+ realsense2-camera-msgs = self.callPackage ./realsense2-camera-msgs {};
+
+ realsense2-description = self.callPackage ./realsense2-description {};
+
  realsense-camera-msgs = self.callPackage ./realsense-camera-msgs {};
 
  realsense-ros2-camera = self.callPackage ./realsense-ros2-camera {};

--- a/distros/dashing/librealsense2/default.nix
+++ b/distros/dashing/librealsense2/default.nix
@@ -2,24 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, glfw3, gtk3, libGL, libGLU, libusb1, linuxHeaders, openssl, pkg-config, udev }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-dashing-librealsense2";
-  version = "2.16.5-r1";
+  version = "2.45.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/librealsense-release/archive/release/dashing/librealsense2/2.16.5-1.tar.gz";
-    name = "2.16.5-1.tar.gz";
-    sha256 = "8200ccf50818a19a4dcd625f099e960c38285c2181cef249da10fae25206ee07";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/dashing/librealsense2/2.45.0-1.tar.gz";
+    name = "2.45.0-1.tar.gz";
+    sha256 = "525cb4c6d9c249e14402fa204abae875bd06308872a088751e20a461e0722862";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ glfw3 gtk3 libGL libGLU libusb1 linuxHeaders openssl udev ];
+  buildInputs = [ libusb1 openssl pkg-config udev ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300 and D400 cameras. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project, including multi-camera capture.'';
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/dashing/realsense2-camera-msgs/default.nix
+++ b/distros/dashing/realsense2-camera-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-camera-msgs";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_camera_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "88ad2af34aa78f98d787ed0bea856323d2763e23db5edec62d6043884e2d4009";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing realsense camera messages definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/realsense2-camera/default.nix
+++ b/distros/dashing/realsense2-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-camera";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_camera/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ad46182ff3c4d50654ccebe7df56ffdf5ada0ca470e1b7af9876f9d5ced15245";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera package allowing access to Intel SR300, D400 and L500 3D cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/dashing/realsense2-description/default.nix
+++ b/distros/dashing/realsense2-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-dashing-realsense2-description";
+  version = "3.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/dashing/realsense2_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "05e681ef40cc31ba2353bc536fc96a764416a3e00609de45dfab6d33cba5b4fe";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-ros rclcpp rclcpp-components realsense2-camera-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera description package for Intel 3D D400 cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ament-cmake-ros/default.nix
+++ b/distros/foxy/ament-cmake-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, domain-coordinator }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-ros";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "9fc0c46e7be8f40ddf5938ed7cf3657b8f591111b9134ece9d1a703a2666961f";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/ament_cmake_ros/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "c3799ed35c6541e8f0143c483206c770b037fd4c30fe9e46f10c6179ee8a164d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-foxy-bosch-locator-bridge";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "198862ab0d43504568c8129df228af3bea299c162b0ff095dd7872fb3c66d143";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs launch-xml nav-msgs pcl-conversions poco rclcpp rosidl-default-runtime std-srvs tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The bosch_locator_bridge package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/domain-coordinator/default.nix
+++ b/distros/foxy/domain-coordinator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-domain-coordinator";
-  version = "0.9.1-r1";
+  version = "0.9.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.1-1.tar.gz";
-    name = "0.9.1-1.tar.gz";
-    sha256 = "af7d7476efae55600ff613e1899a5ec47687ab7922e5bf0a7182bb0df3834344";
+    url = "https://github.com/ros2-gbp/ament_cmake_ros-release/archive/release/foxy/domain_coordinator/0.9.2-1.tar.gz";
+    name = "0.9.2-1.tar.gz";
+    sha256 = "515283f770b058bacaad143ba983c1e560ab22a601779b6e97c84facca818d5e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -156,6 +156,8 @@ self: super: {
 
  bondcpp = self.callPackage ./bondcpp {};
 
+ bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
+
  builtin-interfaces = self.callPackage ./builtin-interfaces {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
@@ -616,6 +618,8 @@ self: super: {
 
  mobileye-560-660-msgs = self.callPackage ./mobileye-560-660-msgs {};
 
+ mocap-msgs = self.callPackage ./mocap-msgs {};
+
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
  move-base-msgs = self.callPackage ./move-base-msgs {};
@@ -843,6 +847,8 @@ self: super: {
  plotjuggler-ros = self.callPackage ./plotjuggler-ros {};
 
  pluginlib = self.callPackage ./pluginlib {};
+
+ point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
 
  pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
@@ -1186,6 +1192,8 @@ self: super: {
 
  rqt-reconfigure = self.callPackage ./rqt-reconfigure {};
 
+ rqt-robot-dashboard = self.callPackage ./rqt-robot-dashboard {};
+
  rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
@@ -1429,6 +1437,8 @@ self: super: {
  uncrustify-vendor = self.callPackage ./uncrustify-vendor {};
 
  unique-identifier-msgs = self.callPackage ./unique-identifier-msgs {};
+
+ ur-client-library = self.callPackage ./ur-client-library {};
 
  urdf = self.callPackage ./urdf {};
 

--- a/distros/foxy/mocap-msgs/default.nix
+++ b/distros/foxy/mocap-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rclcpp, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-mocap-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MOCAP4ROS2-Project/mocap_msgs-release/archive/release/foxy/mocap_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "81808d9ac8fc05485cc01e9c469c71e4436cf46ae843e758d24d170e9657f45b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rclcpp rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''mocap_msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.1.0-r1";
+  version = "1.1.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f12c4a9f50465f101258c9687e0855678c18cca181cd5fb13e4e2da997497b94";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.1.1-4.tar.gz";
+    name = "1.1.1-4.tar.gz";
+    sha256 = "29c9ac4bcee1a8593d33d80bc63db73139249bc02c39040b1a194f49188a0ff7";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "064cdd789f8c3b8da8208a7428abbde3e88876d263a4636127d5dd46e74518eb";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "709542b92c3ac61faeffbf8c28d9e4efc4c59116abf14fc3b2542437caefdf0a";
   };
 
   buildType = "catkin";

--- a/distros/foxy/point-cloud-msg-wrapper/default.nix
+++ b/distros/foxy/point-cloud-msg-wrapper/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-point-cloud-msg-wrapper";
+  version = "1.0.5-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/foxy/point_cloud_msg_wrapper/1.0.5-1/point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
+    name = "point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
+    sha256 = "1abbed06a357b7fc3043dfcba91e6d0ebcae2b3140271510a106d817d26c0da1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A point cloud message wrapper that allows for simple and safe msg usage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/py-trees-ros/default.nix
+++ b/distros/foxy/py-trees-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, geometry-msgs, py-trees, py-trees-ros-interfaces, python3Packages, pythonPackages, rcl-interfaces, rclpy, ros2topic, sensor-msgs, std-msgs, tf2-ros, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-py-trees-ros";
-  version = "2.1.0-r1";
+  version = "2.1.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_ros-release/archive/release/foxy/py_trees_ros/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "60ce57d3f63b22e7a60e9c9672b968196474706827afa6f175a6b4fa8e3c2c04";
+    url = "https://github.com/stonier/py_trees_ros-release/archive/release/foxy/py_trees_ros/2.1.1-3.tar.gz";
+    name = "2.1.1-3.tar.gz";
+    sha256 = "1c6cbab03fd44a3c03dd7e5901f4d3e9aa0cfacf756cd923d44ecc43be847c03";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c8b803c1f94d74a6a43379184ccb903f9d890cd452fd8ecec4468f439b7ed74d";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a48aec95f6ac846e3a420003773f1dc33c794c20ae76a546d5f5bde96e1cf19e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "c6b1e27024c24a334742f6acf2d6913d778500efc7de3edab5c936dd04286600";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d3017f181cd72636966fadcf03e71966668353890befe77116b48c3fa91e61a5";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
   propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.2.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "f6f69004cad342ce6d47981efc2104b28c2e498cc1b1b33506274bbe5bff39e9";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "cbc3158f8c918963dab3809980c0560f0f444c5b6c2b80dc47e253bfb2a427a4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-reconfigure/default.nix
+++ b/distros/foxy/rqt-reconfigure/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-xmllint, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-reconfigure";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "db98b17e679c17aee40633d7fb3ff0473b9e94b925ebaf2979d6a04d9eb37858";
+    url = "https://github.com/ros2-gbp/rqt_reconfigure-release/archive/release/foxy/rqt_reconfigure/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6b6c856a869f815c573da23e0f9bba96efc65d1a7f92153afd75f6afef8c69f2";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-robot-dashboard/default.nix
+++ b/distros/foxy/rqt-robot-dashboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, diagnostic-msgs, python-qt-binding, python3Packages, qt-gui, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-robot-monitor }:
+buildRosPackage {
+  pname = "ros-foxy-rqt-robot-dashboard";
+  version = "0.6.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rqt_robot_dashboard-release/archive/release/foxy/rqt_robot_dashboard/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "d4f1a459e3e8327d57aa5c606ed219870db701ed3020b0d937dac83994ed2aa0";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ diagnostic-msgs python-qt-binding qt-gui rclpy rqt-console rqt-gui rqt-gui-py rqt-robot-monitor ];
+  nativeBuildInputs = [ python3Packages.setuptools ];
+
+  meta = {
+    description = ''rqt_robot_dashboard provides an infrastructure for building robot dashboard plugins in rqt.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.7.1-r3";
+  version = "0.7.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "28926ff2f3994d256a0e7d2d7c6a3774f4d98be66cf05c96d23bcab1550f9219";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-4.tar.gz";
+    name = "0.7.1-4.tar.gz";
+    sha256 = "0075eb8125e9d1e46c3ea91b954137a036c9a5fe73b3236e40ea61f87224174a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-msgs/default.nix
+++ b/distros/foxy/system-modes-msgs/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-msgs";
-  version = "0.7.1-r3";
+  version = "0.7.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "9993f0bd62647006dfe60e6708cbfb6e66b62d889dde8365779d862158cbe168";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-4.tar.gz";
+    name = "0.7.1-4.tar.gz";
+    sha256 = "b9a267b941dff73f441b246e569fd91f01400c17512007c3c86a641c1cbf6ba9";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake-cppcheck ament-cmake-cpplint rosidl-default-runtime ];
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.7.1-r3";
+  version = "0.7.1-r4";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "7117fc6f467a6ec92295ad0b49b67bd3fb0c55020051f6b2a7ec513fd88840fb";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-4.tar.gz";
+    name = "0.7.1-4.tar.gz";
+    sha256 = "a0789264cd9c679704af1533ba63fb1a19807ec2839d3bb801d6170719ffd79e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, console-bridge }:
+buildRosPackage {
+  pname = "ros-foxy-ur-client-library";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "bb15dd6655becd4f6a536a34592d2f3e9b67dbd3a23dedd81cbdc74d7891be78";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ ament-cmake console-bridge ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Standalone C++ library for accessing Universal Robots interfaces. This has been forked off the ur_robot_driver.'';
+    license = with lib.licenses; [ asl20 bsd2 "Zlib" mit ];
+  };
+}

--- a/distros/melodic/aruco-pose/default.nix
+++ b/distros/melodic/aruco-pose/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-publisher, image-transport, message-generation, message-runtime, nodelet, ros-pytest, roscpp, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-aruco-pose";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/aruco_pose/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "2506649647c6e2372fe659fe72c03888aefe3fa5a395c765a4d381def7be84ce";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ image-publisher ros-pytest ];
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs image-transport message-generation message-runtime nodelet roscpp rostest sensor-msgs std-msgs tf tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Positioning with ArUco markers'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/clover-blocks/default.nix
+++ b/distros/melodic/clover-blocks/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-clover-blocks";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_blocks/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "e239ebc11090127ed61030db7fa8c71e9218c00dadfb86328d0204ee0412a651";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-generation message-runtime rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Blockly programming support for Clover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/clover-description/default.nix
+++ b/distros/melodic/clover-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-clover-description";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_description/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "343e10bb269be05deb36111a2ca4bbdb6adde31de38df4ff7d660bd35a2fa77e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The clover_description package provides URDF models of the Clover series of quadcopters.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/clover-simulation/default.nix
+++ b/distros/melodic/clover-simulation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, led-msgs, rospy, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-clover-simulation";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_simulation/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "a3ae1cd0f1898d8b65411101dd012b63f7441b3e8b948ef3b3b6acfdf1b77f39";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros led-msgs rospy xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The clover_simulation package provides worlds and launch files for Gazebo.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/clover/default.nix
+++ b/distros/melodic/clover/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, cv-camera, geographiclib, geometry-msgs, led-msgs, mavros, mavros-extras, message-generation, nodelet, pythonPackages, rosbridge-server, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf, tf2, tf2-geometry-msgs, tf2-ros, tf2-web-republisher, visualization-msgs, web-video-server }:
+buildRosPackage {
+  pname = "ros-melodic-clover";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "778f01196b1c57d7b4b622146a5e72757fc97d1dda17fbc0bca67c2b11a6465b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge cv-camera geographiclib geometry-msgs led-msgs mavros mavros-extras message-generation nodelet pythonPackages.lxml rosbridge-server roscpp rospy sensor-msgs std-msgs std-srvs tf tf2 tf2-geometry-msgs tf2-ros tf2-web-republisher visualization-msgs web-video-server ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Clover package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/cpr-common-core-msgs/default.nix
+++ b/distros/melodic/cpr-common-core-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-cpr-common-core-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/cpr_common_core-release/archive/release/melodic/cpr_common_core_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "82eeb5aeef199ad8543b8d7f6fe8087caa6fb4ce68936cfa30d96a01c2c5d6fd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''cpr_common_core_msgs'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/dbw-fca-can/default.nix
+++ b/distros/melodic/dbw-fca-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-can";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "2abd13f0fc3ae8bbd9ca5f346c1b9d61f36a56fe51a1b33e8343f43b07012933";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "ed6706a6ee497bece0f61267f7ef7b21e216ad3c79cf6fcf037c9783f0884307";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dbw-fca-description/default.nix
+++ b/distros/melodic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-description";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "af79b2915a2f7157fda28f56c9fd3e917afbf55504015d0ab0797add1be04636";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "26d7b4037bfa82e49fdff61e2c4efc6f5bfda7c99c40a6081ec15476e5c9e9fa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-joystick-demo/default.nix
+++ b/distros/melodic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-joystick-demo";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "34b2c455eea10d73bc443105314109cd9837792a5e836fb9148cd79314eb544e";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "accb8db15f7f579109ea55c57ab25d7a61c40f975980397a8fa72d032047ebd4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-msgs/default.nix
+++ b/distros/melodic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-msgs";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "56caa5fb543db897ecc2e2dd614488120375fafbf8711c9ce12d9bf3e8b76afb";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "57979b8ef2a270bbd58de137e157bc951249abba8f6b6d56bb5fa1fb603b2518";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca/default.nix
+++ b/distros/melodic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "758a1c41ad0b146d0c5a8a8d74e6a108f3b823ef3b93dcdb157a18a670d033c8";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "449771786211501c849d229b2ea64bebb3219f2ff1a9a4924b6dda1d8b00dab2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-can/default.nix
+++ b/distros/melodic/dbw-mkz-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-can";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "37024979c4ccdba68290b45710c484838cb314dbfabe4210b9e5d38db5c1a763";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "f9739687c666069c032dea89eab27ce849b88cc315712834dbc445a69f9447a7";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dbw-mkz-description/default.nix
+++ b/distros/melodic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-description";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "e19016d5c35787424c02952969ea39ea66454924764afa888514e814af3c0100";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2f02629bf7cc37a406d0846918612ba39d5004cae81b91fb84340ad8bcd8803b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/melodic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-joystick-demo";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "4cc9f1d8308d7a8b0a53b1c9cdb5bf07820d88888ce8ec27ba0dabeb70bff911";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "ceeabf98e13b09d6de9538306fd2dfe2e8e2151f9c93683e689b670fb3d00225";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-msgs/default.nix
+++ b/distros/melodic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-msgs";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "b383073390016e44f2a96a1a3e3798ed0e6d14852e868d1299dbea908890b0a5";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "ffb51c05bdc7b0586d648180a02e581ee49d2739eb484845237771543323352f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz/default.nix
+++ b/distros/melodic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "1d3b8ab5b4a80a9502ceaa15e150c3aa14046819aef84e828959d396998b1330";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "5dd8e343968cc64156151c36c2f52a2055217296347bac4a24eefaf2b5d3fd53";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-can/default.nix
+++ b/distros/melodic/dbw-polaris-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-can";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "2f55c78de5498ad04dbcbdb2e26577ddaff5675e926175de167d0346cd766f4d";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e4d4009f6fe4aea380079f99ba438064f808d3b8232244df76139517e90c898c";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/dbw-polaris-description/default.nix
+++ b/distros/melodic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-description";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "e47d4cc2cf5b8bf9ccd9c60a254517ba9f7e14b0213f53cfc26eb42dc8a60c3b";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "af3c10674ef2b53c465d213369595fc02994e948f3a63458c569de51a3452367";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/melodic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-joystick-demo";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "5401b291debe119909d5828faef1a0f413e9884ce0859400aea26166a3a391a3";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2eb169222ae90f560f008eaedf494180fd381d5ba679de180266e43b9b159f49";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-msgs/default.nix
+++ b/distros/melodic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "923000d293a0504d033c677e4dacdb12aecda4aea53fb43800586cb23082a45a";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "396cc140856577e2e6fed099a808d059205350d441339f44bafa18d4a3844586";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris/default.nix
+++ b/distros/melodic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "ff434ed6877b41ef1679587039114d5f0a560e0674e22ce69d9320d5f30ab421";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "e4c19322c344787cab8c3893fa7e526e01eb455ad3c8f59422078d8abf78c34e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "bffd079ad13b14d2e8b3a82e8b5a37fc4f98827ef63702e61de5ab4049656aae";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "0a8a8916fa8261163f36a177dc778ed9174a9966dc4ab23d69a97a44bf8760c0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "4119569ed9a102c3dd5df8de8a2f2e179c1dbe7950f57bb3702d203af94b3101";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "2923afb18b143779f1c2ffdd59b3dbdd31e8bd5c8bc57290bb182a44ebdc3db0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "d2f61fe166eeda77fbdd0bde3f1ff2af766be6cfc40bd8b8e6a8f5c90338c987";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "568173a34a38a8529b14142c2fb209679b137c3b5fdd378b07320859aa80523a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.7-r1";
+  version = "0.1.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.7-1.tar.gz";
-    name = "0.1.7-1.tar.gz";
-    sha256 = "74524222298f52e02fde55f90690f132a5fb5662193c0a97205d949dc1d326b9";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.8-1.tar.gz";
+    name = "0.1.8-1.tar.gz";
+    sha256 = "033992ccc8bede53c74e4343a7f9d0476b785e8e511884c8d79f0e40efc37800";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -106,6 +106,8 @@ self: super: {
 
  aruco-msgs = self.callPackage ./aruco-msgs {};
 
+ aruco-pose = self.callPackage ./aruco-pose {};
+
  aruco-ros = self.callPackage ./aruco-ros {};
 
  asmach = self.callPackage ./asmach {};
@@ -307,6 +309,14 @@ self: super: {
  cloudwatch-metrics-collector = self.callPackage ./cloudwatch-metrics-collector {};
 
  cloudwatch-metrics-common = self.callPackage ./cloudwatch-metrics-common {};
+
+ clover = self.callPackage ./clover {};
+
+ clover-blocks = self.callPackage ./clover-blocks {};
+
+ clover-description = self.callPackage ./clover-description {};
+
+ clover-simulation = self.callPackage ./clover-simulation {};
 
  cmake-modules = self.callPackage ./cmake-modules {};
 
@@ -557,6 +567,8 @@ self: super: {
  costmap-tf-layer = self.callPackage ./costmap-tf-layer {};
 
  cpp-common = self.callPackage ./cpp-common {};
+
+ cpr-common-core-msgs = self.callPackage ./cpr-common-core-msgs {};
 
  cpr-multimaster-tools = self.callPackage ./cpr-multimaster-tools {};
 
@@ -3438,6 +3450,8 @@ self: super: {
 
  roswww = self.callPackage ./roswww {};
 
+ roswww-static = self.callPackage ./roswww-static {};
+
  rotate-recovery = self.callPackage ./rotate-recovery {};
 
  rotors-comm = self.callPackage ./rotors-comm {};
@@ -3699,6 +3713,8 @@ self: super: {
  self-test = self.callPackage ./self-test {};
 
  semantic-point-annotator = self.callPackage ./semantic-point-annotator {};
+
+ sensor-filters = self.callPackage ./sensor-filters {};
 
  sensor-msgs = self.callPackage ./sensor-msgs {};
 

--- a/distros/melodic/genmypy/default.nix
+++ b/distros/melodic/genmypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-genmypy";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rospypi/genmypy-release/archive/release/melodic/genmypy/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "6ffd972d47af70880c895da63f5c266d79454bde61e9c55a2cae7cba31249bf7";
+    url = "https://github.com/rospypi/genmypy-release/archive/release/melodic/genmypy/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "6a55a01f75fa0cb6ec6fb8eb55d3a89067016bb38f9c0a10c31427c97360573e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/geometric-shapes/default.nix
+++ b/distros/melodic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-geometric-shapes";
-  version = "0.6.3-r1";
+  version = "0.6.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.3-1.tar.gz";
-    name = "0.6.3-1.tar.gz";
-    sha256 = "bb058b1f9ae91e5c03d79a1fb85368a1dad5ab10fc85f173da5498d10a1c9257";
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/melodic/geometric_shapes/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "0f6df13673315030432f153008c0d0eb9a8188911e84ade79d627358ea562e4d";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package contains generic definitions of geometric shapes and bodies.'';
+    description = ''Generic definitions of geometric shapes and bodies.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/magical-ros2-conversion-tool/default.nix
+++ b/distros/melodic/magical-ros2-conversion-tool/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-introspection, roscompile, roslint }:
 buildRosPackage {
   pname = "ros-melodic-magical-ros2-conversion-tool";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/magical_ros2_conversion_tool/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "8434766585163e348ae2bacbc6760f5b1dc4e44db6332c4ae656faa70d18da47";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/magical_ros2_conversion_tool/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "64f1110ed8827dd7a8bf2d5336683dde212b891b2bc023e09cc424125e147dcc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl-msgs/default.nix
+++ b/distros/melodic/mcl-3dl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl-msgs";
-  version = "0.2.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/melodic/mcl_3dl_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "ffce8cd5dfce7939118c69b6e47b65822d52589ad14a0a0de78be29b2d68badf";
+    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/melodic/mcl_3dl_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "ad178c99d899d9f4b493afc8dbaf7f719c04af32bd853ac59bab90b85162a833";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mcl-3dl/default.nix
+++ b/distros/melodic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mcl-3dl";
-  version = "0.5.4-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "2d8ac0768cc58ead32e0a1216e6b3fc8ffca6709eb7deb2ad0329b2b4efc2ef3";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/melodic/mcl_3dl/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "358c116f956375e1dc894ebfed45ea6cb4db998bdae98bf46d8a365c1ba66cec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mocap-optitrack/default.nix
+++ b/distros/melodic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-melodic-mocap-optitrack";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "ff87f22a76366cd37a501fd7dab921b41b4abe0eca8f718e38b1fa5275d666e8";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/melodic/mocap_optitrack/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "b24b882c77e1041170f376a619acdcef1fa07239bd2f669562b873cb5f551113";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "cff6432ec6251c9aacc72c1641dded3fad0ae901ccbf34b9962d547806fe33dd";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6fbedb6a81e3b6d092506d9b2e928e46e735f0e711347c804607b655dc852042";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "1c90bacba37eda2632bb2c7e971ee58c97d9e8dc6bbea4ed8c071287455b00d2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "462d2a3224c59fcf6170b488822c9daf598335ac4befc56ed7a70d49ff7d907a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-upstart/default.nix
+++ b/distros/melodic/robot-upstart/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, util-linux, xacro }:
 buildRosPackage {
   pname = "ros-melodic-robot-upstart";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/melodic/robot_upstart/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "63ba9b49a0439bb01b5f36bc0a25200b82751e9af2ba8a751a8a8de6e76ea121";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/melodic/robot_upstart/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "5c691943bed1f9d4c20a817d902bd00460705f7836d6fc2f3142de8f1c4c8153";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rosunit ];
-  propagatedBuildInputs = [ daemontools nettools roslaunch xacro ];
+  propagatedBuildInputs = [ daemontools nettools roslaunch util-linux xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-introspection/default.nix
+++ b/distros/melodic/ros-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslint, rosmsg }:
 buildRosPackage {
   pname = "ros-melodic-ros-introspection";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/ros_introspection/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "11b5048b3ea5309e40652ebebc6730f2c46e31571735cb142e9dcbd2a5ca84ee";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/ros_introspection/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "6c9df1bb401d4d3f2f564502df7e1ab10bf7b8e623bfe1aef63c5e7deac5bb55";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roscompile/default.nix
+++ b/distros/melodic/roscompile/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, pluginlib-tutorials, python, pythonPackages, ros-introspection, roslint, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-roscompile";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/roscompile/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2ec370c1a07c05c1974b2fade56c09364acd629f95c1745923bbddaff0ddd112";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/melodic/roscompile/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "d80525c66aab6b4152f9d4002a4dbec3d0c2742858c4f80206780f634cf691a9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswww-static/default.nix
+++ b/distros/melodic/roswww-static/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-roswww-static";
+  version = "0.21.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/roswww_static/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "d15218175c9d6ccaac2489434e083d4cac54ff6403af7b69e76560f3a9712cbd";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Static web pages for ROS packages'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/rt-usb-9axisimu-driver/default.nix
+++ b/distros/melodic/rt-usb-9axisimu-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rt-usb-9axisimu-driver";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release/archive/release/melodic/rt_usb_9axisimu_driver/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "5e87b5487d5b3137aa2aa185ec87ebb0b44ca2e13bfbd4bff28aeae41a0c6482";
+    url = "https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release/archive/release/melodic/rt_usb_9axisimu_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d5601c729db3cede96fa28086a40d6bc7ec8346d5dc88ebabc7e856ec68f7989";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sensor-filters/default.nix
+++ b/distros/melodic/sensor-filters/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, filters, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-sensor-filters";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ctu-vras/sensor_filters-release/archive/release/melodic/sensor_filters/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d1f055827741d614e075119e14faf90db3e4974e2d04f1dec6c6c1e968b5a334";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ filters nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple sensor filter chain nodes and nodelets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/allocators/default.nix
+++ b/distros/noetic/allocators/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-allocators";
+  version = "1.0.25-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_realtime-release/archive/release/noetic/allocators/1.0.25-1.tar.gz";
+    name = "1.0.25-1.tar.gz";
+    sha256 = "c633a844f59bc64c53bf03c8f5007a466b79e24d9e405b7fdea0238e727b391c";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains aligned allocation functions, as well as an STL-compatible AlignedAllocator class.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, utillinux }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, utillinux }:
 buildRosPackage {
   pname = "ros-noetic-azure-iot-sdk-c";
-  version = "1.7.0-r3";
+  version = "1.7.0-r4";
 
   src = fetchurl {
-    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-3.tar.gz";
-    name = "1.7.0-3.tar.gz";
-    sha256 = "f3f2075567737c0e23e919dfc043654d8bf3fb2125cc90ba83c06545f4e70bf7";
+    url = "https://github.com/nobleo/azure-iot-sdk-c-release/archive/release/noetic/azure-iot-sdk-c/1.7.0-4.tar.gz";
+    name = "1.7.0-4.tar.gz";
+    sha256 = "a15053f5d1ea349991c07839eaf8c8a8eaa33fdb2c98ad7ae0fd898c1b638aa8";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin curl utillinux ];
+  propagatedBuildInputs = [ catkin curl openssl utillinux ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-bosch-locator-bridge";
+  version = "1.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "a20e31870dd97fa3a0ee9c51a2328eaf4bd5788a46a2ce59e938a0ff3bd61457";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs pcl-conversions poco roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The bosch_locator_bridge package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/calibration-estimation/default.nix
+++ b/distros/noetic/calibration-estimation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, calibration-msgs, catkin, python3Packages, rospy, rostest, sensor-msgs, urdfdom-py, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-calibration-estimation";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/calibration_estimation/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "d48efed94ad8e717abd4e2b2ee34ef8de8085b6b1a12b9dc6e451b5485073ce6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ calibration-msgs python3Packages.matplotlib python3Packages.pykdl python3Packages.scipy rospy rostest sensor-msgs urdfdom-py visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Runs an optimization to estimate the a robot's kinematic parameters. This package is a
+    generic rewrite of pr2_calibration_estimation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/calibration-launch/default.nix
+++ b/distros/noetic/calibration-launch/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, interval-intersection, joint-states-settler, laser-cb-detector, monocam-settler, urdfdom-py }:
+buildRosPackage {
+  pname = "ros-noetic-calibration-launch";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/calibration_launch/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "7e5507f6f3f4762be434ed51f893ef940c17e2b4fec1397e33c7d4d2989585d4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ interval-intersection joint-states-settler laser-cb-detector monocam-settler urdfdom-py ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a collection of launch files that can be helpful in configuring
+    the calibration stack to run on your robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/calibration-msgs/default.nix
+++ b/distros/noetic/calibration-msgs/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-calibration-msgs";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/calibration_msgs/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "03ddbddde4c22035d93800b77a4cd89fe22a3774f96ac5e0112d074fea455e66";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package defines messages for storing calibration samples
+     to be used in full robot calibration procedures. This package
+     is still unstable. Expect the messages to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/calibration-setup-helper/default.nix
+++ b/distros/noetic/calibration-setup-helper/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, calibration-launch, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-calibration-setup-helper";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/calibration_setup_helper/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "c03aba4f47f351f5a1aca2b3ce28e19395c430f3d88f502d8339c8daa01687ae";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ calibration-launch ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a script to generate calibration launch and configurationfiles for your robot.
+    which is based on Michael Ferguson's calibration code'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/calibration/default.nix
+++ b/distros/noetic/calibration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, calibration-estimation, calibration-launch, calibration-msgs, catkin, image-cb-detector, interval-intersection, joint-states-settler, laser-cb-detector, monocam-settler, settlerlib }:
+buildRosPackage {
+  pname = "ros-noetic-calibration";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/calibration/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "5753175e7e772508c85f6fe6652b8f9da83617c33d008a2ceb18a6192eb6276d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ calibration-estimation calibration-launch calibration-msgs image-cb-detector interval-intersection joint-states-settler laser-cb-detector monocam-settler settlerlib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a toolchain running through the robot calibration process. This
+     involves capturing calibration data, estimating parameters, and
+     then updating the URDF.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/chomp-motion-planner/default.nix
+++ b/distros/noetic/chomp-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-chomp-motion-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "40a235087ac33569da3347dc37e333ae46cea50dab95cbc9d971b7bcbd12c58b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/chomp_motion_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "809c50f56d05af23e89f7aea77c85134d1ee93e91a3e3cd47b2236fd0b0f55de";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-can";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "afc3a3ba831ed4f5f5a440d7838a94466ea51e9c91e343e800837695b45f5a5c";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "255a3a8e3b4badee3e3c6fd811271da49f6d5c80038dbc2cb8ec24dbcfbabb77";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-fca-description dbw-fca-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-description";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "7d9e052777ebb63e94efdaa3dca498b79327a85400bb75b7b7e1b7143ce8d4d7";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "50e0e1324da794fea40df40c29bc5906cce9b810d192b28aa36f0a8228d35097";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-joystick-demo";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "d19fdd0973443483739b5f585a0b79a29218f1fe67e7dbc623ed50844aae6050";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "19709b0b133dfa8ad5b129f3df179db18270df2ca595f0402981fc106ee71b08";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-msgs";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "8f98ba7772e145a119dc4cf53b6fafa066cc970f5781082edae4793c60aa6fd9";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "bef0f78b9e56648eccb2902a0e8e32c6188250cea725629bedbeda8edc231754";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca";
-  version = "1.0.10-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "64c1fcc3be602d70b046fa88fd7a08330236e66ca3e70a3d22beffbdaf315974";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d58a31fdc7345fe6dfc5906b2143444a9214b8532fa86a8d7a57d1e310459fa4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-can";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "946b620d59ee76ef68ff1ff07e839ee8f167146a7c00e96d043f1e64d559161f";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c5ce21b3888b71a5f90e714a3c2a4d1b506d37b3efce41581f6ebacd441c66a7";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-mkz-description dbw-mkz-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-description";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "4811f7951a55569dbe480ed2b3dd54b6ad0bf17414f914fc4ea63d2f407a1563";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "7ab02ae3997621fd53c3693f9851bd6fbcdf047b98d5c20eaba770394f5d1612";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-joystick-demo";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "842a370679cdfbed6d8296726e46fbf12a848f58e20d462c79f6771f551d2872";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "37d09beac34caa8b645f7571f0a02a4073fe02b9b6eb96c7f162c0891df045dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-msgs";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "88b83dec55f5a9bf3255423a7be6310f47b9b967b4cabf7a48885c258faa064c";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "72a164dbaec7c221713652023322491fdd8d464c73304a3b3d50537002b17cbf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz";
-  version = "1.2.9-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.2.9-1.tar.gz";
-    name = "1.2.9-1.tar.gz";
-    sha256 = "3dac6cba2f74c36d7604718ee011a8f13b369ef1505d3b903987d24d7bfb7b53";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "ed47697b9e2e238a916afc22a724c6ad7038dd324e0e5b0b8708602b16b72a35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-can/default.nix
+++ b/distros/noetic/dbw-polaris-can/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-can";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "42125be547585ebe2cfd69f5cb5808ba8f9da93c6c1cb1ed811dd61ff2f7f707";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "2515778c68b8f9cb2153e1f886b0d6d5c7b97355ac0acafadab0bcaea7aa53ee";
   };
 
   buildType = "catkin";
   buildInputs = [ dataspeed-can-msg-filters ];
   checkInputs = [ roslaunch ];
-  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-msgs dataspeed-can-usb dataspeed-ulc-can dbw-polaris-description dbw-polaris-msgs geometry-msgs nodelet roscpp roslaunch rospy sensor-msgs socketcan-bridge std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/dbw-polaris-description/default.nix
+++ b/distros/noetic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-description";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "65a9dbff4e56ab7633a7dc7fbf07fc559ed21d6d47888ed799209df42530d222";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9b770811e84e71eae953cb787c745152ad47dd1331ac9e1f36d0b487cedd1a02";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/noetic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-joystick-demo";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "92204a75df535577cb9b3496b11fd2ec003b74de351d336384868ff489262b5c";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dc192c68eebdf67f243944fe805cd7c25939db8b02037513169455b69f718bcd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-msgs/default.nix
+++ b/distros/noetic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-msgs";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "8e25dec0089e6ece276a71fae88247f0623525991484e595ae61231c396118cd";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f964d212b38b5048afe2e312c421e0ef943c9d41e0397431abeff21a73d3724b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris/default.nix
+++ b/distros/noetic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris";
-  version = "0.0.4-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "8f32cfb10ce02b5a0a344d373aaa52c99a3e8b0555cc15044e2ee7dcd523945e";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "0f40796df33956ed30974ccf12340a223fe2b06cfd2c2bca2ab7495e123e163b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ethercat-trigger-controllers/default.nix
+++ b/distros/noetic/ethercat-trigger-controllers/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, libtool, message-generation, message-runtime, pluginlib, pr2-controller-interface, realtime-tools, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-ethercat-trigger-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/ethercat_trigger_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "76eadb510379a0887d67d78299cadf476fd5f4c91465b696b132a551d06ff51d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ diagnostic-msgs libtool message-runtime pluginlib pr2-controller-interface realtime-tools roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers to operate the digital output of the motor controller
+    boards and the projector board. This package has not been reviewed and
+    should be considered unstable.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fadecandy-driver/default.nix
+++ b/distros/noetic/fadecandy-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fadecandy-msgs, libusb1, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-driver";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "0b54a26391d8f1a2c8ef375a254cac0a97f4f39eb0cd01b1fc7f52a7e4f75a37";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_driver/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "5c394c5199a5bbb0fc45a5229d0cd16629438feec207996af14d0c57a114f2f4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fadecandy-msgs/default.nix
+++ b/distros/noetic/fadecandy-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-fadecandy-msgs";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "402372d8c17569423ea2bb5ceb95c12472b45f53e3ea4982a4015e93d62b3ff8";
+    url = "https://github.com/iron-ox/fadecandy_ros-release/archive/release/noetic/fadecandy_msgs/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "ef803f4e2302e6802cc6b2ce57d53070487663411e95463452adfc986ec7f0ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -26,6 +26,8 @@ self: super: {
 
  agni-tf-tools = self.callPackage ./agni-tf-tools {};
 
+ allocators = self.callPackage ./allocators {};
+
  amcl = self.callPackage ./amcl {};
 
  angles = self.callPackage ./angles {};
@@ -118,6 +120,8 @@ self: super: {
 
  boost-sml = self.callPackage ./boost-sml {};
 
+ bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
+
  bota-device-driver = self.callPackage ./bota-device-driver {};
 
  bota-driver = self.callPackage ./bota-driver {};
@@ -127,6 +131,16 @@ self: super: {
  bota-signal-handler = self.callPackage ./bota-signal-handler {};
 
  bota-worker = self.callPackage ./bota-worker {};
+
+ calibration = self.callPackage ./calibration {};
+
+ calibration-estimation = self.callPackage ./calibration-estimation {};
+
+ calibration-launch = self.callPackage ./calibration-launch {};
+
+ calibration-msgs = self.callPackage ./calibration-msgs {};
+
+ calibration-setup-helper = self.callPackage ./calibration-setup-helper {};
 
  camera-calibration = self.callPackage ./camera-calibration {};
 
@@ -646,6 +660,8 @@ self: super: {
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
 
+ ethercat-trigger-controllers = self.callPackage ./ethercat-trigger-controllers {};
+
  executive-smach = self.callPackage ./executive-smach {};
 
  executive-smach-visualization = self.callPackage ./executive-smach-visualization {};
@@ -990,6 +1006,8 @@ self: super: {
 
  ifm3d = self.callPackage ./ifm3d {};
 
+ image-cb-detector = self.callPackage ./image-cb-detector {};
+
  image-common = self.callPackage ./image-common {};
 
  image-exposure-msgs = self.callPackage ./image-exposure-msgs {};
@@ -1040,6 +1058,8 @@ self: super: {
 
  interactive-markers = self.callPackage ./interactive-markers {};
 
+ interval-intersection = self.callPackage ./interval-intersection {};
+
  ipa-3d-fov-visualization = self.callPackage ./ipa-3d-fov-visualization {};
 
  iris-lama = self.callPackage ./iris-lama {};
@@ -1068,7 +1088,15 @@ self: super: {
 
  joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
 
+ joint-states-settler = self.callPackage ./joint-states-settler {};
+
+ joint-trajectory-action = self.callPackage ./joint-trajectory-action {};
+
+ joint-trajectory-action-tools = self.callPackage ./joint-trajectory-action-tools {};
+
  joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
+
+ joint-trajectory-generator = self.callPackage ./joint-trajectory-generator {};
 
  joy = self.callPackage ./joy {};
 
@@ -1162,6 +1190,8 @@ self: super: {
 
  laser-assembler = self.callPackage ./laser-assembler {};
 
+ laser-cb-detector = self.callPackage ./laser-cb-detector {};
+
  laser-filtering = self.callPackage ./laser-filtering {};
 
  laser-filters = self.callPackage ./laser-filters {};
@@ -1229,6 +1259,8 @@ self: super: {
  libuvc-ros = self.callPackage ./libuvc-ros {};
 
  lms1xx = self.callPackage ./lms1xx {};
+
+ lockfree = self.callPackage ./lockfree {};
 
  locomotor = self.callPackage ./locomotor {};
 
@@ -1366,6 +1398,8 @@ self: super: {
 
  mocap-optitrack = self.callPackage ./mocap-optitrack {};
 
+ monocam-settler = self.callPackage ./monocam-settler {};
+
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
  move-base = self.callPackage ./move-base {};
@@ -1379,6 +1413,10 @@ self: super: {
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
  moveit = self.callPackage ./moveit {};
+
+ moveit-calibration-gui = self.callPackage ./moveit-calibration-gui {};
+
+ moveit-calibration-plugins = self.callPackage ./moveit-calibration-plugins {};
 
  moveit-chomp-optimizer-adapter = self.callPackage ./moveit-chomp-optimizer-adapter {};
 
@@ -1734,11 +1772,25 @@ self: super: {
 
  power-msgs = self.callPackage ./power-msgs {};
 
+ pr2-arm-kinematics = self.callPackage ./pr2-arm-kinematics {};
+
+ pr2-arm-move-ik = self.callPackage ./pr2-arm-move-ik {};
+
+ pr2-calibration-controllers = self.callPackage ./pr2-calibration-controllers {};
+
  pr2-common = self.callPackage ./pr2-common {};
+
+ pr2-common-action-msgs = self.callPackage ./pr2-common-action-msgs {};
+
+ pr2-common-actions = self.callPackage ./pr2-common-actions {};
 
  pr2-controller-interface = self.callPackage ./pr2-controller-interface {};
 
  pr2-controller-manager = self.callPackage ./pr2-controller-manager {};
+
+ pr2-controllers = self.callPackage ./pr2-controllers {};
+
+ pr2-controllers-msgs = self.callPackage ./pr2-controllers-msgs {};
 
  pr2-dashboard-aggregator = self.callPackage ./pr2-dashboard-aggregator {};
 
@@ -1746,11 +1798,19 @@ self: super: {
 
  pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
 
+ pr2-gripper-action = self.callPackage ./pr2-gripper-action {};
+
  pr2-hardware-interface = self.callPackage ./pr2-hardware-interface {};
+
+ pr2-head-action = self.callPackage ./pr2-head-action {};
+
+ pr2-kinematics = self.callPackage ./pr2-kinematics {};
 
  pr2-machine = self.callPackage ./pr2-machine {};
 
  pr2-mechanism = self.callPackage ./pr2-mechanism {};
+
+ pr2-mechanism-controllers = self.callPackage ./pr2-mechanism-controllers {};
 
  pr2-mechanism-diagnostics = self.callPackage ./pr2-mechanism-diagnostics {};
 
@@ -1763,6 +1823,10 @@ self: super: {
  pr2-power-board = self.callPackage ./pr2-power-board {};
 
  pr2-power-drivers = self.callPackage ./pr2-power-drivers {};
+
+ pr2-tilt-laser-interface = self.callPackage ./pr2-tilt-laser-interface {};
+
+ pr2-tuck-arms-action = self.callPackage ./pr2-tuck-arms-action {};
 
  prbt-gazebo = self.callPackage ./prbt-gazebo {};
 
@@ -1880,6 +1944,8 @@ self: super: {
 
  robot-localization = self.callPackage ./robot-localization {};
 
+ robot-mechanism-controllers = self.callPackage ./robot-mechanism-controllers {};
+
  robot-nav-rviz-plugins = self.callPackage ./robot-nav-rviz-plugins {};
 
  robot-nav-tools = self.callPackage ./robot-nav-tools {};
@@ -1952,11 +2018,15 @@ self: super: {
 
  ros-pytest = self.callPackage ./ros-pytest {};
 
+ ros-realtime = self.callPackage ./ros-realtime {};
+
  ros-tutorials = self.callPackage ./ros-tutorials {};
 
  ros-type-introspection = self.callPackage ./ros-type-introspection {};
 
  rosapi = self.callPackage ./rosapi {};
+
+ rosatomic = self.callPackage ./rosatomic {};
 
  rosauth = self.callPackage ./rosauth {};
 
@@ -2065,6 +2135,8 @@ self: super: {
  rospy-message-converter = self.callPackage ./rospy-message-converter {};
 
  rospy-tutorials = self.callPackage ./rospy-tutorials {};
+
+ rosrt = self.callPackage ./rosrt {};
 
  rosserial = self.callPackage ./rosserial {};
 
@@ -2196,6 +2268,8 @@ self: super: {
 
  rqt-web = self.callPackage ./rqt-web {};
 
+ rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
+
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
  rviz = self.callPackage ./rviz {};
@@ -2250,6 +2324,8 @@ self: super: {
 
  self-test = self.callPackage ./self-test {};
 
+ sensor-filters = self.callPackage ./sensor-filters {};
+
  sensor-msgs = self.callPackage ./sensor-msgs {};
 
  septentrio-gnss-driver = self.callPackage ./septentrio-gnss-driver {};
@@ -2257,6 +2333,8 @@ self: super: {
  service-tools = self.callPackage ./service-tools {};
 
  sesame-ros = self.callPackage ./sesame-ros {};
+
+ settlerlib = self.callPackage ./settlerlib {};
 
  shape-msgs = self.callPackage ./shape-msgs {};
 
@@ -2269,6 +2347,8 @@ self: super: {
  simple-grasping = self.callPackage ./simple-grasping {};
 
  simulators = self.callPackage ./simulators {};
+
+ single-joint-position-action = self.callPackage ./single-joint-position-action {};
 
  slam-gmapping = self.callPackage ./slam-gmapping {};
 
@@ -2633,6 +2713,8 @@ self: super: {
  wge100-camera-firmware = self.callPackage ./wge100-camera-firmware {};
 
  wge100-driver = self.callPackage ./wge100-driver {};
+
+ wifi-ddwrt = self.callPackage ./wifi-ddwrt {};
 
  wiimote = self.callPackage ./wiimote {};
 

--- a/distros/noetic/genmypy/default.nix
+++ b/distros/noetic/genmypy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, genpy, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-genmypy";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/rospypi/genmypy-release/archive/release/noetic/genmypy/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "888f8ec42b8f6664e3b75acaa8493f213e6c7fea16f6b80a095ea48a6d879de5";
+    url = "https://github.com/rospypi/genmypy-release/archive/release/noetic/genmypy/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "65630a5fe0762662abedd95c8193d9a0141e61511149f780b3d9bbfd69ef3aed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geometric-shapes/default.nix
+++ b/distros/noetic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, boost, catkin, console-bridge, eigen, eigen-stl-containers, octomap, pkg-config, qhull, random-numbers, resource-retriever, rosunit, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geometric-shapes";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/noetic/geometric_shapes/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "9281180d07d4d7b92b16eb819841a3717820342125a50f94c1fd9af036e015b0";
+    url = "https://github.com/ros-gbp/geometric_shapes-release/archive/release/noetic/geometric_shapes/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "6f105fb610c996aabe52df57a2bed75ee9337a01f079495b78a1fa182ed66d63";
   };
 
   buildType = "catkin";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''This package contains generic definitions of geometric shapes and bodies.'';
+    description = ''Generic definitions of geometric shapes and bodies.'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/image-cb-detector/default.nix
+++ b/distros/noetic/image-cb-detector/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, calibration-msgs, catkin, cv-bridge, geometry-msgs, image-transport, message-filters, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-image-cb-detector";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/image_cb_detector/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "ddf60b84fea198d5ef6ba102e7e5464a70ee9cb155a0ba9539b64b92d189ff10";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs calibration-msgs cv-bridge geometry-msgs image-transport message-filters message-runtime roscpp sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provide a node that extracts checkerboard corners from ROS images.
+    This package is still experimental and unstable.
+    Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/interval-intersection/default.nix
+++ b/distros/noetic/interval-intersection/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, boost, calibration-msgs, catkin, geometry-msgs, rosconsole, roscpp, roscpp-serialization, rostime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-interval-intersection";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/interval_intersection/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "4f89e1d18704edfe0222cc81b58b40ed3ea8edfc49c342c14499f6de0fef4387";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs boost calibration-msgs geometry-msgs rosconsole roscpp roscpp-serialization rostime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Tools for calculating the intersection of interval messages coming
+    in on several topics. This package is experimental and unstable.
+    Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joint-states-settler/default.nix
+++ b/distros/noetic/joint-states-settler/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rosconsole, roscpp, roscpp-serialization, settlerlib, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joint-states-settler";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/joint_states_settler/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "ee45d920a5f98e55c7619fe1526c0d75e6d141fee0e6e7cf3dbe4facc16ba38c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs rosconsole roscpp roscpp-serialization settlerlib std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a node that reports how long a subset of joints has been
+     settled. That is, it calculates how long a set of joints has remained
+     within a specified threshold. This package is experimental and unstable.
+     Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joint-trajectory-action-tools/default.nix
+++ b/distros/noetic/joint-trajectory-action-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-trajectory-action, pr2-controllers-msgs, roslib, rospy, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joint-trajectory-action-tools";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/joint_trajectory_action_tools/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "0e2e3aaaa99502094b8e3d01eb11fd97c7343ad034d1396c2d571e83da7e09f7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-trajectory-action pr2-controllers-msgs roslib rospy trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''joint_trajectory_action_tools'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joint-trajectory-action/default.nix
+++ b/distros/noetic/joint-trajectory-action/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pr2-controllers-msgs, roscpp, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-joint-trajectory-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/joint_trajectory_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "420aea15c157faddb4abd0abda90f3b701d3549ca642c6a0435bc06d7db07136";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pr2-controllers-msgs roscpp trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The joint_trajectory_action is a node that exposes an action interface
+     to a joint trajectory controller.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joint-trajectory-generator/default.nix
+++ b/distros/noetic/joint-trajectory-generator/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, joint-trajectory-action, orocos-kdl, pr2-controllers-msgs, roscpp, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-joint-trajectory-generator";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/joint_trajectory_generator/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "d2287a1ee1b9672ccd3e597113761ac8ff41025f73a9b3cdffa992ec8a480bb7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib angles joint-trajectory-action orocos-kdl pr2-controllers-msgs roscpp urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''joint_trajectory_generator action takes in a trajectory specified
+    by a number of joint positions, and it generates a new smooth trajectory
+    through these joint positions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/laser-cb-detector/default.nix
+++ b/distros/noetic/laser-cb-detector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, image-cb-detector, message-filters, roscpp, settlerlib, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-laser-cb-detector";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/laser_cb_detector/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "d5647f95c0a0ad831cdd3c825063cb8cef0baedf204467db0ea72a4f1e035ca7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge image-cb-detector message-filters roscpp settlerlib std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Extracts checkerboard corners from a dense laser snapshot.
+     This package is experimental and unstable. Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/lockfree/default.nix
+++ b/distros/noetic/lockfree/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, allocators, catkin, rosatomic, rosconsole, roslib }:
+buildRosPackage {
+  pname = "ros-noetic-lockfree";
+  version = "1.0.25-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_realtime-release/archive/release/noetic/lockfree/1.0.25-1.tar.gz";
+    name = "1.0.25-1.tar.gz";
+    sha256 = "b72d3a14bcf278cd607e730ad2f0d988f4f03c8d116fdf401fbc75440269a8d5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ allocators rosatomic rosconsole roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The lockfree package contains lock-free data structures for use in multithreaded programming.  These
+     kinds of data structures are generally not as easy to use as single-threaded equivalents, and are not
+     always faster.  If you don't know you need to use one, try another structure with a lock around it
+     first.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/magical-ros2-conversion-tool/default.nix
+++ b/distros/noetic/magical-ros2-conversion-tool/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-introspection, roscompile, roslint }:
 buildRosPackage {
   pname = "ros-noetic-magical-ros2-conversion-tool";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/magical_ros2_conversion_tool/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "239d6d47087638c7081c6133064bb3558a0f1fea45ed8417de26530eed6b6ed5";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/magical_ros2_conversion_tool/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ee4a496fc629420949f653293ac017c24c09981af81f9cc48cd1dc127708ae61";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl-msgs/default.nix
+++ b/distros/noetic/mcl-3dl-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl-msgs";
-  version = "0.2.0-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/noetic/mcl_3dl_msgs/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "f9798340f50b1c3731546201ba912fbe5d66c4cc0d6ff9a5d4582277b5bb3a05";
+    url = "https://github.com/at-wat/mcl_3dl_msgs-release/archive/release/noetic/mcl_3dl_msgs/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "d2ea9655c093e240f4acdd1619cb5a75aa4f73c2d0406f8250a3f5664282034b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mcl-3dl/default.nix
+++ b/distros/noetic/mcl-3dl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, eigen, geometry-msgs, mcl-3dl-msgs, nav-msgs, pcl-ros, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mcl-3dl";
-  version = "0.5.4-r1";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.5.4-1.tar.gz";
-    name = "0.5.4-1.tar.gz";
-    sha256 = "377051c7668e2ca049915362a394f6f641643d5775b88ff60d02abad163e3b48";
+    url = "https://github.com/at-wat/mcl_3dl-release/archive/release/noetic/mcl_3dl/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "307271fe5886008f3a09991dbd62142b090ff93f57eb627001baf45bbf453741";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-actions/default.nix
+++ b/distros/noetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-actions";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "1403ef21f683c48af660faa6d022f356f741a8d2195e61e70fb5866be6abb42e";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c4ec302bc2ff3f358dd583114828668781868338a7db78624b9c7099707e9892";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-description/default.nix
+++ b/distros/noetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mir-description";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "bc2cd5ae680e667c6b68054f6460e16dac7db4dd360b41c5531a86936da9caf6";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "41cc4ada636750c30cfd2c5db98f32dd652f5e6397a7f9eeb3294ac59926d27a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-dwb-critics/default.nix
+++ b/distros/noetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, python3Packages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-dwb-critics";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "962d8a94037fc110a0a007caccb591594cf4c64c625d66463d31c724804cd795";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "cbbe88f045d9d35a762337a537eac300e9a226d8b64de529507a282fb55e9ec1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-gazebo/default.nix
+++ b/distros/noetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mir-gazebo";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d615cd1976c607b67855f7dc38b5d5aeec5fc1ab7b1b3afc91fbe5f5a4fdf38a";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "08be14c18ac8c0b6f75d17621b3b7d9c72638b5c43d3b0e7eea8a93d8f224c99";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-msgs/default.nix
+++ b/distros/noetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-mir-msgs";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "5be240e6ff4067ef2182a8151f36eeb0b94de347f3054538ff35d739bafd8556";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "094d5454ba5dbf2fba1ca3d2fd1e34d2345f3ad1f4c50f5a015e184824583a7a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-navigation/default.nix
+++ b/distros/noetic/mir-navigation/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner }:
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner, teb-local-planner }:
 buildRosPackage {
   pname = "ros-noetic-mir-navigation";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "e81bc632ad1ef28c7181c2fbee62dacd22d2dedf008388371d835e942523fdf7";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "77c4a6ad42c5dd44b7f4493121e844421b37fcc3c7b122125cd0e68a4672dbfe";
   };
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ amcl base-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner ];
+  propagatedBuildInputs = [ amcl base-local-planner dwa-local-planner dwb-critics dwb-local-planner dwb-plugins hector-mapping map-server mir-driver mir-dwb-critics mir-gazebo move-base nav-core-adapter python3Packages.matplotlib sbpl-lattice-planner teb-local-planner ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/mir-robot/default.nix
+++ b/distros/noetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-noetic-mir-robot";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b44682fe2a45b73811e34f7ae350657df1aac3c0aee32a58de2c6b3ab04b6c38";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "7896887c34cc628c2b7e26fcd79aa279fa3238df2935dd4f050a9718acd23203";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mocap-optitrack/default.nix
+++ b/distros/noetic/mocap-optitrack/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geometry-msgs, nav-msgs, roscpp, roslaunch, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-mocap-optitrack";
-  version = "0.1.2-r1";
+  version = "0.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "f2e68932593f5a3388d36fe68a2e74ab49b524eecebff321b1286b45d801e7ac";
+    url = "https://github.com/ros-drivers-gbp/mocap_optitrack-release/archive/release/noetic/mocap_optitrack/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "f716b1b8ee1eb54407d3105c99823da87bb1a8dacc9ee18069e21e0e60084ea7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/monocam-settler/default.nix
+++ b/distros/noetic/monocam-settler/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, rosconsole, roscpp-serialization, settlerlib, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-monocam-settler";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/monocam_settler/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "3366087331b2f73cdec33ae2052a6a903bb1ff7386bb9d6f560cd04f77e6ec97";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs rosconsole roscpp-serialization settlerlib std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Listens on a ImageFeatures topic, and waits for the data to settle.
+     This package is experimental and unstable.
+     Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-calibration-gui/default.nix
+++ b/distros/noetic/moveit-calibration-gui/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, cv-bridge, eigen, geometric-shapes, image-geometry, moveit-calibration-plugins, moveit-core, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-visualization, moveit-visual-tools, pkg-config, pluginlib, qt5, rosconsole, roscpp, rostest, rviz, rviz-visual-tools, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-calibration-gui";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JStech/moveit_calibration-release/archive/release/noetic/moveit_calibration_gui/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6578848f9cbc27af349c82a0e7dd87d5cbcc832441ed133d5c49df02314988fb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ class-loader eigen image-geometry qt5.qtbase ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ cv-bridge geometric-shapes moveit-calibration-plugins moveit-core moveit-ros-perception moveit-ros-planning moveit-ros-planning-interface moveit-ros-visualization moveit-visual-tools pluginlib rosconsole roscpp rviz rviz-visual-tools tf2-eigen ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''MoveIt calibration gui'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-calibration-plugins/default.nix
+++ b/distros/noetic/moveit-calibration-plugins/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, baldor, catkin, criutils, eigen, handeye, jsoncpp, pluginlib, rosconsole, roscpp, rosunit, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-calibration-plugins";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JStech/moveit_calibration-release/archive/release/noetic/moveit_calibration_plugins/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "56adbbdc424c1c5cb95d8274a4dd5b475d71b08994b2cedaed56976dd64106e8";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ baldor criutils handeye jsoncpp pluginlib rosconsole roscpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Plugins of MoveIt calibration'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
+++ b/distros/noetic/moveit-chomp-optimizer-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, pluginlib }:
 buildRosPackage {
   pname = "ros-noetic-moveit-chomp-optimizer-adapter";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "dc3837435a7e86ee4d89fea33cc2d81d6484f299cd3e7143a26ef2e6537193e8";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_chomp_optimizer_adapter/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "1aa5979c14c66b60dcd8a87ed7996ff96bfb602bdada0b6a51491f147f31ffaa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-core/default.nix
+++ b/distros/noetic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, assimp, boost, bullet, catkin, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-core";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e4e4a349f5604a01f56541e3f899a37ec257e83e1ff66d352f0137c3fcad10e2";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_core/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "88991813b5fcfd0789d1febe4be48816377a67c739453751596353db016bdb11";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-fake-controller-manager/default.nix
+++ b/distros/noetic/moveit-fake-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-fake-controller-manager";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "05bedb5272e8382adf359f67f753f6910bddad13a79802c6b02b09b12f86f173";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_fake_controller_manager/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "3e19a9820c7358de9155c09694e4b0e5887cdac02c133f6ab67f742d93681986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-kinematics/default.nix
+++ b/distros/noetic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, moveit-core, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, python3Packages, roscpp, rostest, tf2, tf2-kdl, urdfdom, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-kinematics";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "2c2e4b2098eeec79d6f43f48394136ff9445ac0d41c37e2af9b7f3e907f0fb85";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_kinematics/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "77d008587f3babd794f3b77c9c80e4b198ad3bb74d661e91ec8b97131d323a88";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-chomp/default.nix
+++ b/distros/noetic/moveit-planners-chomp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-core, moveit-ros-planning-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-chomp";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "9fedafd54cde4a54adbf92c6b6e7579a99bb71b406864787afc762d92cca832b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_chomp/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "37066e33108ec29a16479c5fd28af96ca4b81a48016ab269bdc70f8d5bb4b67c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners-ompl/default.nix
+++ b/distros/noetic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, moveit-core, moveit-resources-fanuc-description, moveit-resources-panda-description, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rosconsole, roscpp, rostest, rosunit, tf2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners-ompl";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "97e8073177b88339e04093c31836d56ab1eab521a6bec01841cfe3ddbb08b959";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners_ompl/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "6cef139b3053cbfc87150b36edd159a78f3d3c751a4c6f431386640c8b7e873d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-planners/default.nix
+++ b/distros/noetic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, chomp-motion-planner, moveit-planners-chomp, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-noetic-moveit-planners";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "ce340abcc49d65758ebf52ffa642986af1fbe773e184815a05cb0aab4e2413b7";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_planners/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "9b087dca0031dcb94acec04091f5672947859171363ba31019cd23c3b86e00b3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-plugins/default.nix
+++ b/distros/noetic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-fake-controller-manager, moveit-ros-control-interface, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-noetic-moveit-plugins";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "084587749d27de3a91c8a256a8b5cfe610f0644c6e0804a41b8b1cdee6a5bce4";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_plugins/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "34118c41a54b86d6c11aa10f79c2193a979052493aae598c7ca8800a441f4659";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-benchmarks/default.nix
+++ b/distros/noetic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, moveit-ros-warehouse, pluginlib, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-benchmarks";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "e98a41e04f33e23fd9d5a621c301a2636851ecb4bbeaaf8cae69a5c934b27292";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_benchmarks/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "cd6499b791c37e1ddfe1539df81554267dfe9b0571d9fe1e643e0ed3389b2432";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-control-interface/default.nix
+++ b/distros/noetic/moveit-ros-control-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, controller-manager-msgs, moveit-core, moveit-simple-controller-manager, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-control-interface";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "11b2642a6866855e57552add90147401e299e210d63ddc867e2b6e03ab68ea29";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_control_interface/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d3d970712c101672994853643cfd4e6b97fb74d4ae38c1d7f88e089e97837d54";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-manipulation/default.nix
+++ b/distros/noetic/moveit-ros-manipulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, pluginlib, rosconsole, roscpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-manipulation";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b6261c98a42580ac0fb430f7eeca9172753fc13a1755563cffe7f76e3247ae37";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_manipulation/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "aa58a3b208da3741df0c87f4a092d972d002df2020dc427e01e3b4241448f0a9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-move-group/default.nix
+++ b/distros/noetic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-planning, pluginlib, roscpp, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-move-group";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "617bf760fa919debf0c4f6d791268bd7dd3daeaff6996b85b59f6cf147b8ac83";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_move_group/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "28b9c467c961d753b2bb078591cb4e30fb894a6eddb2b7000ed6244bc50e565d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/noetic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometric-shapes, moveit-core, moveit-msgs, octomap, pluginlib, rosunit, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-occupancy-map-monitor";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c987857a989027bf70ad96ee60aaa6e36d217b8e3078b39084797bbee481af7f";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_occupancy_map_monitor/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c5bc4992a5b12dccb6e512145118e11345721e7946206ef585af6d13f43caa00";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning-interface/default.nix
+++ b/distros/noetic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, eigen, eigenpy, geometry-msgs, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, python3, python3Packages, rosconsole, roscpp, rospy, rostest, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning-interface";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "617c150d1b81fe7fffb05963b33eb0b08448c484ba049c3bedbd69b677f87553";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning_interface/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c047c517d4bd27c4ecbe18bcf8e810d69b8cfc7c283134202b71aaab97de861c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-planning/default.nix
+++ b/distros/noetic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, dynamic-reconfigure, eigen, message-filters, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rosconsole, roscpp, rostest, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-planning";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "b4a4e20c4203194b568b10eea06fdb57a4679188b402300e7ceea60598214bbe";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_planning/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "4cb675b389e7e3b71d956266497a294e56b4bfebc7181bb79a1caeba492346b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-robot-interaction/default.nix
+++ b/distros/noetic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, interactive-markers, moveit-ros-planning, roscpp, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-robot-interaction";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "34d80354ac2d33c044e56334a06b27758ba5d5547a557a7339824ea6f78b89cb";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_robot_interaction/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "c7d3af6783d50fa69eb336f7cdb5676eebacf13a2797a54e8dc3e3bf228d9986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-visualization/default.nix
+++ b/distros/noetic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, eigen, geometric-shapes, interactive-markers, moveit-ros-perception, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rosconsole, roscpp, rospy, rostest, rviz, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-visualization";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "68877ee1daaf5347d467a6177b15b64a03f9b637bcfa1e1852fd4f6d4c218c5b";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_visualization/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "0f05315e600b28b35ce315dab5024252bff179d5ca3c65eb5eebddc47c83c5ee";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros-warehouse/default.nix
+++ b/distros/noetic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-planning, rosconsole, roscpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros-warehouse";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "8d6da5bbf389916e3b057df713461f094c5d6e91103cb9b4ed6e1d521b72f378";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros_warehouse/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5e5545d928cba4bdc8538deb032fc0d7dc1d90367972ad3ce06e28c9a9ede2eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-ros/default.nix
+++ b/distros/noetic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-ros-benchmarks, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-ros";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "131bb5a6e90fdb26576ad1c1d5aa7ea01d75f6bfe7fd4d278c983c607eef6d6c";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_ros/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "3c375e80042df72811e123d60c5d896eda9a1b9f73e44eb885a4efb5ff1555d1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-runtime/default.nix
+++ b/distros/noetic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-planners, moveit-plugins, moveit-ros-manipulation, moveit-ros-move-group, moveit-ros-perception, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-noetic-moveit-runtime";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "51ff138e5495f94027275ca45a5af4e80d9fefb60e9f679bc7e2a2d542ab03e3";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_runtime/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "d4c6d65a9b0c3c372aa1372cd50fe3566267a2d21c1b6b028176d5b0ab6ff455";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-servo/default.nix
+++ b/distros/noetic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, control-toolbox, geometry-msgs, joy-teleop, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, rosparam-shortcuts, rostest, sensor-msgs, spacenav-node, std-msgs, std-srvs, tf2-eigen, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-moveit-servo";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "438f16835e2d7cc679407cee998a639669d74691b78853a58695d5ff84f02390";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_servo/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "f22c7f5a211f2b75d1a7c0af10dc11a449c06f5d9db5eef4c3c53188ff003f6c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-setup-assistant/default.nix
+++ b/distros/noetic/moveit-setup-assistant/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, moveit-core, moveit-resources-panda-moveit-config, moveit-ros-planning, moveit-ros-visualization, ogre1_9, ompl, qt5, rosconsole, roscpp, rosunit, rviz, srdfdom, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-moveit-setup-assistant";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "76e58a570436f5bdf36add482f84cbac92d8c111485d041486e43e78b3460754";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_setup_assistant/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "e3dc269c14577bda99d7fae5a1abd6500ffd23fc7a1daa7fdc10f3abe76e9578";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-simple-controller-manager/default.nix
+++ b/distros/noetic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, moveit-core, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-moveit-simple-controller-manager";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "338d54d1fc03e3596ac9c88d33ca25015027a9996849220b89f008d92e2d7d6e";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit_simple_controller_manager/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "5e9a781b28ec97a3531b66eef4027b13f1a7b3ae9a101d7cee94f34081e6eb95";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit/default.nix
+++ b/distros/noetic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-planners, moveit-plugins, moveit-ros, moveit-setup-assistant }:
 buildRosPackage {
   pname = "ros-noetic-moveit";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "922477480dbdc31f24c4916ae07f567519e7d8b13adcf2af7a679f4e4ffa13a5";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/moveit/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "cfe740a2a6ed38b2016d76cf5e5d51c1abc55fcecfdbb88999aeb1f473f0545b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ocean-battery-driver/default.nix
+++ b/distros/noetic/ocean-battery-driver/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, pr2-msgs, roscpp }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, pr2-msgs, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-ocean-battery-driver";
-  version = "1.1.8-r1";
+  version = "1.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/ocean_battery_driver/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "63b43358d280ade2900d4c1c45f06c8ccf5991df5aad1ff7124e2ddf8d8631c6";
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/ocean_battery_driver/1.1.10-1.tar.gz";
+    name = "1.1.10-1.tar.gz";
+    sha256 = "e7a91c5f3b8eacc62bfade5e8bb1bac9d97a185b250da4531c03bf3b442d9bdf";
   };
 
   buildType = "catkin";
+  buildInputs = [ boost ];
   propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater log4cxx pr2-msgs roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner-testutils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, moveit-commander, moveit-core, moveit-msgs, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner-testutils";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "cd694ae7119ec753265e4827744208f2ff950e285a3006a00e8c6cddcad5933d";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner_testutils/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "a2d2ef2d47ca47021b78fd20310a3470668c90c8683463f68d4ca4417eff59b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pilz-industrial-motion-planner/default.nix
+++ b/distros/noetic/pilz-industrial-motion-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, joint-limits-interface, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-prbt-moveit-config, moveit-resources-prbt-pg70-support, moveit-resources-prbt-support, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-industrial-motion-planner-testutils, pluginlib, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-pilz-industrial-motion-planner";
-  version = "1.1.3-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.3-1.tar.gz";
-    name = "1.1.3-1.tar.gz";
-    sha256 = "c0eb5b2339672ffd06696cc03daf0dec9cd3224e79cbd860ae1f97c58278d211";
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/noetic/pilz_industrial_motion_planner/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "88c34f277802ca4792e4a907931ab1b3c3d895e6f371e95cb45de42f9cadebc4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.1.0-r2";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.1.0-2.tar.gz";
-    name = "1.1.0-2.tar.gz";
-    sha256 = "f9f55efd6772124f574b8710fc74a292dc9aa58dacbd09ebdbb77b42869b5353";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a1757edfa5a790ba1ebe4c6e35a7283b0b4217ecac957987446dc9323297239c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.1.0-r1";
+  version = "3.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "e26803abdfb92355c4b76fb6550aebd9d84857ed535732b8a7104f23e40ead2a";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.1-1.tar.gz";
+    name = "3.1.1-1.tar.gz";
+    sha256 = "ff50855106859fb46d8e6461a14e1ad3033482a9be2e99690b526d44e111f764";
   };
 
   buildType = "catkin";

--- a/distros/noetic/power-monitor/default.nix
+++ b/distros/noetic/power-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, pr2-msgs, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-power-monitor";
-  version = "1.1.8-r1";
+  version = "1.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/power_monitor/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "9940b21f21ffa19ba337411c0d23bd8580e9c03f9eece75f6b32ec5b02764267";
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/power_monitor/1.1.10-1.tar.gz";
+    name = "1.1.10-1.tar.gz";
+    sha256 = "379ca3049bcd3d48bba2379b85a1b37cdd391196e55adc3d2276656940b9387c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-arm-kinematics/default.nix
+++ b/distros/noetic/pr2-arm-kinematics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, cmake-modules, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, pluginlib, roscpp, tf-conversions, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-arm-kinematics";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_kinematics-release/archive/release/noetic/pr2_arm_kinematics/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b0ba5739fbb795b156e5c746810d1ecefe4785d7ad49a2eb5d92fa0313abf20e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ angles geometry-msgs kdl-parser moveit-core moveit-msgs pluginlib roscpp tf-conversions urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a kinematics implementation for the PR2 robot. It can be used to compute forward and inverse kinematics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-arm-move-ik/default.nix
+++ b/distros/noetic/pr2-arm-move-ik/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, pr2-common-action-msgs, pr2-controllers-msgs, roscpp, tf, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-arm-move-ik";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/pr2_arm_move_ik/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "581d5308dc0fb1202eeb529ab4b9dd0b0228afa1f7a0fde9267631992aeb5a98";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs pr2-common-action-msgs pr2-controllers-msgs roscpp tf urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Move the pr2 arm using inverse kinematics'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-calibration-controllers/default.nix
+++ b/distros/noetic/pr2-calibration-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pluginlib, pr2-controller-interface, pr2-mechanism-controllers, pr2-mechanism-model, realtime-tools, robot-mechanism-controllers, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-calibration-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_calibration_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "80da6ee89676f08f30ce5148a52d0d63aefe3db6b58f0ae0c4a0ee445761b1c9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pluginlib pr2-controller-interface pr2-mechanism-controllers pr2-mechanism-model realtime-tools robot-mechanism-controllers roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_calibration_controllers package contains the controllers
+     used to bring all the joints in the PR2 to a calibrated state.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-common-action-msgs/default.nix
+++ b/distros/noetic/pr2-common-action-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-common-action-msgs";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/pr2_common_action_msgs/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "6d678dd60f1cb1ade07d869b5e22d82e532a1441cac83913faec03fb6c19ee51";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_common_action_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-common-actions/default.nix
+++ b/distros/noetic/pr2-common-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-trajectory-action-tools, joint-trajectory-generator, pr2-arm-move-ik, pr2-common-action-msgs, pr2-tilt-laser-interface, pr2-tuck-arms-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-common-actions";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/pr2_common_actions/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "7dfba611208532414ba926f98c67113d8a227a74c74e8eba44e559a76f6364ac";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-trajectory-action-tools joint-trajectory-generator pr2-arm-move-ik pr2-common-action-msgs pr2-tilt-laser-interface pr2-tuck-arms-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Various actions which help in moving the arms of the PR2
+    or getting data from its tilting laser.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controllers-msgs/default.nix
+++ b/distros/noetic/pr2-controllers-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controllers-msgs";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_controllers_msgs/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "f9c03a06ee60764b673fa836ba64064b5c679695c79e0471a169701af1e1605c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages, services, and actions used in the pr2_controllers stack.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controllers/default.nix
+++ b/distros/noetic/pr2-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, ethercat-trigger-controllers, joint-trajectory-action, pr2-calibration-controllers, pr2-controllers-msgs, pr2-gripper-action, pr2-head-action, pr2-mechanism-controllers, robot-mechanism-controllers, single-joint-position-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "27537dbc0e3aecc450ba1a232140e147f2a9958178ac29abdda9aa57926d2f34";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox ethercat-trigger-controllers joint-trajectory-action pr2-calibration-controllers pr2-controllers-msgs pr2-gripper-action pr2-head-action pr2-mechanism-controllers robot-mechanism-controllers single-joint-position-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Contains the controllers that run in realtime on the PR2 and supporting packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-gripper-action/default.nix
+++ b/distros/noetic/pr2-gripper-action/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, pr2-controllers-msgs, pr2-mechanism-controllers, pr2-mechanism-model, robot-mechanism-controllers, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-gripper-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_gripper_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "7f56e298697eca4aa4844f5aba01a82984f78cbdaf180aa269bfad3b08cfad11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs pr2-controllers-msgs pr2-mechanism-controllers pr2-mechanism-model robot-mechanism-controllers roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_gripper_action provides an action interface for using the
+  gripper. Users can specify what position to move to (while limiting the
+  force) and the action will report success when the position is reached or
+  failure when the gripper cannot move any longer.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-head-action/default.nix
+++ b/distros/noetic/pr2-head-action/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, kdl-parser, message-filters, orocos-kdl, pr2-controllers-msgs, roscpp, sensor-msgs, tf, tf-conversions, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-head-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_head_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "cecfe6fe06cc1135881c8e356de9897730ac9013ad6f160a1d5173e544791e72";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib geometry-msgs kdl-parser message-filters orocos-kdl pr2-controllers-msgs roscpp sensor-msgs tf tf-conversions trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The PR2 head action is a node that provides an action interface for
+  pointing the head of the PR2.  It passes trajectory goals to the
+  controller, and reports success when they have finished executing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-kinematics/default.nix
+++ b/distros/noetic/pr2-kinematics/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-arm-kinematics }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-kinematics";
+  version = "1.0.11-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_kinematics-release/archive/release/noetic/pr2_kinematics/1.0.11-1.tar.gz";
+    name = "1.0.11-1.tar.gz";
+    sha256 = "b560d5ef8d8221b354b4ffc810da347d3a47400ac080cca788c1b08de99a4a05";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-arm-kinematics ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_kinematics package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-mechanism-controllers/default.nix
+++ b/distros/noetic/pr2-mechanism-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, diagnostic-msgs, diagnostic-updater, filters, geometry-msgs, message-generation, message-runtime, nav-msgs, pluginlib, pr2-controller-interface, pr2-controllers-msgs, pr2-mechanism-model, pr2-mechanism-msgs, pr2-msgs, realtime-tools, robot-mechanism-controllers, rosconsole, roscpp, rospy, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-mechanism-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/pr2_mechanism_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "5126a1cb20e26793ed2c29a3aea466c4832fdab5cd0675cc665b20c266701ce7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ angles control-toolbox diagnostic-msgs diagnostic-updater filters geometry-msgs message-runtime nav-msgs pluginlib pr2-controller-interface pr2-controllers-msgs pr2-mechanism-model pr2-mechanism-msgs pr2-msgs realtime-tools robot-mechanism-controllers rosconsole roscpp rospy std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_mechanism_controllers package contains realtime
+    controllers that are meant for specific mechanisms of the PR2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-power-board/default.nix
+++ b/distros/noetic/pr2-power-board/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, message-generation, message-runtime, pr2-msgs, roscpp, rospy }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, diagnostic-msgs, diagnostic-updater, log4cxx, message-generation, message-runtime, pr2-msgs, roscpp, rospy }:
 buildRosPackage {
   pname = "ros-noetic-pr2-power-board";
-  version = "1.1.8-r1";
+  version = "1.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_board/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "5c2fa3882b2715207997d77c1660a0f3ac8bbe058b55d964472830d11b84084c";
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_board/1.1.10-1.tar.gz";
+    name = "1.1.10-1.tar.gz";
+    sha256 = "e7db741af1ca396c86b75584015c5688cf32d088d4c3be87792c4b3a879d8e31";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
+  buildInputs = [ boost message-generation ];
   propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater log4cxx message-runtime pr2-msgs roscpp rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/pr2-power-drivers/default.nix
+++ b/distros/noetic/pr2-power-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ocean-battery-driver, power-monitor, pr2-power-board }:
 buildRosPackage {
   pname = "ros-noetic-pr2-power-drivers";
-  version = "1.1.8-r1";
+  version = "1.1.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_drivers/1.1.8-1.tar.gz";
-    name = "1.1.8-1.tar.gz";
-    sha256 = "b516414a382960abb0ed4d2092fa16c4f85ff984d36fbea56704927116e15a19";
+    url = "https://github.com/pr2-gbp/pr2_power_drivers-release/archive/release/noetic/pr2_power_drivers/1.1.10-1.tar.gz";
+    name = "1.1.10-1.tar.gz";
+    sha256 = "49207b2ea4bf92d7ac759ae7bb42dfd4931840fd59631e754f5b2dbccaa12665";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-tilt-laser-interface/default.nix
+++ b/distros/noetic/pr2-tilt-laser-interface/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, eigen, laser-geometry, message-generation, message-runtime, pcl-conversions, pcl-ros, pr2-msgs, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-tilt-laser-interface";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/pr2_tilt_laser_interface/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "89a75cfac26b02cdaffe6a9ba9bd4c24cd3207cd0b8aea49eebf95e15af18f98";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs eigen laser-geometry message-runtime pcl-conversions pcl-ros pr2-msgs roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a set of tools/actions for manipulating the pr2's tilting
+    laser. Simplifies previously complex tasks, such as fetching
+    a single sweep, given a set of desired parameters for both the laser
+    driver and tilting platform.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-tuck-arms-action/default.nix
+++ b/distros/noetic/pr2-tuck-arms-action/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, pr2-common-action-msgs, pr2-controllers-msgs, rospy, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-tuck-arms-action";
+  version = "0.0.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_common_actions-release/archive/release/noetic/pr2_tuck_arms_action/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "6d220c5c9a5d796989de37b20bf5532a64eb4142693572be34ac96e70047e158";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs pr2-common-action-msgs pr2-controllers-msgs rospy trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_tuck_arms_action package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/py-trees-msgs/default.nix
+++ b/distros/noetic/py-trees-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, dynamic-reconfigure, message-generation, message-runtime, std-msgs, uuid-msgs }:
 buildRosPackage {
   pname = "ros-noetic-py-trees-msgs";
-  version = "0.3.6-r1";
+  version = "0.3.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/stonier/py_trees_msgs-release/archive/release/noetic/py_trees_msgs/0.3.6-1.tar.gz";
-    name = "0.3.6-1.tar.gz";
-    sha256 = "a472c703fa0c24a837a7a12176663d4a76cda25e174c58c6b8b700cc430b723c";
+    url = "https://github.com/stonier/py_trees_msgs-release/archive/release/noetic/py_trees_msgs/0.3.7-2.tar.gz";
+    name = "0.3.7-2.tar.gz";
+    sha256 = "9c976c1ff899f72608b244e445fe3900ef0b32b2ac4d7361c3c5ccd1a6f36c4e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-mechanism-controllers/default.nix
+++ b/distros/noetic/robot-mechanism-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, angles, catkin, control-msgs, control-toolbox, diagnostic-msgs, eigen-conversions, filters, geometry-msgs, kdl-parser, libtool, message-filters, message-generation, message-runtime, pluginlib, pr2-controller-interface, pr2-controller-manager, pr2-controllers-msgs, pr2-mechanism-model, realtime-tools, roscpp, rospy, std-msgs, tf, tf-conversions, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-robot-mechanism-controllers";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/robot_mechanism_controllers/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "74305f5067b74273f7fd18d723134d8616b25231a2aa64db5e97cedd3582a847";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib angles control-msgs control-toolbox diagnostic-msgs eigen-conversions filters geometry-msgs kdl-parser libtool message-filters message-runtime pluginlib pr2-controller-interface pr2-controller-manager pr2-controllers-msgs pr2-mechanism-model realtime-tools roscpp rospy std-msgs tf tf-conversions trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Generic Mechanism Controller Library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-upstart/default.nix
+++ b/distros/noetic/robot-upstart/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, daemontools, nettools, roslaunch, roslint, rosunit, util-linux, xacro }:
 buildRosPackage {
   pname = "ros-noetic-robot-upstart";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/noetic/robot_upstart/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "2d3beafd758405574d42425cc0515e3a6918cb0cb423bca696cd49ee319837e9";
+    url = "https://github.com/clearpath-gbp/robot_upstart-release/archive/release/noetic/robot_upstart/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "148590e64f794942f3942dfc780d193eaaca9529bc085cc9627c4859df8f65ee";
   };
 
   buildType = "catkin";
   checkInputs = [ roslint rosunit ];
-  propagatedBuildInputs = [ daemontools nettools roslaunch xacro ];
+  propagatedBuildInputs = [ daemontools nettools roslaunch util-linux xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-introspection/default.nix
+++ b/distros/noetic/ros-introspection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslint, rosmsg }:
 buildRosPackage {
   pname = "ros-noetic-ros-introspection";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/ros_introspection/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "6ac7e259bd429f21e55947434a3965e9646af9ad2dfbecc66528a389f7cc1e01";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/ros_introspection/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "d19b2656c443929ac3bb3d3da82fdd78c34633dee543ba6b58065fe30098dcdf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-realtime/default.nix
+++ b/distros/noetic/ros-realtime/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, allocators, catkin, lockfree, rosatomic, rosrt }:
+buildRosPackage {
+  pname = "ros-noetic-ros-realtime";
+  version = "1.0.25-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_realtime-release/archive/release/noetic/ros_realtime/1.0.25-1.tar.gz";
+    name = "1.0.25-1.tar.gz";
+    sha256 = "0811e1663055633e75b9949b650f0c3c57d0e3a40c476e9980c83ada8ec2566d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ allocators lockfree rosatomic rosrt ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros_realtime package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/noetic/rosatomic/default.nix
+++ b/distros/noetic/rosatomic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-rosatomic";
+  version = "1.0.25-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_realtime-release/archive/release/noetic/rosatomic/1.0.25-1.tar.gz";
+    name = "1.0.25-1.tar.gz";
+    sha256 = "9ccf553073556f61a80da3937f7832a28a0fa6296dea0cf7e2df86e0d3f42806";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rosatomic provides the C++11-style atomic operations by pulling symbols from the proposed Boost.Atomic
+     package into the ros namespace.  Once C++11-style atomics (std::atomic) are available from compilers, rosatomic will
+     conditionally use those instead.'';
+    license = with lib.licenses; [ bsdOriginal boost ];
+  };
+}

--- a/distros/noetic/roscompile/default.nix
+++ b/distros/noetic/roscompile/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pluginlib, pluginlib-tutorials, python3Packages, ros-introspection, roslint, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-roscompile";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/roscompile/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "675aff42dbbf990ffb8eaa64c4e1edd2bd526e47be2cf36e6138d4b49716b946";
+    url = "https://github.com/wu-robotics/roscompile-release/archive/release/noetic/roscompile/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "1f4081ebd062fcc0ebe0bcb6054ba3e0673bc624a48518964dcccc5411587e82";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosrt/default.nix
+++ b/distros/noetic/rosrt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, allocators, catkin, lockfree, rosatomic, roscpp, roslib, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rosrt";
+  version = "1.0.25-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/ros_realtime-release/archive/release/noetic/rosrt/1.0.25-1.tar.gz";
+    name = "1.0.25-1.tar.gz";
+    sha256 = "dfa4dc7b9c2ebd216827b851179eb4011dc2f845a530e7b0039d7e6bf226a704";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ allocators lockfree rosatomic roscpp roslib rosunit std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rosrt provides classes for interfacing with ROS from within realtime systems, such as realtime-safe Publisher and Subscriber classes.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rqt-dep/default.nix
+++ b/distros/noetic/rqt-dep/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python-qt-binding, python3Packages, qt-dotgraph, qt-gui, qt-gui-py-common, rqt-graph, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-dep";
-  version = "0.4.11-r1";
+  version = "0.4.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.11-1.tar.gz";
-    name = "0.4.11-1.tar.gz";
-    sha256 = "ae71c5531c73809ccf544bba2899cbd2d916deccd75e03689479d2b1d0d0b72d";
+    url = "https://github.com/ros-gbp/rqt_dep-release/archive/release/noetic/rqt_dep/0.4.12-1.tar.gz";
+    name = "0.4.12-1.tar.gz";
+    sha256 = "173543b28fd652b17aa90d4be483382b1fb6a2c7cc842fa58c3151293eccc445";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-py-trees/default.nix
+++ b/distros/noetic/rqt-py-trees/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, py-trees, py-trees-msgs, python3Packages, qt-dotgraph, rospy, rqt-bag, rqt-graph, rqt-gui, rqt-gui-py, unique-id }:
 buildRosPackage {
   pname = "ros-noetic-rqt-py-trees";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/stonier/rqt_py_trees-release/archive/release/noetic/rqt_py_trees/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "78101685d5cb8d67ab3ba9a7a263d297b64e52b0fe81bc7ab2182167a05e2408";
+    url = "https://github.com/stonier/rqt_py_trees-release/archive/release/noetic/rqt_py_trees/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "4a243cfcf715beaf4d54717872166e67638d4da8530c1eeda1d78e6046619a79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rt-usb-9axisimu-driver/default.nix
+++ b/distros/noetic/rt-usb-9axisimu-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rt-usb-9axisimu-driver";
+  version = "1.0.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rt-net-gbp/rt_usb_9axisimu_driver-release/archive/release/noetic/rt_usb_9axisimu_driver/1.0.1-5.tar.gz";
+    name = "1.0.1-5.tar.gz";
+    sha256 = "18b1d1c114243756552695909060583ac71c177427b9a4701cb4dadf16557f8f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp roslint sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rt_usb_9axisimu_driver package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sdc21x0/default.nix
+++ b/distros/noetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sdc21x0";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a452f391d4d28527ad083caa028f55c3ab22a2ed3268741eb5254d2df3864a68";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "ed315a6ec7d5a2b6700e894b9883db1dcb9f1fe7921f24b977f5da7a5a7152ff";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sensor-filters/default.nix
+++ b/distros/noetic/sensor-filters/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, filters, nodelet, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-sensor-filters";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ctu-vras/sensor_filters-release/archive/release/noetic/sensor_filters/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "38cd48bd09b52a40608b6ed9cc01fa58b4bfef4c51d7a403539bae72e18e4c92";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ filters nodelet roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple sensor filter chain nodes and nodelets'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/settlerlib/default.nix
+++ b/distros/noetic/settlerlib/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, calibration-msgs, catkin, rosconsole, rostime }:
+buildRosPackage {
+  pname = "ros-noetic-settlerlib";
+  version = "0.10.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/calibration-release/archive/release/noetic/settlerlib/0.10.15-1.tar.gz";
+    name = "0.10.15-1.tar.gz";
+    sha256 = "c33ad16a8254c5b646874efcedcc894821ca38121916a103b29d357101ba2810";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost calibration-msgs rosconsole rostime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Defines helper functions and routines that greatly help when trying to create a settler
+    for a specific sensor channel. This package is experimental and unstable.
+    Expect its APIs to change.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/single-joint-position-action/default.nix
+++ b/distros/noetic/single-joint-position-action/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, pr2-controllers-msgs, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-single-joint-position-action";
+  version = "1.10.18-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_controllers-release/archive/release/noetic/single_joint_position_action/1.10.18-1.tar.gz";
+    name = "1.10.18-1.tar.gz";
+    sha256 = "e69860f0edc1f6aad505b4d4796f59fe477d47193b329072b1f1c80fbe6f35ec";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib pr2-controllers-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The single joint position action is a node that provides an action
+  interface for commanding a trajectory to move a joint to a particular
+  position. The action reports success when the joint reaches the desired
+  position.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/wifi-ddwrt/default.nix
+++ b/distros/noetic/wifi-ddwrt/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pr2-msgs, pythonPackages, rospy, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-wifi-ddwrt";
+  version = "0.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/wifi_ddwrt-release/archive/release/noetic/wifi_ddwrt/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "d1bf36a65c42894d5711c7361a5eff4e391d52fa38e882a07a78be0e80dcac22";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs pr2-msgs pythonPackages.mechanize rospy std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Access to the DD-WRT wifi'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'melodic', 'noetic'] from nix-ros-overlay commit 4b3acef50ef9739d6a7b8a4cd07ffc989699ae10.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *librealsense2 2.16.5-r1 --> 2.45.0-r1*
* *realsense2-camera 3.2.1-r1*
* *realsense2-camera-msgs 3.2.1-r1*
* *realsense2-description 3.2.1-r1*

Foxy Changes:
-------------
* *ament-cmake-ros 0.9.1-r1 --> 0.9.2-r1*
* *bosch-locator-bridge 2.0.1-r1*
* *domain-coordinator 0.9.1-r1 --> 0.9.2-r1*
* *mocap-msgs 0.0.3-r1*
* *plotjuggler 3.1.0-r1 --> 3.1.1-r1*
* *plotjuggler-ros 1.1.0-r1 --> 1.1.1-r4*
* *point-cloud-msg-wrapper 1.0.5-r1*
* *py-trees-ros 2.1.0-r1 --> 2.1.1-r3*
* *realsense2-camera 3.2.0-r1 --> 3.2.1-r1*
* *realsense2-camera-msgs 3.2.0-r1 --> 3.2.1-r1*
* *realsense2-description 3.2.0-r1 --> 3.2.1-r1*
* *rqt-reconfigure 1.0.7-r1 --> 1.0.8-r1*
* *rqt-robot-dashboard 0.6.1-r1*
* *system-modes 0.7.1-r3 --> 0.7.1-r4*
* *system-modes-examples 0.7.1-r3 --> 0.7.1-r4*
* *system-modes-msgs 0.7.1-r3 --> 0.7.1-r4*
* *ur-client-library 0.2.1-r1*

Melodic Changes:
----------------
* *aruco-pose 0.21.2-r1*
* *clover 0.21.2-r1*
* *clover-blocks 0.21.2-r1*
* *clover-description 0.21.2-r1*
* *clover-simulation 0.21.2-r1*
* *cpr-common-core-msgs 0.1.0-r1*
* *dbw-fca 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-can 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-description 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-joystick-demo 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-msgs 1.0.10-r1 --> 1.2.0-r1*
* *dbw-mkz 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-can 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-description 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-joystick-demo 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-msgs 1.2.9-r1 --> 1.4.0-r1*
* *dbw-polaris 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-can 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-description 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-joystick-demo 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-msgs 0.0.4-r1 --> 1.0.0-r1*
* *dingo-control 0.1.7-r1 --> 0.1.8-r1*
* *dingo-description 0.1.7-r1 --> 0.1.8-r1*
* *dingo-msgs 0.1.7-r1 --> 0.1.8-r1*
* *dingo-navigation 0.1.7-r1 --> 0.1.8-r1*
* *genmypy 0.3.0-r1 --> 0.3.1-r1*
* *geometric-shapes 0.6.3-r1 --> 0.6.4-r1*
* *magical-ros2-conversion-tool 1.2.0-r1 --> 1.2.1-r1*
* *mcl-3dl 0.5.4-r1 --> 0.6.0-r1*
* *mcl-3dl-msgs 0.2.0-r1 --> 0.6.0-r1*
* *mocap-optitrack 0.1.2-r1 --> 0.1.3-r1*
* *plotjuggler 3.1.0-r1 --> 3.1.1-r1*
* *plotjuggler-ros 1.1.0-r1 --> 1.1.1-r1*
* *robot-upstart 0.3.2-r1 --> 0.3.3-r1*
* *ros-introspection 1.2.0-r1 --> 1.2.1-r1*
* *roscompile 1.2.0-r1 --> 1.2.1-r1*
* *roswww-static 0.21.2-r1*
* *rt-usb-9axisimu-driver 1.0.0-r1 --> 1.0.1-r1*
* *sensor-filters 1.0.3-r1*

Noetic Changes:
---------------
* *allocators 1.0.25-r1*
* *azure-iot-sdk-c 1.7.0-r3 --> 1.7.0-r4*
* *bosch-locator-bridge 1.0.1-r2*
* *calibration 0.10.15-r1*
* *calibration-estimation 0.10.15-r1*
* *calibration-launch 0.10.15-r1*
* *calibration-msgs 0.10.15-r1*
* *calibration-setup-helper 0.10.15-r1*
* *chomp-motion-planner 1.1.3-r1 --> 1.1.4-r1*
* *dbw-fca 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-can 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-description 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-joystick-demo 1.0.10-r1 --> 1.2.0-r1*
* *dbw-fca-msgs 1.0.10-r1 --> 1.2.0-r1*
* *dbw-mkz 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-can 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-description 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-joystick-demo 1.2.9-r1 --> 1.4.0-r1*
* *dbw-mkz-msgs 1.2.9-r1 --> 1.4.0-r1*
* *dbw-polaris 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-can 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-description 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-joystick-demo 0.0.4-r1 --> 1.0.0-r1*
* *dbw-polaris-msgs 0.0.4-r1 --> 1.0.0-r1*
* *ethercat-trigger-controllers 1.10.18-r1*
* *fadecandy-driver 0.2.1-r1 --> 0.2.2-r1*
* *fadecandy-msgs 0.2.1-r1 --> 0.2.2-r1*
* *genmypy 0.3.0-r1 --> 0.3.1-r1*
* *geometric-shapes 0.7.2-r1 --> 0.7.3-r1*
* *image-cb-detector 0.10.15-r1*
* *interval-intersection 0.10.15-r1*
* *joint-states-settler 0.10.15-r1*
* *joint-trajectory-action 1.10.18-r1*
* *joint-trajectory-action-tools 0.0.12-r1*
* *joint-trajectory-generator 0.0.12-r1*
* *laser-cb-detector 0.10.15-r1*
* *lockfree 1.0.25-r1*
* *magical-ros2-conversion-tool 1.2.0-r1 --> 1.2.1-r1*
* *mcl-3dl 0.5.4-r1 --> 0.6.0-r1*
* *mcl-3dl-msgs 0.2.0-r1 --> 0.6.0-r1*
* *mir-actions 1.1.1-r1 --> 1.1.2-r1*
* *mir-description 1.1.1-r1 --> 1.1.2-r1*
* *mir-dwb-critics 1.1.1-r1 --> 1.1.2-r1*
* *mir-gazebo 1.1.1-r1 --> 1.1.2-r1*
* *mir-msgs 1.1.1-r1 --> 1.1.2-r1*
* *mir-navigation 1.1.1-r1 --> 1.1.2-r1*
* *mir-robot 1.1.1-r1 --> 1.1.2-r1*
* *mocap-optitrack 0.1.2-r1 --> 0.1.3-r1*
* *monocam-settler 0.10.15-r1*
* *moveit 1.1.3-r1 --> 1.1.4-r1*
* *moveit-calibration-gui 0.1.0-r1*
* *moveit-calibration-plugins 0.1.0-r1*
* *moveit-chomp-optimizer-adapter 1.1.3-r1 --> 1.1.4-r1*
* *moveit-core 1.1.3-r1 --> 1.1.4-r1*
* *moveit-fake-controller-manager 1.1.3-r1 --> 1.1.4-r1*
* *moveit-kinematics 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners-chomp 1.1.3-r1 --> 1.1.4-r1*
* *moveit-planners-ompl 1.1.3-r1 --> 1.1.4-r1*
* *moveit-plugins 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-benchmarks 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-control-interface 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-manipulation 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-move-group 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-occupancy-map-monitor 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-planning 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-planning-interface 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-robot-interaction 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-visualization 1.1.3-r1 --> 1.1.4-r1*
* *moveit-ros-warehouse 1.1.3-r1 --> 1.1.4-r1*
* *moveit-runtime 1.1.3-r1 --> 1.1.4-r1*
* *moveit-servo 1.1.3-r1 --> 1.1.4-r1*
* *moveit-setup-assistant 1.1.3-r1 --> 1.1.4-r1*
* *moveit-simple-controller-manager 1.1.3-r1 --> 1.1.4-r1*
* *ocean-battery-driver 1.1.8-r1 --> 1.1.10-r1*
* *pilz-industrial-motion-planner 1.1.3-r1 --> 1.1.4-r1*
* *pilz-industrial-motion-planner-testutils 1.1.3-r1 --> 1.1.4-r1*
* *plotjuggler 3.1.0-r1 --> 3.1.1-r1*
* *plotjuggler-ros 1.1.0-r2 --> 1.1.1-r1*
* *power-monitor 1.1.8-r1 --> 1.1.10-r1*
* *pr2-arm-kinematics 1.0.11-r1*
* *pr2-arm-move-ik 0.0.12-r1*
* *pr2-calibration-controllers 1.10.18-r1*
* *pr2-common-action-msgs 0.0.12-r1*
* *pr2-common-actions 0.0.12-r1*
* *pr2-controllers 1.10.18-r1*
* *pr2-controllers-msgs 1.10.18-r1*
* *pr2-gripper-action 1.10.18-r1*
* *pr2-head-action 1.10.18-r1*
* *pr2-kinematics 1.0.11-r1*
* *pr2-mechanism-controllers 1.10.18-r1*
* *pr2-power-board 1.1.8-r1 --> 1.1.10-r1*
* *pr2-power-drivers 1.1.8-r1 --> 1.1.10-r1*
* *pr2-tilt-laser-interface 0.0.12-r1*
* *pr2-tuck-arms-action 0.0.12-r1*
* *py-trees-msgs 0.3.6-r1 --> 0.3.7-r2*
* *robot-mechanism-controllers 1.10.18-r1*
* *robot-upstart 0.4.0-r1 --> 0.4.1-r1*
* *ros-introspection 1.2.0-r1 --> 1.2.1-r1*
* *ros-realtime 1.0.25-r1*
* *rosatomic 1.0.25-r1*
* *roscompile 1.2.0-r1 --> 1.2.1-r1*
* *rosrt 1.0.25-r1*
* *rqt-dep 0.4.11-r1 --> 0.4.12-r1*
* *rqt-py-trees 0.4.0-r1 --> 0.4.1-r1*
* *rt-usb-9axisimu-driver 1.0.1-r5*
* *sdc21x0 1.1.1-r1 --> 1.1.2-r1*
* *sensor-filters 1.0.3-r1*
* *settlerlib 0.10.15-r1*
* *single-joint-position-action 1.10.18-r1*
* *wifi-ddwrt 0.2.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-gazebo3
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz

