### PR TITLE
rosdistro sync, Sat May 29 00:40:01 2021

### DIFF
--- a/distros/dashing/ament-cmake-gmock/default.nix
+++ b/distros/dashing/ament-cmake-gmock/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock, gmock-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-dashing-ament-cmake-gmock";
   version = "0.7.6-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock gmock-vendor ];
+  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock-vendor gtest ];
   nativeBuildInputs = [ ament-cmake-core ];
 
   meta = {

--- a/distros/dashing/aws-common/default.nix
+++ b/distros/dashing/aws-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, cmake, curl, openssl, ros-environment, utillinux, zlib }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, cmake, curl, openssl, ros-environment, util-linux, zlib }:
 buildRosPackage {
   pname = "ros-dashing-aws-common";
   version = "2.2.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "cmake";
   buildInputs = [ ros-environment ];
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ];
-  propagatedBuildInputs = [ curl openssl utillinux zlib ];
+  propagatedBuildInputs = [ curl openssl util-linux zlib ];
   nativeBuildInputs = [ ament-cmake-gmock ament-cmake-gtest cmake ];
 
   meta = {

--- a/distros/dashing/bondcpp/default.nix
+++ b/distros/dashing/bondcpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, rclcpp, rclcpp-lifecycle, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-dashing-bondcpp";
   version = "2.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib util-linux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/cartographer/default.nix
+++ b/distros/dashing/cartographer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gmock, gtest, lua5, protobuf, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-cartographer";
   version = "1.0.9001-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ gmock gtest python3Packages.sphinx ];
+  buildInputs = [ gtest python3Packages.sphinx ];
   propagatedBuildInputs = [ boost cairo ceres-solver eigen gflags glog lua5 protobuf ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/dashing/libphidget22/default.nix
+++ b/distros/dashing/libphidget22/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-dashing-libphidget22";
   version = "2.0.2-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/dashing/rc-genicam-api/default.nix
+++ b/distros/dashing/rc-genicam-api/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-dashing-rc-genicam-api";
   version = "2.4.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libpng libusb ];
+  propagatedBuildInputs = [ libpng libusb1 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/dashing/test-bond/default.nix
+++ b/distros/dashing/test-bond/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-dashing-test-bond";
   version = "2.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-lifecycle ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp utillinux ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp rclcpp util-linux ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ rosidl-default-generators ];
 

--- a/distros/foxy/ament-cmake-gmock/default.nix
+++ b/distros/foxy/ament-cmake-gmock/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock, gmock-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gmock";
   version = "0.9.8-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock gmock-vendor ];
+  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock-vendor gtest ];
   nativeBuildInputs = [ ament-cmake-core ];
 
   meta = {

--- a/distros/foxy/bondcpp/default.nix
+++ b/distros/foxy/bondcpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, pkg-config, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, pkg-config, rclcpp, rclcpp-lifecycle, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-foxy-bondcpp";
   version = "2.1.0-r1";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib util-linux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/cartographer/default.nix
+++ b/distros/foxy/cartographer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gmock, gtest, lua5, protobuf, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-cartographer";
   version = "1.0.9001-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ gmock gtest python3Packages.sphinx ];
+  buildInputs = [ gtest python3Packages.sphinx ];
   propagatedBuildInputs = [ boost cairo ceres-solver eigen gflags glog lua5 protobuf ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/foxy/kobuki-ftdi/default.nix
+++ b/distros/foxy/kobuki-ftdi/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, libftdi, libusb, pkg-config }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, ecl-build, ecl-command-line, libftdi, libusb1, pkg-config }:
 buildRosPackage {
   pname = "ros-foxy-kobuki-ftdi";
   version = "1.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ecl-build pkg-config ];
-  propagatedBuildInputs = [ ecl-command-line libftdi libusb ];
+  propagatedBuildInputs = [ ecl-command-line libftdi libusb1 ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/foxy/libphidget22/default.nix
+++ b/distros/foxy/libphidget22/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-libphidget22";
   version = "2.0.2-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gmock, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
   version = "2.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ angles ];
-  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common gmock gtest ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common gtest ];
   propagatedBuildInputs = [ console-bridge diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros-msgs message-filters nav-msgs pluginlib python3Packages.click rclcpp rclcpp-components rclpy rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
 

--- a/distros/foxy/rc-genicam-api/default.nix
+++ b/distros/foxy/rc-genicam-api/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-api";
   version = "2.5.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libpng libusb ];
+  propagatedBuildInputs = [ libpng libusb1 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/test-bond/default.nix
+++ b/distros/foxy/test-bond/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, pkg-config, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, pkg-config, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-foxy-test-bond";
   version = "2.1.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-lifecycle ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp pkg-config rclcpp utillinux ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp pkg-config rclcpp util-linux ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ rosidl-default-generators ];
 

--- a/distros/galactic/ament-cmake-gmock/default.nix
+++ b/distros/galactic/ament-cmake-gmock/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock, gmock-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-galactic-ament-cmake-gmock";
   version = "1.1.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock gmock-vendor ];
+  propagatedBuildInputs = [ ament-cmake-gtest ament-cmake-test gmock-vendor gtest ];
   nativeBuildInputs = [ ament-cmake-core ];
 
   meta = {

--- a/distros/galactic/ament-copyright/default.nix
+++ b/distros/galactic/ament-copyright/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-lint, ament-pep257, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-ament-copyright";
+  version = "0.10.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_lint-release/archive/release/galactic/ament_copyright/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "959c6f579b14d15e57344f5f4c9b9abcab0b01931ccde3e92ece1034e1c39a16";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-lint python3Packages.importlib-metadata ];
+
+  meta = {
+    description = ''The ability to check source files for copyright and license
+    information.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ament-package/default.nix
+++ b/distros/galactic/ament-package/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-ament-package";
+  version = "0.12.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_package-release/archive/release/galactic/ament_package/0.12.0-2.tar.gz";
+    name = "0.12.0-2.tar.gz";
+    sha256 = "dcf641a1b3db8b8173f1e979cc2f49cc41ac43365c04f72ba142f54476ea9f97";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ python3Packages.flake8 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.importlib-metadata python3Packages.importlib-resources python3Packages.setuptools ];
+
+  meta = {
+    description = ''The parser for the manifest files in the ament buildsystem.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/bondcpp/default.nix
+++ b/distros/galactic/bondcpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, pkg-config, rclcpp, rclcpp-lifecycle, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, bond, pkg-config, rclcpp, rclcpp-lifecycle, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-galactic-bondcpp";
   version = "3.0.1-r4";
@@ -16,7 +16,7 @@ buildRosPackage {
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib utillinux ];
+  propagatedBuildInputs = [ bond rclcpp rclcpp-lifecycle smclib util-linux ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/cartographer/default.nix
+++ b/distros/galactic/cartographer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gmock, gtest, lua5, protobuf, python3Packages }:
+{ lib, buildRosPackage, fetchurl, boost, cairo, ceres-solver, cmake, eigen, gflags, glog, gtest, lua5, protobuf, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-cartographer";
   version = "1.0.9001-r3";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ gmock gtest python3Packages.sphinx ];
+  buildInputs = [ gtest python3Packages.sphinx ];
   propagatedBuildInputs = [ boost cairo ceres-solver eigen gflags glog lua5 protobuf ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -92,6 +92,8 @@ self: super: {
 
  ament-cmake-xmllint = self.callPackage ./ament-cmake-xmllint {};
 
+ ament-copyright = self.callPackage ./ament-copyright {};
+
  ament-cppcheck = self.callPackage ./ament-cppcheck {};
 
  ament-cpplint = self.callPackage ./ament-cpplint {};
@@ -113,6 +115,8 @@ self: super: {
  ament-mypy = self.callPackage ./ament-mypy {};
 
  ament-nodl = self.callPackage ./ament-nodl {};
+
+ ament-package = self.callPackage ./ament-package {};
 
  ament-pclint = self.callPackage ./ament-pclint {};
 
@@ -369,6 +373,10 @@ self: super: {
  laser-geometry = self.callPackage ./laser-geometry {};
 
  laser-proc = self.callPackage ./laser-proc {};
+
+ launch = self.callPackage ./launch {};
+
+ launch-ros = self.callPackage ./launch-ros {};
 
  launch-testing = self.callPackage ./launch-testing {};
 
@@ -658,6 +666,8 @@ self: super: {
 
  ros2bag = self.callPackage ./ros2bag {};
 
+ ros2cli = self.callPackage ./ros2cli {};
+
  ros2cli-common-extensions = self.callPackage ./ros2cli-common-extensions {};
 
  ros2cli-test-interfaces = self.callPackage ./ros2cli-test-interfaces {};
@@ -735,6 +745,8 @@ self: super: {
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
  rosidl-adapter = self.callPackage ./rosidl-adapter {};
+
+ rosidl-cli = self.callPackage ./rosidl-cli {};
 
  rosidl-cmake = self.callPackage ./rosidl-cmake {};
 

--- a/distros/galactic/launch-ros/default.nix
+++ b/distros/galactic/launch-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-launch-ros";
+  version = "0.14.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/galactic/launch_ros/0.14.2-1.tar.gz";
+    name = "0.14.2-1.tar.gz";
+    sha256 = "db6c0cc59b01aa5492e04d342273b60adccd3d65c0b79016dcd8e695517acca8";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python composition-interfaces launch lifecycle-msgs osrf-pycommon python3Packages.importlib-metadata python3Packages.pyyaml rclpy ];
+
+  meta = {
+    description = ''ROS specific extensions to the launch tool.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/launch/default.nix
+++ b/distros/galactic/launch/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-launch";
+  version = "0.17.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/galactic/launch/0.17.0-2.tar.gz";
+    name = "0.17.0-2.tar.gz";
+    sha256 = "244263e074fb6e3af3df246ae3d742db28e17f9cfd97cce3a9562112620fbb83";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python osrf-pycommon python3Packages.importlib-metadata python3Packages.lark-parser ];
+
+  meta = {
+    description = ''The ROS launch tool.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/libphidget22/default.nix
+++ b/distros/galactic/libphidget22/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-libphidget22";
   version = "2.2.0-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rc-genicam-api/default.nix
+++ b/distros/galactic/rc-genicam-api/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-rc-genicam-api";
   version = "2.5.0-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libpng libusb ];
+  propagatedBuildInputs = [ libpng libusb1 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/ros2cli/default.nix
+++ b/distros/galactic/ros2cli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ros2cli";
+  version = "0.13.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/galactic/ros2cli/0.13.2-1.tar.gz";
+    name = "0.13.2-1.tar.gz";
+    sha256 = "2fe95eb99d64dd3dee6fa7a0fb90f9ee055d564e746d3adfff33608b457b21d5";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest test-msgs ];
+  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata python3Packages.netifaces python3Packages.packaging python3Packages.setuptools rclpy ];
+
+  meta = {
+    description = ''Framework for ROS 2 command line tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rosidl-cli/default.nix
+++ b/distros/galactic/rosidl-cli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-rosidl-cli";
+  version = "2.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosidl-release/archive/release/galactic/rosidl_cli/2.2.1-2.tar.gz";
+    name = "2.2.1-2.tar.gz";
+    sha256 = "594496523a8b30380e1757f666682b02a063cb6998aef7ab13a35cc1a6395f0d";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.argcomplete python3Packages.importlib-metadata ];
+
+  meta = {
+    description = ''Command line tools for ROS interface generation.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/test-bond/default.nix
+++ b/distros/galactic/test-bond/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, pkg-config, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, utillinux }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bond, bondcpp, builtin-interfaces, pkg-config, rclcpp, rclcpp-lifecycle, rosidl-default-generators, rosidl-default-runtime, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-galactic-test-bond";
   version = "3.0.1-r4";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "ament_cmake";
   buildInputs = [ ament-cmake rclcpp-lifecycle ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp pkg-config rclcpp utillinux ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common bond bondcpp pkg-config rclcpp util-linux ];
   propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ rosidl-default-generators ];
 

--- a/distros/melodic/aws-common/default.nix
+++ b/distros/melodic/aws-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, gmock, gtest, openssl, ros-environment, utillinux, zlib }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, gtest, openssl, ros-environment, util-linux, zlib }:
 buildRosPackage {
   pname = "ros-melodic-aws-common";
   version = "2.2.0-r1";
@@ -15,8 +15,8 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ ros-environment ];
-  checkInputs = [ gmock gtest ];
-  propagatedBuildInputs = [ curl openssl utillinux zlib ];
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ curl openssl util-linux zlib ];
   nativeBuildInputs = [ catkin cmake ];
 
   meta = {

--- a/distros/melodic/azure-iot-sdk-c/default.nix
+++ b/distros/melodic/azure-iot-sdk-c/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, utillinux }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-melodic-azure-iot-sdk-c";
   version = "1.7.0-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin curl openssl utillinux ];
+  propagatedBuildInputs = [ catkin curl openssl util-linux ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/bondcpp/default.nix
+++ b/distros/melodic/bondcpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bond, boost, catkin, cmake-modules, roscpp, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, bond, boost, catkin, cmake-modules, roscpp, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-melodic-bondcpp";
   version = "1.8.5-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ bond boost roscpp smclib utillinux ];
+  propagatedBuildInputs = [ bond boost roscpp smclib util-linux ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/bondpy/default.nix
+++ b/distros/melodic/bondpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bond, catkin, pythonPackages, rospy, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, bond, catkin, pythonPackages, rospy, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-melodic-bondpy";
   version = "1.8.5-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ bond ];
-  propagatedBuildInputs = [ rospy smclib utillinux ];
+  propagatedBuildInputs = [ rospy smclib util-linux ];
   nativeBuildInputs = [ catkin pythonPackages.setuptools ];
 
   meta = {

--- a/distros/melodic/cartographer-ros/default.nix
+++ b/distros/melodic/cartographer-ros/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cartographer, cartographer-ros-msgs, catkin, eigen-conversions, geometry-msgs, gflags, glog, gmock, message-runtime, nav-msgs, pcl, pcl-conversions, protobuf, pythonPackages, robot-state-publisher, rosbag, roscpp, roslaunch, roslib, rosunit, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, urdf, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, cartographer, cartographer-ros-msgs, catkin, eigen-conversions, geometry-msgs, gflags, glog, gtest, message-runtime, nav-msgs, pcl, pcl-conversions, protobuf, pythonPackages, robot-state-publisher, rosbag, roscpp, roslaunch, roslib, rosunit, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-cartographer-ros";
   version = "1.0.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ gmock protobuf pythonPackages.sphinx ];
+  buildInputs = [ gtest protobuf pythonPackages.sphinx ];
   checkInputs = [ rosunit ];
   propagatedBuildInputs = [ cartographer cartographer-ros-msgs eigen-conversions geometry-msgs gflags glog message-runtime nav-msgs pcl pcl-conversions robot-state-publisher rosbag roscpp roslaunch roslib sensor-msgs std-msgs tf2 tf2-eigen tf2-ros urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];

--- a/distros/melodic/cartographer/default.nix
+++ b/distros/melodic/cartographer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, cairo, catkin, ceres-solver, eigen, gflags, glog, gmock, lua5, protobuf, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, boost, cairo, catkin, ceres-solver, eigen, gflags, glog, gtest, lua5, protobuf, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-cartographer";
   version = "1.0.0";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  buildInputs = [ gmock pythonPackages.sphinx ];
+  buildInputs = [ gtest pythonPackages.sphinx ];
   propagatedBuildInputs = [ boost cairo ceres-solver eigen gflags glog lua5 protobuf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/catkin/default.nix
+++ b/distros/melodic/catkin/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-catkin";
   version = "0.7.29-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ pythonPackages.mock pythonPackages.nose ];
-  propagatedBuildInputs = [ cmake gmock gtest python pythonPackages.catkin-pkg pythonPackages.empy pythonPackages.nose ];
+  propagatedBuildInputs = [ cmake gtest python pythonPackages.catkin-pkg pythonPackages.empy pythonPackages.nose ];
   nativeBuildInputs = [ cmake pythonPackages.setuptools ];
 
   meta = {

--- a/distros/melodic/cloudwatch-logger/default.nix
+++ b/distros/melodic/cloudwatch-logger/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gmock, gtest, roscpp, rostest, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-logs-common, gtest, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logger";
   version = "2.3.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ aws-common aws-ros1-common cloudwatch-logs-common roscpp std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/cloudwatch-logs-common/default.nix
+++ b/distros/melodic/cloudwatch-logs-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
+{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-logs-common";
   version = "1.1.5-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common dataflow-lite file-management ];
   nativeBuildInputs = [ catkin cmake ];
 

--- a/distros/melodic/cloudwatch-metrics-collector/default.nix
+++ b/distros/melodic/cloudwatch-metrics-collector/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gmock, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, cloudwatch-metrics-common, gtest, ros-monitoring-msgs, roscpp, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-collector";
   version = "2.2.1-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ aws-common aws-ros1-common cloudwatch-metrics-common ros-monitoring-msgs roscpp std-msgs std-srvs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/cloudwatch-metrics-common/default.nix
+++ b/distros/melodic/cloudwatch-metrics-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gmock, gtest }:
+{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, dataflow-lite, file-management, gtest }:
 buildRosPackage {
   pname = "ros-melodic-cloudwatch-metrics-common";
   version = "1.1.5-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common dataflow-lite file-management ];
   nativeBuildInputs = [ catkin cmake ];
 

--- a/distros/melodic/dataflow-lite/default.nix
+++ b/distros/melodic/dataflow-lite/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, cmake, gmock, gtest }:
+{ lib, buildRosPackage, fetchurl, aws-common, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-dataflow-lite";
   version = "1.1.5-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/melodic/ddynamic-reconfigure/default.nix
+++ b/distros/melodic/ddynamic-reconfigure/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gmock, roscpp, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-ddynamic-reconfigure";
   version = "0.3.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/file-management/default.nix
+++ b/distros/melodic/file-management/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gmock, gtest }:
+{ lib, buildRosPackage, fetchurl, aws-common, cmake, dataflow-lite, gtest }:
 buildRosPackage {
   pname = "ros-melodic-file-management";
   version = "1.1.5-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common dataflow-lite ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/melodic/grid-map-filters/default.nix
+++ b/distros/melodic/grid-map-filters/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, filters, gmock, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv3, tbb }:
+{ lib, buildRosPackage, fetchurl, catkin, filters, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv3, tbb }:
 buildRosPackage {
   pname = "ros-melodic-grid-map-filters";
   version = "1.6.4-r2";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros opencv3 tbb ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/h264-encoder-core/default.nix
+++ b/distros/melodic/h264-encoder-core/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, ffmpeg, gmock, gtest }:
+{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, ffmpeg, gtest }:
 buildRosPackage {
   pname = "ros-melodic-h264-encoder-core";
   version = "2.0.3-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common ffmpeg ];
   nativeBuildInputs = [ catkin cmake ];
 

--- a/distros/melodic/h264-video-encoder/default.nix
+++ b/distros/melodic/h264-video-encoder/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-ros1-common, catkin, gmock, gtest, h264-encoder-core, image-transport, image-transport-plugins, kinesis-video-msgs, message-generation, message-runtime, rostest, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-ros1-common, catkin, gtest, h264-encoder-core, image-transport, image-transport-plugins, kinesis-video-msgs, message-generation, message-runtime, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-h264-video-encoder";
   version = "1.1.4-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ aws-ros1-common h264-encoder-core image-transport image-transport-plugins kinesis-video-msgs message-runtime sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/health-metric-collector/default.nix
+++ b/distros/melodic/health-metric-collector/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, message-generation, message-runtime, ros-monitoring-msgs, roscpp, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-health-metric-collector";
   version = "2.0.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ aws-common aws-ros1-common message-generation message-runtime ros-monitoring-msgs roscpp rospy std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/kinesis-manager/default.nix
+++ b/distros/melodic/kinesis-manager/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, curl, gmock, gtest, log4cplus, openssl, pkg-config }:
+{ lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, curl, gtest, log4cplus, openssl, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-manager";
   version = "2.0.3-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common boost curl log4cplus openssl ];
   nativeBuildInputs = [ catkin cmake pkg-config ];
 

--- a/distros/melodic/kinesis-video-streamer/default.nix
+++ b/distros/melodic/kinesis-video-streamer/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, image-transport, kinesis-manager, kinesis-video-msgs, roscpp, rostest, rostopic, std-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, image-transport, kinesis-manager, kinesis-video-msgs, roscpp, rostest, rostopic, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kinesis-video-streamer";
   version = "2.0.3-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest rostopic ];
+  checkInputs = [ gtest rostest rostopic ];
   propagatedBuildInputs = [ aws-common aws-ros1-common image-transport kinesis-manager kinesis-video-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/kobuki-ftdi/default.nix
+++ b/distros/melodic/kobuki-ftdi/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ecl-command-line, libftdi, libusb, pkg-config }:
+{ lib, buildRosPackage, fetchurl, catkin, ecl-command-line, libftdi, libusb1, pkg-config }:
 buildRosPackage {
   pname = "ros-melodic-kobuki-ftdi";
   version = "0.7.12-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ ecl-command-line libftdi libusb ];
+  propagatedBuildInputs = [ ecl-command-line libftdi libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/lex-common/default.nix
+++ b/distros/melodic/lex-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, gmock, gtest, ros-environment }:
+{ lib, buildRosPackage, fetchurl, aws-common, catkin, cmake, gtest, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-lex-common";
   version = "1.0.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ catkin ros-environment ];
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/melodic/lex-node/default.nix
+++ b/distros/melodic/lex-node/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gmock, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
+{ lib, buildRosPackage, fetchurl, aws-common, aws-ros1-common, catkin, gtest, lex-common, lex-common-msgs, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-lex-node";
   version = "2.0.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ aws-common aws-ros1-common lex-common lex-common-msgs roscpp std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/libphidget21/default.nix
+++ b/distros/melodic/libphidget21/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-libphidget21";
   version = "0.7.11-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/libphidgets/default.nix
+++ b/distros/melodic/libphidgets/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-libphidgets";
   version = "0.6.17-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/lusb/default.nix
+++ b/distros/melodic/lusb/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-lusb";
   version = "1.1.0";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ boost libusb ];
+  propagatedBuildInputs = [ boost libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/mrpt1/default.nix
+++ b/distros/melodic/mrpt1/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, eigen, ffmpeg, freeglut, libjpeg, libpcap, libudev, libusb1, octomap, opencv3, python, pythonPackages, suitesparse, wxGTK, zlib }:
+{ lib, buildRosPackage, fetchurl, assimp, boost, catkin, cmake, eigen, ffmpeg, freeglut, libjpeg, libpcap, libusb1, octomap, opencv3, python, pythonPackages, suitesparse, udev, wxGTK, zlib }:
 buildRosPackage {
   pname = "ros-melodic-mrpt1";
   version = "1.5.9-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ assimp boost catkin eigen ffmpeg freeglut libjpeg libpcap libudev libusb1 octomap opencv3 python pythonPackages.numpy suitesparse wxGTK zlib ];
+  propagatedBuildInputs = [ assimp boost catkin eigen ffmpeg freeglut libjpeg libpcap libusb1 octomap opencv3 python pythonPackages.numpy suitesparse udev wxGTK zlib ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/nodelet/default.nix
+++ b/distros/melodic/nodelet/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, utillinux }:
+{ lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-melodic-nodelet";
   version = "1.9.16";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation ];
-  propagatedBuildInputs = [ bondcpp boost message-runtime pluginlib rosconsole roscpp rospy std-msgs utillinux ];
+  propagatedBuildInputs = [ bondcpp boost message-runtime pluginlib rosconsole roscpp rospy std-msgs util-linux ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/openrtm-aist/default.nix
+++ b/distros/melodic/openrtm-aist/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, python, utillinux }:
+{ lib, buildRosPackage, fetchurl, automake, catkin, cmake, doxygen, libtool, omniorb, pkg-config, python, util-linux }:
 buildRosPackage {
   pname = "ros-melodic-openrtm-aist";
   version = "1.1.2-r7";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "cmake";
   buildInputs = [ doxygen python ];
-  propagatedBuildInputs = [ catkin omniorb utillinux ];
+  propagatedBuildInputs = [ catkin omniorb util-linux ];
   nativeBuildInputs = [ automake cmake libtool pkg-config ];
 
   meta = {

--- a/distros/melodic/pal-statistics/default.nix
+++ b/distros/melodic/pal-statistics/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, gmock, pal-statistics-msgs, roscpp, rospy, rostest }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, pal-statistics-msgs, roscpp, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-pal-statistics";
   version = "1.4.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ boost pal-statistics-msgs roscpp rospy ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/ps3joy/default.nix
+++ b/distros/melodic/ps3joy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb1, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ps3joy";
   version = "1.14.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  propagatedBuildInputs = [ bluez diagnostic-msgs libusb linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
+  propagatedBuildInputs = [ bluez diagnostic-msgs libusb1 linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rc-genicam-api/default.nix
+++ b/distros/melodic/rc-genicam-api/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
   version = "2.5.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libpng libusb ];
+  propagatedBuildInputs = [ libpng libusb1 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/rosbag-cloud-recorders/default.nix
+++ b/distros/melodic/rosbag-cloud-recorders/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gmock, gtest, recorder-msgs, rosbag-storage, roscpp, roslint, rostest, topic-tools, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, recorder-msgs, rosbag-storage, roscpp, roslint, rostest, topic-tools, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-rosbag-cloud-recorders";
   version = "1.0.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ actionlib actionlib-msgs aws-common aws-ros1-common boost file-uploader-msgs recorder-msgs rosbag-storage roscpp topic-tools xmlrpcpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rqt-multiplot/default.nix
+++ b/distros/melodic/rqt-multiplot/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qt5, qwt6, rosbag, roscpp, rqt-gui, rqt-gui-cpp, variant-topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, libsForQt5, qt5, rosbag, roscpp, rqt-gui, rqt-gui-cpp, variant-topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-rqt-multiplot";
   version = "0.0.10";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qt5.qtbase qwt6 rosbag roscpp rqt-gui rqt-gui-cpp variant-topic-tools ];
+  propagatedBuildInputs = [ libsForQt5.qwt qt5.qtbase rosbag roscpp rqt-gui rqt-gui-cpp variant-topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/s3-common/default.nix
+++ b/distros/melodic/s3-common/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, gmock }:
+{ lib, buildRosPackage, fetchurl, aws-common, boost, catkin, cmake, gtest }:
 buildRosPackage {
   pname = "ros-melodic-s3-common";
   version = "1.0.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  checkInputs = [ gmock ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ aws-common boost ];
   nativeBuildInputs = [ catkin cmake ];
 

--- a/distros/melodic/s3-file-uploader/default.nix
+++ b/distros/melodic/s3-file-uploader/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gmock, gtest, roscpp, rostest, s3-common }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, aws-common, aws-ros1-common, boost, catkin, file-uploader-msgs, gtest, roscpp, rostest, s3-common }:
 buildRosPackage {
   pname = "ros-melodic-s3-file-uploader";
   version = "1.0.1-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ actionlib actionlib-msgs aws-common aws-ros1-common boost file-uploader-msgs roscpp s3-common ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/schunk-sdh/default.nix
+++ b/distros/melodic/schunk-sdh/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cob-srvs, control-msgs, diagnostic-msgs, dpkg, libntcan, libpcan, libusb, message-generation, message-runtime, roscpp, roslint, sdhlibrary-cpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cob-srvs, control-msgs, diagnostic-msgs, dpkg, libntcan, libpcan, libusb1, message-generation, message-runtime, roscpp, roslint, sdhlibrary-cpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-schunk-sdh";
   version = "0.6.14-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ message-generation roslint ];
-  propagatedBuildInputs = [ actionlib boost cob-srvs control-msgs diagnostic-msgs dpkg libntcan libpcan libusb message-runtime roscpp sdhlibrary-cpp sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
+  propagatedBuildInputs = [ actionlib boost cob-srvs control-msgs diagnostic-msgs dpkg libntcan libpcan libusb1 message-runtime roscpp sdhlibrary-cpp sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/sick-tim/default.nix
+++ b/distros/melodic/sick-tim/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-sick-tim";
   version = "0.0.17-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libusb libusb1 robot-state-publisher roscpp sensor-msgs xacro ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libusb1 robot-state-publisher roscpp sensor-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/usb-cam/default.nix
+++ b/distros/melodic/usb-cam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, ffmpeg, image-transport, roscpp, sensor-msgs, std-msgs, std-srvs, v4l_utils }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, ffmpeg, image-transport, roscpp, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-melodic-usb-cam";
   version = "0.3.6";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager ffmpeg image-transport roscpp sensor-msgs std-msgs std-srvs v4l_utils ];
+  propagatedBuildInputs = [ camera-info-manager ffmpeg image-transport roscpp sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/azure-iot-sdk-c/default.nix
+++ b/distros/noetic/azure-iot-sdk-c/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, utillinux }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake, curl, openssl, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-azure-iot-sdk-c";
   version = "1.7.0-r4";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin curl openssl utillinux ];
+  propagatedBuildInputs = [ catkin curl openssl util-linux ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/bondcpp/default.nix
+++ b/distros/noetic/bondcpp/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bond, boost, catkin, cmake-modules, roscpp, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, bond, boost, catkin, cmake-modules, roscpp, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-bondcpp";
   version = "1.8.6-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules ];
-  propagatedBuildInputs = [ bond boost roscpp smclib utillinux ];
+  propagatedBuildInputs = [ bond boost roscpp smclib util-linux ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/bondpy/default.nix
+++ b/distros/noetic/bondpy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bond, catkin, python3Packages, rospy, smclib, utillinux }:
+{ lib, buildRosPackage, fetchurl, bond, catkin, python3Packages, rospy, smclib, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-bondpy";
   version = "1.8.6-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ bond ];
-  propagatedBuildInputs = [ rospy smclib utillinux ];
+  propagatedBuildInputs = [ rospy smclib util-linux ];
   nativeBuildInputs = [ catkin python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/catkin/default.nix
+++ b/distros/noetic/catkin/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, gmock, gtest, python3Packages }:
+{ lib, buildRosPackage, fetchurl, cmake, gtest, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-catkin";
   version = "0.8.10-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ python3Packages.mock python3Packages.nose ];
-  propagatedBuildInputs = [ cmake gmock gtest python3Packages.catkin-pkg python3Packages.empy python3Packages.nose python3Packages.setuptools ];
+  propagatedBuildInputs = [ cmake gtest python3Packages.catkin-pkg python3Packages.empy python3Packages.nose python3Packages.setuptools ];
   nativeBuildInputs = [ cmake python3Packages.setuptools ];
 
   meta = {

--- a/distros/noetic/ddynamic-reconfigure/default.nix
+++ b/distros/noetic/ddynamic-reconfigure/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gmock, roscpp, rostest }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gtest, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-ddynamic-reconfigure";
   version = "0.3.2-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock rostest ];
+  checkInputs = [ gtest rostest ];
   propagatedBuildInputs = [ dynamic-reconfigure roscpp ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/grid-map-filters/default.nix
+++ b/distros/noetic/grid-map-filters/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, filters, gmock, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv3, tbb }:
+{ lib, buildRosPackage, fetchurl, catkin, filters, grid-map-core, grid-map-msgs, grid-map-ros, gtest, opencv3, tbb }:
 buildRosPackage {
   pname = "ros-noetic-grid-map-filters";
   version = "1.6.4-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  checkInputs = [ gmock gtest ];
+  checkInputs = [ gtest ];
   propagatedBuildInputs = [ filters grid-map-core grid-map-msgs grid-map-ros opencv3 tbb ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/kobuki-ftdi/default.nix
+++ b/distros/noetic/kobuki-ftdi/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, ecl-command-line, libftdi, libusb, pkg-config }:
+{ lib, buildRosPackage, fetchurl, catkin, ecl-command-line, libftdi, libusb1, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-kobuki-ftdi";
   version = "0.7.12-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ pkg-config ];
-  propagatedBuildInputs = [ ecl-command-line libftdi libusb ];
+  propagatedBuildInputs = [ ecl-command-line libftdi libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
   version = "1.0.2-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/libphidgets/default.nix
+++ b/distros/noetic/libphidgets/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, libusb }:
+{ lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidgets";
   version = "0.6.17-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ libusb ];
+  propagatedBuildInputs = [ libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/lusb/default.nix
+++ b/distros/noetic/lusb/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, libusb, libusb1 }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-lusb";
   version = "1.1.0-r1";
@@ -14,8 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  buildInputs = [ libusb1 ];
-  propagatedBuildInputs = [ boost libusb ];
+  propagatedBuildInputs = [ boost libusb1 ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/nodelet/default.nix
+++ b/distros/noetic/nodelet/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, utillinux }:
+{ lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-nodelet";
   version = "1.10.1-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ cmake-modules message-generation ];
-  propagatedBuildInputs = [ bondcpp boost message-runtime pluginlib rosconsole roscpp rospy std-msgs utillinux ];
+  propagatedBuildInputs = [ bondcpp boost message-runtime pluginlib rosconsole roscpp rospy std-msgs util-linux ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ps3joy/default.nix
+++ b/distros/noetic/ps3joy/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, bluez, catkin, diagnostic-msgs, libusb1, linuxConsoleTools, pythonPackages, rosgraph, roslint, rospy, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ps3joy";
   version = "1.15.0-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslint ];
-  propagatedBuildInputs = [ bluez diagnostic-msgs libusb linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
+  propagatedBuildInputs = [ bluez diagnostic-msgs libusb1 linuxConsoleTools pythonPackages.pybluez rosgraph rospy sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb }:
+{ lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
   version = "2.5.0-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ libpng libusb ];
+  propagatedBuildInputs = [ libpng libusb1 ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/rqt-multiplot/default.nix
+++ b/distros/noetic/rqt-multiplot/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, gtest, qt5, qwt6, rosbag, roscpp, rqt-gui, rqt-gui-cpp, variant-topic-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, gtest, libsForQt5, qt5, rosbag, roscpp, rqt-gui, rqt-gui-cpp, variant-topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-rqt-multiplot";
   version = "0.0.12-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   checkInputs = [ gtest ];
-  propagatedBuildInputs = [ qt5.qtbase qwt6 rosbag roscpp rqt-gui rqt-gui-cpp variant-topic-tools ];
+  propagatedBuildInputs = [ libsForQt5.qwt qt5.qtbase rosbag roscpp rqt-gui rqt-gui-cpp variant-topic-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/schunk-sdh/default.nix
+++ b/distros/noetic/schunk-sdh/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cob-srvs, control-msgs, diagnostic-msgs, dpkg, libntcan, libpcan, libusb, message-generation, message-runtime, roscpp, roslint, sdhlibrary-cpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, boost, catkin, cob-srvs, control-msgs, diagnostic-msgs, dpkg, libntcan, libpcan, libusb1, message-generation, message-runtime, roscpp, roslint, sdhlibrary-cpp, sensor-msgs, std-msgs, std-srvs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-schunk-sdh";
   version = "0.6.14-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ message-generation roslint ];
-  propagatedBuildInputs = [ actionlib boost cob-srvs control-msgs diagnostic-msgs dpkg libntcan libpcan libusb message-runtime roscpp sdhlibrary-cpp sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
+  propagatedBuildInputs = [ actionlib boost cob-srvs control-msgs diagnostic-msgs dpkg libntcan libpcan libusb1 message-runtime roscpp sdhlibrary-cpp sensor-msgs std-msgs std-srvs trajectory-msgs urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/sick-tim/default.nix
+++ b/distros/noetic/sick-tim/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, libusb1, robot-state-publisher, roscpp, roslaunch, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-sick-tim";
   version = "0.0.17-r1";
@@ -15,7 +15,7 @@ buildRosPackage {
 
   buildType = "catkin";
   buildInputs = [ roslaunch ];
-  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libusb libusb1 robot-state-publisher roscpp sensor-msgs xacro ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure libusb1 robot-state-publisher roscpp sensor-msgs xacro ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/usb-cam/default.nix
+++ b/distros/noetic/usb-cam/default.nix
@@ -2,7 +2,7 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, ffmpeg, image-transport, roscpp, sensor-msgs, std-msgs, std-srvs, v4l_utils }:
+{ lib, buildRosPackage, fetchurl, camera-info-manager, catkin, ffmpeg, image-transport, roscpp, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-noetic-usb-cam";
   version = "0.3.6-r1";
@@ -14,7 +14,7 @@ buildRosPackage {
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ camera-info-manager ffmpeg image-transport roscpp sensor-msgs std-msgs std-srvs v4l_utils ];
+  propagatedBuildInputs = [ camera-info-manager ffmpeg image-transport roscpp sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 74a6b9f676ddf3f59e282c3dc2a1a5a5fff2e88d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Galactic Changes:
-----------------
* *ament-copyright 0.10.6-r1*
* *ament-package 0.12.0-r2*
* *launch 0.17.0-r2*
* *launch-ros 0.14.2-r1*
* *ros2cli 0.13.2-r1*
* *rosidl-cli 2.2.1-r2*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libccd-dev
 * [ ] libcoin80-dev
 * [ ] libfcl-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz

