### PR TITLE
rosdistro sync, Sat May 29 02:26:02 2021

### DIFF
--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -634,6 +634,8 @@ self: super: {
 
  moveit-common = self.callPackage ./moveit-common {};
 
+ moveit-core = self.callPackage ./moveit-core {};
+
  moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-moveit-core";
+  version = "2.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "a0c03e5809e00caa733d0bd5d447a48d5bf70a07fb4d7a96148d4c9bf7107cf8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl tf2-kdl ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
+
+  meta = {
+    description = ''Core libraries used by MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/cob-obstacle-distance-moveit/default.nix
+++ b/distros/melodic/cob-obstacle-distance-moveit/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cob-control-msgs, cob-moveit-bringup, cob-moveit-config, cob-srvs, eigen-conversions, fcl, geometric-shapes, geometry-msgs, moveit-core, moveit-msgs, moveit-ros-perception, moveit-ros-planning-interface, pkg-config, roscpp, rospy, tf, tf-conversions, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-cob-obstacle-distance-moveit";
+  version = "0.7.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_manipulation-release/archive/release/melodic/cob_obstacle_distance_moveit/0.7.5-1.tar.gz";
+    name = "0.7.5-1.tar.gz";
+    sha256 = "0b60c877eb05d3a1e1e22d33a456688a018bef984bdcb3d4ca173f4850730a3d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ boost cob-control-msgs cob-moveit-bringup cob-moveit-config cob-srvs eigen-conversions fcl geometric-shapes geometry-msgs moveit-core moveit-msgs moveit-ros-perception moveit-ros-planning-interface pkg-config roscpp rospy tf tf-conversions tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides nodes for calculating the minimal distance to robot links, obstacles and octomap using MoveIt!'s PlanningSceneMonitor'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cob-obstacle-distance/default.nix
+++ b/distros/melodic/cob-obstacle-distance/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-cob-obstacle-distance";
+  version = "0.8.12-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_control-release/archive/release/melodic/cob_obstacle_distance/0.8.12-1.tar.gz";
+    name = "0.8.12-1.tar.gz";
+    sha256 = "43d7557c2aebc1f283ca06f26b4f53a8631489927921c56e317416c295f48936";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ assimp boost cob-control-msgs cob-srvs dynamic-reconfigure eigen eigen-conversions fcl geometry-msgs interactive-markers joint-state-publisher kdl-conversions kdl-parser moveit-msgs orocos-kdl pkg-config robot-state-publisher roscpp roslib roslint rospy rviz sensor-msgs shape-msgs std-msgs tf tf-conversions urdf visualization-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_obstacle_distance package calculates distances between both robot links and obstacles to be used for obstacle avoidance within cob_twist_controller framework.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/fcl-catkin/default.nix
+++ b/distros/melodic/fcl-catkin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, libccd, octomap }:
+buildRosPackage {
+  pname = "ros-melodic-fcl-catkin";
+  version = "0.6.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/wxmerkt/fcl_catkin-release/archive/release/melodic/fcl_catkin/0.6.1-2.tar.gz";
+    name = "0.6.1-2.tar.gz";
+    sha256 = "aa0d97c02a9b6ca22c02a263f2279ecefcc1570d1d79ef26fc5a1b15f6d5f5bc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen libccd octomap ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''fcl_catkin'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -464,6 +464,10 @@ self: super: {
 
  cob-object-detection-visualizer = self.callPackage ./cob-object-detection-visualizer {};
 
+ cob-obstacle-distance = self.callPackage ./cob-obstacle-distance {};
+
+ cob-obstacle-distance-moveit = self.callPackage ./cob-obstacle-distance-moveit {};
+
  cob-omni-drive-controller = self.callPackage ./cob-omni-drive-controller {};
 
  cob-perception-common = self.callPackage ./cob-perception-common {};
@@ -983,6 +987,8 @@ self: super: {
  fake-joint-launch = self.callPackage ./fake-joint-launch {};
 
  fake-localization = self.callPackage ./fake-localization {};
+
+ fcl-catkin = self.callPackage ./fcl-catkin {};
 
  fetch-auto-dock-msgs = self.callPackage ./fetch-auto-dock-msgs {};
 
@@ -2104,6 +2110,8 @@ self: super: {
 
  moveit-controller-manager-example = self.callPackage ./moveit-controller-manager-example {};
 
+ moveit-core = self.callPackage ./moveit-core {};
+
  moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
@@ -3109,6 +3117,8 @@ self: super: {
  robot-activity-msgs = self.callPackage ./robot-activity-msgs {};
 
  robot-activity-tutorials = self.callPackage ./robot-activity-tutorials {};
+
+ robot-body-filter = self.callPackage ./robot-body-filter {};
 
  robot-calibration = self.callPackage ./robot-calibration {};
 

--- a/distros/melodic/moveit-core/default.nix
+++ b/distros/melodic/moveit-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, assimp, boost, catkin, code-coverage, console-bridge, eigen, eigen-stl-containers, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pybind11-catkin, random-numbers, rosconsole, roslib, rostime, rosunit, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs, xmlrpcpp }:
+buildRosPackage {
+  pname = "ros-melodic-moveit-core";
+  version = "1.0.8-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/moveit-release/archive/release/melodic/moveit_core/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "cc1c034e5f09b20b275d49db1f94296d43da0cbae1550cc57bd2f1b9419061c0";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ angles code-coverage moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl rosunit tf2-kdl ];
+  propagatedBuildInputs = [ assimp boost console-bridge eigen eigen-stl-containers fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pybind11-catkin random-numbers rosconsole roslib rostime sensor-msgs shape-msgs srdfdom std-msgs tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs xmlrpcpp ];
+  nativeBuildInputs = [ catkin pkg-config ];
+
+  meta = {
+    description = ''Core libraries used by MoveIt!'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/robot-body-filter/default.nix
+++ b/distros/melodic/robot-body-filter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-robot-body-filter";
+  version = "1.1.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/melodic/robot_body_filter/1.1.9-1.tar.gz";
+    name = "1.1.9-1.tar.gz";
+    sha256 = "d16cb56b66e5add7d8c5f35951a7e357ad59eab88a5f89149d4b18ef432afb96";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation pkg-config tf2-eigen tf2-sensor-msgs ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ dynamic-reconfigure fcl filters geometric-shapes geometry-msgs laser-geometry message-runtime moveit-core moveit-ros-perception pcl pcl-conversions roscpp sensor-msgs std-msgs tf2 tf2-ros urdf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Filters the robot's body out of laser scans or point clouds.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/cob-obstacle-distance/default.nix
+++ b/distros/noetic/cob-obstacle-distance/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, assimp, boost, catkin, cob-control-msgs, cob-srvs, dynamic-reconfigure, eigen, eigen-conversions, fcl, geometry-msgs, interactive-markers, joint-state-publisher, kdl-conversions, kdl-parser, moveit-msgs, orocos-kdl, pkg-config, robot-state-publisher, roscpp, roslib, roslint, rospy, rviz, sensor-msgs, shape-msgs, std-msgs, tf, tf-conversions, urdf, visualization-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-cob-obstacle-distance";
+  version = "0.8.13-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ipa320/cob_control-release/archive/release/noetic/cob_obstacle_distance/0.8.13-1.tar.gz";
+    name = "0.8.13-1.tar.gz";
+    sha256 = "88d175b55638bc98c2073a84e6ef7b43a2f1e78f501480d4e430a9f9695f864d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ assimp boost cob-control-msgs cob-srvs dynamic-reconfigure eigen eigen-conversions fcl geometry-msgs interactive-markers joint-state-publisher kdl-conversions kdl-parser moveit-msgs orocos-kdl pkg-config robot-state-publisher roscpp roslib roslint rospy rviz sensor-msgs shape-msgs std-msgs tf tf-conversions urdf visualization-msgs xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The cob_obstacle_distance package calculates distances between both robot links and obstacles to be used for obstacle avoidance within cob_twist_controller framework.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/fcl-catkin/default.nix
+++ b/distros/noetic/fcl-catkin/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, libccd, octomap }:
+buildRosPackage {
+  pname = "ros-noetic-fcl-catkin";
+  version = "0.6.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/wxmerkt/fcl_catkin-release/archive/release/noetic/fcl_catkin/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "7c598aae4e97df1ac798a8966162a5a3dadf27e307ea4883d9c01ac0a15a4929";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ eigen libccd octomap ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''fcl_catkin'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fcl/default.nix
+++ b/distros/noetic/fcl/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake, eigen, libccd, octomap }:
+buildRosPackage {
+  pname = "ros-noetic-fcl";
+  version = "0.6.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/fcl-release/archive/release/noetic/fcl/0.6.1-3.tar.gz";
+    name = "0.6.1-3.tar.gz";
+    sha256 = "d2c748d2b918ed3b3aeab5b8b9a840e4c0e5d0e1e6868cbf6a17201e72effb4c";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ catkin eigen libccd octomap ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''FCL: the Flexible Collision Library'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -324,6 +324,8 @@ self: super: {
 
  cob-object-detection-visualizer = self.callPackage ./cob-object-detection-visualizer {};
 
+ cob-obstacle-distance = self.callPackage ./cob-obstacle-distance {};
+
  cob-omni-drive-controller = self.callPackage ./cob-omni-drive-controller {};
 
  cob-perception-common = self.callPackage ./cob-perception-common {};
@@ -719,6 +721,10 @@ self: super: {
  fadecandy-msgs = self.callPackage ./fadecandy-msgs {};
 
  fake-localization = self.callPackage ./fake-localization {};
+
+ fcl = self.callPackage ./fcl {};
+
+ fcl-catkin = self.callPackage ./fcl-catkin {};
 
  fetch-auto-dock-msgs = self.callPackage ./fetch-auto-dock-msgs {};
 


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit f91e6e19b58807f5af7e87a6b7bd253df843a329.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *moveit-core 2.1.3-r1*

Melodic Changes:
----------------
* *cob-obstacle-distance 0.8.12-r1*
* *cob-obstacle-distance-moveit 0.7.5-r1*
* *fcl-catkin 0.6.1-r2*
* *moveit-core 1.0.8-r1*
* *robot-body-filter 1.1.9-r1*

Noetic Changes:
---------------
* *cob-obstacle-distance 0.8.13-r1*
* *fcl 0.6.1-r3*
* *fcl-catkin 0.6.1-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libomp-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz

