### PR TITLE
rosdistro sync, Fri Jun  4 14:31:06 2021

### DIFF
--- a/distros/dashing/hls-lfcd-lds-driver/default.nix
+++ b/distros/dashing/hls-lfcd-lds-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-dashing-hls-lfcd-lds-driver";
-  version = "2.0.2-r2";
+  version = "2.0.2-r5";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "a8a86f9afe5bffd509761a72a4491e030d78800164fccb7234f96da212f6c0c6";
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/dashing/hls_lfcd_lds_driver/2.0.2-5.tar.gz";
+    name = "2.0.2-5.tar.gz";
+    sha256 = "01068f71336eb3e0073d551085ce16b4f7db53fa8be761d8462a98a8e5187464";
   };
 
   buildType = "ament_cmake";

--- a/distros/dashing/xacro/default.nix
+++ b/distros/dashing/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-dashing-xacro";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "577b7d1a594c81c114317cd310738aefa3ea8a28c3adc7a72a1c6dcae3144ead";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/dashing/xacro/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "52007956467b73d0e7b76126c0aeef7b956710701411b74db4126cca590465f1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "9c3b68aeacba6c46aac9bb8c33e65dfb39a1ce753697d6105ff44a97dab8555b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "2c91a29c0ad15ed6b8f627eb82aba5518aa24823b3bb1e38b779ab4665b5311b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "6572d5fb49924ec38407bcda9bf915936a40b76f8421c07f0b22e7ee831e9c54";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "7ca269a7f3e322c749e490c6d82a71cac5b514e8449ef8e548c5df12e7ac7470";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "53b79e852406bb631acf9a924e56b96c5fa66699873193e9fcdd9cde5665d20c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "cac944baf300ceee9eda074aae402159019107b519d132575708b9d9228436d8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -636,8 +636,6 @@ self: super: {
 
  moveit-core = self.callPackage ./moveit-core {};
 
- moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
-
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
  moveit-msgs = self.callPackage ./moveit-msgs {};

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "ee6a8ec011aca91d9be39046555daf81d5b2190a683a124812017881cb46bb64";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "4d5e450ec665bd265cd807d66dc3afd2cefc66a74a290a5c2268333c667632d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "35e3addcabd5024b5c1dc151a36525f1a286afd8d3d246bc8f16244b3ab7873e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "12c0606cfeef194d56776cc4613d54c50de46b312bce5952db7cfd8e047f4d01";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Common support functionality used throughout MoveIt'';

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a0c03e5809e00caa733d0bd5d447a48d5bf70a07fb4d7a96148d4c9bf7107cf8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "f9c397af5fcc4883ad8f40d4405b4d935fe6246b9df475d9e8d17979e594b586";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, tf2, tf2-kdl, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "055d25d1efd60e673ef7406e51c94a3efd0802b0ab4a3616d752a76f8d785466";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "fb737529c49428d4c40d9d7fb9173f42ea0aed51f9963a94371c805a29f032ca";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
   propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "0570dfb63da3381b5a8e9cb5942d9e4d6bfa8efabe47c4a8f65f3b12922edcf0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "b030972f0be9cb2d5004e3ad4cceb23e55be2ac6072d35ba6b5a3c88bda5cb69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "fc1a04a6395f9f10c987a94aed657d775f7977441ffd1edd70bd5ccbfd90e939";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "0f208d51e4f33020b4d4794467e4f1697cbf59bdbcf15395b17c4a68b2136e93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-fake-controller-manager, moveit-simple-controller-manager }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a4c8f9e773569aaeee597c04b278b1e238e912c5daf1f74acdc900d2ad3aa816";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "7277bf17030bde9826a2ec3b2ec3f084dc48c5674eb6c262b1859ecf1aa52353";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-fake-controller-manager moveit-simple-controller-manager ];
+  propagatedBuildInputs = [ moveit-simple-controller-manager ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "bc924fff5ae73e7316f4cdf7e987e5b8053cf660f2c3a137316805f5a90b5af5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "186724ff600ec93175f45c07e47cdac6562f91be795800f9d7f0e02b80210e57";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "8ac733a7a16bcd435550c1ea67a592c59a51b134357825caef82d38e576aa622";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "93dbca99dbf576adb9081cdd8cad61ea88ab643b20f3a0eb3cef1194d5bb8157";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a0cee173f4a5b743974e2349b42e5585434b8bc10f00478f66deac6f25abfe19";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "809d23843391ac8ee64e5258bc98310d1623e8c03813dd7bf87338bf3356b4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "15f72651cb1b7ce95e93f150c20cfd01e0d262e4ce4b9268245c77ff8ff436f1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "30cebd88af14c5fcd7bed4693a3d168cd5803860e5e3144547e799f2f1986514";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "16702ee70eef83782490308e7bcb75a337ed03af054ab230d302cc72c4b4d68a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "1c0160f7a9c77f03cea1847070c2ff5a699b7bfeb9a9c5f833d152249e71a4b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "48c3f8181b0a0c94306b41576df5d859847b534fa02a116b953190af6063675e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "ce0482cc79feb2b3199493a4d1818ca5f092758477c608e8f3c2c2b1ca79934b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "cf296f63dd39fe0bd6087df6aa60c9a6f4736ba05378185c7b5127a321c6f2ad";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "35aaaead87b4421830603973459e134146d77ebf775335cefb36992326d94029";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "8ed530664d83ea3322cf2d1f2b78cb8483f217fb5061a642435ffb33049851c6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "3e4fcf98eb91e8d065820c13981ba13a674c639a5503e77011e49043151fb2a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "fd6e0967e5199b6179a37d4f9e9e8f83be059bd1c57480248874bf8d19c35c00";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "15a69c0a3fea674361e2c2cc7b8c4d560e2c88b6491e0e621c8cd66f0f2b1de7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "1cce4d0550886ba0e8756d418f954ca1f054754d67b2dff457c3077f97d64335";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "eaade9baed3e3977fbf986d26f9e5a3941d6f247c1786965122fa6596a4b41ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "e214d4a8ef5304049f5fdcfc5a87a94aab398d44e39842eb9cf2b3761d87d09e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "83778e7b6ddddc0c00c5289742bcca773ba728b056424aff1739910bc27ad1b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "2f142eb290f6f90b775a1b7b85c14ce6c5071c791e1026ca27371f2f9a1808a4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "f933f1f5a0b7e03a1759046e3dcd57da9672dd41459b1c18334fddb773dbb825";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "b00a4d399108ecd571571913003896e1d5908f444da72db73901b39c187ffec9";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "0b8c53b7332a99b00b04207f15faf55badda5d486b1773ba8a4b9625b17268c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "7d2c81103a590fd363b375b9edf84f71f2ded6ffeffee421dc3171c5f473c285";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "c0fbb4c46af10be0f1dff59a4eea5b3a6ce2723d658c2f03bccae74b1f10dbc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.1.1-r4";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.1.1-4.tar.gz";
-    name = "1.1.1-4.tar.gz";
-    sha256 = "29c9ac4bcee1a8593d33d80bc63db73139249bc02c39040b1a194f49188a0ff7";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fd33c67f1d90826e1c544b4448305a29d4a7f19f22298e4c496283158501e645";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "709542b92c3ac61faeffbf8c28d9e4efc4c59116abf14fc3b2542437caefdf0a";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "b0d863a857340ecb78d82ee39f73629c26e47e48f44ee70f048c50b21d791431";
   };
 
   buildType = "catkin";

--- a/distros/foxy/point-cloud-msg-wrapper/default.nix
+++ b/distros/foxy/point-cloud-msg-wrapper/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-point-cloud-msg-wrapper";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/foxy/point_cloud_msg_wrapper/1.0.5-1/point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    name = "point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    sha256 = "1abbed06a357b7fc3043dfcba91e6d0ebcae2b3140271510a106d817d26c0da1";
+    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/foxy/point_cloud_msg_wrapper/1.0.6-1/point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.6-1.tar.gz";
+    name = "point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.6-1.tar.gz";
+    sha256 = "a19044b833cfcf4e889d04a9a43d3b83bd38b41b68a628eb5b287c5947a15514";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
-    description = ''A point cloud message wrapper that allows for simple and safe msg usage'';
+    description = ''A point cloud message wrapper that allows for simple and safe PointCloud2 msg usage'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "7ff17086a1ec36510d058ca7e63cc3a786db20d10f1e2232dac45a1b5e4ca6a5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "ba4fdddf27a03a1c9fcec2ca80505513cd2fd1d12ac03f6ebdecb90dfddf9c04";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "f3216a235a70f5c9996360adaee347dfe96482a93ab91add10a3e220a7b09b4c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "3abb8e038ed976cd72c9da679faf4061ccdc86927330d8669bb4926818336746";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "aa3f0150cac8fe8e1ec2dc65a419180e6d09ff5d1e723c0de08905cb2b54c2b5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "83c4c0e6a3795468c428a4f7d4b87124353edb81c171a13de2cbfbb9cb843840";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "54b4769a77cebb458d57864121abd6192ef81dac16f0bb80e5df53ca4c134b1e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "3ebc7ed2de771b3cc4237d67399c99f24b7ff9495e0cc18e11c1205cc7de0c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "38750d602a75d145381801c4f3cda6836bd8e32cae760ff9e4533da47ceccf0f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "67717836f3cdba66672557c13b566274678f65feefef3537a0ac3a5332f8c867";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "395f5100ded0b855f898198c9f1e1a87d0d10a17eea600fee46145488f047451";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "e6f2f189ce2c82b4672ac436d139f51471a15547c6cb9871bc9ee725ee678872";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.6.0-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "a4bb2599135c9f5ca5ea534f5d437d175e66463abadbb41793e434a2292beea1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "0451d46e114fd5a7c70094d9328a31deef17e885c267dfa10419b1fb58b4e27e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-foxy-ur-client-library";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "bb15dd6655becd4f6a536a34592d2f3e9b67dbd3a23dedd81cbdc74d7891be78";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "939c992144de23c1ac4ac5d8cde6a12fef01c8cca515e8eebf90355a376dc15d";
   };
 
   buildType = "cmake";

--- a/distros/foxy/warehouse-ros/default.nix
+++ b/distros/foxy/warehouse-ros/default.nix
@@ -2,18 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geometry-msgs, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-warehouse-ros";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9296addfe4bf5576c2dc5b95a8b2b24b384e2b58425d360be9efc3bcdf817710";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2b45dcda6e48d339486b838ab6e1303f74684effa8de23c145dbfdb30f6c73ac";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ openssl ];
+  checkInputs = [ ament-cmake-copyright ament-lint-auto ];
   propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/xacro/default.nix
+++ b/distros/foxy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-xacro";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "89ed2a540f3b582d58596ef45f2db063ca61dad2710720cd6f405948b118312c";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "a908a72b0aae1a53618b3ef49de9c87d9459d7beba6452de75d9c7a02e1cae16";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -492,6 +492,8 @@ self: super: {
 
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
+ object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
+
  octomap = self.callPackage ./octomap {};
 
  octomap-msgs = self.callPackage ./octomap-msgs {};

--- a/distros/galactic/object-recognition-msgs/default.nix
+++ b/distros/galactic/object-recognition-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-object-recognition-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/object_recognition_msgs-release/archive/release/galactic/object_recognition_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4562f648b5e56b2b264788980932c42035a4ff3f3f7b7ed51f7c2ebf13d228c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Object_recognition_msgs contains the ROS message and the actionlib definition used in object_recognition_core'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/point-cloud-msg-wrapper/default.nix
+++ b/distros/galactic/point-cloud-msg-wrapper/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-point-cloud-msg-wrapper";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/galactic/point_cloud_msg_wrapper/1.0.5-1/point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    name = "point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    sha256 = "293d307fa96af1531eb2e40af41d5d2b22c7950b182bae0eec82ea7bd954d1b0";
+    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/galactic/point_cloud_msg_wrapper/1.0.6-1/point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.6-1.tar.gz";
+    name = "point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.6-1.tar.gz";
+    sha256 = "49013725384b074e58bf83378d0aaa59f0d998e686bedd133c231c524ed5a8c5";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
-    description = ''A point cloud message wrapper that allows for simple and safe msg usage'';
+    description = ''A point cloud message wrapper that allows for simple and safe PointCloud2 msg usage'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/xacro/default.nix
+++ b/distros/galactic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-xacro";
-  version = "2.0.2-r3";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "a19776141cc41b8e0ccb9fc1f37a8027d9be748ea0d7f83a22e45bcaf5c70d36";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "7b4cea7136e4c340cacf3e08d63adfe6e34923baec25425adf0969e6765dbcd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6fbedb6a81e3b6d092506d9b2e928e46e735f0e711347c804607b655dc852042";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b995acb6f1ab9d3426ac97c44145e6972f35e99e61a5970d7edca4baa3634c0a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "462d2a3224c59fcf6170b488822c9daf598335ac4befc56ed7a70d49ff7d907a";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "7b90d76bd39e0d68b1e79fd4ed1a83c66025a1437104937d7dd174a842a58713";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ur-client-library/default.nix
+++ b/distros/melodic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ur-client-library";
-  version = "0.2.0-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "94dca774fb8043d00cbc81d8662388b19c31a2b9d7ac20cc29c5b2ea976069e5";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "2453f6de7998ffac0b6c05d404540b56548fb4ca4929f30edc6216ff23444f4f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.10-r1";
+  version = "1.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.10-1.tar.gz";
-    name = "1.13.10-1.tar.gz";
-    sha256 = "228cda50fb3f54c63392bee37fcf7580e59e8ab806f91a222ccd97dd6265cf1b";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.11-1.tar.gz";
+    name = "1.13.11-1.tar.gz";
+    sha256 = "8a429e9085339ad44d05b10729d51efc5393f28e357d5362c26f689264331cba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-foxglove-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "949c65426a4fdd27eb9b9b653b2482b0ed38faf4d9db6687baa2c6125162089f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''foxglove_msgs extends the common ROS visualization messages with additional
+    useful messages that are supported by Foxglove Studio.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -808,6 +808,8 @@ self: super: {
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
+ foxglove-msgs = self.callPackage ./foxglove-msgs {};
+
  franka-control = self.callPackage ./franka-control {};
 
  franka-description = self.callPackage ./franka-description {};
@@ -1041,6 +1043,8 @@ self: super: {
  imu-complementary-filter = self.callPackage ./imu-complementary-filter {};
 
  imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
+
+ imu-monitor = self.callPackage ./imu-monitor {};
 
  imu-pipeline = self.callPackage ./imu-pipeline {};
 
@@ -1636,6 +1640,8 @@ self: super: {
 
  opw-kinematics = self.callPackage ./opw-kinematics {};
 
+ osm-cartography = self.callPackage ./osm-cartography {};
+
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
  oxford-gps-eth = self.callPackage ./oxford-gps-eth {};
@@ -1788,13 +1794,21 @@ self: super: {
 
  pr2-arm-move-ik = self.callPackage ./pr2-arm-move-ik {};
 
+ pr2-bringup = self.callPackage ./pr2-bringup {};
+
  pr2-calibration-controllers = self.callPackage ./pr2-calibration-controllers {};
+
+ pr2-camera-synchronizer = self.callPackage ./pr2-camera-synchronizer {};
 
  pr2-common = self.callPackage ./pr2-common {};
 
  pr2-common-action-msgs = self.callPackage ./pr2-common-action-msgs {};
 
  pr2-common-actions = self.callPackage ./pr2-common-actions {};
+
+ pr2-computer-monitor = self.callPackage ./pr2-computer-monitor {};
+
+ pr2-controller-configuration = self.callPackage ./pr2-controller-configuration {};
 
  pr2-controller-interface = self.callPackage ./pr2-controller-interface {};
 
@@ -1807,6 +1821,8 @@ self: super: {
  pr2-dashboard-aggregator = self.callPackage ./pr2-dashboard-aggregator {};
 
  pr2-description = self.callPackage ./pr2-description {};
+
+ pr2-ethercat = self.callPackage ./pr2-ethercat {};
 
  pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
 
@@ -1839,6 +1855,10 @@ self: super: {
  pr2-power-board = self.callPackage ./pr2-power-board {};
 
  pr2-power-drivers = self.callPackage ./pr2-power-drivers {};
+
+ pr2-robot = self.callPackage ./pr2-robot {};
+
+ pr2-run-stop-auto-restart = self.callPackage ./pr2-run-stop-auto-restart {};
 
  pr2-teleop = self.callPackage ./pr2-teleop {};
 
@@ -2202,6 +2222,8 @@ self: super: {
 
  rotate-recovery = self.callPackage ./rotate-recovery {};
 
+ route-network = self.callPackage ./route-network {};
+
  rqt = self.callPackage ./rqt {};
 
  rqt-action = self.callPackage ./rqt-action {};
@@ -2251,6 +2273,8 @@ self: super: {
  rqt-plot = self.callPackage ./rqt-plot {};
 
  rqt-pose-view = self.callPackage ./rqt-pose-view {};
+
+ rqt-pr2-dashboard = self.callPackage ./rqt-pr2-dashboard {};
 
  rqt-publisher = self.callPackage ./rqt-publisher {};
 
@@ -2515,6 +2539,8 @@ self: super: {
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 
  test-mavros = self.callPackage ./test-mavros {};
+
+ test-osm = self.callPackage ./test-osm {};
 
  tf = self.callPackage ./tf {};
 

--- a/distros/noetic/imu-monitor/default.nix
+++ b/distros/noetic/imu-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-mechanism-controllers, python3Packages, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-imu-monitor";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/imu_monitor/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "af19afccafb7bc0c0517427a39b495828e0c9dc8df3dcf6661768030a53b4cc3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-mechanism-controllers python3Packages.pykdl rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a single node that monitors the drift of the IMU
+gyroscopes. The results are published to the '/diagnostics' topic and
+are aggregated in the PR2 dashboard.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/network-interface/default.nix
+++ b/distros/noetic/network-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-network-interface";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/network_interface-release/archive/release/noetic/network_interface/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6ba8757292ea0ae9499c9142cf2b47cac91ac0f5f2ffd21c977801657ae38d64";
+    url = "https://github.com/astuff/network_interface-release/archive/release/noetic/network_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b55512f9cb6c73bfe0ba29cde2a3d47a4e9a8e14e339440a57ccd8a5a1cefaf5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/osm-cartography/default.nix
+++ b/distros/noetic/osm-cartography/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, roslaunch, rospy, route-network, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-osm-cartography";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/osm_cartography/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8b5dfd2079b88425f498a5d590460ce9c32a9016413fa00af04fed5800c99da4";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs rospy route-network std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Geographic mapping using Open Street Map data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a1757edfa5a790ba1ebe4c6e35a7283b0b4217ecac957987446dc9323297239c";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e01d38d56a8eb2dd2b6433656032100c7bdf2b57004bc3a3cc5ab741ca648e82";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "ff50855106859fb46d8e6461a14e1ad3033482a9be2e99690b526d44e111f764";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "f30452d7ec4b7a220f59290f5939b5329b1779c70f5c8ffc61fd7a928dbf415f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-bringup/default.nix
+++ b/distros/noetic/pr2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, ethercat-trigger-controllers, imu-monitor, joint-trajectory-action, joy, microstrain-3dmgx2-imu, ocean-battery-driver, power-monitor, pr2-calibration-controllers, pr2-camera-synchronizer, pr2-computer-monitor, pr2-controller-configuration, pr2-controller-manager, pr2-dashboard-aggregator, pr2-description, pr2-ethercat, pr2-gripper-action, pr2-head-action, pr2-machine, pr2-power-board, pr2-run-stop-auto-restart, prosilica-camera, robot-mechanism-controllers, robot-pose-ekf, robot-state-publisher, rosbag, roslaunch, rostest, single-joint-position-action, sound-play, std-srvs, stereo-image-proc, tf2-ros, urg-node, wge100-camera, wifi-ddwrt }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-bringup";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_bringup/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "d8e565fe9a2b5543b7dfe5482ed17712db223d3b668998df9678f5a2295482cd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ diagnostic-aggregator ethercat-trigger-controllers imu-monitor joint-trajectory-action joy microstrain-3dmgx2-imu ocean-battery-driver power-monitor pr2-calibration-controllers pr2-camera-synchronizer pr2-computer-monitor pr2-controller-configuration pr2-controller-manager pr2-dashboard-aggregator pr2-description pr2-ethercat pr2-gripper-action pr2-head-action pr2-machine pr2-power-board pr2-run-stop-auto-restart prosilica-camera robot-mechanism-controllers robot-pose-ekf robot-state-publisher rosbag single-joint-position-action sound-play std-srvs stereo-image-proc tf2-ros urg-node wge100-camera wifi-ddwrt ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and scripts needed to bring a PR2 up into a running state.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-camera-synchronizer/default.nix
+++ b/distros/noetic/pr2-camera-synchronizer/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, dynamic-reconfigure, ethercat-trigger-controllers, rospy, rostest, wge100-camera }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-camera-synchronizer";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_camera_synchronizer/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "3434b67c2318b2123904dd0dd32b046cbb892cb7672fbfa04af36e540b13578f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ diagnostic-msgs dynamic-reconfigure ethercat-trigger-controllers rospy wge100-camera ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+    The PR2 is equipped with a texture projector that can be used to
+    project a texture onto featureless surfaces, allowing their
+    three-dimensional structure to be determined using stereoscopy. The
+    projector operates in a pulsed mode, producing brief (2ms) pulses of
+    light. Cameras that want to see the texture must expose during the
+    projector pulse; other cameras should be expose while the projector is
+    off.
+    </p>
+
+    <p>
+      This package contains the pr2_projector_synchronizer node. Based on its dynamically reconfigurable parameters, this node controls the projector pulsing, and sets up triggering of the WGE100 cameras.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-computer-monitor/default.nix
+++ b/distros/noetic/pr2-computer-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-msgs, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-computer-monitor";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_computer_monitor/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "30b52ef1b9ae7056eeff1be2b99e27b1d069252d3a8d56d1e9e93bb9ead05377";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-msgs roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Monitors the computer's processor and hard drives of the PR2 and publishes data to diagnostics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controller-configuration/default.nix
+++ b/distros/noetic/pr2-controller-configuration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-controller-manager, pr2-gripper-action, pr2-head-action, pr2-machine, robot-mechanism-controllers, roslaunch, single-joint-position-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controller-configuration";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_controller_configuration/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "80b94e8c30c4b63aef0b152254063ea36fc0bea7928d3e5ec94a3149c05c1eac";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ pr2-controller-manager pr2-gripper-action pr2-head-action pr2-machine robot-mechanism-controllers single-joint-position-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Configuration files for PR2 controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-ethercat/default.nix
+++ b/distros/noetic/pr2-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, ethercat-hardware, pr2-controller-manager, realtime-tools, roscpp, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-ethercat";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_ethercat/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "2112a2d2a0e6863abcb6bfaa32d46569e959c2530dc6731e05dd0970471de71b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater ethercat-hardware pr2-controller-manager realtime-tools roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Main loop that runs the robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-robot/default.nix
+++ b/distros/noetic/pr2-robot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, imu-monitor, pr2-bringup, pr2-camera-synchronizer, pr2-computer-monitor, pr2-controller-configuration, pr2-ethercat, pr2-run-stop-auto-restart }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-robot";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_robot/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "368195704a50d088e931ccd3739770e8626bb2df0ab03fb68d9d334d805761e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ imu-monitor pr2-bringup pr2-camera-synchronizer pr2-computer-monitor pr2-controller-configuration pr2-ethercat pr2-run-stop-auto-restart ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack collects PR2-specific components that are used in bringing up
+  a robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-run-stop-auto-restart/default.nix
+++ b/distros/noetic/pr2-run-stop-auto-restart/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-msgs, pr2-power-board, roscpp, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-run-stop-auto-restart";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_run_stop_auto_restart/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "6010ed34f0a7f4e2c01d77f4ec969cdd04782b6e674c9c9d323b49fb456dfd63";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-msgs pr2-power-board roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a node that monitors the state of the run stops of the pr2_robot. When the state of the
+   run stop changes from off to on, this node will automatically enable the power to the motors, and reset
+   the motors. This allows you to use the run stop as a 'pause' button. By using the run stop as a tool to
+   power up the robot, the run stop is also in reach of the user once the robot starts moving.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "1a9680c22468432a6c76e2a72b01fb438f25b890d65a26cb2d7823c17e7ef318";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "9ee850a4e0d2db4656976d527e25e35bf5af9fbb742b5b034061d08aa0dc89d5";
   };
 
   buildType = "catkin";
   buildInputs = [ geographiclib message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/route-network/default.nix
+++ b/distros/noetic/route-network/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, nav-msgs, roslaunch, rospy, rostest, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-route-network";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/route_network/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "aa4bfa6f99b672ea11f480299a2f4d6b35fa70958e6c883f0a2ee7dabe1e4154";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs nav-msgs rospy visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Route network graphing and path planning.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rqt-pr2-dashboard/default.nix
+++ b/distros/noetic/rqt-pr2-dashboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-msgs, pr2-power-board, roslib, rospy, rqt-gui, rqt-gui-py, rqt-robot-dashboard, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-pr2-dashboard";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rqt_pr2_dashboard-release/archive/release/noetic/rqt_pr2_dashboard/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "51ae20c665634bb53dd74bf1400a74c2727e144e4d2574062bebaf3edf012d18";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-msgs pr2-power-board roslib rospy rqt-gui rqt-gui-py rqt-robot-dashboard std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt_pr2_dashboard is a GUI for debugging and controlling low-level state of the PR2.  It shows things like battery status and breaker states, as well as integrating tools like rqt_console and robot_monitor.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/test-osm/default.nix
+++ b/distros/noetic/test-osm/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geodesy, geographic-msgs, osm-cartography, route-network }:
+buildRosPackage {
+  pname = "ros-noetic-test-osm";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/test_osm/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "27f71706cc1daaa3259f46375968d732e637b4b16b6147a22371670c73aee3b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geodesy geographic-msgs osm-cartography route-network ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These are regression tests for the osm_cartography and
+     route_network packages. They are packaged separately to avoid
+     unnecessary implementation dependencies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "0.2.0-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "e7eec06de67fc92fe275b5ac7b55e030acde82e40b683c8b9a9b7d51f7f76cc3";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "da3dfc131f8228144ad70a13fff91a8c6550375d5fe6916fceb4588699a9acc8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.6-r2";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.6-2.tar.gz";
-    name = "1.14.6-2.tar.gz";
-    sha256 = "81a7d1d5350182f96998a12ab4971558c6eccc67821a85e523d04b63dff49584";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "e49a02c2868315b91934b9c8037d3a57e5949825fb38a4f7c7959321c68651b1";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['dashing', 'foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 9fbde27da7c9a15970115c57e1eb1c02a1682dd4.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Dashing Changes:
----------------
* *hls-lfcd-lds-driver 2.0.2-r2 --> 2.0.2-r5*
* *xacro 2.0.5-r1 --> 2.0.6-r1*

Foxy Changes:
-------------
* *controller-interface 0.6.0-r1 --> 0.6.1-r1*
* *controller-manager 0.6.0-r1 --> 0.6.1-r1*
* *controller-manager-msgs 0.6.0-r1 --> 0.6.1-r1*
* *hardware-interface 0.6.0-r1 --> 0.6.1-r1*
* *moveit 2.1.3-r1 --> 2.1.4-r1*
* *moveit-common 2.1.3-r1 --> 2.1.4-r1*
* *moveit-core 2.1.3-r1 --> 2.1.4-r1*
* *moveit-kinematics 2.1.3-r1 --> 2.1.4-r1*
* *moveit-planners 2.1.3-r1 --> 2.1.4-r1*
* *moveit-planners-ompl 2.1.3-r1 --> 2.1.4-r1*
* *moveit-plugins 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-benchmarks 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-move-group 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-occupancy-map-monitor 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-perception 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-planning 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-planning-interface 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-robot-interaction 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-visualization 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-warehouse 2.1.3-r1 --> 2.1.4-r1*
* *moveit-runtime 2.1.3-r1 --> 2.1.4-r1*
* *moveit-servo 2.1.3-r1 --> 2.1.4-r1*
* *moveit-simple-controller-manager 2.1.3-r1 --> 2.1.4-r1*
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r4 --> 1.2.0-r1*
* *point-cloud-msg-wrapper 1.0.5-r1 --> 1.0.6-r1*
* *ros2-control 0.6.0-r1 --> 0.6.1-r1*
* *ros2-control-test-assets 0.6.0-r1 --> 0.6.1-r1*
* *ros2controlcli 0.6.0-r1 --> 0.6.1-r1*
* *run-move-group 2.1.3-r1 --> 2.1.4-r1*
* *run-moveit-cpp 2.1.3-r1 --> 2.1.4-r1*
* *run-ompl-constrained-planning 2.1.3-r1 --> 2.1.4-r1*
* *transmission-interface 0.6.0-r1 --> 0.6.1-r1*
* *ur-client-library 0.2.1-r1 --> 0.2.2-r1*
* *warehouse-ros 2.0.0-r1 --> 2.0.1-r1*
* *xacro 2.0.5-r1 --> 2.0.6-r1*

Galactic Changes:
-----------------
* *object-recognition-msgs 2.0.0-r1*
* *point-cloud-msg-wrapper 1.0.5-r1 --> 1.0.6-r1*
* *xacro 2.0.2-r3 --> 2.0.6-r1*

Melodic Changes:
----------------
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r1 --> 1.2.0-r1*
* *ur-client-library 0.2.0-r1 --> 0.2.2-r1*
* *xacro 1.13.10-r1 --> 1.13.11-r1*

Noetic Changes:
---------------
* *foxglove-msgs 1.0.0-r1*
* *imu-monitor 1.6.32-r1*
* *network-interface 3.0.0-r1 --> 3.1.0-r1*
* *osm-cartography 0.3.0-r1*
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r1 --> 1.2.0-r1*
* *pr2-bringup 1.6.32-r1*
* *pr2-camera-synchronizer 1.6.32-r1*
* *pr2-computer-monitor 1.6.32-r1*
* *pr2-controller-configuration 1.6.32-r1*
* *pr2-ethercat 1.6.32-r1*
* *pr2-robot 1.6.32-r1*
* *pr2-run-stop-auto-restart 1.6.32-r1*
* *robot-localization 2.7.1-r1 --> 2.7.2-r1*
* *route-network 0.3.0-r1*
* *rqt-pr2-dashboard 0.4.0-r1*
* *test-osm 0.3.0-r1*
* *ur-client-library 0.2.0-r1 --> 0.2.2-r1*
* *xacro 1.14.6-r2 --> 1.14.7-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libqglviewer-qt4
 * [ ] libqglviewer-qt4-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-gst-1.0
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz

