### PR TITLE
rosdistro sync, Fri Jun 11 22:09:04 2021

### DIFF
--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "9c3b68aeacba6c46aac9bb8c33e65dfb39a1ce753697d6105ff44a97dab8555b";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a8c63ea8b088a1f34bfdae046c6344f6881af3babdb50688ee2d5a8532bc73f2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle ];
+  propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "6572d5fb49924ec38407bcda9bf915936a40b76f8421c07f0b22e7ee831e9c54";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "05be83c1ffb322a34b44dbbc6ea5fbf2f613dbc839d9628a37e2f31a52bcd3e1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "53b79e852406bb631acf9a924e56b96c5fa66699873193e9fcdd9cde5665d20c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "60d92f98db5a109764056b92e79ba0a095c4ff249b79fb9bd2aee2ef2bbb0529";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fmi-adapter-examples/default.nix
+++ b/distros/foxy/fmi-adapter-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmi-adapter, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-foxy-fmi-adapter-examples";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/foxy/fmi_adapter_examples/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "5c333c2215505baae55f1e1ee2aa0d8ee5a1f1396eff744f417c431ac74865d6";
+    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/foxy/fmi_adapter_examples/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "121b362ebdeb58a1f8a3decbb38e06c23bfd9fcf9c49dd42d10afbeeabf4ad53";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fmi-adapter/default.nix
+++ b/distros/foxy/fmi-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, fmilibrary-vendor, launch, launch-ros, launch-testing, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-fmi-adapter";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/foxy/fmi_adapter/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "ffe6c1b0119e9378fb1d19592ee1a77cf1874e8d750c8d2c85be72954690219d";
+    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/foxy/fmi_adapter/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6417b0dbdd611d744660ce2308c37a621900f35beaf2d79aafdf88481f5565e7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -552,6 +552,8 @@ self: super: {
 
  launch-ros = self.callPackage ./launch-ros {};
 
+ launch-system-modes = self.callPackage ./launch-system-modes {};
+
  launch-testing = self.callPackage ./launch-testing {};
 
  launch-testing-ament-cmake = self.callPackage ./launch-testing-ament-cmake {};
@@ -635,8 +637,6 @@ self: super: {
  moveit-common = self.callPackage ./moveit-common {};
 
  moveit-core = self.callPackage ./moveit-core {};
-
- moveit-fake-controller-manager = self.callPackage ./moveit-fake-controller-manager {};
 
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
@@ -1352,6 +1352,8 @@ self: super: {
 
  test-interface-files = self.callPackage ./test-interface-files {};
 
+ test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
+
  test-msgs = self.callPackage ./test-msgs {};
 
  test-osrf-testing-tools-cpp = self.callPackage ./test-osrf-testing-tools-cpp {};
@@ -1429,8 +1431,6 @@ self: super: {
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlesim = self.callPackage ./turtlesim {};
-
- tvm-vendor = self.callPackage ./tvm-vendor {};
 
  twist-stamper = self.callPackage ./twist-stamper {};
 

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "ee6a8ec011aca91d9be39046555daf81d5b2190a683a124812017881cb46bb64";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "160527dbc3ff3a0ad242b0383c1d5b25875c3f007aff05c3f2c2748e14e8ec79";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-system-modes/default.nix
+++ b/distros/foxy/launch-system-modes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages, rclpy, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "0d3fe2eeb111a4a4b22a1925d117d6fd1f0276a4f137ad9f6f1713dcdd747473";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python launch osrf-pycommon python3Packages.importlib-metadata python3Packages.pyyaml rclpy system-modes-msgs ];
+
+  meta = {
+    description = ''System modes specific extensions to the launch tool, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/libmavconn/default.nix
+++ b/distros/foxy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-libmavconn";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "3204fca5aaed0c348b8837bf8b2b7eea5feb2633e76e8ec3b8ff1752c4842713";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ed6db3e4acc1599ebafd62a8b050f41c3ee4b6b187fcac2eae63dabbd28b80ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.5.5-r1";
+  version = "2021.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.5.5-1.tar.gz";
-    name = "2021.5.5-1.tar.gz";
-    sha256 = "822596ffd11e1420b2732b9b79c67be9b3ad6caf09508bf8bff53c5e2f7d4063";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.6.6-1.tar.gz";
+    name = "2021.6.6-1.tar.gz";
+    sha256 = "5833570b011e6af13b3578edf51d95d5737bc4885a3b21456c0a72ecdaa6351b";
   };
 
   buildType = "cmake";

--- a/distros/foxy/mavros-msgs/default.nix
+++ b/distros/foxy/mavros-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros-msgs";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "dceede1109beec1ce747f51abc8e91c2445d11a9c873542a7d7e9993b4901cad";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "72856c007c99fde1e098e26ca243356557bc2806110901ca6abc2a76decb347f";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geographic-msgs geometry-msgs rosidl-default-runtime sensor-msgs ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs rcl-interfaces rosidl-default-runtime sensor-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2c4b7dbd183cf1ab1afeeb2d08e0cff6cadca3cb781bca08e96f2989d559f147";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "290ebf234f453ee8326761b9c49a2dd3ba63fecc7fd61e786a30003ddac30b1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "35e3addcabd5024b5c1dc151a36525f1a286afd8d3d246bc8f16244b3ab7873e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "12c0606cfeef194d56776cc4613d54c50de46b312bce5952db7cfd8e047f4d01";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Common support functionality used throughout MoveIt'';

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a0c03e5809e00caa733d0bd5d447a48d5bf70a07fb4d7a96148d4c9bf7107cf8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "f9c397af5fcc4883ad8f40d4405b4d935fe6246b9df475d9e8d17979e594b586";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, tf2, tf2-kdl, urdfdom }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "055d25d1efd60e673ef7406e51c94a3efd0802b0ab4a3616d752a76f8d785466";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "fb737529c49428d4c40d9d7fb9173f42ea0aed51f9963a94371c805a29f032ca";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
   propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "0570dfb63da3381b5a8e9cb5942d9e4d6bfa8efabe47c4a8f65f3b12922edcf0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "b030972f0be9cb2d5004e3ad4cceb23e55be2ac6072d35ba6b5a3c88bda5cb69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "fc1a04a6395f9f10c987a94aed657d775f7977441ffd1edd70bd5ccbfd90e939";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "0f208d51e4f33020b4d4794467e4f1697cbf59bdbcf15395b17c4a68b2136e93";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-fake-controller-manager, moveit-simple-controller-manager }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a4c8f9e773569aaeee597c04b278b1e238e912c5daf1f74acdc900d2ad3aa816";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "7277bf17030bde9826a2ec3b2ec3f084dc48c5674eb6c262b1859ecf1aa52353";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-fake-controller-manager moveit-simple-controller-manager ];
+  propagatedBuildInputs = [ moveit-simple-controller-manager ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "bc924fff5ae73e7316f4cdf7e987e5b8053cf660f2c3a137316805f5a90b5af5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "186724ff600ec93175f45c07e47cdac6562f91be795800f9d7f0e02b80210e57";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "8ac733a7a16bcd435550c1ea67a592c59a51b134357825caef82d38e576aa622";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "93dbca99dbf576adb9081cdd8cad61ea88ab643b20f3a0eb3cef1194d5bb8157";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "a0cee173f4a5b743974e2349b42e5585434b8bc10f00478f66deac6f25abfe19";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "809d23843391ac8ee64e5258bc98310d1623e8c03813dd7bf87338bf3356b4c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "15f72651cb1b7ce95e93f150c20cfd01e0d262e4ce4b9268245c77ff8ff436f1";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "30cebd88af14c5fcd7bed4693a3d168cd5803860e5e3144547e799f2f1986514";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "16702ee70eef83782490308e7bcb75a337ed03af054ab230d302cc72c4b4d68a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "1c0160f7a9c77f03cea1847070c2ff5a699b7bfeb9a9c5f833d152249e71a4b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "48c3f8181b0a0c94306b41576df5d859847b534fa02a116b953190af6063675e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "ce0482cc79feb2b3199493a4d1818ca5f092758477c608e8f3c2c2b1ca79934b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "cf296f63dd39fe0bd6087df6aa60c9a6f4736ba05378185c7b5127a321c6f2ad";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "35aaaead87b4421830603973459e134146d77ebf775335cefb36992326d94029";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "8ed530664d83ea3322cf2d1f2b78cb8483f217fb5061a642435ffb33049851c6";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "3e4fcf98eb91e8d065820c13981ba13a674c639a5503e77011e49043151fb2a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "fd6e0967e5199b6179a37d4f9e9e8f83be059bd1c57480248874bf8d19c35c00";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "15a69c0a3fea674361e2c2cc7b8c4d560e2c88b6491e0e621c8cd66f0f2b1de7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "1cce4d0550886ba0e8756d418f954ca1f054754d67b2dff457c3077f97d64335";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "eaade9baed3e3977fbf986d26f9e5a3941d6f247c1786965122fa6596a4b41ca";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "e214d4a8ef5304049f5fdcfc5a87a94aab398d44e39842eb9cf2b3761d87d09e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "83778e7b6ddddc0c00c5289742bcca773ba728b056424aff1739910bc27ad1b8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "2f142eb290f6f90b775a1b7b85c14ce6c5071c791e1026ca27371f2f9a1808a4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "f933f1f5a0b7e03a1759046e3dcd57da9672dd41459b1c18334fddb773dbb825";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "b00a4d399108ecd571571913003896e1d5908f444da72db73901b39c187ffec9";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "0b8c53b7332a99b00b04207f15faf55badda5d486b1773ba8a4b9625b17268c2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "7d2c81103a590fd363b375b9edf84f71f2ded6ffeffee421dc3171c5f473c285";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "c0fbb4c46af10be0f1dff59a4eea5b3a6ce2723d658c2f03bccae74b1f10dbc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.1.1-r4";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.1.1-4.tar.gz";
-    name = "1.1.1-4.tar.gz";
-    sha256 = "29c9ac4bcee1a8593d33d80bc63db73139249bc02c39040b1a194f49188a0ff7";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "fd33c67f1d90826e1c544b4448305a29d4a7f19f22298e4c496283158501e645";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "709542b92c3ac61faeffbf8c28d9e4efc4c59116abf14fc3b2542437caefdf0a";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "b0d863a857340ecb78d82ee39f73629c26e47e48f44ee70f048c50b21d791431";
   };
 
   buildType = "catkin";

--- a/distros/foxy/point-cloud-msg-wrapper/default.nix
+++ b/distros/foxy/point-cloud-msg-wrapper/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-point-cloud-msg-wrapper";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/foxy/point_cloud_msg_wrapper/1.0.5-1/point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    name = "point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    sha256 = "1abbed06a357b7fc3043dfcba91e6d0ebcae2b3140271510a106d817d26c0da1";
+    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/foxy/point_cloud_msg_wrapper/1.0.7-1/point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.7-1.tar.gz";
+    name = "point_cloud_msg_wrapper-release-release-foxy-point_cloud_msg_wrapper-1.0.7-1.tar.gz";
+    sha256 = "552051203ff6efe317e11675745a88de303e3f51490cdc4947a5b8d981ee7277";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
-    description = ''A point cloud message wrapper that allows for simple and safe msg usage'';
+    description = ''A point cloud message wrapper that allows for simple and safe PointCloud2 msg usage'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "7ff17086a1ec36510d058ca7e63cc3a786db20d10f1e2232dac45a1b5e4ca6a5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "c6a0b5d997a8b6715232af44483397fef53bff08e57228cede5077cd3144cabb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "f3216a235a70f5c9996360adaee347dfe96482a93ab91add10a3e220a7b09b4c";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "bc0d694b581b44dc3c111028e4dde1ca0beee1bb89a9e5554130b52309a907b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "aa3f0150cac8fe8e1ec2dc65a419180e6d09ff5d1e723c0de08905cb2b54c2b5";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "4efb15642a0c2891dee6b133fac79779850a5f16d24ba28b052381f4d7afb657";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "54b4769a77cebb458d57864121abd6192ef81dac16f0bb80e5df53ca4c134b1e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "3ebc7ed2de771b3cc4237d67399c99f24b7ff9495e0cc18e11c1205cc7de0c88";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "38750d602a75d145381801c4f3cda6836bd8e32cae760ff9e4533da47ceccf0f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "67717836f3cdba66672557c13b566274678f65feefef3537a0ac3a5332f8c867";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.1.3-r1";
+  version = "2.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.3-1.tar.gz";
-    name = "2.1.3-1.tar.gz";
-    sha256 = "395f5100ded0b855f898198c9f1e1a87d0d10a17eea600fee46145488f047451";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.4-1.tar.gz";
+    name = "2.1.4-1.tar.gz";
+    sha256 = "e6f2f189ce2c82b4672ac436d139f51471a15547c6cb9871bc9ee725ee678872";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, launch, launch-system-modes, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.7.1-r4";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.7.1-4.tar.gz";
-    name = "0.7.1-4.tar.gz";
-    sha256 = "0075eb8125e9d1e46c3ea91b954137a036c9a5fe73b3236e40ea61f87224174a";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "f5c987719f72ddddd37fa64bd20a3417170df8e7a7ff4695a7a59d645c83fada";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
-  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
+  propagatedBuildInputs = [ launch launch-system-modes rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Simple example system and according launch files for the system_modes
+    description = ''Example systems and according launch files for the system_modes
     package.'';
     license = with lib.licenses; [ asl20 ];
   };

--- a/distros/foxy/system-modes-msgs/default.nix
+++ b/distros/foxy/system-modes-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-msgs";
-  version = "0.7.1-r4";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.7.1-4.tar.gz";
-    name = "0.7.1-4.tar.gz";
-    sha256 = "b9a267b941dff73f441b246e569fd91f01400c17512007c3c86a641c1cbf6ba9";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "605a3f2af6338ee36fec057cbcf36d7460224a4867b633f23664d36024978cfb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.7.1-r4";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.7.1-4.tar.gz";
-    name = "0.7.1-4.tar.gz";
-    sha256 = "a0789264cd9c679704af1533ba63fb1a19807ec2839d3bb801d6170719ffd79e";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "70b6fc15164dbc46963b104b0dfd873bddc5527e5500693c8ffe93511ebdb605";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-launch-system-modes/default.nix
+++ b/distros/foxy/test-launch-system-modes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-pep257, ament-index-python, ament-lint-auto, builtin-interfaces, launch-system-modes, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, rclcpp, rclcpp-lifecycle, system-modes, system-modes-examples, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-test-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/test_launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "bb6ab84bd048b0fd43202dd0e4d0bd006b8b8979bd27c45a20720c04b0d62dd5";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-flake8 ament-cmake-pep257 ament-index-python ament-lint-auto launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ builtin-interfaces launch-system-modes lifecycle-msgs rclcpp rclcpp-lifecycle system-modes system-modes-examples system-modes-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch tests for the launch_system_modes package, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.6.0-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.6.0-1.tar.gz";
-    name = "0.6.0-1.tar.gz";
-    sha256 = "a4bb2599135c9f5ca5ea534f5d437d175e66463abadbb41793e434a2292beea1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b27fcc217fd74cc3a15c9719b45d52901cc9c7e36a3cf900656e12a8d070e960";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-foxy-ur-client-library";
-  version = "0.2.1-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "bb15dd6655becd4f6a536a34592d2f3e9b67dbd3a23dedd81cbdc74d7891be78";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "939c992144de23c1ac4ac5d8cde6a12fef01c8cca515e8eebf90355a376dc15d";
   };
 
   buildType = "cmake";

--- a/distros/foxy/warehouse-ros/default.nix
+++ b/distros/foxy/warehouse-ros/default.nix
@@ -2,18 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geometry-msgs, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-warehouse-ros";
-  version = "2.0.0-r1";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "9296addfe4bf5576c2dc5b95a8b2b24b384e2b58425d360be9efc3bcdf817710";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "2b45dcda6e48d339486b838ab6e1303f74684effa8de23c145dbfdb30f6c73ac";
   };
 
   buildType = "ament_cmake";
+  buildInputs = [ openssl ];
+  checkInputs = [ ament-cmake-copyright ament-lint-auto ];
   propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/xacro/default.nix
+++ b/distros/foxy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-xacro";
-  version = "2.0.5-r1";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.5-1.tar.gz";
-    name = "2.0.5-1.tar.gz";
-    sha256 = "89ed2a540f3b582d58596ef45f2db063ca61dad2710720cd6f405948b118312c";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "a908a72b0aae1a53618b3ef49de9c87d9459d7beba6452de75d9c7a02e1cae16";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-cmake-catch2/default.nix
+++ b/distros/galactic/ament-cmake-catch2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
+buildRosPackage {
+  pname = "ros-galactic-ament-cmake-catch2";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_cmake_catch2-release/archive/release/galactic/ament_cmake_catch2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2bce1d5be97df2de18f0cd339e154a374f3e813c3fa94bb4aa15da0441bfc7c7";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake-test ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = ''Allows integrating catch2 tests in the ament buildsystem with CMake'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/control-msgs/default.nix
+++ b/distros/galactic/control-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-control-msgs";
-  version = "3.0.0-r1";
+  version = "3.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/galactic/control_msgs/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "279c970e11e27ead0a0727247ab34d26a3fa0b50d6da7f36a6dd03119ac0aec2";
+    url = "https://github.com/ros2-gbp/control_msgs-release/archive/release/galactic/control_msgs/3.0.0-2.tar.gz";
+    name = "3.0.0-2.tar.gz";
+    sha256 = "c159acb41dab529238cc07e9c0cfb237c72fa99f53625f5d85c40e1c3fbf3599";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/costmap-queue/default.nix
+++ b/distros/galactic/costmap-queue/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, nav2-costmap-2d, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-costmap-queue";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d07b40d34e7569b064a45cf8a403f56ff860929878841fc7bc9b2023cc85dfdf";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/costmap_queue/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "aa13e4abf1b8828da4bb4121f84bc0f3a9401d06a7f5ea16030ac5c089a96e42";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/cyclonedds/default.nix
+++ b/distros/galactic/cyclonedds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cmake, cunit, iceoryx-binding-c, iceoryx-posh, iceoryx-utils, openssl }:
 buildRosPackage {
   pname = "ros-galactic-cyclonedds";
-  version = "0.8.0-r4";
+  version = "0.8.0-r5";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/galactic/cyclonedds/0.8.0-4.tar.gz";
-    name = "0.8.0-4.tar.gz";
-    sha256 = "7d1865b1b65e761b9bdcad37c28be33ac66735b622e3cacf3b700620c359752d";
+    url = "https://github.com/ros2-gbp/cyclonedds-release/archive/release/galactic/cyclonedds/0.8.0-5.tar.gz";
+    name = "0.8.0-5.tar.gz";
+    sha256 = "0a8bcd82551d1b073ed01b0de059a62b6637a58ed6b369cda16b223f89e7503c";
   };
 
   buildType = "cmake";

--- a/distros/galactic/dwb-core/default.nix
+++ b/distros/galactic/dwb-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, dwb-msgs, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-core";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "c925036cc14e63e7ce53f364318d29af04edd17e062ce8273a37824c71a9db9d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_core/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "35ec55f96fa50e8251e1d23e2bcdb9ba58aa85281a2457dae7adbdc57f7014fe";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-critics/default.nix
+++ b/distros/galactic/dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, costmap-queue, dwb-core, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-critics";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "fc247a15202bdfb775277eebca8cfd5d22ab583d035e503367bb11ff8a53f1d1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_critics/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "ae5fa70fd1d235ed395d18a43ebf9969875168274ca90df3a0dff52918923e46";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-msgs/default.nix
+++ b/distros/galactic/dwb-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, nav-2d-msgs, nav-msgs, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-dwb-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d4f3b461a8c0273f55da42926831e03ddfb3abd7d8270b7747988591d9acf2c1";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "f21e619fc13db975ea3b9fbe3582fec7c6ef621bf3007bc4a1d4b51b6331030a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/dwb-plugins/default.nix
+++ b/distros/galactic/dwb-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, dwb-core, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-util, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-dwb-plugins";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "bffaef1a692325f0d6b706f4f8b83c65126c9c13cabb66a594d97ce97205840d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/dwb_plugins/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "0c8cf951fbd24f7556ec04f12d731d4b91481fdcc815d3d585bc5a687adb508b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/fmi-adapter-examples/default.nix
+++ b/distros/galactic/fmi-adapter-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, fmi-adapter, launch, launch-ros }:
 buildRosPackage {
   pname = "ros-galactic-fmi-adapter-examples";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/galactic/fmi_adapter_examples/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "423d1407ec4c3ea2022bbfeb2a3e1da9b7b7f5cce7b817c40f67036a6d291302";
+    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/galactic/fmi_adapter_examples/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "6fa264616c1823d9496d83a2011ea12904205a136c7c79f4506818599d1325c3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/fmi-adapter/default.nix
+++ b/distros/galactic/fmi-adapter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, fmilibrary-vendor, launch, launch-ros, launch-testing, rcl-interfaces, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-fmi-adapter";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/galactic/fmi_adapter/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "99610aff9628eb0f51e6bb2395c039c78efb2a30ccf51c47641538cad9e50234";
+    url = "https://github.com/ros2-gbp/fmi_adapter-release/archive/release/galactic/fmi_adapter/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "ca8fec656cf8281f61501e869589f8feee04a91eb0ba2100cb5d5c6149dfa820";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -24,6 +24,8 @@ self: super: {
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
 
+ ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
+
  ament-cmake-clang-format = self.callPackage ./ament-cmake-clang-format {};
 
  ament-cmake-clang-tidy = self.callPackage ./ament-cmake-clang-tidy {};
@@ -426,6 +428,8 @@ self: super: {
 
  mavlink = self.callPackage ./mavlink {};
 
+ menge-vendor = self.callPackage ./menge-vendor {};
+
  message-filters = self.callPackage ./message-filters {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
@@ -491,6 +495,8 @@ self: super: {
  nodl-python = self.callPackage ./nodl-python {};
 
  ntpd-driver = self.callPackage ./ntpd-driver {};
+
+ object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
 
  octomap = self.callPackage ./octomap {};
 
@@ -629,6 +635,8 @@ self: super: {
  realtime-tools = self.callPackage ./realtime-tools {};
 
  resource-retriever = self.callPackage ./resource-retriever {};
+
+ rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
 
  rmw = self.callPackage ./rmw {};
 

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2021.5.5-r1";
+  version = "2021.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.5.5-1.tar.gz";
-    name = "2021.5.5-1.tar.gz";
-    sha256 = "aab8b0bff4284aa567b3bb101374bc445be2e527f70199e014abdddbb5f81dc1";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.6.6-1.tar.gz";
+    name = "2021.6.6-1.tar.gz";
+    sha256 = "946bdffc6db618d635e3ce9f786e7380fe6c5da298a40ee400e2467c501d08dd";
   };
 
   buildType = "cmake";

--- a/distros/galactic/menge-vendor/default.nix
+++ b/distros/galactic/menge-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, pkg-config, tinyxml }:
+buildRosPackage {
+  pname = "ros-galactic-menge-vendor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/menge_vendor-release/archive/release/galactic/menge_vendor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "25af4778d17722066ce1f6bf922174d33210e2af13dd24c7a4d08cb2047d5c13";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ tinyxml ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Menge is a powerful, cross-platform, modular framework for crowd simulation developed at the University of North Carolina - Chapel Hill. This package includes the core simulation part of origin menge package, with a bit modification for crowd simulation in gazebo and ignition gazebo.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/nav-2d-msgs/default.nix
+++ b/distros/galactic/nav-2d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "0c6b90c5a0c8f508baef3a2cf24857c20fab79be37b2f734717beb436a2e8536";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "564120037b44931dba127f4c12e350a6108bd1e9c262ef0f963487d7e0aee93d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav-2d-utils/default.nix
+++ b/distros/galactic/nav-2d-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-2d-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, std-msgs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav-2d-utils";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "a50d17f807e4ad9038bab98db3466d85051d48f42c568a9739af4c5a66cffae6";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav_2d_utils/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "9e3994b0339257fde5fb9067438d4d724977a3c65d7075a45b27fb3d033d1425";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-amcl/default.nix
+++ b/distros/galactic/nav2-amcl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-ros, launch-testing, message-filters, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-amcl";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "2732918a11f5aaddc8f9368e65dea5a88e74f9118ececff740dc6ef1d8ac6b39";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_amcl/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "ba3fbcbaaae8bffbfb363f27975d5ba01b02b9537a6d0eef462a0169201938a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-behavior-tree/default.nix
+++ b/distros/galactic/nav2-behavior-tree/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, builtin-interfaces, geometry-msgs, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-behavior-tree";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "e4665e100c78df0c797c19c59f41389a559cec2e4d27606731db096dbafc24b9";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_behavior_tree/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6e82a60b2c95a8db28115594e5318bcd759dcaf5392aa3731e460de94efcb507";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bringup/default.nix
+++ b/distros/galactic/nav2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, nav2-common, navigation2, slam-toolbox }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bringup";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "5eb66d17dd5474da7bb1a0229b0f3093a119745778ea3963c588db0b3e6c61ff";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bringup/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3ed5a9a6067cbd6dad29764cb2f44112ba80203436b55e5f04971a6a227dfedb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-bt-navigator/default.nix
+++ b/distros/galactic/nav2-bt-navigator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-msgs, nav2-util, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-bt-navigator";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "40d1889b188d1e7bbf5c74dfa6d6341be51f7f830f23464f8b0d05653e354427";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_bt_navigator/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "cda90ff60ed8e37868ec51fadd5e05ea842dcd59370dd84e5b89c4ec2d94363f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-common/default.nix
+++ b/distros/galactic/nav2-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, launch, launch-ros, osrf-pycommon, python3Packages, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-nav2-common";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "d3723a474c6127e650957190ec9dc509482a1f6305a968787cf2b96deefdc5a8";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_common/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "79f8398a34222d4de9d95d2698e74c1011dc771b6ae7b7ede0b46d3bf5173615";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-controller/default.nix
+++ b/distros/galactic/nav2-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, angles, nav-2d-msgs, nav-2d-utils, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-controller";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "befa6b9adaf7df19b887d8c348a467102854c790ffe0490e019593c1d4d79ebb";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_controller/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "eed68199681dba08ef3588e3b6433b2dfaa1622d45039e7866c5b9ec84fd4d97";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-core/default.nix
+++ b/distros/galactic/nav2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-testing, nav-msgs, nav2-common, nav2-costmap-2d, nav2-util, pluginlib, rclcpp, rclcpp-lifecycle, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-core";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "1d75572ad7568225bac97a989a4361e3044b5d2840f13ab45ab2d873cd7422ec";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_core/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "564e937fae6aa8b3c438b1d591a0dab38fd1171a703bff55eb8c900c7d113e93";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-costmap-2d/default.nix
+++ b/distros/galactic/nav2-costmap-2d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, geometry-msgs, laser-geometry, launch, launch-testing, map-msgs, message-filters, nav-msgs, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-util, nav2-voxel-grid, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-costmap-2d";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8af78d43edcf858dd3a97c57c7f1c54d8592791745ef7ebb0cca182a7223f236";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_costmap_2d/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "93e14ac3e902dc2cf4baf0803e5521b85486624cb8bbe18691a6b46f1966f8a1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-dwb-controller/default.nix
+++ b/distros/galactic/nav2-dwb-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, costmap-queue, dwb-core, dwb-critics, dwb-msgs, dwb-plugins, nav-2d-msgs, nav-2d-utils }:
 buildRosPackage {
   pname = "ros-galactic-nav2-dwb-controller";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "09c673e2180a2d81cb2fe2dd03075116555babc6987a3ae82812da9e01ac46d4";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_dwb_controller/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a40b19b30d64ceb8cdf5ed4da9e4fcc1a2b016a64fa4c3447853a74bc820b1a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-gazebo-spawner/default.nix
+++ b/distros/galactic/nav2-gazebo-spawner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-lint-auto, ament-lint-common, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-gazebo-spawner";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "809754037cc05eb189654f5ed82a77e96a98ffbc926dd0a0b188ecef0a698390";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_gazebo_spawner/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3ad41e9c550800bfff8a7c2bee1b99983b385b333503a63ab66cb9d7c1ead029";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/nav2-lifecycle-manager/default.nix
+++ b/distros/galactic/nav2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bondcpp, geometry-msgs, lifecycle-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp-action, rclcpp-lifecycle, std-msgs, std-srvs, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-lifecycle-manager";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "2f6946efc3116567c8c3d0254b5ac920f57e528c7fa036b358bd6076183a350d";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_lifecycle_manager/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a040f4430e1086aea0ef2bc32bf8a961245463296a32a9493eef76cbdedad83b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-map-server/default.nix
+++ b/distros/galactic/nav2-map-server/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, graphicsmagick, launch, launch-ros, launch-testing, nav-msgs, nav2-common, nav2-msgs, nav2-util, rclcpp, rclcpp-lifecycle, std-msgs, tf2, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-nav2-map-server";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "e28d3acae76b0dceebaf740c89ab91df6b01bb36c6872923aa26826c7aa72348";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_map_server/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "0ef80058086975dd9fcaf14b1f3d989123af53d181e4e53ce52bd3f4769a78c5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-msgs/default.nix
+++ b/distros/galactic/nav2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-msgs";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9520566c1b34b6b1622ba4ea0decac677d5da0f9344b82320d3c58b013017871";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_msgs/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "df8237a1e3e9f0f4716e7427e2ebcc9e89398dbf6b4db561174656a2da1d9c75";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-navfn-planner/default.nix
+++ b/distros/galactic/nav2-navfn-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-navfn-planner";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "fedd03009b3ccc711c715eb9ff4cf60c4159c9ddd974b9138715b7db573d8672";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_navfn_planner/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "d2ddf1e674a26916922d15fa42bd83b9f635b073eeac055a2804c66becc812fc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-planner/default.nix
+++ b/distros/galactic/nav2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-planner";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "ffa978c93808f3a1cc0304bab0fc96315fad170479961692e83ff0e32bf65d4b";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_planner/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "90a9c7e652fdb433934c161cef4298d024ac42954d49b3c5811121c93683591c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-recoveries/default.nix
+++ b/distros/galactic/nav2-recoveries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-behavior-tree, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-recoveries";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "cf241a4e1120e25caf638c93cd95f00332152ace22f194db244e9f00cd5d1b6e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_recoveries/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "6ca713427016dbddc28253636ccea8b2f9e464bafa94fdb685cd855a29b0d22b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
+++ b/distros/galactic/nav2-regulated-pure-pursuit-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-nav2-regulated-pure-pursuit-controller";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "fc2803f06e0306519341bcb8e6954e1a7485ac8f33d995b5b8f32b32dc4a4d6c";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_regulated_pure_pursuit_controller/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a77f046bac38b6b47adaf97392da695c384c1689cb52aec1455175c2fc6452a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-rviz-plugins/default.nix
+++ b/distros/galactic/nav2-rviz-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, nav-msgs, nav2-lifecycle-manager, nav2-msgs, nav2-util, pluginlib, qt5, rclcpp, rclcpp-lifecycle, resource-retriever, rviz-common, rviz-default-plugins, rviz-ogre-vendor, rviz-rendering, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-rviz-plugins";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "630b9ae1ec1a704cb1343dbeded2bb99f8a8679a31dcf752e053871d51d99d64";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_rviz_plugins/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "21eb7c3f58bfd472cf2be3b195745f943ecec2db5372228ed60798df5aeec90c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-smac-planner/default.nix
+++ b/distros/galactic/nav2-smac-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, ceres-solver, eigen, eigen3-cmake-module, geometry-msgs, nav-msgs, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, ompl, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-smac-planner";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "0f727f826984174c037898a7d9e58a6c4b3f6ee376f2c921c198ca8e6bc19c3a";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_smac_planner/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "bd316ceb61497ec63560e6396f522b8203bb4994b852212f021cfb24984918ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-system-tests/default.nix
+++ b/distros/galactic/nav2-system-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, gazebo-ros-pkgs, geometry-msgs, launch, launch-ros, launch-testing, lcov, nav-msgs, nav2-amcl, nav2-behavior-tree, nav2-bringup, nav2-common, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-util, navigation2, python3Packages, rclcpp, rclpy, robot-state-publisher, std-msgs, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-nav2-system-tests";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "1ba25f17fd2d671f7fa646cb7b71a890868ea9249c477effe9ab8d66ac94bb21";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_system_tests/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "655f89f9402d51d1ea9efae0e6eb3968b898088fd51e69b3910989e03ffa1e9a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-util/default.nix
+++ b/distros/galactic/nav2-util/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, bond, bondcpp, boost, geometry-msgs, launch, launch-testing-ament-cmake, lifecycle-msgs, nav-msgs, nav2-common, nav2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, std-srvs, test-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-util";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "8e299037e4c5a785781768c4fbaae02c32d2d88ead65b68a4f2006fa7b704e72";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_util/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "2f211479dbc1f21779a6ea5a3cc26f6c2f72f4aadd6e05b6c4bc25e79a6a87b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-voxel-grid/default.nix
+++ b/distros/galactic/nav2-voxel-grid/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, nav2-common, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-nav2-voxel-grid";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "eb8bc711ef5a48d79f687a04e5bfd979dec587cb70fd7f7d86a7f05d84e81668";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_voxel_grid/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "8f7dbaaf23cb1e7cda49178032a17d960b7096f5abf716d90b144186f35ba5f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nav2-waypoint-follower/default.nix
+++ b/distros/galactic/nav2-waypoint-follower/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-lint-auto, ament-lint-common, cv-bridge, image-transport, nav-msgs, nav2-common, nav2-core, nav2-msgs, nav2-util, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-nav2-waypoint-follower";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9cef03dd72f816ae188643f14a24ec36bfd1363a64f9a1b55d9918b56c821e0e";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/nav2_waypoint_follower/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "f87a5ea48bc9af61570d8e9a1f8623564aca6f137591e94398c44c340346ed43";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/navigation2/default.nix
+++ b/distros/galactic/navigation2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, nav2-amcl, nav2-behavior-tree, nav2-bt-navigator, nav2-controller, nav2-core, nav2-costmap-2d, nav2-dwb-controller, nav2-lifecycle-manager, nav2-map-server, nav2-msgs, nav2-navfn-planner, nav2-planner, nav2-recoveries, nav2-regulated-pure-pursuit-controller, nav2-rviz-plugins, nav2-smac-planner, nav2-util, nav2-voxel-grid, nav2-waypoint-follower }:
 buildRosPackage {
   pname = "ros-galactic-navigation2";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "47b3bc5b7505f9c168537fedda966583fa4384abb3d35d5765d73679a4c14289";
+    url = "https://github.com/SteveMacenski/navigation2-release/archive/release/galactic/navigation2/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "a394e9cf7fda1414845c5b060a3f4157ef2c930af93745298d81b82e16b69fc0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/object-recognition-msgs/default.nix
+++ b/distros/galactic/object-recognition-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-object-recognition-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/object_recognition_msgs-release/archive/release/galactic/object_recognition_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4562f648b5e56b2b264788980932c42035a4ff3f3f7b7ed51f7c2ebf13d228c8";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Object_recognition_msgs contains the ROS message and the actionlib definition used in object_recognition_core'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/point-cloud-msg-wrapper/default.nix
+++ b/distros/galactic/point-cloud-msg-wrapper/default.nix
@@ -2,24 +2,25 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-point-cloud-msg-wrapper";
-  version = "1.0.5-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/galactic/point_cloud_msg_wrapper/1.0.5-1/point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    name = "point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.5-1.tar.gz";
-    sha256 = "293d307fa96af1531eb2e40af41d5d2b22c7950b182bae0eec82ea7bd954d1b0";
+    url = "https://gitlab.com/ApexAI/point_cloud_msg_wrapper-release/-/archive/release/galactic/point_cloud_msg_wrapper/1.0.7-1/point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.7-1.tar.gz";
+    name = "point_cloud_msg_wrapper-release-release-galactic-point_cloud_msg_wrapper-1.0.7-1.tar.gz";
+    sha256 = "806dd274522a1260c4201ffd3ccb1d2e8b8fc2ead67c884dd1702eed0bca2007";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs sensor-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  buildInputs = [ ament-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
-    description = ''A point cloud message wrapper that allows for simple and safe msg usage'';
+    description = ''A point cloud message wrapper that allows for simple and safe PointCloud2 msg usage'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/rmf-visualization-msgs/default.nix
+++ b/distros/galactic/rmf-visualization-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-visualization-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_visualization_msgs-release/archive/release/galactic/rmf_visualization_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "de8cf2549c54fef9a38e9ba49965bd764b065d695569b63f129c4be78c0a6518";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used for visualizations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/xacro/default.nix
+++ b/distros/galactic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-xacro";
-  version = "2.0.2-r3";
+  version = "2.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.2-3.tar.gz";
-    name = "2.0.2-3.tar.gz";
-    sha256 = "a19776141cc41b8e0ccb9fc1f37a8027d9be748ea0d7f83a22e45bcaf5c70d36";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.6-1.tar.gz";
+    name = "2.0.6-1.tar.gz";
+    sha256 = "7b4cea7136e4c340cacf3e08d63adfe6e34923baec25425adf0969e6765dbcd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/bcap-core/default.nix
+++ b/distros/melodic/bcap-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-bcap-core";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_core/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "9a236eeb1a4ad0f7abbb4e515d81f319cb0a6ee8e5c9da1a879020a7b641e073";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_core/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "1d0c1bb6201fd6f52a542770b9fa39ac14aa86dbaeebac2384afbeb8315ff940";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bcap-service-test/default.nix
+++ b/distros/melodic/bcap-service-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bcap-service, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-bcap-service-test";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_service_test/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "52ccd106e855974f1baafec733917e23f13e43f5dda7543c8130f6a4a123ff0e";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_service_test/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "233a8c354d27ea11be4749ef1a1f759b906cc931585019115a913f685b42d87c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bcap-service/default.nix
+++ b/distros/melodic/bcap-service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bcap-core, catkin, message-generation, message-runtime, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-bcap-service";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_service/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "d7a321cec7d104afe52d20dc921eba2e787308954ec897b0fd64223243ab04fd";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/bcap_service/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "efe083be1456bd1c3ac217153fbdffe51dae85a3927497d7d59691595e996ae6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-bringup/default.nix
+++ b/distros/melodic/denso-robot-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-bringup";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_bringup/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "2040bc4c27857b184781d2f98810db4a80337ddf01db76c860f09f552a3a1a32";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_bringup/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "3ff3ec7024f60ea109a6bb0225bf60c7dd3805d648809e06f3df72eb380ac07b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-control/default.nix
+++ b/distros/melodic/denso-robot-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bcap-core, bcap-service, catkin, controller-manager, denso-robot-core, hardware-interface, joint-limits-interface, roscpp, std-msgs, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-control";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_control/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "1e589e72e45771a3426399b93f1d84379dba240117ce71f4f62230cd968d1298";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_control/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "44632e28b7c8dc71fca2aacb9a2022f65fbfbc1cf41b86fa5db23572002c912f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-core-test/default.nix
+++ b/distros/melodic/denso-robot-core-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, bcap-core, catkin, denso-robot-core, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-core-test";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_core_test/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "d1fd5baa4315cbeb5b12bb3ccc38f8c6d643af5eaaf3e7abed6dbdb8efb2e532";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_core_test/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "b500a34855e62c572cb8b2590855e8398d10be29a7a729a168b86a3088cb36ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-core/default.nix
+++ b/distros/melodic/denso-robot-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, bcap-core, bcap-service, catkin, message-generation, message-runtime, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-core";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_core/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "2434d5fabe55b348d3ba33c74d485df22c71944d6932f6a8b8904d60e77197c1";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_core/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c2823db29c7191e68ed73cd9e44f134dd0bed78fcbe2e5f0ad5a47ded3292b1d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-descriptions/default.nix
+++ b/distros/melodic/denso-robot-descriptions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-descriptions";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_descriptions/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "928e088bdec585aceaee70c5e847d7e4a4d3925014ca6569b50e35ccc8b72193";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_descriptions/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "d33cc562bd9f958255926e19a3854aeda0b20a7e54347e96481f73adf2b50e2d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-gazebo/default.nix
+++ b/distros/melodic/denso-robot-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros-control, gazebo-ros-pkgs, joint-state-controller, joint-trajectory-controller }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-gazebo";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_gazebo/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "582a7e77c309ccd7fae05a4e1202de1e398813d41d93c1774579c5a319129673";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_gazebo/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "c7442f7cd0ba21a4ced665b742ba53c22d36ff9a03fa546d1415c969499aa65e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-moveit-config/default.nix
+++ b/distros/melodic/denso-robot-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-visualization, moveit-simple-controller-manager, robot-state-publisher, xacro }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-moveit-config";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_moveit_config/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "5b3d0b52b039421f12b4b11a5cab2a1387cfdb47f971c079a6d05d47d0b7741c";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_moveit_config/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "399a482bbaf6ef0aa129e0607ebec00e9167e0b9230f0b94d271fdbae2fea7d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/denso-robot-ros/default.nix
+++ b/distros/melodic/denso-robot-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bcap-core, bcap-service, bcap-service-test, catkin, denso-robot-bringup, denso-robot-control, denso-robot-core, denso-robot-core-test, denso-robot-descriptions, denso-robot-gazebo, denso-robot-moveit-config }:
 buildRosPackage {
   pname = "ros-melodic-denso-robot-ros";
-  version = "3.1.2-r1";
+  version = "3.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_ros/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "57a2864b88693e5a978eb6d00d3cbdd55cbf1beecfecc6cbeb7feba1ad91b7f8";
+    url = "https://github.com/DENSORobot/denso_robot_ros-release/archive/release/melodic/denso_robot_ros/3.2.0-1.tar.gz";
+    name = "3.2.0-1.tar.gz";
+    sha256 = "356d40c66bd94bd33f33913fd58789687500e1e653402b4f40b1c6799e33fd18";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2588,6 +2588,8 @@ self: super: {
 
  parameter-assertions = self.callPackage ./parameter-assertions {};
 
+ parameter-pa = self.callPackage ./parameter-pa {};
+
  parrot-arsdk = self.callPackage ./parrot-arsdk {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
@@ -3684,6 +3686,10 @@ self: super: {
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
 
+ scaled-controllers = self.callPackage ./scaled-controllers {};
+
+ scaled-joint-trajectory-controller = self.callPackage ./scaled-joint-trajectory-controller {};
+
  scan-to-cloud-converter = self.callPackage ./scan-to-cloud-converter {};
 
  scan-tools = self.callPackage ./scan-tools {};
@@ -3809,6 +3815,10 @@ self: super: {
  spatio-temporal-voxel-layer = self.callPackage ./spatio-temporal-voxel-layer {};
 
  speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
+
+ speed-scaling-interface = self.callPackage ./speed-scaling-interface {};
+
+ speed-scaling-state-controller = self.callPackage ./speed-scaling-state-controller {};
 
  sr-hand-detector = self.callPackage ./sr-hand-detector {};
 

--- a/distros/melodic/leo-description/default.nix
+++ b/distros/melodic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-melodic-leo-description";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo_description/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "8e6ce8a4b951bbfc99a9422b646c267eb685730c239bb7be953d71d9d91bbb32";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo_description/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "360ef65d8f1517a31541eb715af5b66a7fd923dbc776f4a125fac219c70ab23d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-teleop/default.nix
+++ b/distros/melodic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-melodic-leo-teleop";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo_teleop/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "4145f717dae0c316f90a04069a3245a1cbfbfc75fe1e82559eb78cd5a26a08ad";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo_teleop/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "038736af60665c2bcd0b9caf4b0c219ffebd1b8ad2ef1b14a3a0b65a72f0eff1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo/default.nix
+++ b/distros/melodic/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-description, leo-teleop }:
 buildRosPackage {
   pname = "ros-melodic-leo";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "4ea4f60067fd58773e53b0373153b818d5a8b745c066bc6f6e1bb687cd77f324";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/melodic/leo/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "d63f8049a206be39beacb794458eec54e4fb28c3ee6995f201323baf0142cc1b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.5.5-r1";
+  version = "2021.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.5.5-1.tar.gz";
-    name = "2021.5.5-1.tar.gz";
-    sha256 = "c18788153874f44a16720fbf7216b6dcc1c7817d269d7188e4aa1b934e788fdb";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.6.6-1.tar.gz";
+    name = "2021.6.6-1.tar.gz";
+    sha256 = "6a3a62f5f8411d44573b85888788be5e174a9611e76ad5a8ce021e692a1129f2";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mir-actions/default.nix
+++ b/distros/melodic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-actions";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "c7b78c26c1442b17a04340c451da9a25674c5ddee70f9b054278b33987a0ecb5";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_actions/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "b4a703d422b555e11282baf427f89cf06bc3af1c387f9a6bcd5dbe8cf168cc0f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-description/default.nix
+++ b/distros/melodic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-mir-description";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "0564f2d3ca0839e459e590680073f6556f78b49e3d0ed332b4dc039245e1792d";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_description/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "2f1b0aa476e8a253cd247bf99ac572300185a8176c59627f011e526474961039";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-driver/default.nix
+++ b/distros/melodic/mir-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, diagnostic-msgs, dynamic-reconfigure, geometry-msgs, mir-actions, mir-description, mir-msgs, move-base-msgs, nav-msgs, pythonPackages, robot-state-publisher, rosgraph-msgs, roslaunch, rospy, rospy-message-converter, sensor-msgs, std-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-driver";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "e48f9194f54f10fcf7ef9d70a7437eae8c50129791d75bc9d77f42084a67726b";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_driver/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "784746070a1109b8fe6506717d4d9d79731c6a00ca358924b4ab400a3aaa47b1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-dwb-critics/default.nix
+++ b/distros/melodic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, pythonPackages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mir-dwb-critics";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "29ab1e9fb86bf41a017fe5cff782c004e7a8187e34daca0921742e98f3d5fe40";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_dwb_critics/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "248243c2b1066676650f91074be1912df017c0a3579a0d5db76c672a8f5406c4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-gazebo/default.nix
+++ b/distros/melodic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-mir-gazebo";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "2a5455e17a833ca1c4498603c05b4d6de72c65933b74273c9b70daf338a648cc";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_gazebo/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "d13b5b25f25b9320ed7f9a0ece602841cf88ee62c6d23ac62a240a1fa492afcb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-msgs/default.nix
+++ b/distros/melodic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-mir-msgs";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "77c03361f0e213f65f6d710ea373b2af6d83f37a5afd0ad38564a75de43215bc";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_msgs/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ad1218540844d730530c01bddc7742de371e525bcc9e33345a2a4f1f15731d51";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-navigation/default.nix
+++ b/distros/melodic/mir-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, pythonPackages, roslaunch, sbpl-lattice-planner }:
 buildRosPackage {
   pname = "ros-melodic-mir-navigation";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "17970fa4703c743d5b53c81cd2337a3ea27910777f273ec41e16e5b1a1f1e08c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_navigation/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "71f147dada6957cc290b35ee2852714e41e6a6e0ea6655fd172732ea256fe071";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mir-robot/default.nix
+++ b/distros/melodic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-melodic-mir-robot";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "121e765ef12b127dc5cfb80ad47583c123c9f5b993551cab1dcb248d617ef57c";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/mir_robot/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "6e91f38eadf2552b84a889933e602455aa0a6236a27db8f6d33974b85bf9c279";
   };
 
   buildType = "catkin";

--- a/distros/melodic/parameter-pa/default.nix
+++ b/distros/melodic/parameter-pa/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, message-generation, message-runtime, roscpp, roslib }:
+buildRosPackage {
+  pname = "ros-melodic-parameter-pa";
+  version = "1.2.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/TUC-ProAut/ros_parameter-release/archive/release/melodic/parameter_pa/1.2.3-2.tar.gz";
+    name = "1.2.3-2.tar.gz";
+    sha256 = "ecf0983ae4dfc9bcb99e83c332bda449ffa5ee778c8e17e9a1b2c667d0544aa9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cmake-modules eigen message-runtime roscpp roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ProAut parameter package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.5.0-r2";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "e333e6976d731138bf9bd922df2d4b04d7156c81753d46e96e53ce86fc3151fa";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "d6bcb86336ec895fd8752c13fd9d4b1ff75821b38c54388c03c775a717d36b24";
   };
 
   buildType = "cmake";

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "6fbedb6a81e3b6d092506d9b2e928e46e735f0e711347c804607b655dc852042";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b995acb6f1ab9d3426ac97c44145e6972f35e99e61a5970d7edca4baa3634c0a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "462d2a3224c59fcf6170b488822c9daf598335ac4befc56ed7a70d49ff7d907a";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "7b90d76bd39e0d68b1e79fd4ed1a83c66025a1437104937d7dd174a842a58713";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "0ea8886011c8835a7b588a5be82d86de5f7c33d10bdb3162118e1062d954726a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "6977a56aa6ebd55c2fdd9a5b5a771e54de1ce04d734fe55ea605e6219d7fa753";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "3a593b3b67c29e03db7c8db4b31482ccc2fe9c8fa92ab1dda26f0aa9e0a0b6d6";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "ba1922684317bf4cd72559f403dbe777539f958a3b98e22456a80652c1160af4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-roi-manager-gui/default.nix
+++ b/distros/melodic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-melodic-rc-roi-manager-gui";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "41cd87e85fc7a816883ab645631bdca1c29e2c5357eb01b42611110aa2ba5323";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "1646a238a2c14cfd93358afadb2562feccc3f9397335495a40858dcc9a251cd1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "2bc9b1ad5e69fe6dcab4d7d8ee805e2303c18c32664b18d6fae8edfb3f6f2490";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "60d93f70770b054b9369410ead8a14dd5401a326e7f1ab28c26f04deae035c5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "5e190b2a349de4c41cf29b9b39e017db00ff01548c0a735054165c95f48261cf";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "0ba875889282dbc31b58d4b3808e71e7a01eeaa6653dc78725cba4f94befbda7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "969cac0e0d0818eb366ea276997aef8ae32c2fc2bd9fb40cd82aca8a60395575";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "dfcb05e9b5046061e9059414ee2399a7429494f203014d8c0ab0f92ecf2d8c5a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "a6e48dfa09b11200519dcd01ea96c73337b589bb790e3fb144bd3252f64c1ee4";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "2fd6fc988d8687feff0b5393c5e392814a7bfc6a6fd6d22c9645b85db71a2575";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.1.0-r2";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.1.0-2.tar.gz";
-    name = "3.1.0-2.tar.gz";
-    sha256 = "c745f890d987b1b8bf3c7ee4c1c107d425f361a5dcad56ef4cfb26639091ebd2";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "b6985c1ce05e26b49d2893d1718449b6a166e9766aa66e3996e7904d80235733";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.9-r1";
+  version = "2.6.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.9-1.tar.gz";
-    name = "2.6.9-1.tar.gz";
-    sha256 = "342f2898d175fa666fbb506081599aaa431c4fd5e1e54c4c08f11e68e9408394";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.10-1.tar.gz";
+    name = "2.6.10-1.tar.gz";
+    sha256 = "6c29f8412e50f60f391ff48c25e591363661ee99456f70383896617c990c32d5";
   };
 
   buildType = "catkin";
   buildInputs = [ geographiclib message-generation pythonPackages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/scaled-controllers/default.nix
+++ b/distros/melodic/scaled-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, scaled-joint-trajectory-controller, speed-scaling-interface, speed-scaling-state-controller }:
+buildRosPackage {
+  pname = "ros-melodic-scaled-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/melodic/scaled_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "326bb647af2998e8552761864179e37433d7b8902b36fbbb3232d1e7e452ac8d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ scaled-joint-trajectory-controller speed-scaling-interface speed-scaling-state-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''scaled controllers metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/scaled-joint-trajectory-controller/default.nix
+++ b/distros/melodic/scaled-joint-trajectory-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, joint-trajectory-controller, pluginlib, realtime-tools, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-scaled-joint-trajectory-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/melodic/scaled_joint_trajectory_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "6dea8314c90b48ccb9e02a3877059d765b053bb285c9b4ef64b6601c3bf92439";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface joint-trajectory-controller pluginlib realtime-tools std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides controllers that use the speed scaling interface.'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/melodic/sdc21x0/default.nix
+++ b/distros/melodic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-sdc21x0";
-  version = "1.0.7-r1";
+  version = "1.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/sdc21x0/1.0.7-1.tar.gz";
-    name = "1.0.7-1.tar.gz";
-    sha256 = "1196af31b64c8eaf7e1d3338de2fc35915731af10ce73cbd6fd4b22d434ff874";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/melodic/sdc21x0/1.0.8-1.tar.gz";
+    name = "1.0.8-1.tar.gz";
+    sha256 = "ba36cc5570fc9c1e86170c6d6b25c913ff595d792d65b709ea6458be53554c94";
   };
 
   buildType = "catkin";

--- a/distros/melodic/speed-scaling-interface/default.nix
+++ b/distros/melodic/speed-scaling-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-speed-scaling-interface";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/melodic/speed_scaling_interface/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "c862c92b1d5c2d4a118c4868a9bd6bf48ff79c4947233770c99a91da3662148f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Hardware interface reading a scalar value from robot hardware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/speed-scaling-state-controller/default.nix
+++ b/distros/melodic/speed-scaling-state-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, pluginlib, realtime-tools, speed-scaling-interface, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-speed-scaling-state-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/melodic/speed_scaling_state_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "22689826e020b2ad87e2e312836e84c175d291b97d6f782eafdba5c166de4690";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface pluginlib realtime-tools speed-scaling-interface std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS controller providing reading the state of speed scaling on the robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/ur-client-library/default.nix
+++ b/distros/melodic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ur-client-library";
-  version = "0.2.0-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "94dca774fb8043d00cbc81d8662388b19c31a2b9d7ac20cc29c5b2ea976069e5";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "2453f6de7998ffac0b6c05d404540b56548fb4ca4929f30edc6216ff23444f4f";
   };
 
   buildType = "cmake";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.10-r1";
+  version = "1.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.10-1.tar.gz";
-    name = "1.13.10-1.tar.gz";
-    sha256 = "228cda50fb3f54c63392bee37fcf7580e59e8ab806f91a222ccd97dd6265cf1b";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.11-1.tar.gz";
+    name = "1.13.11-1.tar.gz";
+    sha256 = "8a429e9085339ad44d05b10729d51efc5393f28e357d5362c26f689264331cba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/foxglove-msgs/default.nix
+++ b/distros/noetic/foxglove-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-foxglove-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/foxglove/ros_foxglove_msgs-release/archive/release/noetic/foxglove_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "949c65426a4fdd27eb9b9b653b2482b0ed38faf4d9db6687baa2c6125162089f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''foxglove_msgs extends the common ROS visualization messages with additional
+    useful messages that are supported by Foxglove Studio.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -808,6 +808,8 @@ self: super: {
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
+ foxglove-msgs = self.callPackage ./foxglove-msgs {};
+
  franka-control = self.callPackage ./franka-control {};
 
  franka-description = self.callPackage ./franka-description {};
@@ -1042,6 +1044,8 @@ self: super: {
 
  imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
 
+ imu-monitor = self.callPackage ./imu-monitor {};
+
  imu-pipeline = self.callPackage ./imu-pipeline {};
 
  imu-processors = self.callPackage ./imu-processors {};
@@ -1109,8 +1113,6 @@ self: super: {
  joy-listener = self.callPackage ./joy-listener {};
 
  joy-teleop = self.callPackage ./joy-teleop {};
-
- joystick-drivers = self.callPackage ./joystick-drivers {};
 
  joystick-interrupt = self.callPackage ./joystick-interrupt {};
 
@@ -1636,6 +1638,8 @@ self: super: {
 
  opw-kinematics = self.callPackage ./opw-kinematics {};
 
+ osm-cartography = self.callPackage ./osm-cartography {};
+
  osqp-vendor = self.callPackage ./osqp-vendor {};
 
  oxford-gps-eth = self.callPackage ./oxford-gps-eth {};
@@ -1655,6 +1659,8 @@ self: super: {
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 
  panda-moveit-config = self.callPackage ./panda-moveit-config {};
+
+ parameter-pa = self.callPackage ./parameter-pa {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1788,13 +1794,21 @@ self: super: {
 
  pr2-arm-move-ik = self.callPackage ./pr2-arm-move-ik {};
 
+ pr2-bringup = self.callPackage ./pr2-bringup {};
+
  pr2-calibration-controllers = self.callPackage ./pr2-calibration-controllers {};
+
+ pr2-camera-synchronizer = self.callPackage ./pr2-camera-synchronizer {};
 
  pr2-common = self.callPackage ./pr2-common {};
 
  pr2-common-action-msgs = self.callPackage ./pr2-common-action-msgs {};
 
  pr2-common-actions = self.callPackage ./pr2-common-actions {};
+
+ pr2-computer-monitor = self.callPackage ./pr2-computer-monitor {};
+
+ pr2-controller-configuration = self.callPackage ./pr2-controller-configuration {};
 
  pr2-controller-interface = self.callPackage ./pr2-controller-interface {};
 
@@ -1807,6 +1821,8 @@ self: super: {
  pr2-dashboard-aggregator = self.callPackage ./pr2-dashboard-aggregator {};
 
  pr2-description = self.callPackage ./pr2-description {};
+
+ pr2-ethercat = self.callPackage ./pr2-ethercat {};
 
  pr2-ethercat-drivers = self.callPackage ./pr2-ethercat-drivers {};
 
@@ -1840,9 +1856,11 @@ self: super: {
 
  pr2-power-drivers = self.callPackage ./pr2-power-drivers {};
 
- pr2-teleop = self.callPackage ./pr2-teleop {};
+ pr2-robot = self.callPackage ./pr2-robot {};
 
- pr2-teleop-general = self.callPackage ./pr2-teleop-general {};
+ pr2-run-stop-auto-restart = self.callPackage ./pr2-run-stop-auto-restart {};
+
+ pr2-teleop = self.callPackage ./pr2-teleop {};
 
  pr2-tilt-laser-interface = self.callPackage ./pr2-tilt-laser-interface {};
 
@@ -1867,8 +1885,6 @@ self: super: {
  prosilica-camera = self.callPackage ./prosilica-camera {};
 
  prosilica-gige-sdk = self.callPackage ./prosilica-gige-sdk {};
-
- ps3joy = self.callPackage ./ps3joy {};
 
  psen-scan-v2 = self.callPackage ./psen-scan-v2 {};
 
@@ -2202,6 +2218,8 @@ self: super: {
 
  rotate-recovery = self.callPackage ./rotate-recovery {};
 
+ route-network = self.callPackage ./route-network {};
+
  rqt = self.callPackage ./rqt {};
 
  rqt-action = self.callPackage ./rqt-action {};
@@ -2251,6 +2269,8 @@ self: super: {
  rqt-plot = self.callPackage ./rqt-plot {};
 
  rqt-pose-view = self.callPackage ./rqt-pose-view {};
+
+ rqt-pr2-dashboard = self.callPackage ./rqt-pr2-dashboard {};
 
  rqt-publisher = self.callPackage ./rqt-publisher {};
 
@@ -2321,6 +2341,10 @@ self: super: {
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};
 
  sbpl-recovery = self.callPackage ./sbpl-recovery {};
+
+ scaled-controllers = self.callPackage ./scaled-controllers {};
+
+ scaled-joint-trajectory-controller = self.callPackage ./scaled-joint-trajectory-controller {};
 
  scan-to-cloud-converter = self.callPackage ./scan-to-cloud-converter {};
 
@@ -2420,6 +2444,10 @@ self: super: {
 
  speech-recognition-msgs = self.callPackage ./speech-recognition-msgs {};
 
+ speed-scaling-interface = self.callPackage ./speed-scaling-interface {};
+
+ speed-scaling-state-controller = self.callPackage ./speed-scaling-state-controller {};
+
  srdfdom = self.callPackage ./srdfdom {};
 
  stag-ros = self.callPackage ./stag-ros {};
@@ -2515,6 +2543,8 @@ self: super: {
  test-diagnostic-aggregator = self.callPackage ./test-diagnostic-aggregator {};
 
  test-mavros = self.callPackage ./test-mavros {};
+
+ test-osm = self.callPackage ./test-osm {};
 
  tf = self.callPackage ./tf {};
 
@@ -2741,8 +2771,6 @@ self: super: {
  wge100-driver = self.callPackage ./wge100-driver {};
 
  wifi-ddwrt = self.callPackage ./wifi-ddwrt {};
-
- wiimote = self.callPackage ./wiimote {};
 
  willow-maps = self.callPackage ./willow-maps {};
 

--- a/distros/noetic/geodesy/default.nix
+++ b/distros/noetic/geodesy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, geographic-msgs, geometry-msgs, python3Packages, rosunit, sensor-msgs, tf, unique-id, uuid-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geodesy";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geodesy/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "b52d720b7b0623c331b34aeaa28e9101b3a28eb9821d943616c5e13c21442ba2";
+    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geodesy/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "69da32daf80a20fd6bdf586d440a31a17afcadd46eb6999cacbcf4ce63bf3542";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geographic-info/default.nix
+++ b/distros/noetic/geographic-info/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geodesy, geographic-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geographic-info";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geographic_info/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "a19fe073d334e4b20d67d705e9af80c7899de201888a1814b093f02158220cb8";
+    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geographic_info/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "be539a05f207583008d37725779e71984db5d3a5991dbbd19f6e158cd3c90272";
   };
 
   buildType = "catkin";

--- a/distros/noetic/geographic-msgs/default.nix
+++ b/distros/noetic/geographic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, uuid-msgs }:
 buildRosPackage {
   pname = "ros-noetic-geographic-msgs";
-  version = "0.5.5-r1";
+  version = "0.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geographic_msgs/0.5.5-1.tar.gz";
-    name = "0.5.5-1.tar.gz";
-    sha256 = "23116da81c5941eae2ea1b954016f7417c2682a2aa6cbe8f4d2ecaada24e98ae";
+    url = "https://github.com/ros-geographic-info/geographic_info-release/archive/release/noetic/geographic_msgs/0.5.6-1.tar.gz";
+    name = "0.5.6-1.tar.gz";
+    sha256 = "0c19562199a4f9f813362ad87d4345bb8ae77c77c41f7fe332eb672ad19d2d79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-monitor/default.nix
+++ b/distros/noetic/imu-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-mechanism-controllers, python3Packages, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-imu-monitor";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/imu_monitor/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "af19afccafb7bc0c0517427a39b495828e0c9dc8df3dcf6661768030a53b4cc3";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-mechanism-controllers python3Packages.pykdl rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains a single node that monitors the drift of the IMU
+gyroscopes. The results are published to the '/diagnostics' topic and
+are aggregated in the PR2 dashboard.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joy/default.nix
+++ b/distros/noetic/joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, linuxConsoleTools, rosbag, roscpp, roslint, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joy";
-  version = "1.15.0-r1";
+  version = "1.15.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/joy/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "95bd49cd5852d9a20d15d9dbd78ea46eed67a5b51b092b5bb053e74b920ca5bb";
+    url = "https://github.com/ros-gbp/joystick_drivers-release/archive/release/noetic/joy/1.15.1-1.tar.gz";
+    name = "1.15.1-1.tar.gz";
+    sha256 = "d09ea880713158e4a7455a892bd618e1c8d2b634cc9fa5d03b7cf9cf73e1ad0c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-description/default.nix
+++ b/distros/noetic/leo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, rostest, xacro }:
 buildRosPackage {
   pname = "ros-noetic-leo-description";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "6e558c9961fca12f69ef519a8d39766616b0a81533ad9f15e58d3a3d418f0df8";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_description/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "0663ddfecbba76660c215c788834866fc816036cf79734261693a906004fbb17";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo-teleop/default.nix
+++ b/distros/noetic/leo-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joy, teleop-twist-joy, teleop-twist-keyboard }:
 buildRosPackage {
   pname = "ros-noetic-leo-teleop";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "5557e80252f9e223267b11f547936c3606566d0ae13a7823e25a3ae4ab1332cc";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo_teleop/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "a740dbfb0eff660ad84c01f33eddf6a32a6a05c7bc559b502ca6c56e40de6d84";
   };
 
   buildType = "catkin";

--- a/distros/noetic/leo/default.nix
+++ b/distros/noetic/leo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo-description, leo-teleop }:
 buildRosPackage {
   pname = "ros-noetic-leo";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "ec4d01d8815b6a7bfdd25a81c9253acd166942d4da9badae5f651b1c97ac9002";
+    url = "https://github.com/fictionlab-gbp/leo_common-release/archive/release/noetic/leo/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "5f08094f385aff7988ecc1dd21d4fe4f9bfb35a651aea18389199d9eeb58a83d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.5.5-r1";
+  version = "2021.6.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.5.5-1.tar.gz";
-    name = "2021.5.5-1.tar.gz";
-    sha256 = "5e0034dab7c4867b4e2dd8719d2db56eea004c021c996e6d9615c88f7960c37e";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.6.6-1.tar.gz";
+    name = "2021.6.6-1.tar.gz";
+    sha256 = "b241b889ea2d0d3cd3bef3e3bdf6944b54cf18f9d98293ee5d1d2284166f2ff2";
   };
 
   buildType = "cmake";

--- a/distros/noetic/mir-actions/default.nix
+++ b/distros/noetic/mir-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-actions";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "c4ec302bc2ff3f358dd583114828668781868338a7db78624b9c7099707e9892";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_actions/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "5ddda5d8ccb11bfc2d6f645167f14934b31b5a9b4f84fdbc54e99e4db50f9699";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-description/default.nix
+++ b/distros/noetic/mir-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diff-drive-controller, gazebo-ros-control, joint-state-controller, joint-state-publisher, position-controllers, robot-state-publisher, roslaunch, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-mir-description";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "41cc4ada636750c30cfd2c5db98f32dd652f5e6397a7f9eeb3294ac59926d27a";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_description/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "45d7d67e2578802acb22f3dc4404848132d41c4939a232761f84d1b0fbc68fb8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-dwb-critics/default.nix
+++ b/distros/noetic/mir-dwb-critics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, costmap-queue, dwb-critics, dwb-local-planner, geometry-msgs, nav-2d-msgs, nav-2d-utils, nav-core2, nav-grid-iterators, pluginlib, python3Packages, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mir-dwb-critics";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "cbbe88f045d9d35a762337a537eac300e9a226d8b64de529507a282fb55e9ec1";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_dwb_critics/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "162043eb5c6a5065163aad54d6dec3670e66c69e0b1067b6eaeb74c31dfae3d8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-gazebo/default.nix
+++ b/distros/noetic/mir-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, fake-localization, gazebo-ros, joint-state-publisher, mir-description, mir-driver, robot-localization, robot-state-publisher, roslaunch, rostopic, rqt-robot-steering, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-mir-gazebo";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "08be14c18ac8c0b6f75d17621b3b7d9c72638b5c43d3b0e7eea8a93d8f224c99";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_gazebo/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "4ea25a9ff76135343b7664793f48c85c27a5b587c3d2964c58f91cedd4a137f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-msgs/default.nix
+++ b/distros/noetic/mir-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-mir-msgs";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "094d5454ba5dbf2fba1ca3d2fd1e34d2345f3ad1f4c50f5a015e184824583a7a";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_msgs/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "68f7558eea6c125e5a30fb721170c593ff629c4c3c9d201ca60675ca789cecb8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-navigation/default.nix
+++ b/distros/noetic/mir-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, dwb-critics, dwb-local-planner, dwb-plugins, hector-mapping, map-server, mir-driver, mir-dwb-critics, mir-gazebo, move-base, nav-core-adapter, python3Packages, roslaunch, sbpl-lattice-planner, teb-local-planner }:
 buildRosPackage {
   pname = "ros-noetic-mir-navigation";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "77c4a6ad42c5dd44b7f4493121e844421b37fcc3c7b122125cd0e68a4672dbfe";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_navigation/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "f94d866f0d58852d97326ff96225843bd2b1545ba1d9f57e9d2b8782707e479b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mir-robot/default.nix
+++ b/distros/noetic/mir-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mir-actions, mir-description, mir-driver, mir-dwb-critics, mir-gazebo, mir-msgs, mir-navigation, sdc21x0 }:
 buildRosPackage {
   pname = "ros-noetic-mir-robot";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "7896887c34cc628c2b7e26fcd79aa279fa3238df2935dd4f050a9718acd23203";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/mir_robot/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "9525562dc4ede00dc75bfc21fd610f3724d445da2701f5ecb55f6a3946cfbf3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/network-interface/default.nix
+++ b/distros/noetic/network-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roslint, rosunit, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-network-interface";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/network_interface-release/archive/release/noetic/network_interface/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "6ba8757292ea0ae9499c9142cf2b47cac91ac0f5f2ffd21c977801657ae38d64";
+    url = "https://github.com/astuff/network_interface-release/archive/release/noetic/network_interface/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "b55512f9cb6c73bfe0ba29cde2a3d47a4e9a8e14e339440a57ccd8a5a1cefaf5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/osm-cartography/default.nix
+++ b/distros/noetic/osm-cartography/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, roslaunch, rospy, route-network, std-msgs, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-osm-cartography";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/osm_cartography/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "8b5dfd2079b88425f498a5d590460ce9c32a9016413fa00af04fed5800c99da4";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs rospy route-network std-msgs tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Geographic mapping using Open Street Map data.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/parameter-pa/default.nix
+++ b/distros/noetic/parameter-pa/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, message-generation, message-runtime, roscpp, roslib }:
+buildRosPackage {
+  pname = "ros-noetic-parameter-pa";
+  version = "1.2.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/TUC-ProAut/ros_parameter-release/archive/release/noetic/parameter_pa/1.2.3-2.tar.gz";
+    name = "1.2.3-2.tar.gz";
+    sha256 = "f1a8023e6acd9cb328bb3a75167ea023470f21eac302b5f58ab966b9b01065ce";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cmake-modules eigen message-runtime roscpp roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ProAut parameter package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.0-r1";
+  version = "2.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.0-1.tar.gz";
-    name = "2.6.0-1.tar.gz";
-    sha256 = "175fc2605fdaa47ae3fbd22a9048e0c07a83f7ea0d2f4ca4063a7a76c98b16a4";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.1-1.tar.gz";
+    name = "2.6.1-1.tar.gz";
+    sha256 = "e3cbc64999563f286763e321db3b76957ad10d34b30a6c63aed1e1544140fced";
   };
 
   buildType = "cmake";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.1.1-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "a1757edfa5a790ba1ebe4c6e35a7283b0b4217ecac957987446dc9323297239c";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "e01d38d56a8eb2dd2b6433656032100c7bdf2b57004bc3a3cc5ab741ca648e82";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.1.1-r1";
+  version = "3.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.1-1.tar.gz";
-    name = "3.1.1-1.tar.gz";
-    sha256 = "ff50855106859fb46d8e6461a14e1ad3033482a9be2e99690b526d44e111f764";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.2-1.tar.gz";
+    name = "3.1.2-1.tar.gz";
+    sha256 = "f30452d7ec4b7a220f59290f5939b5329b1779c70f5c8ffc61fd7a928dbf415f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pr2-bringup/default.nix
+++ b/distros/noetic/pr2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-aggregator, ethercat-trigger-controllers, imu-monitor, joint-trajectory-action, joy, microstrain-3dmgx2-imu, ocean-battery-driver, power-monitor, pr2-calibration-controllers, pr2-camera-synchronizer, pr2-computer-monitor, pr2-controller-configuration, pr2-controller-manager, pr2-dashboard-aggregator, pr2-description, pr2-ethercat, pr2-gripper-action, pr2-head-action, pr2-machine, pr2-power-board, pr2-run-stop-auto-restart, prosilica-camera, robot-mechanism-controllers, robot-pose-ekf, robot-state-publisher, rosbag, roslaunch, rostest, single-joint-position-action, sound-play, std-srvs, stereo-image-proc, tf2-ros, urg-node, wge100-camera, wifi-ddwrt }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-bringup";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_bringup/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "d8e565fe9a2b5543b7dfe5482ed17712db223d3b668998df9678f5a2295482cd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch rostest ];
+  propagatedBuildInputs = [ diagnostic-aggregator ethercat-trigger-controllers imu-monitor joint-trajectory-action joy microstrain-3dmgx2-imu ocean-battery-driver power-monitor pr2-calibration-controllers pr2-camera-synchronizer pr2-computer-monitor pr2-controller-configuration pr2-controller-manager pr2-dashboard-aggregator pr2-description pr2-ethercat pr2-gripper-action pr2-head-action pr2-machine pr2-power-board pr2-run-stop-auto-restart prosilica-camera robot-mechanism-controllers robot-pose-ekf robot-state-publisher rosbag single-joint-position-action sound-play std-srvs stereo-image-proc tf2-ros urg-node wge100-camera wifi-ddwrt ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and scripts needed to bring a PR2 up into a running state.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-camera-synchronizer/default.nix
+++ b/distros/noetic/pr2-camera-synchronizer/default.nix
@@ -1,0 +1,37 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, dynamic-reconfigure, ethercat-trigger-controllers, rospy, rostest, wge100-camera }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-camera-synchronizer";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_camera_synchronizer/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "3434b67c2318b2123904dd0dd32b046cbb892cb7672fbfa04af36e540b13578f";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  propagatedBuildInputs = [ diagnostic-msgs dynamic-reconfigure ethercat-trigger-controllers rospy wge100-camera ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+    The PR2 is equipped with a texture projector that can be used to
+    project a texture onto featureless surfaces, allowing their
+    three-dimensional structure to be determined using stereoscopy. The
+    projector operates in a pulsed mode, producing brief (2ms) pulses of
+    light. Cameras that want to see the texture must expose during the
+    projector pulse; other cameras should be expose while the projector is
+    off.
+    </p>
+
+    <p>
+      This package contains the pr2_projector_synchronizer node. Based on its dynamically reconfigurable parameters, this node controls the projector pulsing, and sets up triggering of the WGE100 cameras.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-computer-monitor/default.nix
+++ b/distros/noetic/pr2-computer-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-msgs, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-computer-monitor";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_computer_monitor/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "30b52ef1b9ae7056eeff1be2b99e27b1d069252d3a8d56d1e9e93bb9ead05377";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-msgs roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Monitors the computer's processor and hard drives of the PR2 and publishes data to diagnostics.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-controller-configuration/default.nix
+++ b/distros/noetic/pr2-controller-configuration/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-controller-manager, pr2-gripper-action, pr2-head-action, pr2-machine, robot-mechanism-controllers, roslaunch, single-joint-position-action }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-controller-configuration";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_controller_configuration/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "80b94e8c30c4b63aef0b152254063ea36fc0bea7928d3e5ec94a3149c05c1eac";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ pr2-controller-manager pr2-gripper-action pr2-head-action pr2-machine robot-mechanism-controllers single-joint-position-action ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Configuration files for PR2 controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-ethercat/default.nix
+++ b/distros/noetic/pr2-ethercat/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, diagnostic-updater, ethercat-hardware, pr2-controller-manager, realtime-tools, roscpp, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-ethercat";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_ethercat/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "2112a2d2a0e6863abcb6bfaa32d46569e959c2530dc6731e05dd0970471de71b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs diagnostic-updater ethercat-hardware pr2-controller-manager realtime-tools roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Main loop that runs the robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-robot/default.nix
+++ b/distros/noetic/pr2-robot/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, imu-monitor, pr2-bringup, pr2-camera-synchronizer, pr2-computer-monitor, pr2-controller-configuration, pr2-ethercat, pr2-run-stop-auto-restart }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-robot";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_robot/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "368195704a50d088e931ccd3739770e8626bb2df0ab03fb68d9d334d805761e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ imu-monitor pr2-bringup pr2-camera-synchronizer pr2-computer-monitor pr2-controller-configuration pr2-ethercat pr2-run-stop-auto-restart ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This stack collects PR2-specific components that are used in bringing up
+  a robot.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-run-stop-auto-restart/default.nix
+++ b/distros/noetic/pr2-run-stop-auto-restart/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pr2-msgs, pr2-power-board, roscpp, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-run-stop-auto-restart";
+  version = "1.6.32-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_robot-release/archive/release/noetic/pr2_run_stop_auto_restart/1.6.32-1.tar.gz";
+    name = "1.6.32-1.tar.gz";
+    sha256 = "6010ed34f0a7f4e2c01d77f4ec969cdd04782b6e674c9c9d323b49fb456dfd63";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pr2-msgs pr2-power-board roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a node that monitors the state of the run stops of the pr2_robot. When the state of the
+   run stop changes from off to on, this node will automatically enable the power to the motors, and reset
+   the motors. This allows you to use the run stop as a 'pause' button. By using the run stop as a tool to
+   power up the robot, the run stop is also in reach of the user once the robot starts moving.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/noetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rc-hand-eye-calibration-client";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "69e3f4b7f9149b7e649fea6eebcd3a6f6242ba94dac3319c14669ede1bc71e17";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a394c030a235cb8b911287081f83264c458c3791b29a054e56293ee991481ea7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-pick-client/default.nix
+++ b/distros/noetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-pick-client";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "4a73c31e2a82e79672fdea57efbc284d20ed9bbfaae0bf92abce6f9d62615ecb";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "a295d36bef0f6fe2b5687a52b9742d3ad13e47af47baa486140feea08151611d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-roi-manager-gui/default.nix
+++ b/distros/noetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-noetic-rc-roi-manager-gui";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "c74c22da2864caddaa117bebe2bc6628c54ef1f748664e9e6d2773520c0295da";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "f8965c08f16dc14848512026f1096a1d58a8c1cbd660152e66eb1494f29412f6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-silhouettematch-client/default.nix
+++ b/distros/noetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-silhouettematch-client";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "eb603a83609dd4027573d3327afcd587f092b4ef721c09d12dfbcd73f0d7de46";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "b0be90ca7f912d6057ec37f5afe43c408ff72049a6fe1bba15c5d77c96b410d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-tagdetect-client/default.nix
+++ b/distros/noetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-tagdetect-client";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "8e79533945cc68bab87011a6b577f91a72c71931d38a86f60749cbaca9d30f69";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "50be08bbb7bc704c53eb678e533d5b9140c9826e1bc6c3636d7c9168544155f2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-description/default.nix
+++ b/distros/noetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-description";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "cf9291e64dcb56d0c03e73b0e4d6abe48830494f9ecfdf44a08b86900bac42e9";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "9de1f4de29c30df9ca0ee2e1f3acc485322741d2162b2f42a8e34c010f8a060c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-driver/default.nix
+++ b/distros/noetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-driver";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "ddefe057fd1815281df87e4fd28def1cc23a880929630d7591e6b040d77c268e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "5d55fa6111d000eae9805a069ad34f284b762fc4c503afaab3b9b49e52b6d8ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard/default.nix
+++ b/distros/noetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard";
-  version = "3.1.0-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.1.0-1.tar.gz";
-    name = "3.1.0-1.tar.gz";
-    sha256 = "6e8b12775994b606dd3e41dfababb5b667b110455ae41b6b647ce797360fef88";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "daea05992b9169246d5907adfe3de2c531128189543b2376e86b301b5f2a316e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, xmlrpcpp }:
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.1-r1";
+  version = "2.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.1-1.tar.gz";
-    name = "2.7.1-1.tar.gz";
-    sha256 = "1a9680c22468432a6c76e2a72b01fb438f25b890d65a26cb2d7823c17e7ef318";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.2-1.tar.gz";
+    name = "2.7.2-1.tar.gz";
+    sha256 = "9ee850a4e0d2db4656976d527e25e35bf5af9fbb742b5b034061d08aa0dc89d5";
   };
 
   buildType = "catkin";
   buildInputs = [ geographiclib message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros xmlrpcpp ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-numpy/default.nix
+++ b/distros/noetic/ros-numpy/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, python3Packages, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-ros-numpy";
-  version = "0.0.4-r5";
+  version = "0.0.5-r2";
 
   src = fetchurl {
-    url = "https://github.com/eric-wieser/ros_numpy-release/archive/release/noetic/ros_numpy/0.0.4-5.tar.gz";
-    name = "0.0.4-5.tar.gz";
-    sha256 = "180f2c1b702d154971d438181d55b6ee23748e1c14ce426f294f6bc6f0acbc9c";
+    url = "https://github.com/eric-wieser/ros_numpy-release/archive/release/noetic/ros_numpy/0.0.5-2.tar.gz";
+    name = "0.0.5-2.tar.gz";
+    sha256 = "c5153716c9d662840ff0473a9cc0cae3c23586f5cea8ef7b152f11fe0a51d51d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs nav-msgs pythonPackages.numpy rospy sensor-msgs tf ];
+  propagatedBuildInputs = [ geometry-msgs nav-msgs python3Packages.numpy rospy sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/route-network/default.nix
+++ b/distros/noetic/route-network/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, geodesy, geographic-msgs, geometry-msgs, nav-msgs, roslaunch, rospy, rostest, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-route-network";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/route_network/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "aa4bfa6f99b672ea11f480299a2f4d6b35fa70958e6c883f0a2ee7dabe1e4154";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ dynamic-reconfigure geodesy geographic-msgs geometry-msgs nav-msgs rospy visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Route network graphing and path planning.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rqt-pr2-dashboard/default.nix
+++ b/distros/noetic/rqt-pr2-dashboard/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, pr2-msgs, pr2-power-board, roslib, rospy, rqt-gui, rqt-gui-py, rqt-robot-dashboard, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-rqt-pr2-dashboard";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rqt_pr2_dashboard-release/archive/release/noetic/rqt_pr2_dashboard/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "51ae20c665634bb53dd74bf1400a74c2727e144e4d2574062bebaf3edf012d18";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs pr2-msgs pr2-power-board roslib rospy rqt-gui rqt-gui-py rqt-robot-dashboard std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt_pr2_dashboard is a GUI for debugging and controlling low-level state of the PR2.  It shows things like battery status and breaker states, as well as integrating tools like rqt_console and robot_monitor.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/scaled-controllers/default.nix
+++ b/distros/noetic/scaled-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, scaled-joint-trajectory-controller, speed-scaling-interface, speed-scaling-state-controller }:
+buildRosPackage {
+  pname = "ros-noetic-scaled-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/noetic/scaled_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1add0c6dc6c3eb45c4479cd4bc0ee0abf9c73fb7a0e6a2091abf1a046deb1e6b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ scaled-joint-trajectory-controller speed-scaling-interface speed-scaling-state-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''scaled controllers metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/scaled-joint-trajectory-controller/default.nix
+++ b/distros/noetic/scaled-joint-trajectory-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, joint-trajectory-controller, pluginlib, realtime-tools, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-scaled-joint-trajectory-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/noetic/scaled_joint_trajectory_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "7bb6b907dfa16866d5f79b1513ad5efc39ff5ef0c0555ef74cb5b433700bb5a6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface joint-trajectory-controller pluginlib realtime-tools std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides controllers that use the speed scaling interface.'';
+    license = with lib.licenses; [ asl20 bsdOriginal ];
+  };
+}

--- a/distros/noetic/sdc21x0/default.nix
+++ b/distros/noetic/sdc21x0/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-sdc21x0";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "ed315a6ec7d5a2b6700e894b9883db1dcb9f1fe7921f24b977f5da7a5a7152ff";
+    url = "https://github.com/uos-gbp/mir_robot-release/archive/release/noetic/sdc21x0/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "f2f65a3567affcb76ec6089bb0f48f85477ca79b1a8d9a858f575a7a1c2fe31d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/speed-scaling-interface/default.nix
+++ b/distros/noetic/speed-scaling-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-speed-scaling-interface";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/noetic/speed_scaling_interface/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "7aaf59e25c54244b9c6d30dd863fb9151bb011de66a47bc1baeb8836142d302b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Hardware interface reading a scalar value from robot hardware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/speed-scaling-state-controller/default.nix
+++ b/distros/noetic/speed-scaling-state-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, pluginlib, realtime-tools, speed-scaling-interface, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-speed-scaling-state-controller";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_scaled_controllers-release/archive/release/noetic/speed_scaling_state_controller/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "742012d1c84cb0431ec1bad62f6ae3eb3ed7a95e6755adcad66c580e8ed2285d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface pluginlib realtime-tools speed-scaling-interface std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS controller providing reading the state of speed scaling on the robot'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/test-osm/default.nix
+++ b/distros/noetic/test-osm/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geodesy, geographic-msgs, osm-cartography, route-network }:
+buildRosPackage {
+  pname = "ros-noetic-test-osm";
+  version = "0.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-geographic-info/open_street_map-release/archive/release/noetic/test_osm/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "27f71706cc1daaa3259f46375968d732e637b4b16b6147a22371670c73aee3b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geodesy geographic-msgs osm-cartography route-network ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''These are regression tests for the osm_cartography and
+     route_network packages. They are packaged separately to avoid
+     unnecessary implementation dependencies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "0.2.0-r1";
+  version = "0.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.0-1.tar.gz";
-    name = "0.2.0-1.tar.gz";
-    sha256 = "e7eec06de67fc92fe275b5ac7b55e030acde82e40b683c8b9a9b7d51f7f76cc3";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "da3dfc131f8228144ad70a13fff91a8c6550375d5fe6916fceb4588699a9acc8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.6-r2";
+  version = "1.14.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.6-2.tar.gz";
-    name = "1.14.6-2.tar.gz";
-    sha256 = "81a7d1d5350182f96998a12ab4971558c6eccc67821a85e523d04b63dff49584";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.7-1.tar.gz";
+    name = "1.14.7-1.tar.gz";
+    sha256 = "e49a02c2868315b91934b9c8037d3a57e5949825fb38a4f7c7959321c68651b1";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 9fbde27da7c9a15970115c57e1eb1c02a1682dd4.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *controller-interface 0.6.0-r1 --> 0.7.0-r1*
* *controller-manager 0.6.0-r1 --> 0.7.0-r1*
* *controller-manager-msgs 0.6.0-r1 --> 0.7.0-r1*
* *fmi-adapter 2.1.0-r1 --> 2.1.1-r1*
* *fmi-adapter-examples 2.1.0-r1 --> 2.1.1-r1*
* *hardware-interface 0.6.0-r1 --> 0.7.0-r1*
* *launch-system-modes 0.8.0-r1*
* *libmavconn 2.0.0-r1 --> 2.0.1-r1*
* *mavlink 2021.5.5-r1 --> 2021.6.6-r1*
* *mavros 2.0.0-r1 --> 2.0.1-r1*
* *mavros-msgs 2.0.0-r1 --> 2.0.1-r1*
* *moveit 2.1.3-r1 --> 2.1.4-r1*
* *moveit-common 2.1.3-r1 --> 2.1.4-r1*
* *moveit-core 2.1.3-r1 --> 2.1.4-r1*
* *moveit-kinematics 2.1.3-r1 --> 2.1.4-r1*
* *moveit-planners 2.1.3-r1 --> 2.1.4-r1*
* *moveit-planners-ompl 2.1.3-r1 --> 2.1.4-r1*
* *moveit-plugins 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-benchmarks 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-move-group 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-occupancy-map-monitor 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-perception 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-planning 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-planning-interface 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-robot-interaction 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-visualization 2.1.3-r1 --> 2.1.4-r1*
* *moveit-ros-warehouse 2.1.3-r1 --> 2.1.4-r1*
* *moveit-runtime 2.1.3-r1 --> 2.1.4-r1*
* *moveit-servo 2.1.3-r1 --> 2.1.4-r1*
* *moveit-simple-controller-manager 2.1.3-r1 --> 2.1.4-r1*
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r4 --> 1.2.0-r1*
* *point-cloud-msg-wrapper 1.0.5-r1 --> 1.0.7-r1*
* *ros2-control 0.6.0-r1 --> 0.7.0-r1*
* *ros2-control-test-assets 0.6.0-r1 --> 0.7.0-r1*
* *ros2controlcli 0.6.0-r1 --> 0.7.0-r1*
* *run-move-group 2.1.3-r1 --> 2.1.4-r1*
* *run-moveit-cpp 2.1.3-r1 --> 2.1.4-r1*
* *run-ompl-constrained-planning 2.1.3-r1 --> 2.1.4-r1*
* *system-modes 0.7.1-r4 --> 0.8.0-r1*
* *system-modes-examples 0.7.1-r4 --> 0.8.0-r1*
* *system-modes-msgs 0.7.1-r4 --> 0.8.0-r1*
* *test-launch-system-modes 0.8.0-r1*
* *transmission-interface 0.6.0-r1 --> 0.7.0-r1*
* *ur-client-library 0.2.1-r1 --> 0.2.2-r1*
* *warehouse-ros 2.0.0-r1 --> 2.0.1-r1*
* *xacro 2.0.5-r1 --> 2.0.6-r1*

Galactic Changes:
-----------------
* *ament-cmake-catch2 1.2.0-r1*
* *control-msgs 3.0.0-r1 --> 3.0.0-r2*
* *costmap-queue 1.0.5-r1 --> 1.0.6-r1*
* *cyclonedds 0.8.0-r4 --> 0.8.0-r5*
* *dwb-core 1.0.5-r1 --> 1.0.6-r1*
* *dwb-critics 1.0.5-r1 --> 1.0.6-r1*
* *dwb-msgs 1.0.5-r1 --> 1.0.6-r1*
* *dwb-plugins 1.0.5-r1 --> 1.0.6-r1*
* *fmi-adapter 2.1.0-r2 --> 2.1.1-r1*
* *fmi-adapter-examples 2.1.0-r2 --> 2.1.1-r1*
* *mavlink 2021.5.5-r1 --> 2021.6.6-r1*
* *menge-vendor 1.0.0-r1*
* *nav-2d-msgs 1.0.5-r1 --> 1.0.6-r1*
* *nav-2d-utils 1.0.5-r1 --> 1.0.6-r1*
* *nav2-amcl 1.0.5-r1 --> 1.0.6-r1*
* *nav2-behavior-tree 1.0.5-r1 --> 1.0.6-r1*
* *nav2-bringup 1.0.5-r1 --> 1.0.6-r1*
* *nav2-bt-navigator 1.0.5-r1 --> 1.0.6-r1*
* *nav2-common 1.0.5-r1 --> 1.0.6-r1*
* *nav2-controller 1.0.5-r1 --> 1.0.6-r1*
* *nav2-core 1.0.5-r1 --> 1.0.6-r1*
* *nav2-costmap-2d 1.0.5-r1 --> 1.0.6-r1*
* *nav2-dwb-controller 1.0.5-r1 --> 1.0.6-r1*
* *nav2-gazebo-spawner 1.0.5-r1 --> 1.0.6-r1*
* *nav2-lifecycle-manager 1.0.5-r1 --> 1.0.6-r1*
* *nav2-map-server 1.0.5-r1 --> 1.0.6-r1*
* *nav2-msgs 1.0.5-r1 --> 1.0.6-r1*
* *nav2-navfn-planner 1.0.5-r1 --> 1.0.6-r1*
* *nav2-planner 1.0.5-r1 --> 1.0.6-r1*
* *nav2-recoveries 1.0.5-r1 --> 1.0.6-r1*
* *nav2-regulated-pure-pursuit-controller 1.0.5-r1 --> 1.0.6-r1*
* *nav2-rviz-plugins 1.0.5-r1 --> 1.0.6-r1*
* *nav2-smac-planner 1.0.5-r1 --> 1.0.6-r1*
* *nav2-system-tests 1.0.5-r1 --> 1.0.6-r1*
* *nav2-util 1.0.5-r1 --> 1.0.6-r1*
* *nav2-voxel-grid 1.0.5-r1 --> 1.0.6-r1*
* *nav2-waypoint-follower 1.0.5-r1 --> 1.0.6-r1*
* *navigation2 1.0.5-r1 --> 1.0.6-r1*
* *object-recognition-msgs 2.0.0-r1*
* *point-cloud-msg-wrapper 1.0.5-r1 --> 1.0.7-r1*
* *rmf-visualization-msgs 1.2.0-r1*
* *xacro 2.0.2-r3 --> 2.0.6-r1*

Melodic Changes:
----------------
* *bcap-core 3.1.2-r1 --> 3.2.0-r1*
* *bcap-service 3.1.2-r1 --> 3.2.0-r1*
* *bcap-service-test 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-bringup 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-control 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-core 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-core-test 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-descriptions 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-gazebo 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-moveit-config 3.1.2-r1 --> 3.2.0-r1*
* *denso-robot-ros 3.1.2-r1 --> 3.2.0-r1*
* *leo 1.2.1-r1 --> 1.2.2-r1*
* *leo-description 1.2.1-r1 --> 1.2.2-r1*
* *leo-teleop 1.2.1-r1 --> 1.2.2-r1*
* *mavlink 2021.5.5-r1 --> 2021.6.6-r1*
* *mir-actions 1.0.7-r1 --> 1.0.8-r1*
* *mir-description 1.0.7-r1 --> 1.0.8-r1*
* *mir-driver 1.0.7-r1 --> 1.0.8-r1*
* *mir-dwb-critics 1.0.7-r1 --> 1.0.8-r1*
* *mir-gazebo 1.0.7-r1 --> 1.0.8-r1*
* *mir-msgs 1.0.7-r1 --> 1.0.8-r1*
* *mir-navigation 1.0.7-r1 --> 1.0.8-r1*
* *mir-robot 1.0.7-r1 --> 1.0.8-r1*
* *parameter-pa 1.2.3-r2*
* *pinocchio 2.5.0-r2 --> 2.6.1-r1*
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r1 --> 1.2.0-r1*
* *rc-hand-eye-calibration-client 3.1.0-r2 --> 3.2.1-r1*
* *rc-pick-client 3.1.0-r2 --> 3.2.1-r1*
* *rc-roi-manager-gui 3.1.0-r2 --> 3.2.1-r1*
* *rc-silhouettematch-client 3.1.0-r2 --> 3.2.1-r1*
* *rc-tagdetect-client 3.1.0-r2 --> 3.2.1-r1*
* *rc-visard 3.1.0-r2 --> 3.2.1-r1*
* *rc-visard-description 3.1.0-r2 --> 3.2.1-r1*
* *rc-visard-driver 3.1.0-r2 --> 3.2.1-r1*
* *robot-localization 2.6.9-r1 --> 2.6.10-r1*
* *scaled-controllers 0.1.0-r1*
* *scaled-joint-trajectory-controller 0.1.0-r1*
* *sdc21x0 1.0.7-r1 --> 1.0.8-r1*
* *speed-scaling-interface 0.1.0-r1*
* *speed-scaling-state-controller 0.1.0-r1*
* *ur-client-library 0.2.0-r1 --> 0.2.2-r1*
* *xacro 1.13.10-r1 --> 1.13.11-r1*

Noetic Changes:
---------------
* *foxglove-msgs 1.0.0-r1*
* *geodesy 0.5.5-r1 --> 0.5.6-r1*
* *geographic-info 0.5.5-r1 --> 0.5.6-r1*
* *geographic-msgs 0.5.5-r1 --> 0.5.6-r1*
* *imu-monitor 1.6.32-r1*
* *joy 1.15.0-r1 --> 1.15.1-r1*
* *leo 1.2.1-r1 --> 1.2.2-r1*
* *leo-description 1.2.1-r1 --> 1.2.2-r1*
* *leo-teleop 1.2.1-r1 --> 1.2.2-r1*
* *mavlink 2021.5.5-r1 --> 2021.6.6-r1*
* *mir-actions 1.1.2-r1 --> 1.1.3-r1*
* *mir-description 1.1.2-r1 --> 1.1.3-r1*
* *mir-dwb-critics 1.1.2-r1 --> 1.1.3-r1*
* *mir-gazebo 1.1.2-r1 --> 1.1.3-r1*
* *mir-msgs 1.1.2-r1 --> 1.1.3-r1*
* *mir-navigation 1.1.2-r1 --> 1.1.3-r1*
* *mir-robot 1.1.2-r1 --> 1.1.3-r1*
* *network-interface 3.0.0-r1 --> 3.1.0-r1*
* *osm-cartography 0.3.0-r1*
* *parameter-pa 1.2.3-r2*
* *pinocchio 2.6.0-r1 --> 2.6.1-r1*
* *plotjuggler 3.1.1-r1 --> 3.1.2-r1*
* *plotjuggler-ros 1.1.1-r1 --> 1.2.0-r1*
* *pr2-bringup 1.6.32-r1*
* *pr2-camera-synchronizer 1.6.32-r1*
* *pr2-computer-monitor 1.6.32-r1*
* *pr2-controller-configuration 1.6.32-r1*
* *pr2-ethercat 1.6.32-r1*
* *pr2-robot 1.6.32-r1*
* *pr2-run-stop-auto-restart 1.6.32-r1*
* *rc-hand-eye-calibration-client 3.1.0-r1 --> 3.2.1-r1*
* *rc-pick-client 3.1.0-r1 --> 3.2.1-r1*
* *rc-roi-manager-gui 3.1.0-r1 --> 3.2.1-r1*
* *rc-silhouettematch-client 3.1.0-r1 --> 3.2.1-r1*
* *rc-tagdetect-client 3.1.0-r1 --> 3.2.1-r1*
* *rc-visard 3.1.0-r1 --> 3.2.1-r1*
* *rc-visard-description 3.1.0-r1 --> 3.2.1-r1*
* *rc-visard-driver 3.1.0-r1 --> 3.2.1-r1*
* *robot-localization 2.7.1-r1 --> 2.7.2-r1*
* *ros-numpy 0.0.4-r5 --> 0.0.5-r2*
* *route-network 0.3.0-r1*
* *rqt-pr2-dashboard 0.4.0-r1*
* *scaled-controllers 0.1.0-r1*
* *scaled-joint-trajectory-controller 0.1.0-r1*
* *sdc21x0 1.1.2-r1 --> 1.1.3-r1*
* *speed-scaling-interface 0.1.0-r1*
* *speed-scaling-state-controller 0.1.0-r1*
* *test-osm 0.3.0-r1*
* *ur-client-library 0.2.0-r1 --> 0.2.2-r1*
* *xacro 1.14.6-r2 --> 1.14.7-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

