### PR TITLE
rosdistro sync, Fri Jun 18 13:01:20 2021

### DIFF
--- a/distros/foxy/can-dbc-parser/default.nix
+++ b/distros/foxy/can-dbc-parser/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-can-dbc-parser";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a03ed6da83ea2a4a5af468c81250a912f5d85ed4d7ec2b463102dc6fdbd1022a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''DBC file interface.  Read a DBC file, unpack CAN messages and convert to engineering units, pack values into CAN messages for publishing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a8c63ea8b088a1f34bfdae046c6344f6881af3babdb50688ee2d5a8532bc73f2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "a79375f0b4cb545d3bb5ba5bc56aee4061d3140d5a536d982b3e869886b654a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "05be83c1ffb322a34b44dbbc6ea5fbf2f613dbc839d9628a37e2f31a52bcd3e1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "bff11964905d711e3fda7ecd01de6f544f6cf01758b8b88ecd394aef75e05e51";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "60d92f98db5a109764056b92e79ba0a095c4ff249b79fb9bd2aee2ef2bbb0529";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "0f5efb5368578364860a86dc645812de9095b6ac1dfb6a06f3553656819f9367";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-hardware-interface/default.nix
+++ b/distros/foxy/dynamixel-hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, boost, controller-interface, diagnostic-msgs, diagnostic-updater, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, robot-state-publisher, ros2-control, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-dynamixel-hardware-interface";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release/archive/release/foxy/dynamixel_hardware_interface/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "a835274fbe7593d11dcafda4d68104ee0c7d290fb6d911f35df0196b7ee6bb49";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ boost controller-interface diagnostic-msgs diagnostic-updater dynamixel-sdk hardware-interface pluginlib rclcpp realtime-tools robot-state-publisher ros2-control xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Hardware Interface and controllers for dynamixel motors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/gazebo-ros2-control-demos/default.nix
+++ b/distros/foxy/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-controllers, std-msgs, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control-demos";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "387fb517b9ba623dc78b893317eeae84f7e78d90d1871fc3b803f7b43fee636d";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "5b5eec14876bd5ef49ca3b40312baac5bdaea4983c96074b4e5ec4bcae8a40be";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-controllers std-msgs velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/gazebo-ros2-control/default.nix
+++ b/distros/foxy/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "bccf46c151e93760cf2da7db4bb899aba9df87133ee49e7268e07ef56a18cbd1";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "5a673206efaca88a5fe5dd2a52a8f35d9beb64f3e4243f5bc4d2b8cdf82decd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -166,6 +166,8 @@ self: super: {
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
 
+ can-dbc-parser = self.callPackage ./can-dbc-parser {};
+
  can-msgs = self.callPackage ./can-msgs {};
 
  carla-msgs = self.callPackage ./carla-msgs {};
@@ -275,6 +277,8 @@ self: super: {
  dynamic-graph = self.callPackage ./dynamic-graph {};
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
+
+ dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
@@ -896,8 +900,6 @@ self: super: {
 
  random-numbers = self.callPackage ./random-numbers {};
 
- raptor-can-dbc-parser = self.callPackage ./raptor-can-dbc-parser {};
-
  raptor-dbw-can = self.callPackage ./raptor-dbw-can {};
 
  raptor-dbw-joystick = self.callPackage ./raptor-dbw-joystick {};
@@ -923,6 +925,8 @@ self: super: {
  rc-reason-clients = self.callPackage ./rc-reason-clients {};
 
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
+ rcdiscover = self.callPackage ./rcdiscover {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -1432,6 +1436,8 @@ self: super: {
 
  turtlesim = self.callPackage ./turtlesim {};
 
+ twist-mux = self.callPackage ./twist-mux {};
+
  twist-stamper = self.callPackage ./twist-stamper {};
 
  ublox = self.callPackage ./ublox {};
@@ -1453,6 +1459,8 @@ self: super: {
  ur-client-library = self.callPackage ./ur-client-library {};
 
  urdf = self.callPackage ./urdf {};
+
+ urdf-test = self.callPackage ./urdf-test {};
 
  urdfdom = self.callPackage ./urdfdom {};
 

--- a/distros/foxy/geometric-shapes/default.nix
+++ b/distros/foxy/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometric-shapes";
-  version = "2.0.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "43521de7c972e38c71c46db761995d9626c51b7ecd66b83f6b91354f90fc0a79";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6447ed798f309b35795cf9daf595f8219c9cd2ffcdb07622c8ddd4cb7882501d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "160527dbc3ff3a0ad242b0383c1d5b25875c3f007aff05c3f2c2748e14e8ec79";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "fc3fc74344107335b7e7f45455e938ba5a8d22e6f2ea4e38ba88b62bb414e474";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-msgs/default.nix
+++ b/distros/foxy/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-msgs";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_msgs-release/archive/release/foxy/moveit_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "b690359e3a802a9e237707acf9c4d6e3efcb927b13a1fda184b12bf5caeed1d1";
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/foxy/moveit_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "507d19e081f64a7f4dcae9a50663f67c424e5884e4a3a024f284e7ffb6b9fc80";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fd33c67f1d90826e1c544b4448305a29d4a7f19f22298e4c496283158501e645";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "8b8edfe3a0d1afe9de41456f5a7303ec51e5e4854298925b6739afa22d2f76ff";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "b0d863a857340ecb78d82ee39f73629c26e47e48f44ee70f048c50b21d791431";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "2c7a316e1ecfbe23f83e0b43961e1f0b634d9496045bb157ff571cad9965f461";
   };
 
   buildType = "catkin";

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, eigen, geometry-msgs, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "d7e198b295cc882d61d06f917c385e3858835b58a1fb1c6d9f56d6515577b9e6";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "886e171a830e603e12fd3588da6744e0757d9560ecf5394e5d24b4f81ea719c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-can/default.nix
+++ b/distros/foxy/raptor-dbw-can/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs, geometry-msgs, raptor-can-dbc-parser, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, geometry-msgs, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-can";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7ac425ed5bb8d763f558fa26b14bb4bc0195358b643d7df03b1ef87966840332";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "14aa0ceed1d5cbc1d4a6fe871459af434a00f8508c2b4fcba88ebbdca7b32b18";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs geometry-msgs raptor-can-dbc-parser raptor-dbw-msgs raptor-pdu raptor-pdu-msgs rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-dbc-parser can-msgs geometry-msgs raptor-dbw-msgs raptor-pdu raptor-pdu-msgs rclcpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/foxy/raptor-dbw-joystick/default.nix
+++ b/distros/foxy/raptor-dbw-joystick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, raptor-dbw-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-joystick";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "36371901f01d4bf98f084fe30532b61e54f64309e888050a159f88676a2d7f0e";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a5d2193047328e26789260f7a2e2c5ab91d44f7cb9a22f7397eccb5578d1c45a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-msgs/default.nix
+++ b/distros/foxy/raptor-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9c798ad1edff250aabd2a05991be8cbde538d5bfbff1188144a32179d19fb595";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6e998689506478c0289cbb86afa3a4147ee7597e293e4c3d5299a225cf8e406b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu-msgs/default.nix
+++ b/distros/foxy/raptor-pdu-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2f39745a84c4aaae4b23f44cf8a1f10ac54f57d7ee8452119edb790e3e221aa3";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a46bd8710b74a9d51b7b1a3783dd96f3c9b44644d1bb6bc154f71141762e2135";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu/default.nix
+++ b/distros/foxy/raptor-pdu/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs, raptor-can-dbc-parser, raptor-pdu-msgs, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, raptor-pdu-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "cc62f2c4ddc4e698141540b928d36739f7862a8f9d8058e752a6e6d2fd09ca0e";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4fca165e245f927a38bc945277af34fa6af5884b585a3c0e7bc11e9f16baccd1";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs raptor-can-dbc-parser raptor-pdu-msgs rclcpp std-msgs ];
+  propagatedBuildInputs = [ can-dbc-parser can-msgs raptor-pdu-msgs rclcpp std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/foxy/rcdiscover/default.nix
+++ b/distros/foxy/rcdiscover/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-rcdiscover";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/foxy/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f759212447ad9b29e3be4070e3667135c2e16b4deccbc4c9f330f3c417d5541a";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This package contains tools for the discovery of Roboception devices via GigE Vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "c6a0b5d997a8b6715232af44483397fef53bff08e57228cede5077cd3144cabb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "35e10772f1d182091ada1902e717e7f60111c8d19164b71a5c13942f5f984673";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "bc0d694b581b44dc3c111028e4dde1ca0beee1bb89a9e5554130b52309a907b4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "7e80381a0f5e3b1a7572ca40a9b68469be8727dc255037d834ef44bcc36ccf37";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "4efb15642a0c2891dee6b133fac79779850a5f16d24ba28b052381f4d7afb657";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "ecd3ca9891f4e69bd7b25a6b9d110226c79e5e9b5284f8976c36d0edef596102";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "b27fcc217fd74cc3a15c9719b45d52901cc9c7e36a3cf900656e12a8d070e960";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "dd0b3bda53487647909b1f20e33485f297012af4f38d010720414c2a4e8856f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-fake-node/default.nix
+++ b/distros/foxy/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-fake-node";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "fff9bb4bbb00f9025a2fa3299e9d72b142115b01bd52ae02ed875eb8759664ec";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "421f133a1c3f049ef1ecb28ed78452ae89b9707cdbeff59547725d01e6c57e3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-gazebo/default.nix
+++ b/distros/foxy/turtlebot3-gazebo/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3-description }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-gazebo";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "006fbfb6cb78cff7556e7452b3d6c8207cb77e880b08481127bb0f1ad6528fea";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "d0a90b9de5b1bd1b4d669c1eec7565ddc4153d47239eef32b87f7b806906cb11";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 turtlebot3 ];
+  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 turtlebot3-description ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/turtlebot3-simulations/default.nix
+++ b/distros/foxy/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-simulations";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "c75666dd3406bec6dd0490246e77ac6d2dbbb2e6fbbcabe375e49216fcba3b7c";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "faaabdafc9b0404adebbbc0e1c72aec9807b4697c431c556e20b04aeb408d6cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/twist-mux/default.nix
+++ b/distros/foxy/twist-mux/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-twist-mux";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/foxy/twist_mux/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "18805bae9e5dadc57609fe8255a31ac157e2a0289a24d1c21c24b70cdda940af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Twist multiplexer, which multiplex several velocity commands (topics) and
+      allows to priorize or disable them (locks).'';
+    license = with lib.licenses; [ cc-by-nc-sa-40 ];
+  };
+}

--- a/distros/foxy/urdf-test/default.nix
+++ b/distros/foxy/urdf-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-urdf-test";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/urdf_test-ros2-gbp/archive/release/foxy/urdf_test/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "5021683ebf04a99d3c15ef5e16e824abebadb4347d77a9452c77fb9a6c6931dd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The urdf_test package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -308,6 +308,8 @@ self: super: {
 
  geographic-msgs = self.callPackage ./geographic-msgs {};
 
+ geometric-shapes = self.callPackage ./geometric-shapes {};
+
  geometry2 = self.callPackage ./geometry2 {};
 
  geometry-msgs = self.callPackage ./geometry-msgs {};
@@ -380,6 +382,8 @@ self: super: {
 
  launch-ros = self.callPackage ./launch-ros {};
 
+ launch-system-modes = self.callPackage ./launch-system-modes {};
+
  launch-testing = self.callPackage ./launch-testing {};
 
  launch-testing-ament-cmake = self.callPackage ./launch-testing-ament-cmake {};
@@ -435,6 +439,20 @@ self: super: {
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
+
+ moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-resources = self.callPackage ./moveit-resources {};
+
+ moveit-resources-fanuc-description = self.callPackage ./moveit-resources-fanuc-description {};
+
+ moveit-resources-fanuc-moveit-config = self.callPackage ./moveit-resources-fanuc-moveit-config {};
+
+ moveit-resources-panda-description = self.callPackage ./moveit-resources-panda-description {};
+
+ moveit-resources-panda-moveit-config = self.callPackage ./moveit-resources-panda-moveit-config {};
+
+ moveit-resources-pr2-description = self.callPackage ./moveit-resources-pr2-description {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -505,6 +523,8 @@ self: super: {
  octovis = self.callPackage ./octovis {};
 
  ompl = self.callPackage ./ompl {};
+
+ openvslam = self.callPackage ./openvslam {};
 
  orocos-kdl = self.callPackage ./orocos-kdl {};
 
@@ -586,6 +606,8 @@ self: super: {
 
  radar-msgs = self.callPackage ./radar-msgs {};
 
+ random-numbers = self.callPackage ./random-numbers {};
+
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
  rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
@@ -593,6 +615,12 @@ self: super: {
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
 
  rc-genicam-driver = self.callPackage ./rc-genicam-driver {};
+
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
+ rcdiscover = self.callPackage ./rcdiscover {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -636,7 +664,29 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
+
+ rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
+
+ rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
+
+ rmf-dispenser-msgs = self.callPackage ./rmf-dispenser-msgs {};
+
+ rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
+
+ rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
+
+ rmf-ingestor-msgs = self.callPackage ./rmf-ingestor-msgs {};
+
+ rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
+
+ rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
  rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
+
+ rmf-workcell-msgs = self.callPackage ./rmf-workcell-msgs {};
 
  rmw = self.callPackage ./rmw {};
 
@@ -894,6 +944,8 @@ self: super: {
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
 
+ srdfdom = self.callPackage ./srdfdom {};
+
  sros2 = self.callPackage ./sros2 {};
 
  sros2-cmake = self.callPackage ./sros2-cmake {};
@@ -907,6 +959,10 @@ self: super: {
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ stubborn-buddies = self.callPackage ./stubborn-buddies {};
+
+ stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
 
  system-modes = self.callPackage ./system-modes {};
 
@@ -929,6 +985,8 @@ self: super: {
  test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
+
+ test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
 
  test-msgs = self.callPackage ./test-msgs {};
 
@@ -978,6 +1036,26 @@ self: super: {
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
+ turtlebot3 = self.callPackage ./turtlebot3 {};
+
+ turtlebot3-cartographer = self.callPackage ./turtlebot3-cartographer {};
+
+ turtlebot3-description = self.callPackage ./turtlebot3-description {};
+
+ turtlebot3-example = self.callPackage ./turtlebot3-example {};
+
+ turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
+
+ turtlebot3-gazebo = self.callPackage ./turtlebot3-gazebo {};
+
+ turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
+
+ turtlebot3-navigation2 = self.callPackage ./turtlebot3-navigation2 {};
+
+ turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
+ turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
+
  turtlesim = self.callPackage ./turtlesim {};
 
  ublox = self.callPackage ./ublox {};
@@ -1017,6 +1095,8 @@ self: super: {
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ warehouse-ros = self.callPackage ./warehouse-ros {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-geometric-shapes";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "297188a25c428a2ddd49e921c2b89a969ace3ce538fdb6e39bb1d34c31bca12f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pkg-config ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains generic definitions of geometric shapes and bodies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/launch-system-modes/default.nix
+++ b/distros/galactic/launch-system-modes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages, rclpy, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ca94791d4296fac35774317ed0d3abff02930392a8f45b6f03dc7f610998b3ce";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python launch osrf-pycommon python3Packages.importlib-metadata python3Packages.pyyaml rclpy system-modes-msgs ];
+
+  meta = {
+    description = ''System modes specific extensions to the launch tool, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-msgs/default.nix
+++ b/distros/galactic/moveit-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "37ce402737f464583838204fbde1831bdee9fcaa0f8aa337ba02e800cff3e847";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs object-recognition-msgs octomap-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages, services and actions used by MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-fanuc-description/default.nix
+++ b/distros/galactic/moveit-resources-fanuc-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-fanuc-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_fanuc_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6f083913956f4ee0d31d08ceddc87467ec21350698fdbeb07d29337ade8473f4";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Fanuc Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-fanuc-moveit-config/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-fanuc-moveit-config";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_fanuc_moveit_config/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "28cff3264ed792f0990dca38af9ca6b4fa836e55cb9115f125088e699c492e6e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher moveit-resources-fanuc-description robot-state-publisher tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      MoveIt Resources for testing: Fanuc M-10iA.
+    </p>
+    <p>
+      A project-internal configuration for testing in MoveIt.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-panda-description/default.nix
+++ b/distros/galactic/moveit-resources-panda-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-panda-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_panda_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "bbd79344142ad1d08c9e74ba6b347c0545a23aab80fbaf83d2b26264b840a38c";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''panda Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-panda-moveit-config/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-panda-moveit-config";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_panda_moveit_config/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6fd85578912213782703256aa5b4e7a2e87d44e47ddcc886e8f18eba042b9908";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      MoveIt Resources for testing: Franka Emika Panda
+    </p>
+    <p>
+      A project-internal configuration for testing in MoveIt.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-pr2-description/default.nix
+++ b/distros/galactic/moveit-resources-pr2-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-pr2-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_pr2_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4fc7f6309efc8473999c79e2b9ca351ceff6b4798a3843cd44c0c530616ab0f7";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PR2 Resources used for MoveIt! testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources/default.nix
+++ b/distros/galactic/moveit-resources/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "b257da6fb7345b436f09541b9abb4e6f1b256dad57c0c5695369659444f2901d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-resources-pr2-description robot-state-publisher ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/openvslam/default.nix
+++ b/distros/galactic/openvslam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glog, libg2o, libyamlcpp, opencv3 }:
+buildRosPackage {
+  pname = "ros-galactic-openvslam";
+  version = "0.2.3-r3";
+
+  src = fetchurl {
+    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/galactic/openvslam/0.2.3-3.tar.gz";
+    name = "0.2.3-3.tar.gz";
+    sha256 = "942efc34b17b39cd4eb9051f757c00c8c5efb66b1acb09a9beae736189f9b74e";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ eigen glog libg2o libyamlcpp opencv3 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''OpenVSLAM: A Versatile Visual SLAM Framework'';
+    license = with lib.licenses; [ "2-clause BSD" ];
+  };
+}

--- a/distros/galactic/random-numbers/default.nix
+++ b/distros/galactic/random-numbers/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, boost }:
+buildRosPackage {
+  pname = "ros-galactic-random-numbers";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/random_numbers-release/archive/release/galactic/random_numbers/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ce520bd61df0ef1a3929bcb59e8d03e4c8345fc0a42206b4f5880dad71359d80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This  library contains wrappers for generating floating point values, integers, quaternions using boost libraries.
+
+  The constructor of the wrapper is guaranteed to be thread safe and initialize its random number generator to a random seed.
+  Seeds are obtained using a separate and different random number generator.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rc-reason-clients/default.nix
+++ b/distros/galactic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d2e59341adf62d93e74e63fb8aecb2514d6b7da07f7c6c327a7fe91c8ec1079e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.requests rc-reason-msgs rclpy ros2pkg tf2-msgs visualization-msgs ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rc-reason-msgs/default.nix
+++ b/distros/galactic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "44ed59b880e13f073571177f633a592488ef8d409766f299e35d034328bdf7d8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rc-common-msgs rosidl-default-runtime shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rcdiscover/default.nix
+++ b/distros/galactic/rcdiscover/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-galactic-rcdiscover";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/galactic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "47f99b85a9a3a1d6961519a3931b020a49add3eae431d5244354f0944ae7925a";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This package contains tools for the discovery of Roboception devices via GigE Vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rmf-building-map-msgs/default.nix
+++ b/distros/galactic/rmf-building-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-building-map-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_building_map_msgs-release/archive/release/galactic/rmf_building_map_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "32105bd1e925e358048cc1d33d517e8effb1149fce1b07f3a22db3b8de725130";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to send building maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-charger-msgs/default.nix
+++ b/distros/galactic/rmf-charger-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-charger-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_charger_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "91e5bd6743437d99cf2463a789522fc84018df0b5ad628b2d3f9aab62d8f6a94";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains messages regarding charging and discharging'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-cmake-uncrustify/default.nix
+++ b/distros/galactic/rmf-cmake-uncrustify/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-cmake-uncrustify";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_cmake_uncrustify-release/archive/release/galactic/rmf_cmake_uncrustify/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b16e279e4476f18946013027a112ab29462794d48d17fc269492dd86cdf587af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  propagatedBuildInputs = [ ament-cmake-test ament-uncrustify ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''ament_cmake_uncrustify with support for parsing a config file.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-dispenser-msgs/default.nix
+++ b/distros/galactic/rmf-dispenser-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-dispenser-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_dispenser_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "925f68b62baf8a5fbcce1c68d53b050fce94bc768c8e5436df0d28754d280fc2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to dispenser workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-door-msgs/default.nix
+++ b/distros/galactic/rmf-door-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-door-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_door_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1911e95e3c21c0a3a226c1a52511667fac173bc7db6e5aec189e07fa8e20f972";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to doors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-fleet-msgs/default.nix
+++ b/distros/galactic/rmf-fleet-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-fleet-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_fleet_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "794357732594b85329c1373d8d3fe4955ea6dbcd32c90af2b5cf60e5719564af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to fleet managers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-ingestor-msgs/default.nix
+++ b/distros/galactic/rmf-ingestor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-ingestor-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_ingestor_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9c45ed33db91ba0f78874a2d3c8fb76807654c0e080f6fb06200b51431e59bbf";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to ingestor workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-lift-msgs/default.nix
+++ b/distros/galactic/rmf-lift-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-lift-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_lift_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9b4c6b2f74b3eea329b51a2aaf223a5a9215a1913feef87b05de55d7e1cdcc0c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to lifts.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-task-msgs/default.nix
+++ b/distros/galactic/rmf-task-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-task-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_task_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "484cbaf76a57288cf1427f22eccf44ff20b0a8b6302f66439ebc304c8016f951";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to specify tasks'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-msgs/default.nix
+++ b/distros/galactic/rmf-traffic-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_traffic_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "78255a10d00ef93f716bae24b65d918e4ac5e56a468760c308770daeadf1fde9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by the RMF traffic management system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-workcell-msgs/default.nix
+++ b/distros/galactic/rmf-workcell-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-workcell-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_workcell_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c2850542c925c969fe88986d6d28d4e29be06cad8f37f9099e52e46208fb4847";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by all workcells generically to interfact with rmf_core'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmw-cyclonedds-cpp/default.nix
+++ b/distros/galactic/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rmw-cyclonedds-cpp";
-  version = "0.22.2-r1";
+  version = "0.22.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.2-1.tar.gz";
-    name = "0.22.2-1.tar.gz";
-    sha256 = "967f5594262b20f00ea7f005f902ae85e7180441d90639e90330393789d19d26";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.3-1.tar.gz";
+    name = "0.22.3-1.tar.gz";
+    sha256 = "2fc03f09537ea23892b56d173f50b10728f057ae6b56cccbd13848e253c89d6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/srdfdom/default.nix
+++ b/distros/galactic/srdfdom/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
+buildRosPackage {
+  pname = "ros-galactic-srdfdom";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "85093ec96f860df084a864588c8be49480f8f05ac6ed74e93725b92ad366f518";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost urdfdom-headers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ console-bridge console-bridge-vendor tinyxml2-vendor urdf urdfdom-py ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Parser for Semantic Robot Description Format (SRDF).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/stubborn-buddies-msgs/default.nix
+++ b/distros/galactic/stubborn-buddies-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-stubborn-buddies-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/galactic/stubborn_buddies_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bce2abcd2da5bf94ccbea3da174f9961d3b389f17cecf413a61e6342a22f8127";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages to support library of stubborn buddies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/stubborn-buddies/default.nix
+++ b/distros/galactic/stubborn-buddies/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs, stubborn-buddies-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-stubborn-buddies";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/galactic/stubborn_buddies/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f1e8acfe227b52e74579b62d49a703eb9cb5342e73899d2c193a1dea42fdedac";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle rcutils std-msgs stubborn-buddies-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo that uses node composition of lifecycle nodes to achieve fail-over robustness on ROS nodes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/system-modes-examples/default.nix
+++ b/distros/galactic/system-modes-examples/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, launch, launch-system-modes, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-examples";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "9ab24fff6b750f79e393a01b13bfc5e690a0bd5b6b633a898dc79ad00743e6dd";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ada88f621f2ae43f067d76a68f0250f98458f879c035589136defc701536a119";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
-  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
+  propagatedBuildInputs = [ launch launch-system-modes rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Simple example system and according launch files for the system_modes
+    description = ''Example systems and according launch files for the system_modes
     package.'';
     license = with lib.licenses; [ asl20 ];
   };

--- a/distros/galactic/system-modes-msgs/default.nix
+++ b/distros/galactic/system-modes-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-msgs";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "aa03c0679e951ea6502e7c39d66356d29f132b51240405e3c48f3c1af9e1e4a9";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "219aa913637105060717a8be60115acb01422ddf310ef1cdaa84038e99f12320";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/system-modes/default.nix
+++ b/distros/galactic/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "9e30700ca05a3414bb301cc41b6ceb03b150f1d4e1fb404b9456b1e9f57ed38c";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "2863caf47d437d34ec5adc17cdd8703039c08628fb0e17b57a1f4caa707708eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/test-launch-system-modes/default.nix
+++ b/distros/galactic/test-launch-system-modes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-pep257, ament-index-python, ament-lint-auto, builtin-interfaces, launch-system-modes, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, rclcpp, rclcpp-lifecycle, system-modes, system-modes-examples, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-test-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/test_launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e11602477c88318215d55fb1ee8e4bbcfd62b83ddc40311d1c6524c16bf87712";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-flake8 ament-cmake-pep257 ament-index-python ament-lint-auto launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ builtin-interfaces launch-system-modes lifecycle-msgs rclcpp rclcpp-lifecycle system-modes system-modes-examples system-modes-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch tests for the launch_system_modes package, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-cartographer/default.nix
+++ b/distros/galactic/turtlebot3-cartographer/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, cartographer-ros }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-cartographer";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_cartographer/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "8092d9329741a0fa62ee2c49954f4dbf163071a729cbd06d0e88b821c86419ac";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ cartographer-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for cartographer'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-description/default.nix
+++ b/distros/galactic/turtlebot3-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, urdf }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-description";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_description/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "2c64e3fa5c70f7fe3448db292e67b26cbe2ab1f5e30d50a4e4314049cd1bc942";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''3D models of the TurtleBot3 for simulation and visualization'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-example/default.nix
+++ b/distros/galactic/turtlebot3-example/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclpy, sensor-msgs, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-example";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_example/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "4b5f3ad574e487dddf5ed8f8f143e89d95d03663f46981a49517942b57b10fdd";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs rclpy sensor-msgs turtlebot3-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package provides four basic examples for TurtleBot3 (i.e., interactive marker, object detection, patrol and position control).'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-fake-node/default.nix
+++ b/distros/galactic/turtlebot3-fake-node/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-fake-node";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "74dd61d7ca8495e2c42dc03a06e148b6ada531ad091c0357d2010bf882c1e1e4";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake geometry-msgs nav-msgs rclcpp robot-state-publisher sensor-msgs tf2 tf2-msgs turtlebot3-msgs ];
+
+  meta = {
+    description = ''Package for TurtleBot3 fake node. With this package, simple tests can be done without a robot.
+    You can do simple tests using this package on rviz without real robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-gazebo/default.nix
+++ b/distros/galactic/turtlebot3-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-gazebo";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "865093b702e896467230cca014ebd7f24f318bd335b76f9853cdd08864ab5832";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo simulation package for the TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-msgs/default.nix
+++ b/distros/galactic/turtlebot3-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-msgs";
+  version = "2.2.2-r3";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_msgs-release/archive/release/galactic/turtlebot3_msgs/2.2.2-3.tar.gz";
+    name = "2.2.2-3.tar.gz";
+    sha256 = "d9c9487a81573d590ccd599c9a8521c2d5acfe6d3dcb6d3dabe0af19bed97a04";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service types: custom messages and services for TurtleBot3 packages for ROS2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-navigation2/default.nix
+++ b/distros/galactic/turtlebot3-navigation2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, nav2-bringup }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-navigation2";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_navigation2/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "f9ca7897926ba31b7a7e7e75e5824fe49a1f39eead554f2c009a6f9359422fed";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ nav2-bringup ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 launch scripts for navigation2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-simulations/default.nix
+++ b/distros/galactic/turtlebot3-simulations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-simulations";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "6fe67cb191ca2dcab6dd76a8266296360f6f71a55b8370d55f9f0fedb71550c0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot3-fake-node turtlebot3-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 packages for TurtleBot3 simulations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-teleop/default.nix
+++ b/distros/galactic/turtlebot3-teleop/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, geometry-msgs, rclpy }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-teleop";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3_teleop/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "9b0156ea2b0f7b7590f1ba1e6dad3d6e6d0f7dd8653d5d873fd65d14e6abf5dc";
+  };
+
+  buildType = "ament_python";
+  propagatedBuildInputs = [ geometry-msgs rclpy ];
+
+  meta = {
+    description = ''Teleoperation node using keyboard for TurtleBot3.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3/default.nix
+++ b/distros/galactic/turtlebot3/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-bringup, turtlebot3-cartographer, turtlebot3-description, turtlebot3-example, turtlebot3-navigation2, turtlebot3-node, turtlebot3-teleop }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3";
+  version = "2.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3-release/archive/release/galactic/turtlebot3/2.1.2-1.tar.gz";
+    name = "2.1.2-1.tar.gz";
+    sha256 = "2ddd3beb8cefdca04b4479ca4cbc860d187e677e32da3408bc2734ab43ceb779";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot3-bringup turtlebot3-cartographer turtlebot3-description turtlebot3-example turtlebot3-navigation2 turtlebot3-node turtlebot3-teleop ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 packages for TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/warehouse-ros/default.nix
+++ b/distros/galactic/warehouse-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-warehouse-ros";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5b1009c43e08e064d8b54641762d610784cdb276198a0f69bf2934add794af69";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ openssl ];
+  checkInputs = [ ament-cmake-copyright ament-lint-auto ];
+  propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Persistent storage of ROS messages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
+buildRosPackage {
+  pname = "ros-melodic-aques-talk";
+  version = "2.1.22-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a537e5c2bd122d9506710191541a9660a88daa1129f35b974d0fa9bce60a31e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ kakasi nkf sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS interface aques_talk demo program'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "2dc0f7f1140b7b556ee37d5a829d86cebc3aa3ce6f3e8df943f1b669e0532116";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "afc880a08df6dd79c65228e3950bf1fccd18d0e14c393d2da6b191049ec67188";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "14770ef15dabe46dce0d225c13ff12cb35caec1acfc5a4aaa55ba85493f82cda";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "370b4226ab5afc3841f17e1a36cd266910dae6941ff0b6006272d8f03d279732";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-control-msgs/default.nix
+++ b/distros/melodic/cartesian-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-control-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release/archive/release/melodic/cartesian_control_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b950b93403f3867d3b7f1dd634183deb6ebee6b25a4d5b9c87398edc17b3c46c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory execution interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-interface/default.nix
+++ b/distros/melodic/cartesian-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-interface";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "35fce24a8f685c4128e1038cfe1b64add4981fcb4b71fb8af6fa6d5307b69cb7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometry-msgs hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Defines a hardware interface to send Cartesian commands to a robot hardware and read
+    Cartesian states.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-trajectory-controller/default.nix
+++ b/distros/melodic/cartesian-trajectory-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-trajectory-controller";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "c53d014b0325f1af80af6b065ef9fffe2df3d3bf537c174428279fec1467c6ff";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs control-msgs controller-manager-msgs joint-state-controller joint-trajectory-controller robot-state-publisher ros-control-boilerplate rostest trajectory-msgs xacro ];
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-interpolation controller-interface controller-manager hardware-interface kdl-parser pluginlib roscpp rospy speed-scaling-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Cartesian trajectory controller with multiple hardware interface support'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/melodic/cartesian-trajectory-interpolation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-trajectory-interpolation";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "27f3603ede3801f03053d58c974fd681b296656418df670d7d59cc59396234cd";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cartesian-control-msgs joint-trajectory-controller roscpp rospy tf2-eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory interpolation as a standalone library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-chaplus-ros";
+  version = "2.1.22-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "c37f88ea93357f57bf6caeddff4a99565b08d9b95285552c849f7c7e0a0f8917";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.requests rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ROS package for chaplus service'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/combined-robot-hw-tests/default.nix
+++ b/distros/melodic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw-tests";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "3c3c6ba6f41f2a1e256b4c48ac9355b3d9cd38bfa0fbf8a4488860acb4595c55";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "69832526f9f047fbd4241bfd9bcfb67123cb1ffed88383bbc44dba805a51dc0b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/combined-robot-hw/default.nix
+++ b/distros/melodic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "9717f332faad24fa498a054a971f88b9ab575e45167b3f1deb62998c4feda331";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "d09031bea3b3d2d8d5b496f3856e4ea059a585bd2be9cb2f6703750c999560ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-interface/default.nix
+++ b/distros/melodic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-controller-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "66e9d3ad23a251313da649f3d0929d2136c52b3935b11ea9e3f4cdd0225e289f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "05014247fbb6cd7ddd66595f36e61f12e2609cdcb791c6a9a1cbce955632c162";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-msgs/default.nix
+++ b/distros/melodic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-msgs";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "49d27abb925026460ddd92ea2c19ab19609b7dc031a2c94be3cfa23b8e7d9b9c";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "6765242a3a7e2a1e92fe831d01d499286e677dea3f88bc7917c2c3375a96c125";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-tests/default.nix
+++ b/distros/melodic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-tests";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "e31868f421a3393069ba5d9b07120b6c5993de17d0e75452ca8e7d9d8fa4efb5";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "374371fe02df6f27e7e10309953988c02a2fa8470bb7e06f53abc6265717ba30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager/default.nix
+++ b/distros/melodic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "5dd2e1325899cd23680be89e7c4fad5dee0491e1542ecc2947df753e0ae6d5f7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "9fb65b2d3430380e5cc1a7cae9b328af060cbfa5ec8d7ffc75128e3ec5b41bb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "4f15f016383579ae56cf88c1c58f65739ed61f61e78228d1d2d91d24f1f432f9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a961d1f9b2b9f6af11ea5272feb72e89c58b76f6f73fb1847d13814f07b1661c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "1c9f22e09ff7bb87120672c2637b10c6fbfe00ec90a8dae895dfea60ac4f6cdd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "21ca5326b82e1c975ac432a9b41892a51a0fa90706fe15fd6cbe590deb8409d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "99cd6fd74727351fbf8bb43a3a60dcaf5e96a285ced41c9f4c394d60fd3e51c7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "cba733bea85d8ca6709f41e90560571d6caafac0f265a15777399e9a0c101a47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -82,6 +82,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ aques-talk = self.callPackage ./aques-talk {};
+
  ar-track-alvar = self.callPackage ./ar-track-alvar {};
 
  ar-track-alvar-msgs = self.callPackage ./ar-track-alvar-msgs {};
@@ -262,7 +264,15 @@ self: super: {
 
  carrot-planner = self.callPackage ./carrot-planner {};
 
+ cartesian-control-msgs = self.callPackage ./cartesian-control-msgs {};
+
+ cartesian-interface = self.callPackage ./cartesian-interface {};
+
  cartesian-msgs = self.callPackage ./cartesian-msgs {};
+
+ cartesian-trajectory-controller = self.callPackage ./cartesian-trajectory-controller {};
+
+ cartesian-trajectory-interpolation = self.callPackage ./cartesian-trajectory-interpolation {};
 
  cartographer = self.callPackage ./cartographer {};
 
@@ -279,6 +289,8 @@ self: super: {
  catkin-pip = self.callPackage ./catkin-pip {};
 
  catkin-virtualenv = self.callPackage ./catkin-virtualenv {};
+
+ chaplus-ros = self.callPackage ./chaplus-ros {};
 
  checkerboard-detector = self.callPackage ./checkerboard-detector {};
 
@@ -2592,6 +2604,8 @@ self: super: {
 
  parrot-arsdk = self.callPackage ./parrot-arsdk {};
 
+ pass-through-controllers = self.callPackage ./pass-through-controllers {};
+
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
  pcl-msgs = self.callPackage ./pcl-msgs {};
@@ -3036,6 +3050,10 @@ self: super: {
 
  rc-pick-client = self.callPackage ./rc-pick-client {};
 
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
  rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
 
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
@@ -3251,6 +3269,8 @@ self: super: {
  ros-control-boilerplate = self.callPackage ./ros-control-boilerplate {};
 
  ros-controllers = self.callPackage ./ros-controllers {};
+
+ ros-controllers-cartesian = self.callPackage ./ros-controllers-cartesian {};
 
  ros-core = self.callPackage ./ros-core {};
 
@@ -4083,6 +4103,8 @@ self: super: {
  tuw-vehicle-msgs = self.callPackage ./tuw-vehicle-msgs {};
 
  tvm-vendor = self.callPackage ./tvm-vendor {};
+
+ twist-controller = self.callPackage ./twist-controller {};
 
  twist-mux = self.callPackage ./twist-mux {};
 

--- a/distros/melodic/graceful-controller-ros/default.nix
+++ b/distros/melodic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller-ros";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "6bbb00212bf3c8ac004bd96c34667cda8c28bff64a0ce16205a43f8abf73068b";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b4637050cf6bd9f01a16b064389b3a30d1a739b76d7c5f234f2add7009081b05";
   };
 
   buildType = "catkin";

--- a/distros/melodic/graceful-controller/default.nix
+++ b/distros/melodic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5523188e4a57d11d9b6da6b80877646578b621f1788cd62f1114d66d99b716c9";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c682e31e87543d1624c5cee00831ec7d2fbe7339220135002422917afd9585b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hardware-interface/default.nix
+++ b/distros/melodic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-hardware-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "12b51dc4acecbcb9708127d984e587166aa1882301096389be9e62fbfe74d9e5";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "b80c58cf8ee11ea90f4efbe8498f686bc6b0e64c023b933e4abc1994f05b6bcc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-limits-interface/default.nix
+++ b/distros/melodic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-melodic-joint-limits-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "da866a60a8165b5757f4894971049cc884f82ff806d7e5e1b84785bd8db4c6c2";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "823ce3b28e894f53139b27f00606a291b891e791dc193069d478c91055cb14d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
+{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "1230ca69543b25fe233ad7cb15a8bad1359af779e0dcd7d3fa9a556ff38e9cc6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "e9462eb12a7dc81c6a47e9dca701ab7aee844b6c5d74d0ae28adfafd3e029af2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks dialogflow-task-executive downward ff ffha gdrive-ros julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping rostwitter sesame-ros slic voice-text ];
+  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks dialogflow-task-executive downward ff ffha gdrive-ros google-cloud-texttospeech julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping rostwitter sesame-ros slic voice-text ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "f9ecc88f3dcc306bc97af128153ed152917ed835ea1bc5f0b8ffc8096279d096";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "645cbcb2d731344c20ab293169104e821495c49eb8b0ffdecc0844c0f2603c34";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters-jsk-patch/default.nix
+++ b/distros/melodic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters-jsk-patch";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "6f4d3b7603c2136bcee88baed6fb17ba6f2697a36bfbdd7c89624bf9d0be19ad";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "5fb7cc733051f087d74e9345de022ecbacdc5d7ce500cfe084d2b79614c7e533";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "905631640d2cf267a0c0c6c921470f7e1e986f2859e7302fe431ed45c52830a4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "6b51e5fbe7ae691b329f8ff19de65617a9d694ebf06011832d043c8a2101290c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "0772c84e89ec4ee8e4ddac0e42ee1543b586dc12e5ec8b98e69876999f0d329e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "9a6b98bf3366af7e8fcd205dc09ec3976243037f5c4eeccbe5045740aaa76421";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "36bbbab7b76409e1995490b8da7e7137c51189b5ae6a18271c0c94c095df9004";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "b0c9074c493b4ce9237e2668b87ed95a8a9389537a8fe3bafd1bf7d98afe329e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "3f10e85ae3f503134406c164c21939cf74588f6f38687ceb96d0f835085f8701";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "e3fff426221703d58aca43e821fade1f92dda4fb60472c77aed6b966827a6b9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "c2b25156aad79ecc96a2d4cbc1eed1c480b94ea40af8004f8bb4ad0b064b3f0d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a952ba2d8e901984ee14bfb07058fab067bc6a277ac8d7c08b4a66a3f9930cd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "5286726c5c8d2d19d493ae1c357614680cdb4cd3877db19076dfe2d6cf44ce58";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "5f89bc3505223a68f915e106d6cf319cb5deabeae6d1cc403b6de5a5a4645402";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pass-through-controllers/default.nix
+++ b/distros/melodic/pass-through-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-control-msgs, cartesian-interface, cartesian-trajectory-controller, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, dynamic-reconfigure, geometry-msgs, hardware-interface, roscpp, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-pass-through-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release/archive/release/melodic/pass_through_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1e0d15cfe95e465317a70c03241a729dee9eb7eee7c737e156754a711f2d0959";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs cartesian-trajectory-controller control-msgs controller-manager-msgs rostest xacro ];
+  propagatedBuildInputs = [ actionlib cartesian-control-msgs cartesian-interface controller-interface controller-manager dynamic-reconfigure geometry-msgs hardware-interface roscpp speed-scaling-interface trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Trajectory controllers (joint-based and Cartesian) that forward trajectories
+    directly to a robot controller and let it handle trajectory interpolation and execution.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "b995acb6f1ab9d3426ac97c44145e6972f35e99e61a5970d7edca4baa3634c0a";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "b3087d35d7652c9fca10c8a5cd50158892c07f3fa23d0528aa7bd18e1007dcc8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "7b90d76bd39e0d68b1e79fd4ed1a83c66025a1437104937d7dd174a842a58713";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "306c00500f6af51b436341c4a6fab0e76a088bcc152e9b78b72d5f0366bc4032";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-genicam-driver/default.nix
+++ b/distros/melodic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-driver";
-  version = "0.5.0-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "d4a54226f8593bd1ec396cba39209d0208fed05fd076a3c9ad6476224ff0c9f7";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "061603525595b683a2f6042b84a7daf4fc040d935996abc31d76006e83d51207";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "773d5496e448df0f049a9c7280153920e3040461070b2b9cb5a131bcfcec71a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ddynamic-reconfigure-python message-runtime pythonPackages.requests rc-reason-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "ff54aa120cbcc25182a8b936b4528ea8f7e2ad0cc174a8bdd0f83d9090508fb7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rc-common-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rcdiscover/default.nix
+++ b/distros/melodic/rcdiscover/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-melodic-rcdiscover";
-  version = "1.0.3-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "955e29e3c5b93c905c027c2323becbdf278828f731f43ead3eb16522e544c52a";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b8c4bb1f6fe20b91777d783f6863eeae11f45f42a081a56f168fee1c2ef52c6f";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/ros-control/default.nix
+++ b/distros/melodic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-ros-control";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "a5cacff3ae3536a9afa3e224d5299160bf545a7e6ae866ea4319abe63e91aca7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "3f1eedc90b71c32c00741cd89d1f597a3fa84916416fdf705171b9a775d5e2c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers-cartesian/default.nix
+++ b/distros/melodic/ros-controllers-cartesian/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
+buildRosPackage {
+  pname = "ros-melodic-ros-controllers-cartesian";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "aed8fd120127c93460f448cf0083ae790c0354b182339138ab916d59d6f1e90f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-controller cartesian-trajectory-interpolation twist-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''scaled controllers metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "848a6da4df6cf977bdd2c5f626b40391258d7f30df00f181144491844006eeed";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "76924e3f260093adae48bffbe2b49222ca2c00707bfb33483285a0c2c22cb4a1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "ad6542e6c227d8ccdec1a8f45f97d73bedc09477bab243f2eaf7e15acbfc2b3c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "4dcc5cac04ce4650df0d01835a074f4211f217b8532be1b4fd9ed5e28512afc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-controller-manager/default.nix
+++ b/distros/melodic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-controller-manager";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "d1a3c797567d977ef0c802165baef646bfe79039541dc843bd3765ecc16286f2";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "a0b95b62508520a28777ce405681283895487126fc06f6985230de6b5e59c546";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "95ddd1143652531c2b970f83ef7e79e53d11d3133f1f945c25a5633ca33d286f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "2af99e9bce75677ce360cf070170595c53cac6a59d20fe8c84dc57dd3a5cff68";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "828e7bd2d1b6c163bf9088e0402524568e7941280daba55f48bc6c7bb6471b86";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "2f989a35ecf0d095454620fefa76fe0802d71806cdd834011595436a1c5c42a7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/transmission-interface/default.nix
+++ b/distros/melodic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-transmission-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "386fc220e65adee3bbd695bf09363c953a1569cba4b610c8049da3a20691b0a1";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "29a214b71892ff82b0e71f07b2d8fa98487ac97e2936dc3ad82d0801792f405c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-controller/default.nix
+++ b/distros/melodic/twist-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-twist-controller";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "065830f775aa9cf86cf47c7a63714a31e3aa58688b0f1144c4c028f96d3eac2c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface controller-interface dynamic-reconfigure geometry-msgs hardware-interface realtime-tools roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller accepting Cartesian twist messages in order to move a robot manipulator.
+    It uses a Cartesian interface to the robot, so that the robot hardware takes care about
+    doing the inverse kinematics. This could be used e.g. for visual servoing applications.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "409a462a24d07c8cfb462b8b7a127871d42f022cf56df4c7e3404b7a38a4c6ae";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "eed24d2b0ae5c11193df2589df08da92ed66e159030ed07fb6f63ebcde03ca5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ypspur-ros/default.nix
+++ b/distros/melodic/ypspur-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, trajectory-msgs, ypspur }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ypspur }:
 buildRosPackage {
   pname = "ros-melodic-ypspur-ros";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/ypspur_ros-release/archive/release/melodic/ypspur_ros/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "549a9844ee5da0f095df90904564d7c37ab28fbc7f8422a1ec00334d6032f8b9";
+    url = "https://github.com/openspur/ypspur_ros-release/archive/release/melodic/ypspur_ros/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "32bb414bf802855cc4d468b7a5078fa17d3ea81358b1867a301f67f31c7e58d8";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf trajectory-msgs ypspur ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ypspur ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "5c23b0a14ceb4f24bc56883d2d27de462490926a66a23589e4bd1d13301bf6a3";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "23f563369e94501bb09f64ed544b80ed071630d5aeb8001f54da0e1237b5093e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-control-msgs/default.nix
+++ b/distros/noetic/cartesian-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-control-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release/archive/release/noetic/cartesian_control_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "88d6f5a6c0add62f1ade742e8741e077fe434382cd7b9f0a743aeb24c15caa1b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory execution interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-interface/default.nix
+++ b/distros/noetic/cartesian-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-interface";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "f26a08869430d07984b31f1453d35f7864d299555ce6fc93675c9ef46f15ef1a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometry-msgs hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Defines a hardware interface to send Cartesian commands to a robot hardware and read
+    Cartesian states.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-trajectory-controller/default.nix
+++ b/distros/noetic/cartesian-trajectory-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-trajectory-controller";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "2d4eb4fc3806b27cd08882ca84f87e9092af26844b9056725230984390e9887b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs control-msgs controller-manager-msgs joint-state-controller joint-trajectory-controller robot-state-publisher ros-control-boilerplate rostest trajectory-msgs xacro ];
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-interpolation controller-interface controller-manager hardware-interface kdl-parser pluginlib roscpp rospy speed-scaling-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Cartesian trajectory controller with multiple hardware interface support'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/noetic/cartesian-trajectory-interpolation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-trajectory-interpolation";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "d2a79242bd158696e4d9a9c5f0c393b5af8ebcf86c3844452a544ffcb3f1a00d";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cartesian-control-msgs joint-trajectory-controller roscpp rospy tf2-eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory interpolation as a standalone library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/combined-robot-hw-tests/default.nix
+++ b/distros/noetic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw-tests";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "9bbc883bd884879f0ac7149163189eb93e315d8bba74f0d7d3848263e4550636";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "57d0f45a1c83806f29f340d513773c30e96fc859e671e57bd212628574297db9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/combined-robot-hw/default.nix
+++ b/distros/noetic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "b8d9eb13fa81e4f0bfc78554d16b7b4328469e6e1cb7a00ccd99f4f2288ef6b4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "44ecca784dfa95ad551d5c6dd7adc087a0356d40a7291369f1b58cd7b036918b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-interface/default.nix
+++ b/distros/noetic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-controller-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "a99e7a076bb57cdd48413187a11301fdab94220ee2a2a0b9f3eb4e082c9c6334";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "0dd568ca9911eb3e8e18de228d2df4191c64c1b56c1d0826d24f7f67b66b2a79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-msgs/default.nix
+++ b/distros/noetic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-msgs";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "ceca5487523ab05221259b4a29ea2eeb530d07619f05382e613b986497429967";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "ea8b3fb9d8920666496f71622704923e5581e9993ad34ffd51df1f0a30fdd966";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-tests/default.nix
+++ b/distros/noetic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-tests";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "319b8faea49fcf827640cff43ac3e8d0b3296a190d3365c863e7438bc763a03e";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "13f618c1c8f7403f760f13bfa07d0d6b102e564b70bd115914fe661f2dee9497";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager/default.nix
+++ b/distros/noetic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "e340db15c944cc52367bb6a41a13e720dbaba588c11f97915d970e29dee5e02d";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "56cf18b0745a8504ff2006f612d0be05a1f71c8e9062814d40df434a255d993c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f35b747b2ed7e25785f23f6238d14cff1f25fd70c8e1df8b89bccc475b9dfa1d";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "8cf5a8da963e16139d510f77d4c5b302f443f8eff85efe8e47200bef4ad5c044";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "692393aed0b39e79e6ff08e04273126b931b672568baca7062a86572a20d3f1f";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "48eab98ddf97ac7e2adee655d4c1ce4c9d3fbd152bd7fe980feb8cd1746606ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "5cdbc1a2faf60754bfb506c71c766215b47d84165f8a54aabd6faab9db0b08b8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "118b2a5754ef2839be99ec0bc90e71651dd3d67ac62328830715941c538ce3ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f8f5bcfb8121fd2bf2d2d6a95d7084e9297e901962151805469708761e03b3c9";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "add33ba307dbd9f4a90192dda911ec466d854e7774cd199489afaad75c83f4f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "47cd5261df2ae3f07ec7145db669e74033abae8f3802f99089f4662e7235e6c6";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "d3a724bac511e84f4d1ffd046cf5ba0006a6adf5fcbef6888ca8c5fccc9968e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -166,7 +166,15 @@ self: super: {
 
  carrot-planner = self.callPackage ./carrot-planner {};
 
+ cartesian-control-msgs = self.callPackage ./cartesian-control-msgs {};
+
+ cartesian-interface = self.callPackage ./cartesian-interface {};
+
  cartesian-msgs = self.callPackage ./cartesian-msgs {};
+
+ cartesian-trajectory-controller = self.callPackage ./cartesian-trajectory-controller {};
+
+ cartesian-trajectory-interpolation = self.callPackage ./cartesian-trajectory-interpolation {};
 
  catch-ros = self.callPackage ./catch-ros {};
 
@@ -1556,6 +1564,8 @@ self: super: {
 
  ncd-parser = self.callPackage ./ncd-parser {};
 
+ neo-local-planner = self.callPackage ./neo-local-planner {};
+
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
  neonavigation = self.callPackage ./neonavigation {};
@@ -1661,6 +1671,8 @@ self: super: {
  panda-moveit-config = self.callPackage ./panda-moveit-config {};
 
  parameter-pa = self.callPackage ./parameter-pa {};
+
+ pass-through-controllers = self.callPackage ./pass-through-controllers {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1938,6 +1950,10 @@ self: super: {
 
  rc-pick-client = self.callPackage ./rc-pick-client {};
 
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
  rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
 
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
@@ -2035,6 +2051,8 @@ self: super: {
  ros-control-boilerplate = self.callPackage ./ros-control-boilerplate {};
 
  ros-controllers = self.callPackage ./ros-controllers {};
+
+ ros-controllers-cartesian = self.callPackage ./ros-controllers-cartesian {};
 
  ros-core = self.callPackage ./ros-core {};
 
@@ -2633,6 +2651,8 @@ self: super: {
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlesim = self.callPackage ./turtlesim {};
+
+ twist-controller = self.callPackage ./twist-controller {};
 
  twist-mux = self.callPackage ./twist-mux {};
 

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5fe8b1babb21b884a807c147772d3f8cc320f17a8ecfdba6930251675e381f15";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "957ba8bc12549f73afb8f9f9d54b8dc9072e8c3005dd3bdafc54ab211edd3501";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "b83f69f2b081a4ba3d31a70a20ed629e926897868918e8b01a998773d9546294";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7a108688036ed6803dc0a9560ff0ee23d2fb26c325d1ea4b994767fd501f3e9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "4b06301c7c7dd97b2b4fc839b7892c41126dd3fc5164cd3377f632677a1fc7a8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "8a308353861c5fa7b1cf374b0d88eca845621cf3bf430229e649732f8e13de21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hardware-interface/default.nix
+++ b/distros/noetic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-hardware-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "599c3579366d95a3c6debff690ac69db156da5b3a153b60747efffd0b63603be";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "16bf376a04d3fb720ae204b3ef0b2ef7be36ca92bef987b3644caf88dffaca1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "68c79e5cf692eae894b3dd178ddef0de606af5e07fe1f6a90a99352ef2027c46";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "d5aa66065b7e8637f293704b830e157a4b4e36b17b671c775ca35934d5a6cefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-limits-interface/default.nix
+++ b/distros/noetic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-noetic-joint-limits-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "3aea41db9b4c6079483a53a3e09001cc585ac34ae1a392166d93a81256207502";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "1b3ce53ea8cf91b6cf80e2785a94cd4c30dddd83f5624002b0644db28510e5dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "2b31f7599a1a6680d18e99f931e0e3bdfb55953e430f1d10e9d3516f5a33e171";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "e0968620e901d8ca8a2e1a4d032d5afde60acdbf61440a63073483c008c093ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "3d57f554bf2b22d0c5154820dd3ec70c062817cec6ddeb10dbaa7f347ea20337";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "53720e691240d1a87f4d8b1829207a3345ef6928db56de85d62cee6b95edf322";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neo-local-planner/default.nix
+++ b/distros/noetic/neo-local-planner/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-neo-local-planner";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/neobotix/neo_local_planner-release/archive/release/noetic/neo_local_planner/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "40b93b3cde461c30dd909faa95aca65cf4619191b3e4178cc9c3fa65bb4891ca";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ base-local-planner costmap-2d dynamic-reconfigure nav-core nav-msgs pluginlib roscpp tf2-geometry-msgs tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a spline based implementation to local robot navigation on a plane.
+
+		This package's ROS wrapper adheres to the
+        BaseLocalPlanner interface specified in the <a href="http://wiki.ros.org/nav_core">nav_core</a> package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pass-through-controllers/default.nix
+++ b/distros/noetic/pass-through-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-control-msgs, cartesian-interface, cartesian-trajectory-controller, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, dynamic-reconfigure, geometry-msgs, hardware-interface, roscpp, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pass-through-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release/archive/release/noetic/pass_through_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "834c1e9209fde4334698a94439895dcc9656191010add47169c3a89f5be56cb8";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs cartesian-trajectory-controller control-msgs controller-manager-msgs rostest xacro ];
+  propagatedBuildInputs = [ actionlib cartesian-control-msgs cartesian-interface controller-interface controller-manager dynamic-reconfigure geometry-msgs hardware-interface roscpp speed-scaling-interface trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Trajectory controllers (joint-based and Cartesian) that forward trajectories
+    directly to a robot controller and let it handle trajectory interpolation and execution.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e01d38d56a8eb2dd2b6433656032100c7bdf2b57004bc3a3cc5ab741ca648e82";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "df7beb44529236073957920b5e0afe58bb4effc20f7e5848e46feb29cdb19f8b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "f30452d7ec4b7a220f59290f5939b5329b1779c70f5c8ffc61fd7a928dbf415f";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.2.0-2.tar.gz";
+    name = "3.2.0-2.tar.gz";
+    sha256 = "b8515b7eea6d7de2ca67390d3319c7739425c22a1bca9a941bcc46b07429e085";
   };
 
   buildType = "catkin";

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "83af262bfff6d1100f9f0bfd2b0938dbd8cb9ae3645efd7260c878650189ee88";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "eb065ab91e1908cb598cf0ad100582163e0b99d4ddc7790568a99ffa4ff176b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.5.0-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "b46a0b005ba84b31997044db978324f30a0fb5db0706c2640b18a511ae271768";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "dae3b74a8b547d79490ac46446ca11c188d60b6c2bd27e84100eda2e797e5b47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "79146598921a250241531a7325675c63fb5a5ac72dd40aaa81730bd674c4697f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ddynamic-reconfigure-python message-runtime python3Packages.requests rc-reason-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "ba2c6748e5e0f8b2a0660a91627b99b7323acfc906771fa76426a17545047ba5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rc-common-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rcdiscover/default.nix
+++ b/distros/noetic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-rcdiscover";
-  version = "1.0.4-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1400f55c27d3c7362326001cb6b4b44cd08628f6ab2e3bd211e4536382348e34";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "785cfe918435b1998ff3f646859706eb18dd0bf52e985881c0dedaa426594c8b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ros-control/default.nix
+++ b/distros/noetic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-ros-control";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "46203493ec39e9f1d64d7a9961345977e4034be6905f215fb0d25c9b9c93b14f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "d161e78552c7f67b55d4b910f7db1e924974a7862c04ae927e9c1179e8af963c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers-cartesian/default.nix
+++ b/distros/noetic/ros-controllers-cartesian/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
+buildRosPackage {
+  pname = "ros-noetic-ros-controllers-cartesian";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "68724e5cfc44273534383ae564613526df3e1e88222c1a4b9142d72db5e7cb05";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-controller cartesian-trajectory-interpolation twist-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''scaled controllers metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "12ff5d09f3611d3422985ec00bb0e246ee3d01c51a63326fe5ec0a3d3e8efc5c";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "7ad4a7b2a5a080efc80f130f2b25b20fb61a87b7dcf8234962d861a0e84c889e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-controller-manager/default.nix
+++ b/distros/noetic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-controller-manager";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "941fbec8959a2369d0caf97c6604a1ce13fb0b4ffbbb1d241cdcbb4a2c439920";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "61da60d40bc290b5b9efe99226b78480340ba4e93659de5f66c66b312083eb33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "604cfc7981de96c5b8cddab7904ea5db35b31607b103f9f1f2221e23be0682dd";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "68fe23d5f1543ca1aaea9774afcef57f3563303be6ca59bb43fda925c66c3551";
   };
 
   buildType = "catkin";

--- a/distros/noetic/transmission-interface/default.nix
+++ b/distros/noetic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-transmission-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "cce664686d2a60a3880936817d3a560cafc49693455787e2f872052de18462c4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "5105c573a9eace338fc2d3b1a09a3ffc87824fe3f1680c2343d40bd0ee551de5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/twist-controller/default.nix
+++ b/distros/noetic/twist-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-twist-controller";
+  version = "0.1.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.2-2.tar.gz";
+    name = "0.1.2-2.tar.gz";
+    sha256 = "2f3e248bb56754719198aed76100b2b66b0706f9aee8eb378302e9cdaa3fb6c7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface controller-interface dynamic-reconfigure geometry-msgs hardware-interface realtime-tools roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller accepting Cartesian twist messages in order to move a robot manipulator.
+    It uses a Cartesian interface to the robot, so that the robot hardware takes care about
+    doing the inverse kinematics. This could be used e.g. for visual servoing applications.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f4c93c0a7ea10a062fec2329a76e23dfdcbf4da2ac307aeb0638f54bc8c25a09";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "5281f0510e937a8ce981053f9bbc4c9c81ea84254b097fb6df2481edf4963fed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur-ros/default.nix
+++ b/distros/noetic/ypspur-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, trajectory-msgs, ypspur }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ypspur }:
 buildRosPackage {
   pname = "ros-noetic-ypspur-ros";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "46f5e3977e8b4799293fc898da5386915802ed7fb54c7bad5774bfba8bd6a36c";
+    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "ed60ad59fb73ba811bd1703436c47aab4cd43bd30d9233787f5bbca1442670f1";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf trajectory-msgs ypspur ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ypspur ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit de81aededb7c70b36c6c00c2410af1768b2d357e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *can-dbc-parser 1.1.0-r1*
* *controller-interface 0.7.0-r1 --> 0.7.1-r1*
* *controller-manager 0.7.0-r1 --> 0.7.1-r1*
* *controller-manager-msgs 0.7.0-r1 --> 0.7.1-r1*
* *dynamixel-hardware-interface 0.0.3-r1*
* *gazebo-ros2-control 0.0.2-r1 --> 0.0.3-r1*
* *gazebo-ros2-control-demos 0.0.2-r1 --> 0.0.3-r1*
* *geometric-shapes 2.0.2-r1 --> 2.1.0-r1*
* *hardware-interface 0.7.0-r1 --> 0.7.1-r1*
* *moveit-msgs 2.0.1-r1 --> 2.1.0-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.0-r2*
* *plotjuggler-ros 1.2.0-r1 --> 1.4.0-r1*
* *quaternion-operation 0.0.4-r1 --> 0.0.5-r1*
* *raptor-dbw-can 1.0.0-r1 --> 1.1.0-r1*
* *raptor-dbw-joystick 1.0.0-r1 --> 1.1.0-r1*
* *raptor-dbw-msgs 1.0.0-r1 --> 1.1.0-r1*
* *raptor-pdu 1.0.0-r1 --> 1.1.0-r1*
* *raptor-pdu-msgs 1.0.0-r1 --> 1.1.0-r1*
* *rcdiscover 1.1.2-r1*
* *ros2-control 0.7.0-r1 --> 0.7.1-r1*
* *ros2-control-test-assets 0.7.0-r1 --> 0.7.1-r1*
* *ros2controlcli 0.7.0-r1 --> 0.7.1-r1*
* *transmission-interface 0.7.0-r1 --> 0.7.1-r1*
* *turtlebot3-fake-node 2.2.2-r1 --> 2.2.3-r1*
* *turtlebot3-gazebo 2.2.2-r1 --> 2.2.3-r1*
* *turtlebot3-simulations 2.2.2-r1 --> 2.2.3-r1*
* *twist-mux 4.0.1-r1*
* *urdf-test 2.0.0-r2*

Galactic Changes:
-----------------
* *geometric-shapes 2.1.0-r1*
* *launch-system-modes 0.8.0-r1*
* *moveit-msgs 2.1.0-r1*
* *moveit-resources 2.0.2-r1*
* *moveit-resources-fanuc-description 2.0.2-r1*
* *moveit-resources-fanuc-moveit-config 2.0.2-r1*
* *moveit-resources-panda-description 2.0.2-r1*
* *moveit-resources-panda-moveit-config 2.0.2-r1*
* *moveit-resources-pr2-description 2.0.2-r1*
* *openvslam 0.2.3-r3*
* *random-numbers 2.0.1-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.1.2-r1*
* *rmf-building-map-msgs 1.2.0-r1*
* *rmf-charger-msgs 1.3.0-r1*
* *rmf-cmake-uncrustify 1.2.0-r1*
* *rmf-dispenser-msgs 1.3.0-r1*
* *rmf-door-msgs 1.3.0-r1*
* *rmf-fleet-msgs 1.3.0-r1*
* *rmf-ingestor-msgs 1.3.0-r1*
* *rmf-lift-msgs 1.3.0-r1*
* *rmf-task-msgs 1.3.0-r1*
* *rmf-traffic-msgs 1.3.0-r1*
* *rmf-workcell-msgs 1.3.0-r1*
* *rmw-cyclonedds-cpp 0.22.2-r1 --> 0.22.3-r1*
* *srdfdom 2.0.2-r1*
* *stubborn-buddies 1.0.0-r1*
* *stubborn-buddies-msgs 1.0.0-r1*
* *system-modes 0.7.1-r3 --> 0.8.0-r1*
* *system-modes-examples 0.7.1-r3 --> 0.8.0-r1*
* *system-modes-msgs 0.7.1-r3 --> 0.8.0-r1*
* *test-launch-system-modes 0.8.0-r1*
* *turtlebot3 2.1.2-r1*
* *turtlebot3-cartographer 2.1.2-r1*
* *turtlebot3-description 2.1.2-r1*
* *turtlebot3-example 2.1.2-r1*
* *turtlebot3-fake-node 2.2.4-r1*
* *turtlebot3-gazebo 2.2.4-r1*
* *turtlebot3-msgs 2.2.2-r3*
* *turtlebot3-navigation2 2.1.2-r1*
* *turtlebot3-simulations 2.2.4-r1*
* *turtlebot3-teleop 2.1.2-r1*
* *warehouse-ros 2.0.1-r1*

Melodic Changes:
----------------
* *aques-talk 2.1.22-r1*
* *assimp-devel 2.1.21-r3 --> 2.1.22-r1*
* *bayesian-belief-networks 2.1.21-r3 --> 2.1.22-r1*
* *cartesian-control-msgs 0.1.0-r1*
* *cartesian-interface 0.1.2-r1*
* *cartesian-trajectory-controller 0.1.2-r1*
* *cartesian-trajectory-interpolation 0.1.2-r1*
* *chaplus-ros 2.1.22-r1*
* *combined-robot-hw 0.18.3-r1 --> 0.18.4-r1*
* *combined-robot-hw-tests 0.18.3-r1 --> 0.18.4-r1*
* *controller-interface 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager-msgs 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager-tests 0.18.3-r1 --> 0.18.4-r1*
* *downward 2.1.21-r3 --> 2.1.22-r1*
* *ff 2.1.21-r3 --> 2.1.22-r1*
* *ffha 2.1.21-r3 --> 2.1.22-r1*
* *graceful-controller 0.3.1-r1 --> 0.4.0-r1*
* *graceful-controller-ros 0.3.1-r1 --> 0.4.0-r1*
* *hardware-interface 0.18.3-r1 --> 0.18.4-r1*
* *joint-limits-interface 0.18.3-r1 --> 0.18.4-r1*
* *jsk-3rdparty 2.1.21-r3 --> 2.1.22-r1*
* *julius 2.1.21-r3 --> 2.1.22-r1*
* *laser-filters-jsk-patch 2.1.21-r3 --> 2.1.22-r1*
* *libcmt 2.1.21-r3 --> 2.1.22-r1*
* *libsiftfast 2.1.21-r3 --> 2.1.22-r1*
* *lpg-planner 2.1.21-r3 --> 2.1.22-r1*
* *mini-maxwell 2.1.21-r3 --> 2.1.22-r1*
* *nlopt 2.1.21-r3 --> 2.1.22-r1*
* *opt-camera 2.1.21-r3 --> 2.1.22-r1*
* *pass-through-controllers 0.1.0-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.0-r2*
* *plotjuggler-ros 1.2.0-r1 --> 1.4.0-r1*
* *rc-genicam-driver 0.5.0-r1 --> 0.5.2-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.0.3-r1 --> 1.1.2-r1*
* *ros-control 0.18.3-r1 --> 0.18.4-r1*
* *ros-controllers-cartesian 0.1.2-r1*
* *rospatlite 2.1.21-r3 --> 2.1.22-r1*
* *rosping 2.1.21-r3 --> 2.1.22-r1*
* *rqt-controller-manager 0.18.3-r1 --> 0.18.4-r1*
* *sesame-ros 2.1.21-r3 --> 2.1.22-r1*
* *slic 2.1.21-r3 --> 2.1.22-r1*
* *transmission-interface 0.18.3-r1 --> 0.18.4-r1*
* *twist-controller 0.1.2-r1*
* *voice-text 2.1.21-r3 --> 2.1.22-r1*
* *ypspur-ros 0.3.4-r1 --> 0.3.5-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.18.1-r1 --> 0.19.0-r1*
* *cartesian-control-msgs 0.1.0-r1*
* *cartesian-interface 0.1.2-r2*
* *cartesian-trajectory-controller 0.1.2-r2*
* *cartesian-trajectory-interpolation 0.1.2-r2*
* *combined-robot-hw 0.19.4-r1 --> 0.19.5-r1*
* *combined-robot-hw-tests 0.19.4-r1 --> 0.19.5-r1*
* *controller-interface 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager-msgs 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager-tests 0.19.4-r1 --> 0.19.5-r1*
* *diff-drive-controller 0.18.1-r1 --> 0.19.0-r1*
* *effort-controllers 0.18.1-r1 --> 0.19.0-r1*
* *force-torque-sensor-controller 0.18.1-r1 --> 0.19.0-r1*
* *forward-command-controller 0.18.1-r1 --> 0.19.0-r1*
* *four-wheel-steering-controller 0.18.1-r1 --> 0.19.0-r1*
* *graceful-controller 0.3.1-r1 --> 0.4.0-r1*
* *graceful-controller-ros 0.3.1-r1 --> 0.4.0-r1*
* *gripper-action-controller 0.18.1-r1 --> 0.19.0-r1*
* *hardware-interface 0.19.4-r1 --> 0.19.5-r1*
* *imu-sensor-controller 0.18.1-r1 --> 0.19.0-r1*
* *joint-limits-interface 0.19.4-r1 --> 0.19.5-r1*
* *joint-state-controller 0.18.1-r1 --> 0.19.0-r1*
* *joint-trajectory-controller 0.18.1-r1 --> 0.19.0-r1*
* *neo-local-planner 1.0.1-r1*
* *pass-through-controllers 0.1.0-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.0-r2*
* *plotjuggler-ros 1.2.0-r1 --> 1.4.0-r1*
* *position-controllers 0.18.1-r1 --> 0.19.0-r1*
* *rc-genicam-driver 0.5.0-r1 --> 0.5.2-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.0.4-r1 --> 1.1.2-r1*
* *ros-control 0.19.4-r1 --> 0.19.5-r1*
* *ros-controllers 0.18.1-r1 --> 0.19.0-r1*
* *ros-controllers-cartesian 0.1.2-r2*
* *rqt-controller-manager 0.19.4-r1 --> 0.19.5-r1*
* *rqt-joint-trajectory-controller 0.18.1-r1 --> 0.19.0-r1*
* *transmission-interface 0.19.4-r1 --> 0.19.5-r1*
* *twist-controller 0.1.2-r2*
* *velocity-controllers 0.18.1-r1 --> 0.19.0-r1*
* *ypspur-ros 0.3.4-r1 --> 0.3.5-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] dynamixel_sdk
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] hls_lfcd_lds_driver
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

