### PR TITLE
rosdistro sync, Fri Jun 25 12:45:04 2021

### DIFF
--- a/distros/foxy/can-dbc-parser/default.nix
+++ b/distros/foxy/can-dbc-parser/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-can-dbc-parser";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a03ed6da83ea2a4a5af468c81250a912f5d85ed4d7ec2b463102dc6fdbd1022a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ can-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''DBC file interface.  Read a DBC file, unpack CAN messages and convert to engineering units, pack values into CAN messages for publishing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "a8c63ea8b088a1f34bfdae046c6344f6881af3babdb50688ee2d5a8532bc73f2";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "a79375f0b4cb545d3bb5ba5bc56aee4061d3140d5a536d982b3e869886b654a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "05be83c1ffb322a34b44dbbc6ea5fbf2f613dbc839d9628a37e2f31a52bcd3e1";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "bff11964905d711e3fda7ecd01de6f544f6cf01758b8b88ecd394aef75e05e51";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "60d92f98db5a109764056b92e79ba0a095c4ff249b79fb9bd2aee2ef2bbb0529";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "0f5efb5368578364860a86dc645812de9095b6ac1dfb6a06f3553656819f9367";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-hardware-interface/default.nix
+++ b/distros/foxy/dynamixel-hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, boost, controller-interface, diagnostic-msgs, diagnostic-updater, dynamixel-sdk, hardware-interface, pluginlib, rclcpp, realtime-tools, robot-state-publisher, ros2-control, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-dynamixel-hardware-interface";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/dynamixel_hardware_interface-release/archive/release/foxy/dynamixel_hardware_interface/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "a835274fbe7593d11dcafda4d68104ee0c7d290fb6d911f35df0196b7ee6bb49";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ boost controller-interface diagnostic-msgs diagnostic-updater dynamixel-sdk hardware-interface pluginlib rclcpp realtime-tools robot-state-publisher ros2-control xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Hardware Interface and controllers for dynamixel motors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/foxy/dynamixel-sdk-custom-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-dynamixel-sdk-custom-interfaces";
-  version = "3.7.40-r3";
+  version = "3.7.40-r4";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_custom_interfaces/3.7.40-3.tar.gz";
-    name = "3.7.40-3.tar.gz";
-    sha256 = "e8c452ce95561229e9c8f99e7e78ee344a67d2be42d10b3cf682cc513303266d";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_custom_interfaces/3.7.40-4.tar.gz";
+    name = "3.7.40-4.tar.gz";
+    sha256 = "7cedf9b2f2312b3a061299c2e9686cbf9e0b351f937c7dce9f812e88c9992aa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-sdk-examples/default.nix
+++ b/distros/foxy/dynamixel-sdk-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-dynamixel-sdk-examples";
-  version = "3.7.40-r3";
+  version = "3.7.40-r4";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_examples/3.7.40-3.tar.gz";
-    name = "3.7.40-3.tar.gz";
-    sha256 = "5e82d978e5f4d62d95ac24010d90512e6d3c1ebed7da064545f68c116b60fc2b";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk_examples/3.7.40-4.tar.gz";
+    name = "3.7.40-4.tar.gz";
+    sha256 = "056dbb39bef40eab9d8708e9d528e4a2448925c9d01fdd4b6c6c7007a61baa36";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/dynamixel-sdk/default.nix
+++ b/distros/foxy/dynamixel-sdk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-dynamixel-sdk";
-  version = "3.7.40-r3";
+  version = "3.7.40-r4";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk/3.7.40-3.tar.gz";
-    name = "3.7.40-3.tar.gz";
-    sha256 = "63485d65ef4d98ef89fd488cab1168077e38ec26ec3449b91c32a22505201a3b";
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/foxy/dynamixel_sdk/3.7.40-4.tar.gz";
+    name = "3.7.40-4.tar.gz";
+    sha256 = "c78aafa4e33d923a2e727bd06e9cddc775b73cc68db9da4d11e3ca3635b2c8cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gazebo-ros2-control-demos/default.nix
+++ b/distros/foxy/gazebo-ros2-control-demos/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-controllers, std-msgs, velocity-controllers, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, control-msgs, effort-controllers, gazebo-ros, gazebo-ros2-control, hardware-interface, joint-state-controller, joint-trajectory-controller, launch, launch-ros, rclcpp, rclcpp-action, robot-state-publisher, ros2-control, ros2-controllers, std-msgs, velocity-controllers, xacro }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control-demos";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "387fb517b9ba623dc78b893317eeae84f7e78d90d1871fc3b803f7b43fee636d";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control_demos/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "5b5eec14876bd5ef49ca3b40312baac5bdaea4983c96074b4e5ec4bcae8a40be";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ rclcpp-action ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-controllers std-msgs velocity-controllers xacro ];
+  propagatedBuildInputs = [ ament-index-python control-msgs effort-controllers gazebo-ros gazebo-ros2-control hardware-interface joint-state-controller joint-trajectory-controller launch launch-ros rclcpp robot-state-publisher ros2-control ros2-controllers std-msgs velocity-controllers xacro ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/gazebo-ros2-control/default.nix
+++ b/distros/foxy/gazebo-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, controller-manager, gazebo-dev, gazebo-ros, hardware-interface, pluginlib, rclcpp, std-msgs, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gazebo-ros2-control";
-  version = "0.0.2-r1";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "bccf46c151e93760cf2da7db4bb899aba9df87133ee49e7268e07ef56a18cbd1";
+    url = "https://github.com/ros2-gbp/gazebo_ros2_control-release/archive/release/foxy/gazebo_ros2_control/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "5a673206efaca88a5fe5dd2a52a8f35d9beb64f3e4243f5bc4d2b8cdf82decd6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -166,6 +166,8 @@ self: super: {
 
  camera-info-manager = self.callPackage ./camera-info-manager {};
 
+ can-dbc-parser = self.callPackage ./can-dbc-parser {};
+
  can-msgs = self.callPackage ./can-msgs {};
 
  carla-msgs = self.callPackage ./carla-msgs {};
@@ -275,6 +277,8 @@ self: super: {
  dynamic-graph = self.callPackage ./dynamic-graph {};
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
+
+ dynamixel-hardware-interface = self.callPackage ./dynamixel-hardware-interface {};
 
  dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
 
@@ -876,6 +880,8 @@ self: super: {
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
 
+ qpoases-vendor = self.callPackage ./qpoases-vendor {};
+
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
  qt-gui = self.callPackage ./qt-gui {};
@@ -895,8 +901,6 @@ self: super: {
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
  random-numbers = self.callPackage ./random-numbers {};
-
- raptor-can-dbc-parser = self.callPackage ./raptor-can-dbc-parser {};
 
  raptor-dbw-can = self.callPackage ./raptor-dbw-can {};
 
@@ -923,6 +927,8 @@ self: super: {
  rc-reason-clients = self.callPackage ./rc-reason-clients {};
 
  rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
+ rcdiscover = self.callPackage ./rcdiscover {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -1432,6 +1438,8 @@ self: super: {
 
  turtlesim = self.callPackage ./turtlesim {};
 
+ twist-mux = self.callPackage ./twist-mux {};
+
  twist-stamper = self.callPackage ./twist-stamper {};
 
  ublox = self.callPackage ./ublox {};
@@ -1453,6 +1461,8 @@ self: super: {
  ur-client-library = self.callPackage ./ur-client-library {};
 
  urdf = self.callPackage ./urdf {};
+
+ urdf-test = self.callPackage ./urdf-test {};
 
  urdfdom = self.callPackage ./urdfdom {};
 

--- a/distros/foxy/geometric-shapes/default.nix
+++ b/distros/foxy/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-geometric-shapes";
-  version = "2.0.2-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "43521de7c972e38c71c46db761995d9626c51b7ecd66b83f6b91354f90fc0a79";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/foxy/geometric_shapes/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "6447ed798f309b35795cf9daf595f8219c9cd2ffcdb07622c8ddd4cb7882501d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "160527dbc3ff3a0ad242b0383c1d5b25875c3f007aff05c3f2c2748e14e8ec79";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "fc3fc74344107335b7e7f45455e938ba5a8d22e6f2ea4e38ba88b62bb414e474";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/libmavconn/default.nix
+++ b/distros/foxy/libmavconn/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-libmavconn";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "ed6db3e4acc1599ebafd62a8b050f41c3ee4b6b187fcac2eae63dabbd28b80ef";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/libmavconn/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "1ace47d553aa6a398fe4d2b90cb52dec75cd86114a724df6631da74eea737604";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros-msgs/default.nix
+++ b/distros/foxy/mavros-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros-msgs";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "72856c007c99fde1e098e26ca243356557bc2806110901ca6abc2a76decb347f";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "6f9d25bfb7647eab9067758e347c9821a892465d88ebf0cd36f0d53672d0ff1f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavros/default.nix
+++ b/distros/foxy/mavros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-mavros";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "290ebf234f453ee8326761b9c49a2dd3ba63fecc7fd61e786a30003ddac30b1d";
+    url = "https://github.com/mavlink/mavros-release/archive/release/foxy/mavros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "2eb8ca5204643e4a9434677433e9505f301f6b2eb280c49dfb28f48e7c300a6c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-msgs/default.nix
+++ b/distros/foxy/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-msgs";
-  version = "2.0.1-r1";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_msgs-release/archive/release/foxy/moveit_msgs/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "b690359e3a802a9e237707acf9c4d6e3efcb927b13a1fda184b12bf5caeed1d1";
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/foxy/moveit_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "507d19e081f64a7f4dcae9a50663f67c424e5884e4a3a024f284e7ffb6b9fc80";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "fd33c67f1d90826e1c544b4448305a29d4a7f19f22298e4c496283158501e645";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "add291faf30c6fde2b5ff4776f1ac283c13d01f957c2ad2fe2b65c07c502733e";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "b0d863a857340ecb78d82ee39f73629c26e47e48f44ee70f048c50b21d791431";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "7d88c36d8fae75d1f7d41f1406e77e1f860fde4392fa658af9275aeeb1f6de01";
   };
 
   buildType = "catkin";

--- a/distros/foxy/qpoases-vendor/default.nix
+++ b/distros/foxy/qpoases-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, subversion }:
+buildRosPackage {
+  pname = "ros-foxy-qpoases-vendor";
+  version = "3.2.3-r2";
+
+  src = fetchurl {
+    url = "https://github.com/Autoware-AI/qpoases_vendor-release/archive/release/foxy/qpoases_vendor/3.2.3-2.tar.gz";
+    name = "3.2.3-2.tar.gz";
+    sha256 = "5dd8deecfed630f13b4b913df8b17fad61ebb1f6976dde219b1f02df66050ba7";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ subversion ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Wrapper around qpOASES to make it available to the ROS ecosystem.'';
+    license = with lib.licenses; [ asl20 lgpl2 ];
+  };
+}

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, eigen, geometry-msgs, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "d7e198b295cc882d61d06f917c385e3858835b58a1fb1c6d9f56d6515577b9e6";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "886e171a830e603e12fd3588da6744e0757d9560ecf5394e5d24b4f81ea719c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-can/default.nix
+++ b/distros/foxy/raptor-dbw-can/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs, geometry-msgs, raptor-can-dbc-parser, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, geometry-msgs, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-can";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "7ac425ed5bb8d763f558fa26b14bb4bc0195358b643d7df03b1ef87966840332";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "14aa0ceed1d5cbc1d4a6fe871459af434a00f8508c2b4fcba88ebbdca7b32b18";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs geometry-msgs raptor-can-dbc-parser raptor-dbw-msgs raptor-pdu raptor-pdu-msgs rclcpp sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ can-dbc-parser can-msgs geometry-msgs raptor-dbw-msgs raptor-pdu raptor-pdu-msgs rclcpp sensor-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/foxy/raptor-dbw-joystick/default.nix
+++ b/distros/foxy/raptor-dbw-joystick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, raptor-dbw-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-joystick";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "36371901f01d4bf98f084fe30532b61e54f64309e888050a159f88676a2d7f0e";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a5d2193047328e26789260f7a2e2c5ab91d44f7cb9a22f7397eccb5578d1c45a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-msgs/default.nix
+++ b/distros/foxy/raptor-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9c798ad1edff250aabd2a05991be8cbde538d5bfbff1188144a32179d19fb595";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6e998689506478c0289cbb86afa3a4147ee7597e293e4c3d5299a225cf8e406b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu-msgs/default.nix
+++ b/distros/foxy/raptor-pdu-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu-msgs";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2f39745a84c4aaae4b23f44cf8a1f10ac54f57d7ee8452119edb790e3e221aa3";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a46bd8710b74a9d51b7b1a3783dd96f3c9b44644d1bb6bc154f71141762e2135";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu/default.nix
+++ b/distros/foxy/raptor-pdu/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs, raptor-can-dbc-parser, raptor-pdu-msgs, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, raptor-pdu-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu";
-  version = "1.0.0-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "cc62f2c4ddc4e698141540b928d36739f7862a8f9d8058e752a6e6d2fd09ca0e";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4fca165e245f927a38bc945277af34fa6af5884b585a3c0e7bc11e9f16baccd1";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ can-msgs raptor-can-dbc-parser raptor-pdu-msgs rclcpp std-msgs ];
+  propagatedBuildInputs = [ can-dbc-parser can-msgs raptor-pdu-msgs rclcpp std-msgs ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/foxy/rcdiscover/default.nix
+++ b/distros/foxy/rcdiscover/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-rcdiscover";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/foxy/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f759212447ad9b29e3be4070e3667135c2e16b4deccbc4c9f330f3c417d5541a";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This package contains tools for the discovery of Roboception devices via GigE Vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "c6a0b5d997a8b6715232af44483397fef53bff08e57228cede5077cd3144cabb";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "35e10772f1d182091ada1902e717e7f60111c8d19164b71a5c13942f5f984673";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "bc0d694b581b44dc3c111028e4dde1ca0beee1bb89a9e5554130b52309a907b4";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "7e80381a0f5e3b1a7572ca40a9b68469be8727dc255037d834ef44bcc36ccf37";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "4efb15642a0c2891dee6b133fac79779850a5f16d24ba28b052381f4d7afb657";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "ecd3ca9891f4e69bd7b25a6b9d110226c79e5e9b5284f8976c36d0edef596102";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "270887797058dc09e40f1736b305d0718ecaab7004351711e42ae5ca400d793d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "63df880de10fcf407c395b0dd2ad0bf38cf160c3e370230aa8e6891b49fc835c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "9bbe8d8f53e842460b4963dfcc1117a735831fe027e7260964d9ae4744f3e67e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "dbe6bf7dab75fe4f18ef8d6efb6739f58a7ccc1eef2f0ee85f4be09f62e48ebe";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "4299e355d5b1542d114dd23655b65435e6d107fec87705aee2238676f5fa5fc6";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "09a02e702ee921f7473fe1bbd97a63373986dbee484bdbdf04f5464d6b74b82a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "96bf4e91f947c92596f76d87afc205a98102167e46783611b201cde39abe5ecb";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "c353bca18cc752233fdcff751c211f72738775655024eacc6b73b933904acc25";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "cba0ed167f8f64c2b4c9615ef8df7af5dadafa3e7361c93c5e0d21a45f0b4822";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "6b108568e600f98fe816f4edef76cd6ad806c236372739157d2e4d4017f1f432";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "ef76e79e64e55f8c5d0b4e8fb8cb3578b00934a230e71a448917db152d4d0af1";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "81c29efdc09d20e76f2bd0da3b7ca01a7b60a1bb8f058bc5467a85f68deade18";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "060c2e8cea86e6d887baaf82b79483578353fc5d1a8dd56b97d20a13a3a84eaa";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "b937d5a8561b9eb39fb441fe25fd1f3605caa50d981b19ec6236847eb6c6fb77";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.1-r1";
+  version = "8.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.1-1.tar.gz";
-    name = "8.2.1-1.tar.gz";
-    sha256 = "309f990dd6a39180792dd1b7e7b1b771c08bc78bfa8ae343387dfb198fe24795";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.2-1.tar.gz";
+    name = "8.2.2-1.tar.gz";
+    sha256 = "fd899ddcd93971eb78612dda61e1d9f0aaa487a2c63db56d1cd7d417f16a351e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.7.0-r1";
+  version = "0.7.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.0-1.tar.gz";
-    name = "0.7.0-1.tar.gz";
-    sha256 = "b27fcc217fd74cc3a15c9719b45d52901cc9c7e36a3cf900656e12a8d070e960";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.1-1.tar.gz";
+    name = "0.7.1-1.tar.gz";
+    sha256 = "dd0b3bda53487647909b1f20e33485f297012af4f38d010720414c2a4e8856f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-fake-node/default.nix
+++ b/distros/foxy/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-fake-node";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "fff9bb4bbb00f9025a2fa3299e9d72b142115b01bd52ae02ed875eb8759664ec";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_fake_node/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "421f133a1c3f049ef1ecb28ed78452ae89b9707cdbeff59547725d01e6c57e3c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtlebot3-gazebo/default.nix
+++ b/distros/foxy/turtlebot3-gazebo/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3 }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2, turtlebot3-description }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-gazebo";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "006fbfb6cb78cff7556e7452b3d6c8207cb77e880b08481127bb0f1ad6528fea";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_gazebo/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "d0a90b9de5b1bd1b4d669c1eec7565ddc4153d47239eef32b87f7b806906cb11";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 turtlebot3 ];
+  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 turtlebot3-description ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/turtlebot3-simulations/default.nix
+++ b/distros/foxy/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-turtlebot3-simulations";
-  version = "2.2.2-r1";
+  version = "2.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.2-1.tar.gz";
-    name = "2.2.2-1.tar.gz";
-    sha256 = "c75666dd3406bec6dd0490246e77ac6d2dbbb2e6fbbcabe375e49216fcba3b7c";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/foxy/turtlebot3_simulations/2.2.3-1.tar.gz";
+    name = "2.2.3-1.tar.gz";
+    sha256 = "faaabdafc9b0404adebbbc0e1c72aec9807b4697c431c556e20b04aeb408d6cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/twist-mux/default.nix
+++ b/distros/foxy/twist-mux/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-xmllint, ament-lint-auto, ament-lint-common, diagnostic-updater, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, rclcpp, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-twist-mux";
+  version = "4.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/twist_mux-release/archive/release/foxy/twist_mux/4.0.1-1.tar.gz";
+    name = "4.0.1-1.tar.gz";
+    sha256 = "18805bae9e5dadc57609fe8255a31ac157e2a0289a24d1c21c24b70cdda940af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-xmllint ament-lint-auto ament-lint-common launch launch-testing launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ diagnostic-updater geometry-msgs rclcpp std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Twist multiplexer, which multiplex several velocity commands (topics) and
+      allows to priorize or disable them (locks).'';
+    license = with lib.licenses; [ cc-by-nc-sa-40 ];
+  };
+}

--- a/distros/foxy/ur-client-library/default.nix
+++ b/distros/foxy/ur-client-library/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, boost, cmake, console-bridge }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-foxy-ur-client-library";
-  version = "0.2.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "939c992144de23c1ac4ac5d8cde6a12fef01c8cca515e8eebf90355a376dc15d";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/foxy/ur_client_library/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "d460990dd5bd6786184e7bcdc90cc7f1d4bf64054fc4e47dbfb08f532d003667";
   };
 
   buildType = "cmake";
-  buildInputs = [ boost ];
   propagatedBuildInputs = [ ament-cmake console-bridge ];
   nativeBuildInputs = [ cmake ];
 

--- a/distros/foxy/urdf-test/default.nix
+++ b/distros/foxy/urdf-test/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-urdf-test";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/urdf_test-ros2-gbp/archive/release/foxy/urdf_test/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "5021683ebf04a99d3c15ef5e16e824abebadb4347d77a9452c77fb9a6c6931dd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The urdf_test package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dynamixel-sdk-custom-interfaces/default.nix
+++ b/distros/galactic/dynamixel-sdk-custom-interfaces/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-dynamixel-sdk-custom-interfaces";
+  version = "3.7.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/galactic/dynamixel_sdk_custom_interfaces/3.7.40-1.tar.gz";
+    name = "3.7.40-1.tar.gz";
+    sha256 = "c0867bceda098687932c89f75b9ce8dbcac63d3dcaad395d071e662637848c09";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS2 custom interface examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dynamixel-sdk-examples/default.nix
+++ b/distros/galactic/dynamixel-sdk-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dynamixel-sdk, dynamixel-sdk-custom-interfaces, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-dynamixel-sdk-examples";
+  version = "3.7.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/galactic/dynamixel_sdk_examples/3.7.40-1.tar.gz";
+    name = "3.7.40-1.tar.gz";
+    sha256 = "3a9c19cd0fff9f42d31aaf52cf2c0336eabf4b575cdcadd24e97bda3c1dee313";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dynamixel-sdk dynamixel-sdk-custom-interfaces rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 examples using ROBOTIS DYNAMIXEL SDK'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dynamixel-sdk/default.nix
+++ b/distros/galactic/dynamixel-sdk/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-dynamixel-sdk";
+  version = "3.7.40-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/dynamixel_sdk-release/archive/release/galactic/dynamixel_sdk/3.7.40-1.tar.gz";
+    name = "3.7.40-1.tar.gz";
+    sha256 = "1da0c352e65a649664e0666a9c53c7a0a09e2699329bdce3a9a86af767986669";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package is wrapping version of ROBOTIS Dynamixel SDK for ROS 2. The ROBOTIS Dynamixel SDK, or SDK, is a software development library that provides Dynamixel control functions for packet communication. The API is designed for Dynamixel actuators and Dynamixel-based platforms.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -230,6 +230,12 @@ self: super: {
 
  dynamic-edt-3d = self.callPackage ./dynamic-edt-3d {};
 
+ dynamixel-sdk = self.callPackage ./dynamixel-sdk {};
+
+ dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
+
+ dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
@@ -308,6 +314,8 @@ self: super: {
 
  geographic-msgs = self.callPackage ./geographic-msgs {};
 
+ geometric-shapes = self.callPackage ./geometric-shapes {};
+
  geometry2 = self.callPackage ./geometry2 {};
 
  geometry-msgs = self.callPackage ./geometry-msgs {};
@@ -380,6 +388,8 @@ self: super: {
 
  launch-ros = self.callPackage ./launch-ros {};
 
+ launch-system-modes = self.callPackage ./launch-system-modes {};
+
  launch-testing = self.callPackage ./launch-testing {};
 
  launch-testing-ament-cmake = self.callPackage ./launch-testing-ament-cmake {};
@@ -395,6 +405,8 @@ self: super: {
  libcurl-vendor = self.callPackage ./libcurl-vendor {};
 
  libg2o = self.callPackage ./libg2o {};
+
+ libmavconn = self.callPackage ./libmavconn {};
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
@@ -428,6 +440,10 @@ self: super: {
 
  mavlink = self.callPackage ./mavlink {};
 
+ mavros = self.callPackage ./mavros {};
+
+ mavros-msgs = self.callPackage ./mavros-msgs {};
+
  menge-vendor = self.callPackage ./menge-vendor {};
 
  message-filters = self.callPackage ./message-filters {};
@@ -435,6 +451,22 @@ self: super: {
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
+
+ moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-resources = self.callPackage ./moveit-resources {};
+
+ moveit-resources-fanuc-description = self.callPackage ./moveit-resources-fanuc-description {};
+
+ moveit-resources-fanuc-moveit-config = self.callPackage ./moveit-resources-fanuc-moveit-config {};
+
+ moveit-resources-panda-description = self.callPackage ./moveit-resources-panda-description {};
+
+ moveit-resources-panda-moveit-config = self.callPackage ./moveit-resources-panda-moveit-config {};
+
+ moveit-resources-pr2-description = self.callPackage ./moveit-resources-pr2-description {};
+
+ nao-interfaces = self.callPackage ./nao-interfaces {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -506,6 +538,8 @@ self: super: {
 
  ompl = self.callPackage ./ompl {};
 
+ openvslam = self.callPackage ./openvslam {};
+
  orocos-kdl = self.callPackage ./orocos-kdl {};
 
  osqp-vendor = self.callPackage ./osqp-vendor {};
@@ -558,6 +592,12 @@ self: super: {
 
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
+ plotjuggler = self.callPackage ./plotjuggler {};
+
+ plotjuggler-msgs = self.callPackage ./plotjuggler-msgs {};
+
+ plotjuggler-ros = self.callPackage ./plotjuggler-ros {};
+
  pluginlib = self.callPackage ./pluginlib {};
 
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
@@ -586,6 +626,8 @@ self: super: {
 
  radar-msgs = self.callPackage ./radar-msgs {};
 
+ random-numbers = self.callPackage ./random-numbers {};
+
  rc-common-msgs = self.callPackage ./rc-common-msgs {};
 
  rc-dynamics-api = self.callPackage ./rc-dynamics-api {};
@@ -593,6 +635,12 @@ self: super: {
  rc-genicam-api = self.callPackage ./rc-genicam-api {};
 
  rc-genicam-driver = self.callPackage ./rc-genicam-driver {};
+
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
+ rcdiscover = self.callPackage ./rcdiscover {};
 
  rcl = self.callPackage ./rcl {};
 
@@ -636,7 +684,31 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
+
+ rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
+
+ rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
+
+ rmf-dispenser-msgs = self.callPackage ./rmf-dispenser-msgs {};
+
+ rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
+
+ rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
+
+ rmf-ingestor-msgs = self.callPackage ./rmf-ingestor-msgs {};
+
+ rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
+
+ rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
+ rmf-utils = self.callPackage ./rmf-utils {};
+
  rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
+
+ rmf-workcell-msgs = self.callPackage ./rmf-workcell-msgs {};
 
  rmw = self.callPackage ./rmw {};
 
@@ -890,9 +962,13 @@ self: super: {
 
  smclib = self.callPackage ./smclib {};
 
+ soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
+
  spdlog-vendor = self.callPackage ./spdlog-vendor {};
 
  sqlite3-vendor = self.callPackage ./sqlite3-vendor {};
+
+ srdfdom = self.callPackage ./srdfdom {};
 
  sros2 = self.callPackage ./sros2 {};
 
@@ -907,6 +983,10 @@ self: super: {
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ stubborn-buddies = self.callPackage ./stubborn-buddies {};
+
+ stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
 
  system-modes = self.callPackage ./system-modes {};
 
@@ -929,6 +1009,8 @@ self: super: {
  test-bond = self.callPackage ./test-bond {};
 
  test-interface-files = self.callPackage ./test-interface-files {};
+
+ test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
 
  test-msgs = self.callPackage ./test-msgs {};
 
@@ -978,6 +1060,14 @@ self: super: {
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
+ turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
+
+ turtlebot3-gazebo = self.callPackage ./turtlebot3-gazebo {};
+
+ turtlebot3-msgs = self.callPackage ./turtlebot3-msgs {};
+
+ turtlebot3-simulations = self.callPackage ./turtlebot3-simulations {};
+
  turtlesim = self.callPackage ./turtlesim {};
 
  ublox = self.callPackage ./ublox {};
@@ -1017,6 +1107,8 @@ self: super: {
  vision-opencv = self.callPackage ./vision-opencv {};
 
  visualization-msgs = self.callPackage ./visualization-msgs {};
+
+ warehouse-ros = self.callPackage ./warehouse-ros {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-geometric-shapes";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "297188a25c428a2ddd49e921c2b89a969ace3ce538fdb6e39bb1d34c31bca12f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pkg-config ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains generic definitions of geometric shapes and bodies.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/launch-system-modes/default.nix
+++ b/distros/galactic/launch-system-modes/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages, rclpy, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ca94791d4296fac35774317ed0d3abff02930392a8f45b6f03dc7f610998b3ce";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python launch osrf-pycommon python3Packages.importlib-metadata python3Packages.pyyaml rclpy system-modes-msgs ];
+
+  meta = {
+    description = ''System modes specific extensions to the launch tool, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/libmavconn/default.nix
+++ b/distros/galactic/libmavconn/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, console-bridge, mavlink, python3Packages }:
+buildRosPackage {
+  pname = "ros-galactic-libmavconn";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/libmavconn/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "e1e5c116f69d4f66e5e77966708ccd571018f8cb924add5a57ffa0ae0e1a942f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ python3Packages.empy ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio console-bridge mavlink ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''MAVLink communication library.
+    This library provide unified connection handling classes
+    and URL to connection object mapper.
+
+    This library can be used in standalone programs.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/galactic/mavros-msgs/default.nix
+++ b/distros/galactic/mavros-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geographic-msgs, geometry-msgs, rcl-interfaces, rosidl-default-generators, rosidl-default-runtime, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-mavros-msgs";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "85be741c9fb840422699b2318e12410d93aee5cb3ae786b764498bd737531462";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs rcl-interfaces rosidl-default-runtime sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''mavros_msgs defines messages for <a href="http://wiki.ros.org/mavros">MAVROS</a>.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/galactic/mavros/default.nix
+++ b/distros/galactic/mavros/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, angles, console-bridge, diagnostic-msgs, diagnostic-updater, eigen, eigen-stl-containers, eigen3-cmake-module, geographic-msgs, geographiclib, geometry-msgs, gtest, libmavconn, mavlink, mavros-msgs, message-filters, nav-msgs, pluginlib, python3Packages, rclcpp, rclcpp-components, rclpy, rcpputils, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-mavros";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/mavlink/mavros-release/archive/release/galactic/mavros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "4f4a1ad97e98766b84937af980edf3d39880bbf684a47d7638ad1a35918b6e4b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ angles ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common gtest ];
+  propagatedBuildInputs = [ console-bridge diagnostic-msgs diagnostic-updater eigen eigen-stl-containers eigen3-cmake-module geographic-msgs geographiclib geometry-msgs libmavconn mavlink mavros-msgs message-filters nav-msgs pluginlib python3Packages.click rclcpp rclcpp-components rclpy rcpputils rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python eigen3-cmake-module ];
+
+  meta = {
+    description = ''MAVROS -- MAVLink extendable communication node for ROS
+    with proxy for Ground Control Station.'';
+    license = with lib.licenses; [ gpl3 lgpl2 bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-msgs/default.nix
+++ b/distros/galactic/moveit-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-msgs";
+  version = "2.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "37ce402737f464583838204fbde1831bdee9fcaa0f8aa337ba02e800cff3e847";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ action-msgs geometry-msgs object-recognition-msgs octomap-msgs rosidl-default-runtime sensor-msgs shape-msgs std-msgs trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages, services and actions used by MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-fanuc-description/default.nix
+++ b/distros/galactic/moveit-resources-fanuc-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-fanuc-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_fanuc_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6f083913956f4ee0d31d08ceddc87467ec21350698fdbeb07d29337ade8473f4";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Fanuc Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-fanuc-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-fanuc-moveit-config/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, robot-state-publisher, tf2-ros, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-fanuc-moveit-config";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_fanuc_moveit_config/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "28cff3264ed792f0990dca38af9ca6b4fa836e55cb9115f125088e699c492e6e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher moveit-resources-fanuc-description robot-state-publisher tf2-ros xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      MoveIt Resources for testing: Fanuc M-10iA.
+    </p>
+    <p>
+      A project-internal configuration for testing in MoveIt.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-panda-description/default.nix
+++ b/distros/galactic/moveit-resources-panda-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-panda-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_panda_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "bbd79344142ad1d08c9e74ba6b347c0545a23aab80fbaf83d2b26264b840a38c";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''panda Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-panda-moveit-config/default.nix
+++ b/distros/galactic/moveit-resources-panda-moveit-config/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, joint-state-publisher-gui, moveit-resources-panda-description, robot-state-publisher, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-panda-moveit-config";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_panda_moveit_config/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "6fd85578912213782703256aa5b4e7a2e87d44e47ddcc886e8f18eba042b9908";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher joint-state-publisher-gui moveit-resources-panda-description robot-state-publisher xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''<p>
+      MoveIt Resources for testing: Franka Emika Panda
+    </p>
+    <p>
+      A project-internal configuration for testing in MoveIt.
+    </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources-pr2-description/default.nix
+++ b/distros/galactic/moveit-resources-pr2-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources-pr2-description";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources_pr2_description/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "4fc7f6309efc8473999c79e2b9ca351ceff6b4798a3843cd44c0c530616ab0f7";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PR2 Resources used for MoveIt! testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-resources/default.nix
+++ b/distros/galactic/moveit-resources/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, joint-state-publisher, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, robot-state-publisher }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-resources";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_resources-release/archive/release/galactic/moveit_resources/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "b257da6fb7345b436f09541b9abb4e6f1b256dad57c0c5695369659444f2901d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ joint-state-publisher moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-resources-pr2-description robot-state-publisher ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Resources used for MoveIt testing'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/nao-interfaces/default.nix
+++ b/distros/galactic/nao-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-nao-interfaces";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/nao_interfaces-release/archive/release/galactic/nao_interfaces/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "4315ed423139f8ff30caab19a860260f0a54d096cbe945b34eac665fe87b0e69";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces to be used with a NAO robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/openvslam/default.nix
+++ b/distros/galactic/openvslam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake, eigen, glog, libg2o, libyamlcpp, opencv3 }:
+buildRosPackage {
+  pname = "ros-galactic-openvslam";
+  version = "0.2.3-r3";
+
+  src = fetchurl {
+    url = "https://github.com/OpenVSLAM-Community/openvslam-release/archive/release/galactic/openvslam/0.2.3-3.tar.gz";
+    name = "0.2.3-3.tar.gz";
+    sha256 = "942efc34b17b39cd4eb9051f757c00c8c5efb66b1acb09a9beae736189f9b74e";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ eigen glog libg2o libyamlcpp opencv3 ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''OpenVSLAM: A Versatile Visual SLAM Framework'';
+    license = with lib.licenses; [ "2-clause BSD" ];
+  };
+}

--- a/distros/galactic/plotjuggler-msgs/default.nix
+++ b/distros/galactic/plotjuggler-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-plotjuggler-msgs";
+  version = "0.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/galactic/plotjuggler_msgs/0.1.2-1.tar.gz";
+    name = "0.1.2-1.tar.gz";
+    sha256 = "7ff43f03d9b027a4ec4b54cf73168c3eba87ba81dbb9c9671f40da0887af8e5d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-cmake ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Special Messages for PlotJuggler'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/plotjuggler-ros/default.nix
+++ b/distros/galactic/plotjuggler-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-plotjuggler-ros";
+  version = "1.5.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/galactic/plotjuggler_ros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "5de2877f63666b5f7dfa3b5c3b4bbc2e0baf54f86420faecd78b82bb4609239c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ binutils boost diagnostic-msgs fastcdr geometry-msgs nav-msgs plotjuggler plotjuggler-msgs qt5.qtbase qt5.qtsvg qt5.qtwebsockets rclcpp rcpputils rosbag2 rosbag2-transport sensor-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PlotJuggler plugin for ROS'';
+    license = with lib.licenses; [ gpl3 ];
+  };
+}

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
+buildRosPackage {
+  pname = "ros-galactic-plotjuggler";
+  version = "3.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.2.1-2.tar.gz";
+    name = "3.2.1-2.tar.gz";
+    sha256 = "3791ade6fb304f5f1197504231ce09fa42bc5a76e3b165cec1121015c4342ae9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ament-index-cpp binutils boost cppzmq qt5.qtbase qt5.qtsvg qt5.qtwebsockets qt5.qtx11extras ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PlotJuggler: juggle with data'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/galactic/random-numbers/default.nix
+++ b/distros/galactic/random-numbers/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-cmake, boost }:
+buildRosPackage {
+  pname = "ros-galactic-random-numbers";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/random_numbers-release/archive/release/galactic/random_numbers/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "ce520bd61df0ef1a3929bcb59e8d03e4c8345fc0a42206b4f5880dad71359d80";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ boost ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This  library contains wrappers for generating floating point values, integers, quaternions using boost libraries.
+
+  The constructor of the wrapper is guaranteed to be thread safe and initialize its random number generator to a random seed.
+  Seeds are obtained using a separate and different random number generator.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rc-reason-clients/default.nix
+++ b/distros/galactic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, python3Packages, pythonPackages, rc-reason-msgs, rclpy, ros2pkg, tf2-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "d2e59341adf62d93e74e63fb8aecb2514d6b7da07f7c6c327a7fe91c8ec1079e";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.requests rc-reason-msgs rclpy ros2pkg tf2-msgs visualization-msgs ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rc-reason-msgs/default.nix
+++ b/distros/galactic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, geometry-msgs, rc-common-msgs, rosidl-default-generators, rosidl-default-runtime, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients-release/archive/release/galactic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "44ed59b880e13f073571177f633a592488ef8d409766f299e35d034328bdf7d8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rc-common-msgs rosidl-default-runtime shape-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rcdiscover/default.nix
+++ b/distros/galactic/rcdiscover/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-galactic-rcdiscover";
+  version = "1.1.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/galactic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "47f99b85a9a3a1d6961519a3931b020a49add3eae431d5244354f0944ae7925a";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''This package contains tools for the discovery of Roboception devices via GigE Vision.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rmf-building-map-msgs/default.nix
+++ b/distros/galactic/rmf-building-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-building-map-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_building_map_msgs-release/archive/release/galactic/rmf_building_map_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "32105bd1e925e358048cc1d33d517e8effb1149fce1b07f3a22db3b8de725130";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to send building maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-charger-msgs/default.nix
+++ b/distros/galactic/rmf-charger-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-charger-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_charger_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "91e5bd6743437d99cf2463a789522fc84018df0b5ad628b2d3f9aab62d8f6a94";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains messages regarding charging and discharging'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-cmake-uncrustify/default.nix
+++ b/distros/galactic/rmf-cmake-uncrustify/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-cmake-uncrustify";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_cmake_uncrustify-release/archive/release/galactic/rmf_cmake_uncrustify/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b16e279e4476f18946013027a112ab29462794d48d17fc269492dd86cdf587af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  propagatedBuildInputs = [ ament-cmake-test ament-uncrustify ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''ament_cmake_uncrustify with support for parsing a config file.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-dispenser-msgs/default.nix
+++ b/distros/galactic/rmf-dispenser-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-dispenser-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_dispenser_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "925f68b62baf8a5fbcce1c68d53b050fce94bc768c8e5436df0d28754d280fc2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to dispenser workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-door-msgs/default.nix
+++ b/distros/galactic/rmf-door-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-door-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_door_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1911e95e3c21c0a3a226c1a52511667fac173bc7db6e5aec189e07fa8e20f972";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to doors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-fleet-msgs/default.nix
+++ b/distros/galactic/rmf-fleet-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-fleet-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_fleet_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "794357732594b85329c1373d8d3fe4955ea6dbcd32c90af2b5cf60e5719564af";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to fleet managers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-ingestor-msgs/default.nix
+++ b/distros/galactic/rmf-ingestor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-ingestor-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_ingestor_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9c45ed33db91ba0f78874a2d3c8fb76807654c0e080f6fb06200b51431e59bbf";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to ingestor workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-lift-msgs/default.nix
+++ b/distros/galactic/rmf-lift-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-lift-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_lift_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "9b4c6b2f74b3eea329b51a2aaf223a5a9215a1913feef87b05de55d7e1cdcc0c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to lifts.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-task-msgs/default.nix
+++ b/distros/galactic/rmf-task-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-task-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_task_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "484cbaf76a57288cf1427f22eccf44ff20b0a8b6302f66439ebc304c8016f951";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to specify tasks'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-msgs/default.nix
+++ b/distros/galactic/rmf-traffic-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_traffic_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "78255a10d00ef93f716bae24b65d918e4ac5e56a468760c308770daeadf1fde9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by the RMF traffic management system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-utils/default.nix
+++ b/distros/galactic/rmf-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, cmake, rmf-cmake-uncrustify }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-utils";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_utils-release/archive/release/galactic/rmf_utils/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "88ba1f6a4a78fe123faafc7674e8e80d92e55e154fe9c909bccae8c3d1b171d5";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ cmake ];
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+
+  meta = {
+    description = ''Simple C++ programming utilities used by Robotics Middleware Framework packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-workcell-msgs/default.nix
+++ b/distros/galactic/rmf-workcell-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-workcell-msgs";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_workcell_msgs/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "c2850542c925c969fe88986d6d28d4e29be06cad8f37f9099e52e46208fb4847";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by all workcells generically to interfact with rmf_core'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmw-cyclonedds-cpp/default.nix
+++ b/distros/galactic/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-galactic-rmw-cyclonedds-cpp";
-  version = "0.22.2-r1";
+  version = "0.22.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.2-1.tar.gz";
-    name = "0.22.2-1.tar.gz";
-    sha256 = "967f5594262b20f00ea7f005f902ae85e7180441d90639e90330393789d19d26";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/galactic/rmw_cyclonedds_cpp/0.22.3-1.tar.gz";
+    name = "0.22.3-1.tar.gz";
+    sha256 = "2fc03f09537ea23892b56d173f50b10728f057ae6b56cccbd13848e253c89d6e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-vision-msgs/default.nix
+++ b/distros/galactic/soccer-vision-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-soccer-vision-msgs";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/galactic/soccer_vision_msgs/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "45ecaf07aa73795b72c927bf264a8a628a0319dcedd4955ffc73021b549e05e4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/srdfdom/default.nix
+++ b/distros/galactic/srdfdom/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
+buildRosPackage {
+  pname = "ros-galactic-srdfdom";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "85093ec96f860df084a864588c8be49480f8f05ac6ed74e93725b92ad366f518";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost urdfdom-headers ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  propagatedBuildInputs = [ console-bridge console-bridge-vendor tinyxml2-vendor urdf urdfdom-py ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Parser for Semantic Robot Description Format (SRDF).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/stubborn-buddies-msgs/default.nix
+++ b/distros/galactic/stubborn-buddies-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-stubborn-buddies-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/galactic/stubborn_buddies_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "bce2abcd2da5bf94ccbea3da174f9961d3b389f17cecf413a61e6342a22f8127";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages to support library of stubborn buddies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/stubborn-buddies/default.nix
+++ b/distros/galactic/stubborn-buddies/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs, stubborn-buddies-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-stubborn-buddies";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/galactic/stubborn_buddies/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "f1e8acfe227b52e74579b62d49a703eb9cb5342e73899d2c193a1dea42fdedac";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle rcutils std-msgs stubborn-buddies-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo that uses node composition of lifecycle nodes to achieve fail-over robustness on ROS nodes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/system-modes-examples/default.nix
+++ b/distros/galactic/system-modes-examples/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, launch, launch-system-modes, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-examples";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "9ab24fff6b750f79e393a01b13bfc5e690a0bd5b6b633a898dc79ad00743e6dd";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ada88f621f2ae43f067d76a68f0250f98458f879c035589136defc701536a119";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-gmock ament-cmake-gtest ament-cmake-pep257 ament-cmake-uncrustify ament-lint-auto ];
-  propagatedBuildInputs = [ rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
+  propagatedBuildInputs = [ launch launch-system-modes rclcpp rclcpp-lifecycle ros2launch system-modes system-modes-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''Simple example system and according launch files for the system_modes
+    description = ''Example systems and according launch files for the system_modes
     package.'';
     license = with lib.licenses; [ asl20 ];
   };

--- a/distros/galactic/system-modes-msgs/default.nix
+++ b/distros/galactic/system-modes-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-msgs";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "aa03c0679e951ea6502e7c39d66356d29f132b51240405e3c48f3c1af9e1e4a9";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "219aa913637105060717a8be60115acb01422ddf310ef1cdaa84038e99f12320";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/system-modes/default.nix
+++ b/distros/galactic/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes";
-  version = "0.7.1-r3";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.7.1-3.tar.gz";
-    name = "0.7.1-3.tar.gz";
-    sha256 = "9e30700ca05a3414bb301cc41b6ceb03b150f1d4e1fb404b9456b1e9f57ed38c";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "2863caf47d437d34ec5adc17cdd8703039c08628fb0e17b57a1f4caa707708eb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/test-launch-system-modes/default.nix
+++ b/distros/galactic/test-launch-system-modes/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-pep257, ament-index-python, ament-lint-auto, builtin-interfaces, launch-system-modes, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, rclcpp, rclcpp-lifecycle, system-modes, system-modes-examples, system-modes-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-test-launch-system-modes";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/test_launch_system_modes/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e11602477c88318215d55fb1ee8e4bbcfd62b83ddc40311d1c6524c16bf87712";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-flake8 ament-cmake-pep257 ament-index-python ament-lint-auto launch-testing-ament-cmake launch-testing-ros ];
+  propagatedBuildInputs = [ builtin-interfaces launch-system-modes lifecycle-msgs rclcpp rclcpp-lifecycle system-modes system-modes-examples system-modes-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch tests for the launch_system_modes package, i.e. launch actions, events, and event
+    handlers for system modes.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-fake-node/default.nix
+++ b/distros/galactic/turtlebot3-fake-node/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-fake-node";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "74dd61d7ca8495e2c42dc03a06e148b6ada531ad091c0357d2010bf882c1e1e4";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake geometry-msgs nav-msgs rclcpp robot-state-publisher sensor-msgs tf2 tf2-msgs turtlebot3-msgs ];
+
+  meta = {
+    description = ''Package for TurtleBot3 fake node. With this package, simple tests can be done without a robot.
+    You can do simple tests using this package on rviz without real robots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-gazebo/default.nix
+++ b/distros/galactic/turtlebot3-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-gazebo";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "865093b702e896467230cca014ebd7f24f318bd335b76f9853cdd08864ab5832";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-ros-pkgs geometry-msgs nav-msgs rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo simulation package for the TurtleBot3'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-msgs/default.nix
+++ b/distros/galactic/turtlebot3-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-msgs";
+  version = "2.2.2-r3";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_msgs-release/archive/release/galactic/turtlebot3_msgs/2.2.2-3.tar.gz";
+    name = "2.2.2-3.tar.gz";
+    sha256 = "d9c9487a81573d590ccd599c9a8521c2d5acfe6d3dcb6d3dabe0af19bed97a04";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service types: custom messages and services for TurtleBot3 packages for ROS2'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-simulations/default.nix
+++ b/distros/galactic/turtlebot3-simulations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
+buildRosPackage {
+  pname = "ros-galactic-turtlebot3-simulations";
+  version = "2.2.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-1.tar.gz";
+    name = "2.2.4-1.tar.gz";
+    sha256 = "6fe67cb191ca2dcab6dd76a8266296360f6f71a55b8370d55f9f0fedb71550c0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ turtlebot3-fake-node turtlebot3-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS 2 packages for TurtleBot3 simulations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/warehouse-ros/default.nix
+++ b/distros/galactic/warehouse-ros/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-warehouse-ros";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "5b1009c43e08e064d8b54641762d610784cdb276198a0f69bf2934add794af69";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ openssl ];
+  checkInputs = [ ament-cmake-copyright ament-lint-auto ];
+  propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Persistent storage of ROS messages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
+buildRosPackage {
+  pname = "ros-melodic-aques-talk";
+  version = "2.1.22-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a537e5c2bd122d9506710191541a9660a88daa1129f35b974d0fa9bce60a31e4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ kakasi nkf sound-play ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS interface aques_talk demo program'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "2dc0f7f1140b7b556ee37d5a829d86cebc3aa3ce6f3e8df943f1b669e0532116";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "afc880a08df6dd79c65228e3950bf1fccd18d0e14c393d2da6b191049ec67188";
   };
 
   buildType = "catkin";

--- a/distros/melodic/astuff-sensor-msgs/default.nix
+++ b/distros/melodic/astuff-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, delphi-esr-msgs, delphi-srr-msgs, derived-object-msgs, ibeo-msgs, kartech-linear-actuator-msgs, mobileye-560-660-msgs, neobotix-usboard-msgs, pacmod-msgs, radar-msgs, ros-environment }:
 buildRosPackage {
   pname = "ros-melodic-astuff-sensor-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/astuff_sensor_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "9e66ef493c6ad8152a2b2ac9f4d36f7d09f20ed5e83ee66f335e171bd27a93c8";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/astuff_sensor_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "a96b19f4f23210692d87fdc878b65082a2fab92235461559b586608338996dbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "14770ef15dabe46dce0d225c13ff12cb35caec1acfc5a4aaa55ba85493f82cda";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "370b4226ab5afc3841f17e1a36cd266910dae6941ff0b6006272d8f03d279732";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.5.9-1/bota_driver-release-release-melodic-bota_driver-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_driver-0.5.9-1.tar.gz";
-    sha256 = "746165368b4474d44ef6b22e001fcca9f5157c1872c7a74038df4faec9800751";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.6.0-3/bota_driver-release-release-melodic-bota_driver-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_driver-0.6.0-3.tar.gz";
+    sha256 = "81a71cc679a7748f57570b6b1593d27c33b504e13a6e80700887e8ff72460a5c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-msgs rokubimini-serial ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.5.9-1/bota_driver-release-release-melodic-bota_node-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_node-0.5.9-1.tar.gz";
-    sha256 = "d44e0034b91e8cfabd81199784d0dc92df6e08972305bea1205df1103d9993d2";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.6.0-3/bota_driver-release-release-melodic-bota_node-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_node-0.6.0-3.tar.gz";
+    sha256 = "8c742bea9e76ab6a776edb1fb758767ffc1bbfc228c8e1b9bce25c482118c82f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.5.9-1/bota_driver-release-release-melodic-bota_signal_handler-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_signal_handler-0.5.9-1.tar.gz";
-    sha256 = "958e8f2b500204f0a4ac5f082ce1b3689b50c2a6388e2b93d444ed5da30f2b1e";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.6.0-3/bota_driver-release-release-melodic-bota_signal_handler-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_signal_handler-0.6.0-3.tar.gz";
+    sha256 = "0e7f2a00a6e2103052d38d7c99bf8f5204e175bd7d118dbd055f109cc101d54d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.5.9-1/bota_driver-release-release-melodic-bota_worker-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_worker-0.5.9-1.tar.gz";
-    sha256 = "6d7c78d1cba130da8635e9be9f8da0b03418b574811a85f451aa53f72c9756f6";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.6.0-3/bota_driver-release-release-melodic-bota_worker-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_worker-0.6.0-3.tar.gz";
+    sha256 = "2e2bcd1a6860e2c0a1a58cffa9a06cbaa53640195df9dada6157f38e6dee4e13";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-control-msgs/default.nix
+++ b/distros/melodic/cartesian-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-control-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release/archive/release/melodic/cartesian_control_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b950b93403f3867d3b7f1dd634183deb6ebee6b25a4d5b9c87398edc17b3c46c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory execution interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-interface/default.nix
+++ b/distros/melodic/cartesian-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-interface";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "d3b6f0185a16c13a29e0992f324542ff0bc53d8e5b4cd5f79f8589137eeb72be";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometry-msgs hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Defines a hardware interface to send Cartesian commands to a robot hardware and read
+    Cartesian states.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-trajectory-controller/default.nix
+++ b/distros/melodic/cartesian-trajectory-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-trajectory-controller";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "c46a01abaeb00170a359eb7a8a7068edb8983f88385c35d0437ba7cc64059bdc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs control-msgs controller-manager-msgs joint-state-controller joint-trajectory-controller robot-state-publisher ros-control-boilerplate rostest trajectory-msgs xacro ];
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-interpolation controller-interface controller-manager hardware-interface kdl-parser pluginlib roscpp rospy speed-scaling-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Cartesian trajectory controller with multiple hardware interface support'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/melodic/cartesian-trajectory-interpolation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-melodic-cartesian-trajectory-interpolation";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "106dcf4af4f487b26db8189c1e2b8b9bb8cbb00d33ac9cb505095945c901a9f6";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cartesian-control-msgs joint-trajectory-controller roscpp rospy tf2-eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory interpolation as a standalone library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-chaplus-ros";
+  version = "2.1.22-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "c37f88ea93357f57bf6caeddff4a99565b08d9b95285552c849f7c7e0a0f8917";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.requests rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ROS package for chaplus service'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/combined-robot-hw-tests/default.nix
+++ b/distros/melodic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw-tests";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "3c3c6ba6f41f2a1e256b4c48ac9355b3d9cd38bfa0fbf8a4488860acb4595c55";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw_tests/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "69832526f9f047fbd4241bfd9bcfb67123cb1ffed88383bbc44dba805a51dc0b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/combined-robot-hw/default.nix
+++ b/distros/melodic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-combined-robot-hw";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "9717f332faad24fa498a054a971f88b9ab575e45167b3f1deb62998c4feda331";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/combined_robot_hw/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "d09031bea3b3d2d8d5b496f3856e4ea059a585bd2be9cb2f6703750c999560ab";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-interface/default.nix
+++ b/distros/melodic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-controller-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "66e9d3ad23a251313da649f3d0929d2136c52b3935b11ea9e3f4cdd0225e289f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "05014247fbb6cd7ddd66595f36e61f12e2609cdcb791c6a9a1cbce955632c162";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-msgs/default.nix
+++ b/distros/melodic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-msgs";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "49d27abb925026460ddd92ea2c19ab19609b7dc031a2c94be3cfa23b8e7d9b9c";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_msgs/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "6765242a3a7e2a1e92fe831d01d499286e677dea3f88bc7917c2c3375a96c125";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager-tests/default.nix
+++ b/distros/melodic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager-tests";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "e31868f421a3393069ba5d9b07120b6c5993de17d0e75452ca8e7d9d8fa4efb5";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager_tests/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "374371fe02df6f27e7e10309953988c02a2fa8470bb7e06f53abc6265717ba30";
   };
 
   buildType = "catkin";

--- a/distros/melodic/controller-manager/default.nix
+++ b/distros/melodic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-controller-manager";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "5dd2e1325899cd23680be89e7c4fad5dee0491e1542ecc2947df753e0ae6d5f7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/controller_manager/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "9fb65b2d3430380e5cc1a7cae9b328af060cbfa5ec8d7ffc75128e3ec5b41bb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/copernicus-base/default.nix
+++ b/distros/melodic/copernicus-base/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-base";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_base/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "cdd488a29f262e20e249e710e488cdd3dffb8bf78055aa322520431316eeac5c";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_base package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-control/default.nix
+++ b/distros/melodic/copernicus-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, copernicus-msgs, diff-drive-controller, dynamic-reconfigure, gazebo-ros-control, joint-state-controller, roscpp, std-msgs, twist-mux }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-control";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2784e62785f7ccc852a56b863c0be8a9f6c458afd8b7f619d7874e062ce68074";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager copernicus-msgs diff-drive-controller dynamic-reconfigure gazebo-ros-control joint-state-controller roscpp std-msgs twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_control package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-description/default.nix
+++ b/distros/melodic/copernicus-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roslaunch, urdf, velodyne-description, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-description";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "45755a8f02a7d84af410f684521f622839193ad68ca03a009c29c8df44d36182";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch velodyne-description ];
+  propagatedBuildInputs = [ urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-localization/default.nix
+++ b/distros/melodic/copernicus-localization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-localization }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-localization";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_localization/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "cfc491a7c55762b8ebd73ef2a3161ca650e1b49771e2f97548fe0ef5ab54e539";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-localization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_localization package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-msgs/default.nix
+++ b/distros/melodic/copernicus-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-msgs";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "a78a7f39a5ab5918285b4b8e6f8d07db07c8da29ad5754410e28f8123ff70132";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-navigation/default.nix
+++ b/distros/melodic/copernicus-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, dwa-local-planner, global-planner, gmapping, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-navigation";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_navigation/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "aea86ea189044f29f15e382e225901e0dc38d7862b5f7aae0bcb17797f021698";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl dwa-local-planner global-planner gmapping map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-rules/default.nix
+++ b/distros/melodic/copernicus-rules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-rules";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_rules/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "48795a9fbeb822abda74d770993b82c9a8a58321824c8a048250c84fe2857f29";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.pyusb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_rules package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/copernicus-teleoperator/default.nix
+++ b/distros/melodic/copernicus-teleoperator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, copernicus-msgs, geometry-msgs, roscpp, sensor-msgs, teleop-twist-joy, teleop-twist-keyboard }:
+buildRosPackage {
+  pname = "ros-melodic-copernicus-teleoperator";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/copernicus-release/archive/release/melodic/copernicus_teleoperator/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7de39e838268a097a798978f1ebf21f70565ccba35e2ec9b4fbada41c98d6c43";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib-msgs copernicus-msgs geometry-msgs roscpp sensor-msgs teleop-twist-joy teleop-twist-keyboard ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The copernicus_teleoperator package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "a23610a356631f3f0688da2b3646183ceeeb2da63a9cabe733493b30794a0a19";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "06392b3a48b6732ab992cb671c725fa159fdf9e83073ca292aad3a741022dc86";
   };
 
   buildType = "catkin";

--- a/distros/melodic/delphi-esr-msgs/default.nix
+++ b/distros/melodic/delphi-esr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-esr-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_esr_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "92e4d1b61fe7b3658dcf55643dacbbf5594b53a51d5868a36776fcabd08f1704";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_esr_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "610a69fa08410ae871622aefa5896e7fe99c94c3776dca97e63291dcde2118b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/delphi-mrr-msgs/default.nix
+++ b/distros/melodic/delphi-mrr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-mrr-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_mrr_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "e39cbf4c8107a205996d98997f167513c81f5b2f364875b033213c438523ab28";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_mrr_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "ae772ab11e180eade5e1f1cde8f83d403b4bd2c3ae87fc0964ac20cf49d1cf39";
   };
 
   buildType = "catkin";

--- a/distros/melodic/delphi-srr-msgs/default.nix
+++ b/distros/melodic/delphi-srr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-delphi-srr-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_srr_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "d5848c18dad69762d5f942df492639043c6aa1347b87c4ff8d1348243db0334f";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/delphi_srr_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "5e7b8a7119dcb32fcf621af3cdc777e08d09ee14778f1ea1c9c9cd9a983941df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/derived-object-msgs/default.nix
+++ b/distros/melodic/derived-object-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, radar-msgs, ros-environment, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-derived-object-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/derived_object_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "56782e3b607e2f56060747ae3328ca771620484e361386a58328aff21e97c420";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/derived_object_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "643100d5f56828608ddd6648416bf3ddc08b5617ea211eba133fef3b0a3a7934";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "4f15f016383579ae56cf88c1c58f65739ed61f61e78228d1d2d91d24f1f432f9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a961d1f9b2b9f6af11ea5272feb72e89c58b76f6f73fb1847d13814f07b1661c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "1c9f22e09ff7bb87120672c2637b10c6fbfe00ec90a8dae895dfea60ac4f6cdd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "21ca5326b82e1c975ac432a9b41892a51a0fa90706fe15fd6cbe590deb8409d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "99cd6fd74727351fbf8bb43a3a60dcaf5e96a285ced41c9f4c394d60fd3e51c7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "cba733bea85d8ca6709f41e90560571d6caafac0f265a15777399e9a0c101a47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -82,6 +82,8 @@ self: super: {
 
  apriltag-ros = self.callPackage ./apriltag-ros {};
 
+ aques-talk = self.callPackage ./aques-talk {};
+
  ar-track-alvar = self.callPackage ./ar-track-alvar {};
 
  ar-track-alvar-msgs = self.callPackage ./ar-track-alvar-msgs {};
@@ -212,8 +214,6 @@ self: super: {
 
  boost-sml = self.callPackage ./boost-sml {};
 
- bota-device-driver = self.callPackage ./bota-device-driver {};
-
  bota-driver = self.callPackage ./bota-driver {};
 
  bota-node = self.callPackage ./bota-node {};
@@ -262,7 +262,15 @@ self: super: {
 
  carrot-planner = self.callPackage ./carrot-planner {};
 
+ cartesian-control-msgs = self.callPackage ./cartesian-control-msgs {};
+
+ cartesian-interface = self.callPackage ./cartesian-interface {};
+
  cartesian-msgs = self.callPackage ./cartesian-msgs {};
+
+ cartesian-trajectory-controller = self.callPackage ./cartesian-trajectory-controller {};
+
+ cartesian-trajectory-interpolation = self.callPackage ./cartesian-trajectory-interpolation {};
 
  cartographer = self.callPackage ./cartographer {};
 
@@ -279,6 +287,8 @@ self: super: {
  catkin-pip = self.callPackage ./catkin-pip {};
 
  catkin-virtualenv = self.callPackage ./catkin-virtualenv {};
+
+ chaplus-ros = self.callPackage ./chaplus-ros {};
 
  checkerboard-detector = self.callPackage ./checkerboard-detector {};
 
@@ -559,6 +569,22 @@ self: super: {
  controller-manager-tests = self.callPackage ./controller-manager-tests {};
 
  convex-decomposition = self.callPackage ./convex-decomposition {};
+
+ copernicus-base = self.callPackage ./copernicus-base {};
+
+ copernicus-control = self.callPackage ./copernicus-control {};
+
+ copernicus-description = self.callPackage ./copernicus-description {};
+
+ copernicus-localization = self.callPackage ./copernicus-localization {};
+
+ copernicus-msgs = self.callPackage ./copernicus-msgs {};
+
+ copernicus-navigation = self.callPackage ./copernicus-navigation {};
+
+ copernicus-rules = self.callPackage ./copernicus-rules {};
+
+ copernicus-teleoperator = self.callPackage ./copernicus-teleoperator {};
 
  costmap-2d = self.callPackage ./costmap-2d {};
 
@@ -2592,6 +2618,8 @@ self: super: {
 
  parrot-arsdk = self.callPackage ./parrot-arsdk {};
 
+ pass-through-controllers = self.callPackage ./pass-through-controllers {};
+
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
  pcl-msgs = self.callPackage ./pcl-msgs {};
@@ -3036,6 +3064,10 @@ self: super: {
 
  rc-pick-client = self.callPackage ./rc-pick-client {};
 
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
  rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
 
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
@@ -3222,12 +3254,6 @@ self: super: {
 
  rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
 
- rokubimini-examples = self.callPackage ./rokubimini-examples {};
-
- rokubimini-factory = self.callPackage ./rokubimini-factory {};
-
- rokubimini-manager = self.callPackage ./rokubimini-manager {};
-
  rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
 
  rokubimini-serial = self.callPackage ./rokubimini-serial {};
@@ -3251,6 +3277,8 @@ self: super: {
  ros-control-boilerplate = self.callPackage ./ros-control-boilerplate {};
 
  ros-controllers = self.callPackage ./ros-controllers {};
+
+ ros-controllers-cartesian = self.callPackage ./ros-controllers-cartesian {};
 
  ros-core = self.callPackage ./ros-core {};
 
@@ -4083,6 +4111,8 @@ self: super: {
  tuw-vehicle-msgs = self.callPackage ./tuw-vehicle-msgs {};
 
  tvm-vendor = self.callPackage ./tvm-vendor {};
+
+ twist-controller = self.callPackage ./twist-controller {};
 
  twist-mux = self.callPackage ./twist-mux {};
 

--- a/distros/melodic/graceful-controller-ros/default.nix
+++ b/distros/melodic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller-ros";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "6bbb00212bf3c8ac004bd96c34667cda8c28bff64a0ce16205a43f8abf73068b";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "b4637050cf6bd9f01a16b064389b3a30d1a739b76d7c5f234f2add7009081b05";
   };
 
   buildType = "catkin";

--- a/distros/melodic/graceful-controller/default.nix
+++ b/distros/melodic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-graceful-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5523188e4a57d11d9b6da6b80877646578b621f1788cd62f1114d66d99b716c9";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/melodic/graceful_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "c682e31e87543d1624c5cee00831ec7d2fbe7339220135002422917afd9585b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hardware-interface/default.nix
+++ b/distros/melodic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-hardware-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "12b51dc4acecbcb9708127d984e587166aa1882301096389be9e62fbfe74d9e5";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/hardware_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "b80c58cf8ee11ea90f4efbe8498f686bc6b0e64c023b933e4abc1994f05b6bcc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-gazebo-plugins/default.nix
+++ b/distros/melodic/hector-gazebo-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gazebo, gazebo-dev, gazebo-ros, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gazebo, gazebo-dev, gazebo-ros, geographic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-hector-gazebo-plugins";
-  version = "0.5.1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_plugins/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "950bd57e9157767ab5699a7b93eee1083a484633b26f8931b433c71755716159";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_plugins/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "a215cd06c58b2ab21a634c69f5debcfff0f189c92faf6e6371fe1392610a511a";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev message-generation ];
-  propagatedBuildInputs = [ dynamic-reconfigure gazebo gazebo-ros geometry-msgs message-runtime nav-msgs roscpp std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure gazebo gazebo-ros geographic-msgs geometry-msgs message-runtime nav-msgs roscpp std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/hector-gazebo-thermal-camera/default.nix
+++ b/distros/melodic/hector-gazebo-thermal-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-plugins, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-hector-gazebo-thermal-camera";
-  version = "0.5.1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_thermal_camera/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "6a3221be450c74fed270dcff5e3399e8e5650169b2bdf36ecf588a9602d95a2c";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_thermal_camera/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "dcd0abbdd0b1bf98a7b10e37e08f6822214a4c088f3068ff6f4fed38d928ea39";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-gazebo-worlds/default.nix
+++ b/distros/melodic/hector-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, hector-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-hector-gazebo-worlds";
-  version = "0.5.1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_worlds/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "71ada41731ad64e3a1815c57a0f4ef98f526afaf0decf58eb26745721a39ce5b";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo_worlds/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "f155a9a3e1bf7eb33b575241e2a049056ced64687bf207ae23c90efeb60a55ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-gazebo/default.nix
+++ b/distros/melodic/hector-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-gazebo-plugins, hector-gazebo-thermal-camera, hector-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-melodic-hector-gazebo";
-  version = "0.5.1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "e474b78636582cd62c773aa6f4951ee850aa2f1afb3896e93d3a171a7037287f";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_gazebo/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "5a0f19ce263c79bed61d68679fa7cacb0e14549ce62945b253c5ea30a7510062";
   };
 
   buildType = "catkin";

--- a/distros/melodic/hector-sensors-gazebo/default.nix
+++ b/distros/melodic/hector-sensors-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, hector-gazebo-plugins, hector-sensors-description }:
 buildRosPackage {
   pname = "ros-melodic-hector-sensors-gazebo";
-  version = "0.5.1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_sensors_gazebo/0.5.1-0.tar.gz";
-    name = "0.5.1-0.tar.gz";
-    sha256 = "f6c2dbc7c925947b911f5fc7065443bd12d24193b7a9168347c560fab1300d09";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/melodic/hector_sensors_gazebo/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "1233ccf3a39ff184ec0376f06473d50ed22d8562f5a06ad6d251efb58b26e446";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ibeo-msgs/default.nix
+++ b/distros/melodic/ibeo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-ibeo-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/ibeo_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "6ac11a7e60287acc8f6840aed34b682da8a0b70e95a41e27b886fe50c3590f0b";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/ibeo_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "0e7dc35d20626bbd58866e4dbbcc1bd00b8bdd1b09d5487629311d0fa91c04e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joint-limits-interface/default.nix
+++ b/distros/melodic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-melodic-joint-limits-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "da866a60a8165b5757f4894971049cc884f82ff806d7e5e1b84785bd8db4c6c2";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/joint_limits_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "823ce3b28e894f53139b27f00606a291b891e791dc193069d478c91055cb14d8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "c8edd28c1e6b4f3b482691c05ed16a489fde9f9a208961ca4091a7edf332dcb6";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "c0a76bbb0c21c48e857a843778217320de64c507e7440fb0c94bb9ee5069c6ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
+{ lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "1230ca69543b25fe233ad7cb15a8bad1359af779e0dcd7d3fa9a556ff38e9cc6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "e9462eb12a7dc81c6a47e9dca701ab7aee844b6c5d74d0ae28adfafd3e029af2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks dialogflow-task-executive downward ff ffha gdrive-ros julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping rostwitter sesame-ros slic voice-text ];
+  propagatedBuildInputs = [ assimp-devel bayesian-belief-networks dialogflow-task-executive downward ff ffha gdrive-ros google-cloud-texttospeech julius julius-ros libcmt libsiftfast mini-maxwell nlopt opt-camera pgm-learner rospatlite rosping rostwitter sesame-ros slic voice-text ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "f9ecc88f3dcc306bc97af128153ed152917ed835ea1bc5f0b8ffc8096279d096";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "645cbcb2d731344c20ab293169104e821495c49eb8b0ffdecc0844c0f2603c34";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kartech-linear-actuator-msgs/default.nix
+++ b/distros/melodic/kartech-linear-actuator-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kartech-linear-actuator-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/kartech_linear_actuator_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "33a0021ae7939c2452a3d4df3387a268b031676108a9f9bf2fe0b65b4938654d";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/kartech_linear_actuator_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "3fa3af9c845b1d7844947dd1e7147d5cc00935a20733c740fca379d2b1069a1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters-jsk-patch/default.nix
+++ b/distros/melodic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters-jsk-patch";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "6f4d3b7603c2136bcee88baed6fb17ba6f2697a36bfbdd7c89624bf9d0be19ad";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "5fb7cc733051f087d74e9345de022ecbacdc5d7ce500cfe084d2b79614c7e533";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "905631640d2cf267a0c0c6c921470f7e1e986f2859e7302fe431ed45c52830a4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "6b51e5fbe7ae691b329f8ff19de65617a9d694ebf06011832d043c8a2101290c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "0772c84e89ec4ee8e4ddac0e42ee1543b586dc12e5ec8b98e69876999f0d329e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "9a6b98bf3366af7e8fcd205dc09ec3976243037f5c4eeccbe5045740aaa76421";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "36bbbab7b76409e1995490b8da7e7137c51189b5ae6a18271c0c94c095df9004";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "b0c9074c493b4ce9237e2668b87ed95a8a9389537a8fe3bafd1bf7d98afe329e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "601ee3d4cf8420b0f4e295e673363fef6e1ed0454595c797abd5f19c3fbe66b2";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "44de099e841a55c1c8a68178858cdd2d5d4d341d1aa2dabd371e085050317e69";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "3f10e85ae3f503134406c164c21939cf74588f6f38687ceb96d0f835085f8701";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "e3fff426221703d58aca43e821fade1f92dda4fb60472c77aed6b966827a6b9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mobileye-560-660-msgs/default.nix
+++ b/distros/melodic/mobileye-560-660-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-mobileye-560-660-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/mobileye_560_660_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "235c48b33b96b63d5bd8a8cb31ca5089759418df563d823390d2b6a963b160b9";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/mobileye_560_660_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "952c7980abc7d35a66fec1e791bcc1c78cc80ce737ca1db50d10664c2f011301";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neobotix-usboard-msgs/default.nix
+++ b/distros/melodic/neobotix-usboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-neobotix-usboard-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/neobotix_usboard_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "5d0e86a2a5dfeaf650ce7b3f799e9166ff9a7646b38fee46484bc430a31b6748";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/neobotix_usboard_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "8e3808b58c3ad9838b1305e754baab380f6c8e95b6dd9be062f2bd9563f080d5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "da76151565b6ae46dcaabc5e7e8c6bc7779bc66b406e6aef5719ba20e813a636";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "3fb1cb2114916f4b6d9658b6e4dc70a3b131bfcaf38681946f71ae7099277262";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "6c9a3e028b694663cb0858be0d7a08c75a54f0fe5f6a3420bd91b1c05514f2eb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "db346e0b32e1baa9176c30283a147085aaa0357b6fd707be53ebe8d3276fbfea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "6e95b0c10eb833934c7c6ab3d8489ee355f5599a9425bc4bc65d29313a22a1eb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "b0e230c3ed5f1935966c0070e90c72209900f3daf25a041353d387ffa3cd380b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "c2b25156aad79ecc96a2d4cbc1eed1c480b94ea40af8004f8bb4ad0b064b3f0d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "a952ba2d8e901984ee14bfb07058fab067bc6a277ac8d7c08b4a66a3f9930cd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "4c26b2682d74788241b9ed6e54dc30d3b37d27cb8cb7a430560b467cf8633c8f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "731521d8cadd3547278ba1eb85de6b5622b2fc6202def52334afdacb76c0f553";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "5286726c5c8d2d19d493ae1c357614680cdb4cd3877db19076dfe2d6cf44ce58";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "5f89bc3505223a68f915e106d6cf319cb5deabeae6d1cc403b6de5a5a4645402";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pacmod-msgs/default.nix
+++ b/distros/melodic/pacmod-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pacmod-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/pacmod_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "3bf0ce0f3c1971b85a0af45522044352ea6f6e5b1baa313563cc8fc035536eb6";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/pacmod_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "4778add999c3cc09f4961506e49e9a8d4b1d6fcfde80033e27944ee722824fcb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pass-through-controllers/default.nix
+++ b/distros/melodic/pass-through-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-control-msgs, cartesian-interface, cartesian-trajectory-controller, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, dynamic-reconfigure, geometry-msgs, hardware-interface, roscpp, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-melodic-pass-through-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release/archive/release/melodic/pass_through_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "1e0d15cfe95e465317a70c03241a729dee9eb7eee7c737e156754a711f2d0959";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs cartesian-trajectory-controller control-msgs controller-manager-msgs rostest xacro ];
+  propagatedBuildInputs = [ actionlib cartesian-control-msgs cartesian-interface controller-interface controller-manager dynamic-reconfigure geometry-msgs hardware-interface roscpp speed-scaling-interface trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Trajectory controllers (joint-based and Cartesian) that forward trajectories
+    directly to a robot controller and let it handle trajectory interpolation and execution.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "4dc661e773f89fade69bd6781adaee76e882859e8ab56bcdacaa4bc8f1e76c98";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "febc9c253d95c53d6a5d38b159df8031485c13edf8432e4cfb2d5b2f8a204c40";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler-ros/default.nix
+++ b/distros/melodic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "b995acb6f1ab9d3426ac97c44145e6972f35e99e61a5970d7edca4baa3634c0a";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/melodic/plotjuggler_ros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9ba0903e11cc5eac95d47d4789f1300e097486721ab554adabc3ff791c21edce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "7b90d76bd39e0d68b1e79fd4ed1a83c66025a1437104937d7dd174a842a58713";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "080f24423050014f15feadaaa64038e3cf5a3a27cee98a193820cad43b1d8329";
   };
 
   buildType = "catkin";

--- a/distros/melodic/radar-msgs/default.nix
+++ b/distros/melodic/radar-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-radar-msgs";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/radar_msgs/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "637348f9732137f78066d3b40d49e04da010f5d928c12754157f4b9fb0364919";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/melodic/radar_msgs/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "c55597681355351a5e26d6398459265c6d477134c8eeb3f0d70ec22b175feac8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-genicam-driver/default.nix
+++ b/distros/melodic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-driver";
-  version = "0.5.0-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "d4a54226f8593bd1ec396cba39209d0208fed05fd076a3c9ad6476224ff0c9f7";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "061603525595b683a2f6042b84a7daf4fc040d935996abc31d76006e83d51207";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-reason-clients/default.nix
+++ b/distros/melodic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, pythonPackages, rc-reason-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-melodic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "773d5496e448df0f049a9c7280153920e3040461070b2b9cb5a131bcfcec71a5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ddynamic-reconfigure-python message-runtime pythonPackages.requests rc-reason-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rc-reason-msgs/default.nix
+++ b/distros/melodic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/melodic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "ff54aa120cbcc25182a8b936b4528ea8f7e2ad0cc174a8bdd0f83d9090508fb7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rc-common-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rcdiscover/default.nix
+++ b/distros/melodic/rcdiscover/default.nix
@@ -2,19 +2,18 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-melodic-rcdiscover";
-  version = "1.0.3-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "955e29e3c5b93c905c027c2323becbdf278828f731f43ead3eb16522e544c52a";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "b8c4bb1f6fe20b91777d783f6863eeae11f45f42a081a56f168fee1c2ef52c6f";
   };
 
   buildType = "cmake";
-  propagatedBuildInputs = [ catkin ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.5.9-1/bota_driver-release-release-melodic-rokubimini_bus_manager-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.5.9-1.tar.gz";
-    sha256 = "fc15c519675390554411cc7f4d97e44e6e9cc08446931e7ada663e55fb057702";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.6.0-3/bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-3.tar.gz";
+    sha256 = "2905cb6d10c6e585b09545c91e2ae4a4c23cf831999d676883b2a71c998e5cce";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini ];
+  propagatedBuildInputs = [ bota-node rokubimini ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.5.9-1/bota_driver-release-release-melodic-rokubimini_description-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_description-0.5.9-1.tar.gz";
-    sha256 = "123c4e83ffe29893dfa08fc0c658d7c0a8dc58cf4afaf559f5cd289c2e9ba9d2";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.6.0-3/bota_driver-release-release-melodic-rokubimini_description-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_description-0.6.0-3.tar.gz";
+    sha256 = "0f49d319244e206be84c06269024f338f89c52f485a24b48434666540a8cf3b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.5.9-1/bota_driver-release-release-melodic-rokubimini_ethercat-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.5.9-1.tar.gz";
-    sha256 = "c27ad8bcf946c3f868919d483bb3101be4ec38aafa0509553e622342f12d5921";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.6.0-3/bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-3.tar.gz";
+    sha256 = "d76813c08f79c6eb52a4528c45e197d87036d71a884da96f2c8637e6be57fb10";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.5.9-1/bota_driver-release-release-melodic-rokubimini_msgs-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.5.9-1.tar.gz";
-    sha256 = "7bb9923860cee0f7c2b78442b0a11a3ac2c575066951798fde72911446de42a9";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.6.0-3/bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-3.tar.gz";
+    sha256 = "f4a7e27c251f1712d3df98786a7d4ca3147fa635a85927e82770ca730bff59e7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.5.9-1/bota_driver-release-release-melodic-rokubimini_serial-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_serial-0.5.9-1.tar.gz";
-    sha256 = "92215ac80fb96ecbc07ca2fb903086e81ebd904f11b582036c433aa79b7478f8";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.6.0-3/bota_driver-release-release-melodic-rokubimini_serial-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_serial-0.6.0-3.tar.gz";
+    sha256 = "bfe09c08763c66553379585efe12994280088c45b3f18cb1f52ea2957006bfe1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, roslib, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.5.9-r1";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.5.9-1/bota_driver-release-release-melodic-rokubimini-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini-0.5.9-1.tar.gz";
-    sha256 = "1314be344985c14fbdb60dbcf7db88f3e715472ef744ace5fc465b5d851802d9";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.6.0-3/bota_driver-release-release-melodic-rokubimini-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini-0.6.0-3.tar.gz";
+    sha256 = "00816ea9f86db6a9580dd54ffeae8a0066718b451fee9f757d58c2b63efd8cd3";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp roslib sensor-msgs ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ eigen geometry-msgs roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ros-control/default.nix
+++ b/distros/melodic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-ros-control";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "a5cacff3ae3536a9afa3e224d5299160bf545a7e6ae866ea4319abe63e91aca7";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/ros_control/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "3f1eedc90b71c32c00741cd89d1f597a3fa84916416fdf705171b9a775d5e2c1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers-cartesian/default.nix
+++ b/distros/melodic/ros-controllers-cartesian/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
+buildRosPackage {
+  pname = "ros-melodic-ros-controllers-cartesian";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "ab8bfadf8aa20429f57c061e79db446aebeea4bcfe285f785220d2b64d2bd212";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-controller cartesian-trajectory-interpolation twist-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for Cartesian ROS controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "848a6da4df6cf977bdd2c5f626b40391258d7f30df00f181144491844006eeed";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "76924e3f260093adae48bffbe2b49222ca2c00707bfb33483285a0c2c22cb4a1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "ad6542e6c227d8ccdec1a8f45f97d73bedc09477bab243f2eaf7e15acbfc2b3c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "4dcc5cac04ce4650df0d01835a074f4211f217b8532be1b4fd9ed5e28512afc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-controller-manager/default.nix
+++ b/distros/melodic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-melodic-rqt-controller-manager";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "d1a3c797567d977ef0c802165baef646bfe79039541dc843bd3765ecc16286f2";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/rqt_controller_manager/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "a0b95b62508520a28777ce405681283895487126fc06f6985230de6b5e59c546";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-rviz/default.nix
+++ b/distros/melodic/rqt-rviz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, pluginlib, qt5, rqt-gui, rqt-gui-cpp, rviz }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, class-loader, pluginlib, qt5, rqt-gui, rqt-gui-cpp, rviz }:
 buildRosPackage {
   pname = "ros-melodic-rqt-rviz";
-  version = "0.6.0";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/melodic/rqt_rviz/0.6.0-0.tar.gz";
-    name = "0.6.0-0.tar.gz";
-    sha256 = "23e3aa89701e33665c95e1bd0f0df853a52a8bfd433c352071ba9ff597b8ecb7";
+    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/melodic/rqt_rviz/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "b9fcb50156f163d73e52c3128524dfac04c4bfecfe76562926aa7780e9adf6b3";
   };
 
   buildType = "catkin";
-  buildInputs = [ qt5.qtbase ];
+  buildInputs = [ class-loader qt5.qtbase ];
   propagatedBuildInputs = [ boost pluginlib rqt-gui rqt-gui-cpp rviz ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.17-r1";
+  version = "1.13.18-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.17-1.tar.gz";
-    name = "1.13.17-1.tar.gz";
-    sha256 = "b06a1273a338d4e849ce9b59d4f5da5a2b203a22accb8f7968e029781c0a458a";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.18-1.tar.gz";
+    name = "1.13.18-1.tar.gz";
+    sha256 = "9a4abeea819218a692718889d4a960baefea947c818e9f12abbbb1974e1c95c6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "26455c2ac67e48d5752daaeb58fad1e007e01f2ba07b6a53597555180030fa5d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "27575ceb198545d2e463ae739ab581a56ba4e59d7e6cfbe7fcf0e138f1aaf0e5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "95ddd1143652531c2b970f83ef7e79e53d11d3133f1f945c25a5633ca33d286f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "2af99e9bce75677ce360cf070170595c53cac6a59d20fe8c84dc57dd3a5cff68";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "828e7bd2d1b6c163bf9088e0402524568e7941280daba55f48bc6c7bb6471b86";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "2f989a35ecf0d095454620fefa76fe0802d71806cdd834011595436a1c5c42a7";
   };
 
   buildType = "cmake";

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "38397b9f34e6ea684bedd145324fc5366619679e837e619933d8dab467782e3f";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "d19de80f539e0390ed2d3f3d42cbc782dcb49f0c74d5186b6a268d0808a7d8bc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "4d1b13e2f9f8fe0c5e196ba80c2849500274b75eadd22be60e9a324fb17ae000";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "22652522e436d7c52e1637b5e2c96d6a815baa208bd2ce89b0738f50a2db0c9e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/transmission-interface/default.nix
+++ b/distros/melodic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-melodic-transmission-interface";
-  version = "0.18.3-r1";
+  version = "0.18.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.18.3-1.tar.gz";
-    name = "0.18.3-1.tar.gz";
-    sha256 = "386fc220e65adee3bbd695bf09363c953a1569cba4b610c8049da3a20691b0a1";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/melodic/transmission_interface/0.18.4-1.tar.gz";
+    name = "0.18.4-1.tar.gz";
+    sha256 = "29a214b71892ff82b0e71f07b2d8fa98487ac97e2936dc3ad82d0801792f405c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/twist-controller/default.nix
+++ b/distros/melodic/twist-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-twist-controller";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "f5d5f9aefac0e3063ac9153eb7090a95038fb43f90ceb80346c08b93d3c96ddd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface controller-interface dynamic-reconfigure geometry-msgs hardware-interface realtime-tools roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller accepting Cartesian twist messages in order to move a robot manipulator.
+    It uses a Cartesian interface to the robot, so that the robot hardware takes care about
+    doing the inverse kinematics. This could be used e.g. for visual servoing applications.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/ur-client-library/default.nix
+++ b/distros/melodic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-melodic-ur-client-library";
-  version = "0.2.2-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "2453f6de7998ffac0b6c05d404540b56548fb4ca4929f30edc6216ff23444f4f";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/melodic/ur_client_library/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "8cca441a3b463d919308266893d64a333bcf03447806f75b6d7209c218bef032";
   };
 
   buildType = "cmake";

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.21-r3";
+  version = "2.1.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.21-3.tar.gz";
-    name = "2.1.21-3.tar.gz";
-    sha256 = "409a462a24d07c8cfb462b8b7a127871d42f022cf56df4c7e3404b7a38a4c6ae";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.22-1.tar.gz";
+    name = "2.1.22-1.tar.gz";
+    sha256 = "eed24d2b0ae5c11193df2589df08da92ed66e159030ed07fb6f63ebcde03ca5d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ypspur-ros/default.nix
+++ b/distros/melodic/ypspur-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, trajectory-msgs, ypspur }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ypspur }:
 buildRosPackage {
   pname = "ros-melodic-ypspur-ros";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/ypspur_ros-release/archive/release/melodic/ypspur_ros/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "549a9844ee5da0f095df90904564d7c37ab28fbc7f8422a1ec00334d6032f8b9";
+    url = "https://github.com/openspur/ypspur_ros-release/archive/release/melodic/ypspur_ros/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "32bb414bf802855cc4d468b7a5078fa17d3ea81358b1867a301f67f31c7e58d8";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf trajectory-msgs ypspur ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ypspur ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ackermann-steering-controller/default.nix
+++ b/distros/noetic/ackermann-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, controller-manager-msgs, diff-drive-controller, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rostest, std-msgs, std-srvs, tf, urdfdom, xacro }:
 buildRosPackage {
   pname = "ros-noetic-ackermann-steering-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "5c23b0a14ceb4f24bc56883d2d27de462490926a66a23589e4bd1d13301bf6a3";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ackermann_steering_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "23f563369e94501bb09f64ed544b80ed071630d5aeb8001f54da0e1237b5093e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, bota-device-driver, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-factory, rokubimini-manager, rokubimini-msgs, rokubimini-serial }:
+{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.5.9-1/bota_driver-release-release-noetic-bota_driver-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_driver-0.5.9-1.tar.gz";
-    sha256 = "3856bb0976f89e5b413f1b824395473ec2943510bca5b6952401aeb54436de73";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.0-2/bota_driver-release-release-noetic-bota_driver-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver-0.6.0-2.tar.gz";
+    sha256 = "feec512fef97f7f40aee864154922d566c7cca17d9aaae565cc28fad60d11fa5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ bota-device-driver rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-factory rokubimini-manager rokubimini-msgs rokubimini-serial ];
+  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-msgs rokubimini-serial ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-node";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.5.9-1/bota_driver-release-release-noetic-bota_node-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_node-0.5.9-1.tar.gz";
-    sha256 = "b20079f9b2f5ece652337fc90570b3242ae525f506bfd4a9a05d45aa0d850e96";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.0-2/bota_driver-release-release-noetic-bota_node-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_node-0.6.0-2.tar.gz";
+    sha256 = "18c7e8a3a7611dfe384e9a1146fc5e208be85c7042423ff15c0b0a8a0c0c22cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-signal-handler";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.5.9-1/bota_driver-release-release-noetic-bota_signal_handler-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_signal_handler-0.5.9-1.tar.gz";
-    sha256 = "f5028c231265611b9ebe00996d80711f136fbf9d27f102b7ee591d64cce8716c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.0-2/bota_driver-release-release-noetic-bota_signal_handler-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.0-2.tar.gz";
+    sha256 = "6d0e411519113c14a3b20a16269f7db2241b7876333705bd8b19c9238580dff6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-worker";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.5.9-1/bota_driver-release-release-noetic-bota_worker-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_worker-0.5.9-1.tar.gz";
-    sha256 = "3d3daffc122a327a77abd4022608c502d886d3c92a553cae770f8673e4b0e94f";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.0-2/bota_driver-release-release-noetic-bota_worker-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_worker-0.6.0-2.tar.gz";
+    sha256 = "8c065c81ba508d2dcf5f79064651362233254b5c13b42e9df7e28f3448410ecb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-control-msgs/default.nix
+++ b/distros/noetic/cartesian-control-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-control-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_cartesian_control_msgs-release/archive/release/noetic/cartesian_control_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "88d6f5a6c0add62f1ade742e8741e077fe434382cd7b9f0a743aeb24c15caa1b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory execution interface.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-interface/default.nix
+++ b/distros/noetic/cartesian-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-interface";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "5fdd869842258eab6342f8fa8f0f41206e30fbfdc706c46b042a7ca708a84f30";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ geometry-msgs hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Defines a hardware interface to send Cartesian commands to a robot hardware and read
+    Cartesian states.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-trajectory-controller/default.nix
+++ b/distros/noetic/cartesian-trajectory-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-trajectory-controller";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "882ca6abac1e790866c7bdf43fdb0b41bda431666b6383628a293eab1ad32835";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs control-msgs controller-manager-msgs joint-state-controller joint-trajectory-controller robot-state-publisher ros-control-boilerplate rostest trajectory-msgs xacro ];
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-interpolation controller-interface controller-manager hardware-interface kdl-parser pluginlib roscpp rospy speed-scaling-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A Cartesian trajectory controller with multiple hardware interface support'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/noetic/cartesian-trajectory-interpolation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-noetic-cartesian-trajectory-interpolation";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "3b56a4850e1c23e5a796710e962aa0c46649a9a6af4df6161b67a5cef6d8917f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ cartesian-control-msgs joint-trajectory-controller roscpp rospy tf2-eigen ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Cartesian trajectory interpolation as a standalone library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/combined-robot-hw-tests/default.nix
+++ b/distros/noetic/combined-robot-hw-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-manager, controller-manager-msgs, controller-manager-tests, hardware-interface, pluginlib, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw-tests";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "9bbc883bd884879f0ac7149163189eb93e315d8bba74f0d7d3848263e4550636";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw_tests/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "57d0f45a1c83806f29f340d513773c30e96fc859e671e57bd212628574297db9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/combined-robot-hw/default.nix
+++ b/distros/noetic/combined-robot-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-combined-robot-hw";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "b8d9eb13fa81e4f0bfc78554d16b7b4328469e6e1cb7a00ccd99f4f2288ef6b4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/combined_robot_hw/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "44ecca784dfa95ad551d5c6dd7adc087a0356d40a7291369f1b58cd7b036918b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-interface/default.nix
+++ b/distros/noetic/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-controller-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "a99e7a076bb57cdd48413187a11301fdab94220ee2a2a0b9f3eb4e082c9c6334";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "0dd568ca9911eb3e8e18de228d2df4191c64c1b56c1d0826d24f7f67b66b2a79";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-msgs/default.nix
+++ b/distros/noetic/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, rospy, rosservice, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-msgs";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "ceca5487523ab05221259b4a29ea2eeb530d07619f05382e613b986497429967";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_msgs/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "ea8b3fb9d8920666496f71622704923e5581e9993ad34ffd51df1f0a30fdd966";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager-tests/default.nix
+++ b/distros/noetic/controller-manager-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, rosbash, roscpp, rosnode, rospy, rostest }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager-tests";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "319b8faea49fcf827640cff43ac3e8d0b3296a190d3365c863e7438bc763a03e";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager_tests/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "13f618c1c8f7403f760f13bfa07d0d6b102e564b70bd115914fe661f2dee9497";
   };
 
   buildType = "catkin";

--- a/distros/noetic/controller-manager/default.nix
+++ b/distros/noetic/controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager-msgs, hardware-interface, pluginlib, python3Packages, roscpp, rosparam, rospy, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-controller-manager";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "e340db15c944cc52367bb6a41a13e720dbaba588c11f97915d970e29dee5e02d";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/controller_manager/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "56cf18b0745a8504ff2006f612d0be05a1f71c8e9062814d40df434a255d993c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "878eddb4b2d5a2e400ce201272886fc3357bf78375dd5b506bbb0154c85e4548";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "c12309230ec4b6764a680ebf1d1198d24468529a0f10e913b17f12f0d99eda76";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-esr-msgs/default.nix
+++ b/distros/noetic/delphi-esr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-esr-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_esr_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "eddb38859f716d8d4b24bcca98afaf5a6a5e12950b28a2090852f46b6e4dcc11";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_esr_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "f4816ec2a907d27373333aa1f5b7cd7aa10acb4ef7f0559050306eff505e6bb6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-mrr-msgs/default.nix
+++ b/distros/noetic/delphi-mrr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-mrr-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_mrr_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "6a99916042065253f66a1ffbe11e5bffc84b34c49b8f9d7d1075af2e0dc66728";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_mrr_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "b39751d2d083eb15e6f451ea08c663e6a6df39fbdf798e1b7a14db97322b0171";
   };
 
   buildType = "catkin";

--- a/distros/noetic/delphi-srr-msgs/default.nix
+++ b/distros/noetic/delphi-srr-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-delphi-srr-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_srr_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "8eefc78fbbbd7afa9f23b7ad39134a02f9a9ce9ce44e4e4bbc660324ba21f67a";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/delphi_srr_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "e98611f4018f79280fcbe2cefaf100e7af127b2c76c9d42fbbeaf3f622e4c3d7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/derived-object-msgs/default.nix
+++ b/distros/noetic/derived-object-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, ros-environment, shape-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-derived-object-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/derived_object_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "1fff6c0bd05b79f989d167655e30ea713e9b65bd501141402dd5f80bf780798c";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/derived_object_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "4ea1519b31275a2df6f3ca203077fca8b5447d588c02e69898463d3c3a9a7037";
   };
 
   buildType = "catkin";

--- a/distros/noetic/diff-drive-controller/default.nix
+++ b/distros/noetic/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, control-msgs, controller-interface, controller-manager, dynamic-reconfigure, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, rosgraph-msgs, rostest, rostopic, std-srvs, tf, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-diff-drive-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f35b747b2ed7e25785f23f6238d14cff1f25fd70c8e1df8b89bccc475b9dfa1d";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/diff_drive_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "8cf5a8da963e16139d510f77d4c5b302f443f8eff85efe8e47200bef4ad5c044";
   };
 
   buildType = "catkin";

--- a/distros/noetic/effort-controllers/default.nix
+++ b/distros/noetic/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, forward-command-controller, hardware-interface, joint-state-controller, pluginlib, realtime-tools, robot-state-publisher, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-effort-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "692393aed0b39e79e6ff08e04273126b931b672568baca7062a86572a20d3f1f";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/effort_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "48eab98ddf97ac7e2adee655d4c1ce4c9d3fbd152bd7fe980feb8cd1746606ca";
   };
 
   buildType = "catkin";

--- a/distros/noetic/force-torque-sensor-controller/default.nix
+++ b/distros/noetic/force-torque-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-force-torque-sensor-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "5cdbc1a2faf60754bfb506c71c766215b47d84165f8a54aabd6faab9db0b08b8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/force_torque_sensor_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "118b2a5754ef2839be99ec0bc90e71651dd3d67ac62328830715941c538ce3ae";
   };
 
   buildType = "catkin";

--- a/distros/noetic/forward-command-controller/default.nix
+++ b/distros/noetic/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, realtime-tools, roscpp, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-forward-command-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f8f5bcfb8121fd2bf2d2d6a95d7084e9297e901962151805469708761e03b3c9";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/forward_command_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "add33ba307dbd9f4a90192dda911ec466d854e7774cd199489afaad75c83f4f8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/four-wheel-steering-controller/default.nix
+++ b/distros/noetic/four-wheel-steering-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, controller-interface, controller-manager, four-wheel-steering-msgs, geometry-msgs, hardware-interface, nav-msgs, pluginlib, realtime-tools, roscpp, rosgraph-msgs, rostest, std-msgs, std-srvs, tf, urdf-geometry-parser, xacro }:
 buildRosPackage {
   pname = "ros-noetic-four-wheel-steering-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "47cd5261df2ae3f07ec7145db669e74033abae8f3802f99089f4662e7235e6c6";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/four_wheel_steering_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "d3a724bac511e84f4d1ffd046cf5ba0006a6adf5fcbef6888ca8c5fccc9968e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -122,8 +122,6 @@ self: super: {
 
  bosch-locator-bridge = self.callPackage ./bosch-locator-bridge {};
 
- bota-device-driver = self.callPackage ./bota-device-driver {};
-
  bota-driver = self.callPackage ./bota-driver {};
 
  bota-node = self.callPackage ./bota-node {};
@@ -166,7 +164,15 @@ self: super: {
 
  carrot-planner = self.callPackage ./carrot-planner {};
 
+ cartesian-control-msgs = self.callPackage ./cartesian-control-msgs {};
+
+ cartesian-interface = self.callPackage ./cartesian-interface {};
+
  cartesian-msgs = self.callPackage ./cartesian-msgs {};
+
+ cartesian-trajectory-controller = self.callPackage ./cartesian-trajectory-controller {};
+
+ cartesian-trajectory-interpolation = self.callPackage ./cartesian-trajectory-interpolation {};
 
  catch-ros = self.callPackage ./catch-ros {};
 
@@ -1556,6 +1562,8 @@ self: super: {
 
  ncd-parser = self.callPackage ./ncd-parser {};
 
+ neo-local-planner = self.callPackage ./neo-local-planner {};
+
  neobotix-usboard-msgs = self.callPackage ./neobotix-usboard-msgs {};
 
  neonavigation = self.callPackage ./neonavigation {};
@@ -1661,6 +1669,8 @@ self: super: {
  panda-moveit-config = self.callPackage ./panda-moveit-config {};
 
  parameter-pa = self.callPackage ./parameter-pa {};
+
+ pass-through-controllers = self.callPackage ./pass-through-controllers {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1938,6 +1948,10 @@ self: super: {
 
  rc-pick-client = self.callPackage ./rc-pick-client {};
 
+ rc-reason-clients = self.callPackage ./rc-reason-clients {};
+
+ rc-reason-msgs = self.callPackage ./rc-reason-msgs {};
+
  rc-roi-manager-gui = self.callPackage ./rc-roi-manager-gui {};
 
  rc-silhouettematch-client = self.callPackage ./rc-silhouettematch-client {};
@@ -2008,12 +2022,6 @@ self: super: {
 
  rokubimini-ethercat = self.callPackage ./rokubimini-ethercat {};
 
- rokubimini-examples = self.callPackage ./rokubimini-examples {};
-
- rokubimini-factory = self.callPackage ./rokubimini-factory {};
-
- rokubimini-manager = self.callPackage ./rokubimini-manager {};
-
  rokubimini-msgs = self.callPackage ./rokubimini-msgs {};
 
  rokubimini-serial = self.callPackage ./rokubimini-serial {};
@@ -2035,6 +2043,8 @@ self: super: {
  ros-control-boilerplate = self.callPackage ./ros-control-boilerplate {};
 
  ros-controllers = self.callPackage ./ros-controllers {};
+
+ ros-controllers-cartesian = self.callPackage ./ros-controllers-cartesian {};
 
  ros-core = self.callPackage ./ros-core {};
 
@@ -2612,6 +2622,18 @@ self: super: {
 
  turtlebot3 = self.callPackage ./turtlebot3 {};
 
+ turtlebot3-autorace-2020 = self.callPackage ./turtlebot3-autorace-2020 {};
+
+ turtlebot3-autorace-camera = self.callPackage ./turtlebot3-autorace-camera {};
+
+ turtlebot3-autorace-core = self.callPackage ./turtlebot3-autorace-core {};
+
+ turtlebot3-autorace-detect = self.callPackage ./turtlebot3-autorace-detect {};
+
+ turtlebot3-autorace-driving = self.callPackage ./turtlebot3-autorace-driving {};
+
+ turtlebot3-autorace-msgs = self.callPackage ./turtlebot3-autorace-msgs {};
+
  turtlebot3-bringup = self.callPackage ./turtlebot3-bringup {};
 
  turtlebot3-description = self.callPackage ./turtlebot3-description {};
@@ -2633,6 +2655,8 @@ self: super: {
  turtlebot3-teleop = self.callPackage ./turtlebot3-teleop {};
 
  turtlesim = self.callPackage ./turtlesim {};
+
+ twist-controller = self.callPackage ./twist-controller {};
 
  twist-mux = self.callPackage ./twist-mux {};
 

--- a/distros/noetic/graceful-controller-ros/default.nix
+++ b/distros/noetic/graceful-controller-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, base-local-planner, catkin, costmap-2d, dynamic-reconfigure, geometry-msgs, graceful-controller, nav-core, nav-msgs, pluginlib, roscpp, std-msgs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller-ros";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "5fe8b1babb21b884a807c147772d3f8cc320f17a8ecfdba6930251675e381f15";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller_ros/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "957ba8bc12549f73afb8f9f9d54b8dc9072e8c3005dd3bdafc54ab211edd3501";
   };
 
   buildType = "catkin";

--- a/distros/noetic/graceful-controller/default.nix
+++ b/distros/noetic/graceful-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-graceful-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "b83f69f2b081a4ba3d31a70a20ed629e926897868918e8b01a998773d9546294";
+    url = "https://github.com/mikeferguson/graceful_controller-gbp/archive/release/noetic/graceful_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "7a108688036ed6803dc0a9560ff0ee23d2fb26c325d1ea4b994767fd501f3e9e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/gripper-action-controller/default.nix
+++ b/distros/noetic/gripper-action-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, control-msgs, control-toolbox, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, urdf }:
 buildRosPackage {
   pname = "ros-noetic-gripper-action-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "4b06301c7c7dd97b2b4fc839b7892c41126dd3fc5164cd3377f632677a1fc7a8";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/gripper_action_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "8a308353861c5fa7b1cf374b0d88eca845621cf3bf430229e649732f8e13de21";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hardware-interface/default.nix
+++ b/distros/noetic/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-hardware-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "599c3579366d95a3c6debff690ac69db156da5b3a153b60747efffd0b63603be";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/hardware_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "16bf376a04d3fb720ae204b3ef0b2ef7be36ca92bef987b3644caf88dffaca1a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-gazebo-plugins/default.nix
+++ b/distros/noetic/hector-gazebo-plugins/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gazebo, gazebo-dev, gazebo-ros, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, std-msgs, std-srvs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, gazebo, gazebo-dev, gazebo-ros, geographic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-hector-gazebo-plugins";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_plugins/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "d542732d47227c31baf71fa393a181f516e269efefddc3ca64bdddeeae8d7867";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_plugins/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "69f1b1d7f5c99497a402a1ac263605e80f820f1c9fc166c61ea4c7dca9af8da6";
   };
 
   buildType = "catkin";
   buildInputs = [ gazebo-dev message-generation ];
-  propagatedBuildInputs = [ dynamic-reconfigure gazebo gazebo-ros geometry-msgs message-runtime nav-msgs roscpp std-msgs std-srvs tf ];
+  propagatedBuildInputs = [ dynamic-reconfigure gazebo gazebo-ros geographic-msgs geometry-msgs message-runtime nav-msgs roscpp std-msgs std-srvs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/hector-gazebo-thermal-camera/default.nix
+++ b/distros/noetic/hector-gazebo-thermal-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-plugins, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-hector-gazebo-thermal-camera";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_thermal_camera/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "ee40ddebaf2ffffd2194dc3d529742a87cced11f9b1e1191ab0f193a2c3c78e5";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_thermal_camera/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "64ac64b5360fd91f91890f06fe200f1c05e509a49bb8614dcb43f8cf4375f01b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-gazebo-worlds/default.nix
+++ b/distros/noetic/hector-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros, hector-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-noetic-hector-gazebo-worlds";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_worlds/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "93cc02726ca22b5c9b5f90f4620996c75998c3598b86e3f2b4463dc9f1dfb583";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo_worlds/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "9f031c0dc2cdc17c197b11771da7a0d8afa8b9063ec206af2ff3825b339573e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-gazebo/default.nix
+++ b/distros/noetic/hector-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hector-gazebo-plugins, hector-gazebo-thermal-camera, hector-gazebo-worlds }:
 buildRosPackage {
   pname = "ros-noetic-hector-gazebo";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "d98090e13ab216cd9373e37e45c2b1d036964be4ba758554a67f7a5175a96de9";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_gazebo/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "f1627f9c2f509743aab146bd88f51e3fb8407acdc79613d9e39844c212e53cd8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/hector-sensors-gazebo/default.nix
+++ b/distros/noetic/hector-sensors-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, hector-gazebo-plugins, hector-sensors-description }:
 buildRosPackage {
   pname = "ros-noetic-hector-sensors-gazebo";
-  version = "0.5.3-r1";
+  version = "0.5.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_sensors_gazebo/0.5.3-1.tar.gz";
-    name = "0.5.3-1.tar.gz";
-    sha256 = "d3f9828077271e47f60b41a71af04338da993a188aa40c339365a6fb900920d5";
+    url = "https://github.com/tu-darmstadt-ros-pkg-gbp/hector_gazebo-release/archive/release/noetic/hector_sensors_gazebo/0.5.4-1.tar.gz";
+    name = "0.5.4-1.tar.gz";
+    sha256 = "bc0da9a58e2e5cb58449c13458bbe9863b1fbe1eb0a1f34f31c336c5fbb9c186";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ibeo-msgs/default.nix
+++ b/distros/noetic/ibeo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ibeo-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/ibeo_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "d3444d954ef9fb4ca54a1649051d275756f7bdf0312716a14a7c1ca60311dd8e";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/ibeo_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "f0e57dc58d1148f5c8bb9dc5723f9c5b5cc3a4e86d02ab110b5e03f595c659e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/imu-sensor-controller/default.nix
+++ b/distros/noetic/imu-sensor-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-imu-sensor-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "68c79e5cf692eae894b3dd178ddef0de606af5e07fe1f6a90a99352ef2027c46";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/imu_sensor_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "d5aa66065b7e8637f293704b830e157a4b4e36b17b671c775ca35934d5a6cefc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-limits-interface/default.nix
+++ b/distros/noetic/joint-limits-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, roscpp, rostest, urdf }:
 buildRosPackage {
   pname = "ros-noetic-joint-limits-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "3aea41db9b4c6079483a53a3e09001cc585ac34ae1a392166d93a81256207502";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/joint_limits_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "1b3ce53ea8cf91b6cf80e2785a94cd4c30dddd83f5624002b0644db28510e5dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-state-controller/default.nix
+++ b/distros/noetic/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-joint-state-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "2b31f7599a1a6680d18e99f931e0e3bdfb55953e430f1d10e9d3516f5a33e171";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_state_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "e0968620e901d8ca8a2e1a4d032d5afde60acdbf61440a63073483c008c093ba";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joint-trajectory-controller/default.nix
+++ b/distros/noetic/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, angles, boost, catkin, code-coverage, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, realtime-tools, roscpp, rostest, std-msgs, trajectory-msgs, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-joint-trajectory-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "3d57f554bf2b22d0c5154820dd3ec70c062817cec6ddeb10dbaa7f347ea20337";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/joint_trajectory_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "53720e691240d1a87f4d8b1829207a3345ef6928db56de85d62cee6b95edf322";
   };
 
   buildType = "catkin";

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "4febe1a1361ed5ef1b2235aa97f9897a94b8db857af764beb5618d140b2af399";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "1ac9ed1b3dbb86118de53541e1a098209fb495be21b81dcabfbdc188f809de41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/kartech-linear-actuator-msgs/default.nix
+++ b/distros/noetic/kartech-linear-actuator-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-kartech-linear-actuator-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/kartech_linear_actuator_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "409afffc6e63a693cb50418eba87e72cf78eb1ba0f7880a2f6e96f8a191d15d4";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/kartech_linear_actuator_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "3e6cd3bac9e7693fd27ffd3318a85d9537fdb749e15626d1e920b1084b6de628";
   };
 
   buildType = "catkin";

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "e3cae3b5f006219a14ea691e38003777e026d1bc1758d54cf6d9d5023b4676ab";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "aa4a9e49cdc5d85853d1b614d7c3ca9761f4e54232fc8f5b2f8e4585840a1b41";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mobileye-560-660-msgs/default.nix
+++ b/distros/noetic/mobileye-560-660-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-mobileye-560-660-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/mobileye_560_660_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "1cf02b923107a5819d73568f60334ef610f9282e50114caee919844b5d9bd889";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/mobileye_560_660_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "37fdd5604617ffda80d4926bb39e588dedaebdd430f25f234c2a2f15b8807109";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neo-local-planner/default.nix
+++ b/distros/noetic/neo-local-planner/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, base-local-planner, catkin, cmake-modules, costmap-2d, dynamic-reconfigure, nav-core, nav-msgs, pluginlib, roscpp, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-neo-local-planner";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/neobotix/neo_local_planner-release/archive/release/noetic/neo_local_planner/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "40b93b3cde461c30dd909faa95aca65cf4619191b3e4178cc9c3fa65bb4891ca";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ base-local-planner costmap-2d dynamic-reconfigure nav-core nav-msgs pluginlib roscpp tf2-geometry-msgs tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package provides a spline based implementation to local robot navigation on a plane.
+
+		This package's ROS wrapper adheres to the
+        BaseLocalPlanner interface specified in the <a href="http://wiki.ros.org/nav_core">nav_core</a> package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/neobotix-usboard-msgs/default.nix
+++ b/distros/noetic/neobotix-usboard-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-neobotix-usboard-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/neobotix_usboard_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "f94f71b1bdc621c541bc1035c9ed794dd6b7f79432d9a9482587108aa36b0b52";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/neobotix_usboard_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "caefc604c5d3ad50449839b1d48d05cc3d2c0f3695abb2c89ac1411d9e5f1500";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "3bc18e0ea0715037267e9a0922144f521f50e30e049561db231876c5d226b9c4";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "0b3e8fa8c9047e9fcbb8ae8e536e48bbfea7dc2d16f31c0c426ba20cfdabba7d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "b888d6841d3370b3025166b8af0f2ef5816535a8f4ba5ecdbc000430b9f75bba";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "3c764ef682de3917c676ab3a434aca99c1e45c538042681dfb411b79b8fd1196";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "fbc67584929d31b357defd99f937ee341089b5b9cbcf540a8f9b2a86ee72b2cd";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "87b080dba20d0ce30fcd5a4310ceafdcd4149eb3cf5f6d916b027d782e30d7be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "3c09ba3ff30562c0e8d363aad6be62cd424f0899ff71d442180c61924fc47c35";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "6d36ca975656411c5871ccadb514b6f92a21a705a4ddf8a95f5892da184a4a18";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pacmod-msgs/default.nix
+++ b/distros/noetic/pacmod-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, ros-environment, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-pacmod-msgs";
-  version = "3.2.0-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/pacmod_msgs/3.2.0-1.tar.gz";
-    name = "3.2.0-1.tar.gz";
-    sha256 = "89925d3c86b63efc2b0895533470a22f8f5daede220268f98042ea66fdc7f803";
+    url = "https://github.com/astuff/astuff_sensor_msgs-release/archive/release/noetic/pacmod_msgs/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "1c8266219b44c9c89d23c1f4d18e015d0a07493ca623625fc95010dd5c135bea";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pass-through-controllers/default.nix
+++ b/distros/noetic/pass-through-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-control-msgs, cartesian-interface, cartesian-trajectory-controller, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, dynamic-reconfigure, geometry-msgs, hardware-interface, roscpp, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-pass-through-controllers";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers-release/archive/release/noetic/pass_through_controllers/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "834c1e9209fde4334698a94439895dcc9656191010add47169c3a89f5be56cb8";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ actionlib actionlib-msgs cartesian-trajectory-controller control-msgs controller-manager-msgs rostest xacro ];
+  propagatedBuildInputs = [ actionlib cartesian-control-msgs cartesian-interface controller-interface controller-manager dynamic-reconfigure geometry-msgs hardware-interface roscpp speed-scaling-interface trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Trajectory controllers (joint-based and Cartesian) that forward trajectories
+    directly to a robot controller and let it handle trajectory interpolation and execution.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "05c679ad14e7bc7fd9f9347eb98b441ebe78ad215eb151edf89fe0c8fdde4850";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "38ab016aec2340731c583cdf946cef406c911f1fe9f27993e7a75b6b29d16c72";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.2.0-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "e01d38d56a8eb2dd2b6433656032100c7bdf2b57004bc3a3cc5ab741ca648e82";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "3cf6215a67353ddfa11e9aa5a016d7d255364790f5b8f3dd0e3f0c462d59116c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.1.2-r1";
+  version = "3.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "f30452d7ec4b7a220f59290f5939b5329b1779c70f5c8ffc61fd7a928dbf415f";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.2.1-1.tar.gz";
+    name = "3.2.1-1.tar.gz";
+    sha256 = "d5739d38d9878dfd43f504f049d110d5e4e5666fa3d6a8b8f88b6303eeed3ab2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/position-controllers/default.nix
+++ b/distros/noetic/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, forward-command-controller, hardware-interface, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-position-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "83af262bfff6d1100f9f0bfd2b0938dbd8cb9ae3645efd7260c878650189ee88";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/position_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "eb065ab91e1908cb598cf0ad100582163e0b99d4ddc7790568a99ffa4ff176b4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.5.0-r1";
+  version = "0.5.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.0-1.tar.gz";
-    name = "0.5.0-1.tar.gz";
-    sha256 = "b46a0b005ba84b31997044db978324f30a0fb5db0706c2640b18a511ae271768";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.2-1.tar.gz";
+    name = "0.5.2-1.tar.gz";
+    sha256 = "dae3b74a8b547d79490ac46446ca11c188d60b6c2bd27e84100eda2e797e5b47";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-reason-clients/default.nix
+++ b/distros/noetic/rc-reason-clients/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ddynamic-reconfigure-python, message-runtime, python3Packages, rc-reason-msgs, rospy }:
+buildRosPackage {
+  pname = "ros-noetic-rc-reason-clients";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_clients/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "79146598921a250241531a7325675c63fb5a5ac72dd40aaa81730bd674c4697f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ddynamic-reconfigure-python message-runtime python3Packages.requests rc-reason-msgs rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clients for interfacing with Roboception reason modules on rc_visard and rc_cube.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rc-reason-msgs/default.nix
+++ b/distros/noetic/rc-reason-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rc-common-msgs, shape-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rc-reason-msgs";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/roboception-gbp/rc_reason_clients_ros-release/archive/release/noetic/rc_reason_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "ba2c6748e5e0f8b2a0660a91627b99b7323acfc906771fa76426a17545047ba5";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime rc-common-msgs shape-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Msg and srv definitions for rc_reason_clients'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rcdiscover/default.nix
+++ b/distros/noetic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-rcdiscover";
-  version = "1.0.4-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "1400f55c27d3c7362326001cb6b4b44cd08628f6ab2e3bd211e4536382348e34";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "785cfe918435b1998ff3f646859706eb18dd0bf52e985881c0dedaa426594c8b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini }:
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-bus-manager";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.5.9-1/bota_driver-release-release-noetic-rokubimini_bus_manager-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.5.9-1.tar.gz";
-    sha256 = "5c9f1e9e21c08e7220e73aa5ff1b1a622c1b9893c7102534a968c3b17f93f09d";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.0-2/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-2.tar.gz";
+    sha256 = "7c4b930f7ec8d897d92a7a758d9577f448197a4bf4232685acb8366cc53fe35c";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini ];
+  propagatedBuildInputs = [ bota-node rokubimini ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-description";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.5.9-1/bota_driver-release-release-noetic-rokubimini_description-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_description-0.5.9-1.tar.gz";
-    sha256 = "73f171ecf7e9031aca25f6b4012e3417193fdca3f4d59e5aa3f1c14b667ee3a0";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.0-2/bota_driver-release-release-noetic-rokubimini_description-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.0-2.tar.gz";
+    sha256 = "79460eacaf87f24a5d566e5bb3b8365b1fbbcc57767a6410884078240643eb29";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-ethercat";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.5.9-1/bota_driver-release-release-noetic-rokubimini_ethercat-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.5.9-1.tar.gz";
-    sha256 = "8c2681b05be392e06fe8b6eb65254dfd3fd3427bf8a49d0576d606a00bf95dea";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.0-2/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-2.tar.gz";
+    sha256 = "b321c08a896b365d165b5cd288f5a502aca53bcf9e1a6ea7709a9e52a5ba51e9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-msgs";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.5.9-1/bota_driver-release-release-noetic-rokubimini_msgs-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.5.9-1.tar.gz";
-    sha256 = "11a9f250b1cba12992b2cb52dbb2ab8b1eeb0009b3269cff05bebd4554819e7b";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.0-2/bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-2.tar.gz";
+    sha256 = "1bc8689f8c7c8d3019a7440eafd4a855e90cb8d3332aa920c1be4238f34ca0d3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-serial";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.5.9-1/bota_driver-release-release-noetic-rokubimini_serial-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_serial-0.5.9-1.tar.gz";
-    sha256 = "74da8f1aeaa50393a5410906ed3a4dce5b2181b46c3c883448f5d32bc0b3f216";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.0-2/bota_driver-release-release-noetic-rokubimini_serial-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.0-2.tar.gz";
+    sha256 = "d696a91e061d068923f479437569b4cf007b51f0c2dad69157e3ec7cd01c76c7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, libyamlcpp, roscpp, roslib, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini";
-  version = "0.5.9-r1";
+  version = "0.6.0-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.5.9-1/bota_driver-release-release-noetic-rokubimini-0.5.9-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini-0.5.9-1.tar.gz";
-    sha256 = "e25350a7d8567854cde78dfa6da3c6d7866129ab75c5802229d39452ed51e44b";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.0-2/bota_driver-release-release-noetic-rokubimini-0.6.0-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini-0.6.0-2.tar.gz";
+    sha256 = "0f7e2f207c1d8f139811338f3ccb637338bac932635e4f0be1151f7577c7a502";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ eigen geometry-msgs libyamlcpp roscpp roslib sensor-msgs ];
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ eigen geometry-msgs roscpp sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-control/default.nix
+++ b/distros/noetic/ros-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, combined-robot-hw, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-limits-interface, realtime-tools, transmission-interface }:
 buildRosPackage {
   pname = "ros-noetic-ros-control";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "46203493ec39e9f1d64d7a9961345977e4034be6905f215fb0d25c9b9c93b14f";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/ros_control/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "d161e78552c7f67b55d4b910f7db1e924974a7862c04ae927e9c1179e8af963c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-controllers-cartesian/default.nix
+++ b/distros/noetic/ros-controllers-cartesian/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
+buildRosPackage {
+  pname = "ros-noetic-ros-controllers-cartesian";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "eb3a8412f517dd6aa3a06ab62c52e36fbc0cda9b23e7a504daf25989c4e23e8b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface cartesian-trajectory-controller cartesian-trajectory-interpolation twist-controller ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for Cartesian ROS controllers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ros-controllers/default.nix
+++ b/distros/noetic/ros-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-steering-controller, catkin, diff-drive-controller, effort-controllers, force-torque-sensor-controller, forward-command-controller, gripper-action-controller, imu-sensor-controller, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "12ff5d09f3611d3422985ec00bb0e246ee3d01c51a63326fe5ec0a3d3e8efc5c";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/ros_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "7ad4a7b2a5a080efc80f130f2b25b20fb61a87b7dcf8234962d861a0e84c889e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-controller-manager/default.nix
+++ b/distros/noetic/rqt-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager-msgs, python3Packages, rospy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-rqt-controller-manager";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "941fbec8959a2369d0caf97c6604a1ce13fb0b4ffbbb1d241cdcbb4a2c439920";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/rqt_controller_manager/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "61da60d40bc290b5b9efe99226b78480340ba4e93659de5f66c66b312083eb33";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-joint-trajectory-controller/default.nix
+++ b/distros/noetic/rqt-joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, python-qt-binding, python3Packages, qt-gui, rospy, rqt-gui, rqt-gui-py, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-joint-trajectory-controller";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "604cfc7981de96c5b8cddab7904ea5db35b31607b103f9f1f2221e23be0682dd";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/rqt_joint_trajectory_controller/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "68fe23d5f1543ca1aaea9774afcef57f3563303be6ca59bb43fda925c66c3551";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-rviz/default.nix
+++ b/distros/noetic/rqt-rviz/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, boost, catkin, pluginlib, qt5, rqt-gui, rqt-gui-cpp, rviz }:
+{ lib, buildRosPackage, fetchurl, boost, catkin, class-loader, pluginlib, qt5, rqt-gui, rqt-gui-cpp, rviz }:
 buildRosPackage {
   pname = "ros-noetic-rqt-rviz";
-  version = "0.6.1-r1";
+  version = "0.7.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/noetic/rqt_rviz/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "6f5b15589e87d6a7776cd346a5e288b820467ad810302df31582300b0243bbf3";
+    url = "https://github.com/ros-gbp/rqt_rviz-release/archive/release/noetic/rqt_rviz/0.7.0-1.tar.gz";
+    name = "0.7.0-1.tar.gz";
+    sha256 = "a654c09013c36efb408a635700dbd62bf8c37da8f9a5c53aaefe790a49fc7ad7";
   };
 
   buildType = "catkin";
-  buildInputs = [ qt5.qtbase ];
+  buildInputs = [ class-loader qt5.qtbase ];
   propagatedBuildInputs = [ boost pluginlib rqt-gui rqt-gui-cpp rviz ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.7-r1";
+  version = "1.14.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.7-1.tar.gz";
-    name = "1.14.7-1.tar.gz";
-    sha256 = "8a5af0440229aba171490192afffc54085630f9a8aabb93f2ea52a4fa69c001b";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.8-1.tar.gz";
+    name = "1.14.8-1.tar.gz";
+    sha256 = "49d3a8402f365b9c81e0dc0e8cd544cdabe25e0a04651dc9b646e8707e8f9e06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "ed74eef1b4cae09479b1670ef699cadbf249b05705bbddcad18215d75ba37147";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "9b1ab4db7f58b5b33c5c011fcfd3fbbcd69889d95182f270b00e097c2dce7bcb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "ed32b479352a1074d379510660eeeb41a62159ea8576f8373217b2e9bf19a264";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "a57bdbf32c0ef5af08b43ae3e03c134ab75c14c8372b744930693bfc1514ad9a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.10-r1";
+  version = "0.10.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.10-1.tar.gz";
-    name = "0.10.10-1.tar.gz";
-    sha256 = "612865f53e0d81e28ba6d089fa8c939a8cb8449b5ce13b9aeba24209c019419d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.11-1.tar.gz";
+    name = "0.10.11-1.tar.gz";
+    sha256 = "41609700f7cda6a10dabb04a85cf7db215b83f55dc757c611f84da651c4c4eb5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/transmission-interface/default.nix
+++ b/distros/noetic/transmission-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, hardware-interface, pluginlib, resource-retriever, roscpp, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-transmission-interface";
-  version = "0.19.4-r1";
+  version = "0.19.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.19.4-1.tar.gz";
-    name = "0.19.4-1.tar.gz";
-    sha256 = "cce664686d2a60a3880936817d3a560cafc49693455787e2f872052de18462c4";
+    url = "https://github.com/ros-gbp/ros_control-release/archive/release/noetic/transmission_interface/0.19.5-1.tar.gz";
+    name = "0.19.5-1.tar.gz";
+    sha256 = "5105c573a9eace338fc2d3b1a09a3ffc87824fe3f1680c2343d40bd0ee551de5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-autorace-2020/default.nix
+++ b/distros/noetic/turtlebot3-autorace-2020/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, turtlebot3-autorace-camera, turtlebot3-autorace-core, turtlebot3-autorace-detect, turtlebot3-autorace-driving, turtlebot3-autorace-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-2020";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_2020/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "e41b55aafd603d76d2b6270a4ed9a2d771da7ac15e90f34823c95a3a432bfac7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ turtlebot3-autorace-camera turtlebot3-autorace-core turtlebot3-autorace-detect turtlebot3-autorace-driving turtlebot3-autorace-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TurtleBot3 AutoRace 2020 ROS 1 packages (meta package)'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/turtlebot3-autorace-camera/default.nix
+++ b/distros/noetic/turtlebot3-autorace-camera/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, pythonPackages, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-camera";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_camera/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "894e634fd19fa53b1e4041e6dfd29588291969d612c78b8e6c2d388d60b2270a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure pythonPackages.enum34 pythonPackages.numpy pythonPackages.opencv3 rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TurtleBot3 AutoRace ROS package that controls Raspberry Pi Camera, and process the image'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/turtlebot3-autorace-core/default.nix
+++ b/distros/noetic/turtlebot3-autorace-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages, roslaunch, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-core";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_core/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "b12960f4765807e11f6b26b0df57ee7c7905e3ed29847e8ff5b3d7fbebe8b04e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pythonPackages.enum34 pythonPackages.numpy roslaunch rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TurtleBot3 AutoRace ROS package that TurtleBot3 Auto's core'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/turtlebot3-autorace-detect/default.nix
+++ b/distros/noetic/turtlebot3-autorace-detect/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, move-base-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-detect";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_detect/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "527fb800331750397222f79a5821b07cd0ddba54391647b70412938e2100b275";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure geometry-msgs move-base-msgs nav-msgs pythonPackages.enum34 pythonPackages.numpy pythonPackages.opencv3 rospy sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''AutoRace ROS packages for feature detection with TurtleBot3 Auto'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/turtlebot3-autorace-driving/default.nix
+++ b/distros/noetic/turtlebot3-autorace-driving/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, pythonPackages, rospy, sensor-msgs, std-msgs, tf, turtlebot3-autorace-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-driving";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_driving/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "5c43ec90714b913c4061502534c7176d20f0e7cd78710252decd93b56464c750";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nav-msgs pythonPackages.enum34 pythonPackages.numpy rospy sensor-msgs std-msgs tf turtlebot3-autorace-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''TurtleBot3 AutoRace ROS package that TurtleBot3 Auto driving'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/turtlebot3-autorace-msgs/default.nix
+++ b/distros/noetic/turtlebot3-autorace-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-turtlebot3-autorace-msgs";
+  version = "1.1.0-r7";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_autorace_2020_release/archive/release/noetic/turtlebot3_autorace_msgs/1.1.0-7.tar.gz";
+    name = "1.1.0-7.tar.gz";
+    sha256 = "4fce4e1f725b2eb980e9c499c2063fa0aab3c0accfb59017f52f91aece9423e1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The turtlebot3_autorace_msgs package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/twist-controller/default.nix
+++ b/distros/noetic/twist-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-twist-controller";
+  version = "0.1.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.3-1.tar.gz";
+    name = "0.1.3-1.tar.gz";
+    sha256 = "253ef7df1ede94caf0c028ca4ab17196216aceb3bea364285a6ea837424c95d4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cartesian-interface controller-interface dynamic-reconfigure geometry-msgs hardware-interface realtime-tools roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ros_control controller accepting Cartesian twist messages in order to move a robot manipulator.
+    It uses a Cartesian interface to the robot, so that the robot hardware takes care about
+    doing the inverse kinematics. This could be used e.g. for visual servoing applications.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/ur-client-library/default.nix
+++ b/distros/noetic/ur-client-library/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, console-bridge }:
 buildRosPackage {
   pname = "ros-noetic-ur-client-library";
-  version = "0.2.2-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "da3dfc131f8228144ad70a13fff91a8c6550375d5fe6916fceb4588699a9acc8";
+    url = "https://github.com/UniversalRobots/Universal_Robots_Client_Library-release/archive/release/noetic/ur_client_library/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "9398c88246ba5578db779a85b9d5ddd171668d13873a1a00a781d823452f39ee";
   };
 
   buildType = "cmake";

--- a/distros/noetic/velocity-controllers/default.nix
+++ b/distros/noetic/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, forward-command-controller, hardware-interface, pluginlib, realtime-tools, roscpp, std-msgs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-velocity-controllers";
-  version = "0.18.1-r1";
+  version = "0.19.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.18.1-1.tar.gz";
-    name = "0.18.1-1.tar.gz";
-    sha256 = "f4c93c0a7ea10a062fec2329a76e23dfdcbf4da2ac307aeb0638f54bc8c25a09";
+    url = "https://github.com/ros-gbp/ros_controllers-release/archive/release/noetic/velocity_controllers/0.19.0-1.tar.gz";
+    name = "0.19.0-1.tar.gz";
+    sha256 = "5281f0510e937a8ce981053f9bbc4c9c81ea84254b097fb6df2481edf4963fed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ypspur-ros/default.nix
+++ b/distros/noetic/ypspur-ros/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf, trajectory-msgs, ypspur }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, ypspur }:
 buildRosPackage {
   pname = "ros-noetic-ypspur-ros";
-  version = "0.3.4-r1";
+  version = "0.3.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.3.4-1.tar.gz";
-    name = "0.3.4-1.tar.gz";
-    sha256 = "46f5e3977e8b4799293fc898da5386915802ed7fb54c7bad5774bfba8bd6a36c";
+    url = "https://github.com/openspur/ypspur_ros-release/archive/release/noetic/ypspur_ros/0.3.5-1.tar.gz";
+    name = "0.3.5-1.tar.gz";
+    sha256 = "ed60ad59fb73ba811bd1703436c47aab4cd43bd30d9233787f5bbca1442670f1";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslint rostest ];
-  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf trajectory-msgs ypspur ];
+  propagatedBuildInputs = [ diagnostic-msgs geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros trajectory-msgs ypspur ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit de81aededb7c70b36c6c00c2410af1768b2d357e.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *can-dbc-parser 1.1.0-r1*
* *controller-interface 0.7.0-r1 --> 0.7.1-r1*
* *controller-manager 0.7.0-r1 --> 0.7.1-r1*
* *controller-manager-msgs 0.7.0-r1 --> 0.7.1-r1*
* *dynamixel-hardware-interface 0.0.3-r1*
* *dynamixel-sdk 3.7.40-r3 --> 3.7.40-r4*
* *dynamixel-sdk-custom-interfaces 3.7.40-r3 --> 3.7.40-r4*
* *dynamixel-sdk-examples 3.7.40-r3 --> 3.7.40-r4*
* *gazebo-ros2-control 0.0.2-r1 --> 0.0.3-r1*
* *gazebo-ros2-control-demos 0.0.2-r1 --> 0.0.3-r1*
* *geometric-shapes 2.0.2-r1 --> 2.1.0-r1*
* *hardware-interface 0.7.0-r1 --> 0.7.1-r1*
* *libmavconn 2.0.1-r1 --> 2.0.3-r1*
* *mavros 2.0.1-r1 --> 2.0.3-r1*
* *mavros-msgs 2.0.1-r1 --> 2.0.3-r1*
* *moveit-msgs 2.0.1-r1 --> 2.1.0-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.1-r1*
* *plotjuggler-ros 1.2.0-r1 --> 1.5.0-r1*
* *qpoases-vendor 3.2.3-r2*
* *quaternion-operation 0.0.4-r1 --> 0.0.5-r1*
* *raptor-dbw-can 1.0.0-r1 --> 1.1.0-r1*
* *raptor-dbw-joystick 1.0.0-r1 --> 1.1.0-r1*
* *raptor-dbw-msgs 1.0.0-r1 --> 1.1.0-r1*
* *raptor-pdu 1.0.0-r1 --> 1.1.0-r1*
* *raptor-pdu-msgs 1.0.0-r1 --> 1.1.0-r1*
* *rcdiscover 1.1.2-r1*
* *ros2-control 0.7.0-r1 --> 0.7.1-r1*
* *ros2-control-test-assets 0.7.0-r1 --> 0.7.1-r1*
* *ros2controlcli 0.7.0-r1 --> 0.7.1-r1*
* *rviz-assimp-vendor 8.2.1-r1 --> 8.2.2-r1*
* *rviz-common 8.2.1-r1 --> 8.2.2-r1*
* *rviz-default-plugins 8.2.1-r1 --> 8.2.2-r1*
* *rviz-ogre-vendor 8.2.1-r1 --> 8.2.2-r1*
* *rviz-rendering 8.2.1-r1 --> 8.2.2-r1*
* *rviz-rendering-tests 8.2.1-r1 --> 8.2.2-r1*
* *rviz-visual-testing-framework 8.2.1-r1 --> 8.2.2-r1*
* *rviz2 8.2.1-r1 --> 8.2.2-r1*
* *transmission-interface 0.7.0-r1 --> 0.7.1-r1*
* *turtlebot3-fake-node 2.2.2-r1 --> 2.2.3-r1*
* *turtlebot3-gazebo 2.2.2-r1 --> 2.2.3-r1*
* *turtlebot3-simulations 2.2.2-r1 --> 2.2.3-r1*
* *twist-mux 4.0.1-r1*
* *ur-client-library 0.2.2-r1 --> 1.0.0-r1*
* *urdf-test 2.0.0-r2*

Galactic Changes:
-----------------
* *dynamixel-sdk 3.7.40-r1*
* *dynamixel-sdk-custom-interfaces 3.7.40-r1*
* *dynamixel-sdk-examples 3.7.40-r1*
* *geometric-shapes 2.1.0-r1*
* *launch-system-modes 0.8.0-r1*
* *libmavconn 2.0.3-r1*
* *mavros 2.0.3-r1*
* *mavros-msgs 2.0.3-r1*
* *moveit-msgs 2.1.0-r1*
* *moveit-resources 2.0.2-r1*
* *moveit-resources-fanuc-description 2.0.2-r1*
* *moveit-resources-fanuc-moveit-config 2.0.2-r1*
* *moveit-resources-panda-description 2.0.2-r1*
* *moveit-resources-panda-moveit-config 2.0.2-r1*
* *moveit-resources-pr2-description 2.0.2-r1*
* *nao-interfaces 0.0.2-r1*
* *openvslam 0.2.3-r3*
* *plotjuggler 3.2.1-r2*
* *plotjuggler-msgs 0.1.2-r1*
* *plotjuggler-ros 1.5.0-r1*
* *random-numbers 2.0.1-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.1.2-r1*
* *rmf-building-map-msgs 1.2.0-r1*
* *rmf-charger-msgs 1.3.0-r1*
* *rmf-cmake-uncrustify 1.2.0-r1*
* *rmf-dispenser-msgs 1.3.0-r1*
* *rmf-door-msgs 1.3.0-r1*
* *rmf-fleet-msgs 1.3.0-r1*
* *rmf-ingestor-msgs 1.3.0-r1*
* *rmf-lift-msgs 1.3.0-r1*
* *rmf-task-msgs 1.3.0-r1*
* *rmf-traffic-msgs 1.3.0-r1*
* *rmf-utils 1.3.0-r1*
* *rmf-workcell-msgs 1.3.0-r1*
* *rmw-cyclonedds-cpp 0.22.2-r1 --> 0.22.3-r1*
* *soccer-vision-msgs 0.0.1-r1*
* *srdfdom 2.0.2-r1*
* *stubborn-buddies 1.0.0-r1*
* *stubborn-buddies-msgs 1.0.0-r1*
* *system-modes 0.7.1-r3 --> 0.8.0-r1*
* *system-modes-examples 0.7.1-r3 --> 0.8.0-r1*
* *system-modes-msgs 0.7.1-r3 --> 0.8.0-r1*
* *test-launch-system-modes 0.8.0-r1*
* *turtlebot3-fake-node 2.2.4-r1*
* *turtlebot3-gazebo 2.2.4-r1*
* *turtlebot3-msgs 2.2.2-r3*
* *turtlebot3-simulations 2.2.4-r1*
* *warehouse-ros 2.0.1-r1*

Melodic Changes:
----------------
* *aques-talk 2.1.22-r1*
* *assimp-devel 2.1.21-r3 --> 2.1.22-r1*
* *astuff-sensor-msgs 3.0.1-r1 --> 3.0.2-r1*
* *bayesian-belief-networks 2.1.21-r3 --> 2.1.22-r1*
* *bota-driver 0.5.9-r1 --> 0.6.0-r3*
* *bota-node 0.5.9-r1 --> 0.6.0-r3*
* *bota-signal-handler 0.5.9-r1 --> 0.6.0-r3*
* *bota-worker 0.5.9-r1 --> 0.6.0-r3*
* *cartesian-control-msgs 0.1.0-r1*
* *cartesian-interface 0.1.3-r1*
* *cartesian-trajectory-controller 0.1.3-r1*
* *cartesian-trajectory-interpolation 0.1.3-r1*
* *chaplus-ros 2.1.22-r1*
* *combined-robot-hw 0.18.3-r1 --> 0.18.4-r1*
* *combined-robot-hw-tests 0.18.3-r1 --> 0.18.4-r1*
* *controller-interface 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager-msgs 0.18.3-r1 --> 0.18.4-r1*
* *controller-manager-tests 0.18.3-r1 --> 0.18.4-r1*
* *copernicus-base 1.1.0-r1*
* *copernicus-control 1.1.0-r1*
* *copernicus-description 1.1.0-r1*
* *copernicus-localization 1.1.0-r1*
* *copernicus-msgs 1.1.0-r1*
* *copernicus-navigation 1.1.0-r1*
* *copernicus-rules 1.1.0-r1*
* *copernicus-teleoperator 1.1.0-r1*
* *costmap-cspace 0.10.10-r1 --> 0.10.11-r1*
* *delphi-esr-msgs 3.0.1-r1 --> 3.0.2-r1*
* *delphi-mrr-msgs 3.0.1-r1 --> 3.0.2-r1*
* *delphi-srr-msgs 3.0.1-r1 --> 3.0.2-r1*
* *derived-object-msgs 3.0.1-r1 --> 3.0.2-r1*
* *downward 2.1.21-r3 --> 2.1.22-r1*
* *ff 2.1.21-r3 --> 2.1.22-r1*
* *ffha 2.1.21-r3 --> 2.1.22-r1*
* *graceful-controller 0.3.1-r1 --> 0.4.0-r1*
* *graceful-controller-ros 0.3.1-r1 --> 0.4.0-r1*
* *hardware-interface 0.18.3-r1 --> 0.18.4-r1*
* *hector-gazebo 0.5.1 --> 0.5.4-r1*
* *hector-gazebo-plugins 0.5.1 --> 0.5.4-r1*
* *hector-gazebo-thermal-camera 0.5.1 --> 0.5.4-r1*
* *hector-gazebo-worlds 0.5.1 --> 0.5.4-r1*
* *hector-sensors-gazebo 0.5.1 --> 0.5.4-r1*
* *ibeo-msgs 3.0.1-r1 --> 3.0.2-r1*
* *joint-limits-interface 0.18.3-r1 --> 0.18.4-r1*
* *joystick-interrupt 0.10.10-r1 --> 0.10.11-r1*
* *jsk-3rdparty 2.1.21-r3 --> 2.1.22-r1*
* *julius 2.1.21-r3 --> 2.1.22-r1*
* *kartech-linear-actuator-msgs 3.0.1-r1 --> 3.0.2-r1*
* *laser-filters-jsk-patch 2.1.21-r3 --> 2.1.22-r1*
* *libcmt 2.1.21-r3 --> 2.1.22-r1*
* *libsiftfast 2.1.21-r3 --> 2.1.22-r1*
* *lpg-planner 2.1.21-r3 --> 2.1.22-r1*
* *map-organizer 0.10.10-r1 --> 0.10.11-r1*
* *mini-maxwell 2.1.21-r3 --> 2.1.22-r1*
* *mobileye-560-660-msgs 3.0.1-r1 --> 3.0.2-r1*
* *neobotix-usboard-msgs 3.0.1-r1 --> 3.0.2-r1*
* *neonavigation 0.10.10-r1 --> 0.10.11-r1*
* *neonavigation-common 0.10.10-r1 --> 0.10.11-r1*
* *neonavigation-launch 0.10.10-r1 --> 0.10.11-r1*
* *nlopt 2.1.21-r3 --> 2.1.22-r1*
* *obj-to-pointcloud 0.10.10-r1 --> 0.10.11-r1*
* *opt-camera 2.1.21-r3 --> 2.1.22-r1*
* *pacmod-msgs 3.0.1-r1 --> 3.0.2-r1*
* *pass-through-controllers 0.1.0-r1*
* *planner-cspace 0.10.10-r1 --> 0.10.11-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.1-r1*
* *plotjuggler-ros 1.2.0-r1 --> 1.5.0-r1*
* *radar-msgs 3.0.1-r1 --> 3.0.2-r1*
* *rc-genicam-driver 0.5.0-r1 --> 0.5.2-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.0.3-r1 --> 1.1.2-r1*
* *rokubimini 0.5.9-r1 --> 0.6.0-r3*
* *rokubimini-bus-manager 0.5.9-r1 --> 0.6.0-r3*
* *rokubimini-description 0.5.9-r1 --> 0.6.0-r3*
* *rokubimini-ethercat 0.5.9-r1 --> 0.6.0-r3*
* *rokubimini-msgs 0.5.9-r1 --> 0.6.0-r3*
* *rokubimini-serial 0.5.9-r1 --> 0.6.0-r3*
* *ros-control 0.18.3-r1 --> 0.18.4-r1*
* *ros-controllers-cartesian 0.1.3-r1*
* *rospatlite 2.1.21-r3 --> 2.1.22-r1*
* *rosping 2.1.21-r3 --> 2.1.22-r1*
* *rqt-controller-manager 0.18.3-r1 --> 0.18.4-r1*
* *rqt-rviz 0.6.0 --> 0.7.0-r1*
* *rviz 1.13.17-r1 --> 1.13.18-r1*
* *safety-limiter 0.10.10-r1 --> 0.10.11-r1*
* *sesame-ros 2.1.21-r3 --> 2.1.22-r1*
* *slic 2.1.21-r3 --> 2.1.22-r1*
* *track-odometry 0.10.10-r1 --> 0.10.11-r1*
* *trajectory-tracker 0.10.10-r1 --> 0.10.11-r1*
* *transmission-interface 0.18.3-r1 --> 0.18.4-r1*
* *twist-controller 0.1.3-r1*
* *ur-client-library 0.2.2-r1 --> 0.3.1-r1*
* *voice-text 2.1.21-r3 --> 2.1.22-r1*
* *ypspur-ros 0.3.4-r1 --> 0.3.5-r1*

Noetic Changes:
---------------
* *ackermann-steering-controller 0.18.1-r1 --> 0.19.0-r1*
* *bota-driver 0.5.9-r1 --> 0.6.0-r2*
* *bota-node 0.5.9-r1 --> 0.6.0-r2*
* *bota-signal-handler 0.5.9-r1 --> 0.6.0-r2*
* *bota-worker 0.5.9-r1 --> 0.6.0-r2*
* *cartesian-control-msgs 0.1.0-r1*
* *cartesian-interface 0.1.3-r1*
* *cartesian-trajectory-controller 0.1.3-r1*
* *cartesian-trajectory-interpolation 0.1.3-r1*
* *combined-robot-hw 0.19.4-r1 --> 0.19.5-r1*
* *combined-robot-hw-tests 0.19.4-r1 --> 0.19.5-r1*
* *controller-interface 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager-msgs 0.19.4-r1 --> 0.19.5-r1*
* *controller-manager-tests 0.19.4-r1 --> 0.19.5-r1*
* *costmap-cspace 0.10.10-r1 --> 0.10.11-r1*
* *delphi-esr-msgs 3.2.0-r1 --> 3.3.0-r1*
* *delphi-mrr-msgs 3.2.0-r1 --> 3.3.0-r1*
* *delphi-srr-msgs 3.2.0-r1 --> 3.3.0-r1*
* *derived-object-msgs 3.2.0-r1 --> 3.3.0-r1*
* *diff-drive-controller 0.18.1-r1 --> 0.19.0-r1*
* *effort-controllers 0.18.1-r1 --> 0.19.0-r1*
* *force-torque-sensor-controller 0.18.1-r1 --> 0.19.0-r1*
* *forward-command-controller 0.18.1-r1 --> 0.19.0-r1*
* *four-wheel-steering-controller 0.18.1-r1 --> 0.19.0-r1*
* *graceful-controller 0.3.1-r1 --> 0.4.0-r1*
* *graceful-controller-ros 0.3.1-r1 --> 0.4.0-r1*
* *gripper-action-controller 0.18.1-r1 --> 0.19.0-r1*
* *hardware-interface 0.19.4-r1 --> 0.19.5-r1*
* *hector-gazebo 0.5.3-r1 --> 0.5.4-r1*
* *hector-gazebo-plugins 0.5.3-r1 --> 0.5.4-r1*
* *hector-gazebo-thermal-camera 0.5.3-r1 --> 0.5.4-r1*
* *hector-gazebo-worlds 0.5.3-r1 --> 0.5.4-r1*
* *hector-sensors-gazebo 0.5.3-r1 --> 0.5.4-r1*
* *ibeo-msgs 3.2.0-r1 --> 3.3.0-r1*
* *imu-sensor-controller 0.18.1-r1 --> 0.19.0-r1*
* *joint-limits-interface 0.19.4-r1 --> 0.19.5-r1*
* *joint-state-controller 0.18.1-r1 --> 0.19.0-r1*
* *joint-trajectory-controller 0.18.1-r1 --> 0.19.0-r1*
* *joystick-interrupt 0.10.10-r1 --> 0.10.11-r1*
* *kartech-linear-actuator-msgs 3.2.0-r1 --> 3.3.0-r1*
* *map-organizer 0.10.10-r1 --> 0.10.11-r1*
* *mobileye-560-660-msgs 3.2.0-r1 --> 3.3.0-r1*
* *neo-local-planner 1.0.1-r1*
* *neobotix-usboard-msgs 3.2.0-r1 --> 3.3.0-r1*
* *neonavigation 0.10.10-r1 --> 0.10.11-r1*
* *neonavigation-common 0.10.10-r1 --> 0.10.11-r1*
* *neonavigation-launch 0.10.10-r1 --> 0.10.11-r1*
* *obj-to-pointcloud 0.10.10-r1 --> 0.10.11-r1*
* *pacmod-msgs 3.2.0-r1 --> 3.3.0-r1*
* *pass-through-controllers 0.1.0-r1*
* *planner-cspace 0.10.10-r1 --> 0.10.11-r1*
* *plotjuggler 3.1.2-r1 --> 3.2.1-r1*
* *plotjuggler-ros 1.2.0-r1 --> 1.5.0-r1*
* *position-controllers 0.18.1-r1 --> 0.19.0-r1*
* *rc-genicam-driver 0.5.0-r1 --> 0.5.2-r1*
* *rc-reason-clients 0.2.1-r1*
* *rc-reason-msgs 0.2.1-r1*
* *rcdiscover 1.0.4-r1 --> 1.1.2-r1*
* *rokubimini 0.5.9-r1 --> 0.6.0-r2*
* *rokubimini-bus-manager 0.5.9-r1 --> 0.6.0-r2*
* *rokubimini-description 0.5.9-r1 --> 0.6.0-r2*
* *rokubimini-ethercat 0.5.9-r1 --> 0.6.0-r2*
* *rokubimini-msgs 0.5.9-r1 --> 0.6.0-r2*
* *rokubimini-serial 0.5.9-r1 --> 0.6.0-r2*
* *ros-control 0.19.4-r1 --> 0.19.5-r1*
* *ros-controllers 0.18.1-r1 --> 0.19.0-r1*
* *ros-controllers-cartesian 0.1.3-r1*
* *rqt-controller-manager 0.19.4-r1 --> 0.19.5-r1*
* *rqt-joint-trajectory-controller 0.18.1-r1 --> 0.19.0-r1*
* *rqt-rviz 0.6.1-r1 --> 0.7.0-r1*
* *rviz 1.14.7-r1 --> 1.14.8-r1*
* *safety-limiter 0.10.10-r1 --> 0.10.11-r1*
* *track-odometry 0.10.10-r1 --> 0.10.11-r1*
* *trajectory-tracker 0.10.10-r1 --> 0.10.11-r1*
* *transmission-interface 0.19.4-r1 --> 0.19.5-r1*
* *turtlebot3-autorace-2020 1.1.0-r7*
* *turtlebot3-autorace-camera 1.1.0-r7*
* *turtlebot3-autorace-core 1.1.0-r7*
* *turtlebot3-autorace-detect 1.1.0-r7*
* *turtlebot3-autorace-driving 1.1.0-r7*
* *turtlebot3-autorace-msgs 1.1.0-r7*
* *twist-controller 0.1.3-r1*
* *ur-client-library 0.2.2-r1 --> 0.3.1-r1*
* *velocity-controllers 0.18.1-r1 --> 0.19.0-r1*
* *ypspur-ros 0.3.4-r1 --> 0.3.5-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

