### PR TITLE
rosdistro sync, Fri Jul  2 13:02:26 2021

### DIFF
--- a/distros/foxy/ament-index-cpp/default.nix
+++ b/distros/foxy/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-ament-index-cpp";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_cpp/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "5df0a4d5b914c42e92419ca120ea2647622d1b614069d639411fdbbb96ffbd65";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_cpp/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "be3cb84b6d21b9ef200735ad2837c86968f409d27c463c2534922794eafe2ef1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-index-python/default.nix
+++ b/distros/foxy/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-index-python";
-  version = "1.0.2-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_python/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "75164565cdd37e714af887bcf276df352427e0db3a89a51e78f950f2b5a383fe";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/foxy/ament_index_python/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "0836dc79b482dfb39e8683d61e8f1027a1765e06874fcd16781fb20198deddef";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "603f485e1f5686cfde2ae49d449ddc80901dce0f082b82ecef8ce1854dbdfcb2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3dbce9d3f47b38244c3e435d7379ce6f2fb98d10495d4f278014a8e0212a2763";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "3a332b74d6a8e89c0dc88d2a05461e4e0d20ae54e3e3319f318b7eb786a71cb3";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "06f339b629e3d77118798e3a9b288382a1f6e35239d7aaf2667cf1f33f583a7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-foxy-force-torque-sensor-broadcaster";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "8e9929a8fe0f8631beac16ba54e2fb1474d5567ec1fec8150b45b6dbc35b7d64";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller to publish state of force-torque sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "1b26e6f102db4d303e3b566ca5c2383c3fd22de5e804b48dd49400fff003e805";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6e4d2636672e89795db672c9e55aa0f9d0aba085c08d9389c3ddb403039ed94d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -422,6 +422,8 @@ self: super: {
 
  foonathan-memory-vendor = self.callPackage ./foonathan-memory-vendor {};
 
+ force-torque-sensor-broadcaster = self.callPackage ./force-torque-sensor-broadcaster {};
+
  forward-command-controller = self.callPackage ./forward-command-controller {};
 
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
@@ -468,6 +470,8 @@ self: super: {
 
  grbl-ros = self.callPackage ./grbl-ros {};
 
+ gripper-controllers = self.callPackage ./gripper-controllers {};
+
  gtest-vendor = self.callPackage ./gtest-vendor {};
 
  hardware-interface = self.callPackage ./hardware-interface {};
@@ -495,6 +499,8 @@ self: super: {
  image-transport-plugins = self.callPackage ./image-transport-plugins {};
 
  image-view = self.callPackage ./image-view {};
+
+ imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
 
  interactive-markers = self.callPackage ./interactive-markers {};
 
@@ -617,6 +623,8 @@ self: super: {
  marti-status-msgs = self.callPackage ./marti-status-msgs {};
 
  marti-visualization-msgs = self.callPackage ./marti-visualization-msgs {};
+
+ massrobotics-amr-sender = self.callPackage ./massrobotics-amr-sender {};
 
  mavlink = self.callPackage ./mavlink {};
 
@@ -1387,6 +1395,8 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf-transformations = self.callPackage ./tf-transformations {};
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
 

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-foxy-gripper-controllers";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e16b634fb377dd6c56a57663a00b96234140310785f76324be03d6d0d2df7fb7";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs control-toolbox controller-interface hardware-interface rclcpp rclcpp-action realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The gripper_controllers package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-imu-sensor-broadcaster";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "1dc90effed167877ccc3b5407e7dfc5bbf7c76bda02ec1914c49b048771dd2c2";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller to publish readings of IMU sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "47bb39c16cbc7631b57c269198be62b1674e41c8a24b6c54508e27c06ac764f9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "fef5bc8e18b8d14466a17234e9e3d9d487ac6bbd797f92ff6bd86b1f365b3b9f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "6f74fdc8f499412c3fa54afa9a41a65cead72dce356722be6588e1c8e46988ab";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "1254b40d094fa58ecd2d945179a20fd803a96b597b3bc0ab6ee072edfdc1be3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "33f4bec0a12ead0180743a03ff6f5966d31552c300be438f7245dc439f842d91";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "5ec2f59ac4dfc1e8f53e8b2bd54b90a1575f9778e619c17d6a32c0fdbab49f30";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
-  propagatedBuildInputs = [ angles control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle rcutils realtime-tools trajectory-msgs ];
+  propagatedBuildInputs = [ angles control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/launch-pal/default.nix
+++ b/distros/foxy/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-pal";
-  version = "0.0.2-r3";
+  version = "0.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.2-3.tar.gz";
-    name = "0.0.2-3.tar.gz";
-    sha256 = "40d7edd6eb447e7a05dbb6e0b42159c722caf4882a056e656542404ca2c0e954";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "3487c6fbe6e9af8269bca39c514bc141151d850a89d20e6fd6362faa6694f8e0";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/librealsense2/default.nix
+++ b/distros/foxy/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-foxy-librealsense2";
-  version = "2.45.0-r1";
+  version = "2.48.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.45.0-1.tar.gz";
-    name = "2.45.0-1.tar.gz";
-    sha256 = "3ac5359c3e7e21c29d588b99b729577043dfbfd48c6bea21ee25d07ea12028ee";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/foxy/librealsense2/2.48.0-1.tar.gz";
+    name = "2.48.0-1.tar.gz";
+    sha256 = "e690af321d9a44456920751bf885d94acbdcff9e6448fe3d9707ac0a28868700";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/massrobotics-amr-sender/default.nix
+++ b/distros/foxy/massrobotics-amr-sender/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, python3Packages, pythonPackages, rclpy, tf2, tf2-bullet, tf2-eigen, tf2-eigen-kdl, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
+buildRosPackage {
+  pname = "ros-foxy-massrobotics-amr-sender";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/inorbit-ai/ros_amr_interop-release/archive/release/foxy/massrobotics_amr_sender/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "b9c69911bba3d3f4343fad093bcc3ba4eab28bf8225804167fb0419a6aea79f2";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 python3Packages.jsonschema python3Packages.mock python3Packages.pep8 pythonPackages.pytest ];
+  propagatedBuildInputs = [ python3Packages.websockets rclpy tf2 tf2-bullet tf2-eigen tf2-eigen-kdl tf2-geometry-msgs tf2-kdl tf2-msgs tf2-py tf2-ros tf2-sensor-msgs tf2-tools ];
+
+  meta = {
+    description = ''MassRobotics AMR Interop Sender'';
+    license = with lib.licenses; [ "3-Clause BSD License" ];
+  };
+}

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "12c0606cfeef194d56776cc4613d54c50de46b312bce5952db7cfd8e047f4d01";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "dd6371048f91a3d25b3ca93d0f21aed0a30c606876a1c3d812f592370771898f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "f9c397af5fcc4883ad8f40d4405b4d935fe6246b9df475d9e8d17979e594b586";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0c9a76c30b1816507dc084b1c854598ed118bf80c3792fd2692582c43bfc41a8";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl tf2-kdl ];
-  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
 
   meta = {

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "fb737529c49428d4c40d9d7fb9173f42ea0aed51f9963a94371c805a29f032ca";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2667dbb97470f68455a61923fa2cea452128c97ef0c768a68113a46ada9d338c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "b030972f0be9cb2d5004e3ad4cceb23e55be2ac6072d35ba6b5a3c88bda5cb69";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "864dba69ac7966c319314a5155d1c51a9dbb43bf3c9991d5d87ccd7abcc831e0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "0f208d51e4f33020b4d4794467e4f1697cbf59bdbcf15395b17c4a68b2136e93";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e583ba8b7ceb80222b364e02f9524e401f587b76018a955f54a4c068434485bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "7277bf17030bde9826a2ec3b2ec3f084dc48c5674eb6c262b1859ecf1aa52353";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "b5b53416d43a88e88a3ccf2c8f55d3785ce0e1cc9905285298a8fd0a5d399c86";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "186724ff600ec93175f45c07e47cdac6562f91be795800f9d7f0e02b80210e57";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6fca70210286173666efe351972ce675e3ab9cb7a254b493906ff77f305188f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "93dbca99dbf576adb9081cdd8cad61ea88ab643b20f3a0eb3cef1194d5bb8157";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "58152a8b8852369733595522c1cd558d808d1673e0ec9b713bea18b5eb605190";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "809d23843391ac8ee64e5258bc98310d1623e8c03813dd7bf87338bf3356b4c7";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "604bc1813f9feb88d2a38a8d5b85d5d4925d35dc456d3b7da9efd196c3872c7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "30cebd88af14c5fcd7bed4693a3d168cd5803860e5e3144547e799f2f1986514";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "a1e1e06b700db74f56bdd4b9e61590a9564c950ea0db7083c346c40ae42d4d5f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport libGL libGLU llvmPackages.openmp message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor object-recognition-msgs pluginlib rclcpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros urdf ];
+  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport libGL libGLU llvmPackages.openmp message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor moveit-ros-planning object-recognition-msgs pluginlib rclcpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "1c0160f7a9c77f03cea1847070c2ff5a699b7bfeb9a9c5f833d152249e71a4b3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "26a119b85b03fa0436edc299497b39a8b051eaa02474df5c7cbc45112a7e9b76";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "ce0482cc79feb2b3199493a4d1818ca5f092758477c608e8f3c2c2b1ca79934b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6709130e688e766f910a85b17eec0b1bfafafcb4740932f3004cefb0685cc403";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "35aaaead87b4421830603973459e134146d77ebf775335cefb36992326d94029";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "bf050dd6a9b24ec66a40f99524a9349a8c0c6a2fa4de2046784c310a58206f33";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "3e4fcf98eb91e8d065820c13981ba13a674c639a5503e77011e49043151fb2a2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "8ab2372fddf1b7efcf09c0e04967e32b208db9f89526ab668e59a75fd5d95c78";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "15a69c0a3fea674361e2c2cc7b8c4d560e2c88b6491e0e621c8cd66f0f2b1de7";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1ef600d5c105cb46c43012aa0c5a1c53e31f571d9a95cf46ae10b6e6b19e15bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "eaade9baed3e3977fbf986d26f9e5a3941d6f247c1786965122fa6596a4b41ca";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "3b316776ba1b0512cf282522c51662b7d801c268589db1a75a79d64bc590434e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "83778e7b6ddddc0c00c5289742bcca773ba728b056424aff1739910bc27ad1b8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "aa2fa897e7efca15876c0c8ad04811f93082ca2af00a3902bf12879ac6dd458a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "f933f1f5a0b7e03a1759046e3dcd57da9672dd41459b1c18334fddb773dbb825";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "adff94dc2e09d4f5d739036fafde598664351b8c95ef68bc5984b915dbc3a4f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "0b8c53b7332a99b00b04207f15faf55badda5d486b1773ba8a4b9625b17268c2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "66681f29c860743607a6c72240541da7b8b3335922dfafb88fbc1a67ce529e19";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "c0fbb4c46af10be0f1dff59a4eea5b3a6ce2723d658c2f03bccae74b1f10dbc3";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "2d50e382d95f563c0e2827ef90da94317e2c446e2e1387f3ae55f40e1ddabf63";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "0c5c75c15f600dbef0a77de03e9b40d101c5ea2a5b24d3d39c9a3d06c4991de9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "67fbaceb5a62772eb2e41487682737a3134af52cc5f26b6feca4b9ea3f31a59f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, forward-command-controller, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "d49e70a24954afaa0e66cb55c1063888d264838e0b3386e5bd6e11626063d1e6";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "1d4aabf7d66422d8a5ffc84306123178f342af63c95b665eccfed9a453f3844a";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ diff-drive-controller effort-controllers forward-command-controller joint-state-broadcaster joint-state-controller joint-trajectory-controller position-controllers velocity-controllers ];
+  propagatedBuildInputs = [ diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-state-controller joint-trajectory-controller position-controllers velocity-controllers ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rqt-publisher/default.nix
+++ b/distros/foxy/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-publisher";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "9001466e4057b2cb174aab4a7e41916b6d15f53ba1f8a351b17d8cdf080a0117";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/foxy/rqt_publisher/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "87e69813d50f6ef700d02075257d47b712f3ecf26d8abc2257786f1a461308ea";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "3ebc7ed2de771b3cc4237d67399c99f24b7ff9495e0cc18e11c1205cc7de0c88";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "14adab3f57004822bbd01824c22ae77e8e5a5aebe93533833ff6dfe462c782a5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "67717836f3cdba66672557c13b566274678f65feefef3537a0ac3a5332f8c867";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "6cf13e20dbe99025d9633f74107bcd557b6b6c5dba591bb9b062b509f5e0e526";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.1.4-r1";
+  version = "2.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.1.4-1.tar.gz";
-    name = "2.1.4-1.tar.gz";
-    sha256 = "e6f2f189ce2c82b4672ac436d139f51471a15547c6cb9871bc9ee725ee678872";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "9f4141186c8d7e60b2c110c8639d5d3c0d08d9e006aea35049d1f63821fd830d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf-transformations/default.nix
+++ b/distros/foxy/tf-transformations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-foxy-tf-transformations";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/tf_transformations_release/archive/release/foxy/tf_transformations/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "3121c9c3a744914be0069131884e86bcd0bbb1bc1bde0c517b895f15c3843235";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ pythonPackages.numpy ];
+
+  meta = {
+    description = ''Reimplementation of the tf/transformations.py library for common Python spatial operations'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.3.1-r1";
+  version = "0.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.3.1-1.tar.gz";
-    name = "0.3.1-1.tar.gz";
-    sha256 = "2f976e0c02442f7b78c998fa42e82b6db9ad636cfbf2ab6d116510bb670bc5c7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "e80b180d663f1c2a2a92cf387ac06474dc7a3b964d0d43ce29ad46f95cbf0947";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/warehouse-ros/default.nix
+++ b/distros/foxy/warehouse-ros/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-warehouse-ros";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "2b45dcda6e48d339486b838ab6e1303f74684effa8de23c145dbfdb30f6c73ac";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/foxy/warehouse_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "b6a9d43d7d0790ed9df2bffc86629c2007ed33158491da1470c595368fa74582";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ openssl ];
   checkInputs = [ ament-cmake-copyright ament-lint-auto ];
-  propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ boost geometry-msgs openssl pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/ament-index-cpp/default.nix
+++ b/distros/galactic/ament-index-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-ament-index-cpp";
-  version = "1.0.6-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/galactic/ament_index_cpp/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "fabf4e643048728f1e058a764f11c77f8cb0b564b597a4ae81689b3e11bc05ac";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/galactic/ament_index_cpp/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "cb146c8b712674cc8c91c9032e3b037cc528b2b528940df9f4364ccbd60f4b58";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ament-index-python/default.nix
+++ b/distros/galactic/ament-index-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
 buildRosPackage {
   pname = "ros-galactic-ament-index-python";
-  version = "1.0.6-r1";
+  version = "1.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/galactic/ament_index_python/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "09ca2a61311e12d97a84049c158b61db8b47030dd99a16b02e6dc2de4df031fd";
+    url = "https://github.com/ros2-gbp/ament_index-release/archive/release/galactic/ament_index_python/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "529abc3962dd0e80307be71ca3cd3946da25a988f328b2fad720abd63e02427a";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -410,6 +410,8 @@ self: super: {
 
  libphidget22 = self.callPackage ./libphidget22 {};
 
+ librealsense2 = self.callPackage ./librealsense2 {};
+
  libstatistics-collector = self.callPackage ./libstatistics-collector {};
 
  libyaml-vendor = self.callPackage ./libyaml-vendor {};
@@ -452,7 +454,21 @@ self: super: {
 
  mouse-teleop = self.callPackage ./mouse-teleop {};
 
+ moveit = self.callPackage ./moveit {};
+
+ moveit-common = self.callPackage ./moveit-common {};
+
+ moveit-core = self.callPackage ./moveit-core {};
+
+ moveit-kinematics = self.callPackage ./moveit-kinematics {};
+
  moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-planners = self.callPackage ./moveit-planners {};
+
+ moveit-planners-ompl = self.callPackage ./moveit-planners-ompl {};
+
+ moveit-plugins = self.callPackage ./moveit-plugins {};
 
  moveit-resources = self.callPackage ./moveit-resources {};
 
@@ -465,6 +481,32 @@ self: super: {
  moveit-resources-panda-moveit-config = self.callPackage ./moveit-resources-panda-moveit-config {};
 
  moveit-resources-pr2-description = self.callPackage ./moveit-resources-pr2-description {};
+
+ moveit-ros = self.callPackage ./moveit-ros {};
+
+ moveit-ros-benchmarks = self.callPackage ./moveit-ros-benchmarks {};
+
+ moveit-ros-move-group = self.callPackage ./moveit-ros-move-group {};
+
+ moveit-ros-occupancy-map-monitor = self.callPackage ./moveit-ros-occupancy-map-monitor {};
+
+ moveit-ros-perception = self.callPackage ./moveit-ros-perception {};
+
+ moveit-ros-planning = self.callPackage ./moveit-ros-planning {};
+
+ moveit-ros-planning-interface = self.callPackage ./moveit-ros-planning-interface {};
+
+ moveit-ros-robot-interaction = self.callPackage ./moveit-ros-robot-interaction {};
+
+ moveit-ros-visualization = self.callPackage ./moveit-ros-visualization {};
+
+ moveit-ros-warehouse = self.callPackage ./moveit-ros-warehouse {};
+
+ moveit-runtime = self.callPackage ./moveit-runtime {};
+
+ moveit-servo = self.callPackage ./moveit-servo {};
+
+ moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
  nao-interfaces = self.callPackage ./nao-interfaces {};
 
@@ -608,6 +650,8 @@ self: super: {
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
 
+ qpoases-vendor = self.callPackage ./qpoases-vendor {};
+
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
 
  qt-gui = self.callPackage ./qt-gui {};
@@ -680,6 +724,12 @@ self: super: {
 
  rcutils = self.callPackage ./rcutils {};
 
+ realsense2-camera = self.callPackage ./realsense2-camera {};
+
+ realsense2-camera-msgs = self.callPackage ./realsense2-camera-msgs {};
+
+ realsense2-description = self.callPackage ./realsense2-description {};
+
  realtime-tools = self.callPackage ./realtime-tools {};
 
  resource-retriever = self.callPackage ./resource-retriever {};
@@ -701,6 +751,8 @@ self: super: {
  rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
 
  rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-traffic = self.callPackage ./rmf-traffic {};
 
  rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
 
@@ -924,6 +976,12 @@ self: super: {
 
  rttest = self.callPackage ./rttest {};
 
+ run-move-group = self.callPackage ./run-move-group {};
+
+ run-moveit-cpp = self.callPackage ./run-moveit-cpp {};
+
+ run-ompl-constrained-planning = self.callPackage ./run-ompl-constrained-planning {};
+
  rviz2 = self.callPackage ./rviz2 {};
 
  rviz-assimp-vendor = self.callPackage ./rviz-assimp-vendor {};
@@ -1037,6 +1095,8 @@ self: super: {
  tf2-sensor-msgs = self.callPackage ./tf2-sensor-msgs {};
 
  tf2-tools = self.callPackage ./tf2-tools {};
+
+ tf-transformations = self.callPackage ./tf-transformations {};
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometric-shapes";
-  version = "2.1.0-r1";
+  version = "2.1.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "297188a25c428a2ddd49e921c2b89a969ace3ce538fdb6e39bb1d34c31bca12f";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-2.tar.gz";
+    name = "2.1.0-2.tar.gz";
+    sha256 = "b9e0b3411f625d8136db04625f7fae1a45311f1f8e6c3072653dc1d0428889f9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/librealsense2/default.nix
+++ b/distros/galactic/librealsense2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
+buildRosPackage {
+  pname = "ros-galactic-librealsense2";
+  version = "2.48.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.48.0-1.tar.gz";
+    name = "2.48.0-1.tar.gz";
+    sha256 = "adc3306a0b5c9e579605dc01d33162927143145b631778f918be837f587b2525";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ libusb1 openssl pkg-config udev ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Library for capturing data from the Intel(R) RealSense(TM) SR300, D400 Depth cameras and T2xx Tracking devices. This effort was initiated to better support researchers, creative coders, and app developers in domains such as robotics, virtual reality, and the internet of things. Several often-requested features of RealSense(TM); devices are implemented in this project.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-common";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "8d9346d9e219da36d8a6a1ae34a28599eb77c4e7bfe3b33c19a2752fcfa009f4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Common support functionality used throughout MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-core";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "86dad4e9ae13874f7f0a52f0f8837130d908a05a3854338d52275d989213b986";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl tf2-kdl ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
+
+  meta = {
+    description = ''Core libraries used by MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-kinematics";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d7db0fcd41b664836a3e00a42ffe97a95918196a57d4072bd7869b4e33618ffc";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-fanuc-description moveit-resources-fanuc-moveit-config moveit-resources-panda-description moveit-resources-panda-moveit-config moveit-ros-planning ros-testing ];
+  propagatedBuildInputs = [ class-loader eigen moveit-core moveit-msgs orocos-kdl pluginlib pythonPackages.lxml tf2 tf2-kdl urdfdom ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for all inverse kinematics solvers in MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-planners-ompl";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5f6fa8e2d29ac7e6c5cc62e64ad882f7981e4f86407b3f1cf9f3b31ae3419284";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common eigen moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-resources-pr2-description tf2-eigen ];
+  propagatedBuildInputs = [ llvmPackages.openmp moveit-core moveit-msgs moveit-ros-planning ompl pluginlib rclcpp tf2-eigen tf2-ros ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''MoveIt interface to OMPL'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-planners";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "038dab70bba47b262821b759a2cc4004c037eb94484a2c10223730704e734a10";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-planners-ompl ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that installs all available planners for MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-plugins";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "1f0b0c8b913a40b7c7e789ffde59819dc574ac8903ce0554ee54994735d17e88";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-simple-controller-manager ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for MoveIt plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-benchmarks";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "46714294f3bdef60fba8b986dce85f6d0a406977ec45564bacd3f4f479cbfa99";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost moveit-ros-planning moveit-ros-warehouse pluginlib rclcpp tf2-eigen ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Enhanced tools for benchmarks in MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-move-group";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "12559c70e3b9e5703563f84e9a36b786b65f2808da869417276f707ea214a742";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-fanuc-moveit-config ];
+  propagatedBuildInputs = [ moveit-core moveit-kinematics moveit-ros-occupancy-map-monitor moveit-ros-planning pluginlib rclcpp rclcpp-action std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The move_group node for MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d1d56a698d8718558b38380b338d3aeb38fb5278dd8e83e592dcd30f7f8db191";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-core moveit-msgs octomap pluginlib rclcpp tf2-ros ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Components of MoveIt connecting to occupancy map'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-perception";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f6dd9a6cbe95dac9f04c7d222c158e0029a36f83408933b317919ad3a032e77b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cv-bridge freeglut glew image-transport libGL libGLU llvmPackages.openmp message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor moveit-ros-planning object-recognition-msgs pluginlib rclcpp sensor-msgs tf2 tf2-eigen tf2-geometry-msgs tf2-ros urdf ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components of MoveIt connecting to perception'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-planning-interface";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d93670f52b4424617992d758a121a78b9ecd1951ee446a896acaacb350a1de20";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen moveit-common ];
+  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Components of MoveIt that offer simpler interfaces to planning and execution'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-planning";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "82d768c61b59150571dcf2bd328290ce3d0e72e457c52ee2a23f9b895f04823d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
+  propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
+  nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
+
+  meta = {
+    description = ''Planning components of MoveIt that use ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-robot-interaction";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "0ce64dcc4bc3db1c2a6d1189b75d3fd7943ec7682046713c590d911fcf76bbeb";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ interactive-markers moveit-ros-planning rclcpp tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components of MoveIt that offer interaction via interactive markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-visualization";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d6b25ca30a9a4595490c40157848d22b778f55865224421d9486db02aaace325";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ class-loader eigen moveit-common ogre1_9 qt5.qtbase ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometric-shapes interactive-markers moveit-ros-planning-interface moveit-ros-robot-interaction moveit-ros-warehouse object-recognition-msgs pluginlib rclcpp rclpy rviz2 tf2-eigen ];
+  nativeBuildInputs = [ ament-cmake pkg-config ];
+
+  meta = {
+    description = ''Components of MoveIt that offer visualization'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-warehouse";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "d94845bee9e43e5444a0d0e565379099449cf5761b82272c2005d1c4250daaf4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core moveit-ros-planning rclcpp tf2-eigen tf2-ros warehouse-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components of MoveIt connecting to MongoDB'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "847aabc9299d352ea45aee4d0382e99b606a2a8923c8e751963cd06735fa933b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-benchmarks moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-robot-interaction moveit-ros-visualization moveit-ros-warehouse ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Components of MoveIt that use ROS'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-runtime";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "e38f7b7b588fb46b379023a0f57f583ebbeeb44c4ccd0364f06ae201445d68f7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros-move-group moveit-ros-planning moveit-ros-planning-interface moveit-ros-warehouse ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''moveit_runtime meta package contains MoveIt packages that are essential for its runtime (e.g. running MoveIt on robots).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-servo";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ad9a7b980c6b0aa145dba1a4810c4356e8d21c225f79cec68fa3db7baa23fa3d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides real-time manipulator Cartesian and joint servoing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-simple-controller-manager";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "ebc7c2448d230125be11e1a414b7655ab4ec6868b126c585086fa63dbfcb5b87";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ control-msgs moveit-core pluginlib rclcpp rclcpp-action ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A generic, simple controller manager plugin for MoveIt.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
+buildRosPackage {
+  pname = "ros-galactic-moveit";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "f200e9b10018aef20c2f3657079a126a0e6d1d689e00ef96d72bf8b8c482dd70";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-core moveit-planners moveit-plugins moveit-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta package that contains all essential packages of MoveIt 2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/qpoases-vendor/default.nix
+++ b/distros/galactic/qpoases-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, subversion }:
+buildRosPackage {
+  pname = "ros-galactic-qpoases-vendor";
+  version = "3.2.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/Autoware-AI/qpoases_vendor-release/archive/release/galactic/qpoases_vendor/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "ccfecd402a919e2d21c675029594e75d87ab07cd9416983af070ededd2f792c5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ subversion ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Wrapper around qpOASES to make it available to the ROS ecosystem.'';
+    license = with lib.licenses; [ asl20 lgpl2 ];
+  };
+}

--- a/distros/galactic/realsense2-camera-msgs/default.nix
+++ b/distros/galactic/realsense2-camera-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-realsense2-camera-msgs";
+  version = "3.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "1444eae3dbc9ba23a62666cfb7aa917afcb31ec00edd27f21e7b7355d0977a70";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing realsense camera messages definitions.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/realsense2-camera/default.nix
+++ b/distros/galactic/realsense2-camera/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-realsense2-camera";
+  version = "3.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "a0e416884327da905b9a66ebf1215fe77d84f4424933cc37c1861d86f3bc2d14";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ros-environment ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common opencv3 ];
+  propagatedBuildInputs = [ builtin-interfaces cv-bridge eigen geometry-msgs image-transport launch-ros librealsense2 nav-msgs rclcpp rclcpp-components realsense2-camera-msgs sensor-msgs std-msgs std-srvs tf2 tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera package allowing access to Intel SR300, D400 and L500 3D cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/realsense2-description/default.nix
+++ b/distros/galactic/realsense2-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
+buildRosPackage {
+  pname = "ros-galactic-realsense2-description";
+  version = "3.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "fd73bf268ec673aa2d0d3440672b7b1ffd8bb2d9c0617577d6fe0bf6855e5e75";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ launch-ros rclcpp rclcpp-components realsense2-camera-msgs xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''RealSense Camera description package for Intel 3D D400 cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic/default.nix
+++ b/distros/galactic/rmf-traffic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, fcl, libccd, rmf-cmake-uncrustify, rmf-utils }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_traffic-release/archive/release/galactic/rmf_traffic/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "b4b6789cf2a06f24e396962cf4a92bd3f4a5c1b4e527051a655a78aaf52d46c4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ fcl libccd ];
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ eigen rmf-utils ];
+
+  meta = {
+    description = ''Package for managing traffic in the Robotics Middleware Framework'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-publisher/default.nix
+++ b/distros/galactic/rqt-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-publisher";
-  version = "1.1.2-r1";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/galactic/rqt_publisher/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "6708b051edc075b0ccffcf6868a59eee4047075e45197a6b0c7ed2f4c79304f2";
+    url = "https://github.com/ros2-gbp/rqt_publisher-release/archive/release/galactic/rqt_publisher/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "99b91fc6592e4a5878ab8f2165c1aa3ac9d232c1e8dbf5ebb43ac91b3937f765";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/run-move-group/default.nix
+++ b/distros/galactic/run-move-group/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+buildRosPackage {
+  pname = "ros-galactic-run-move-group";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "762f994116876259c9b776090ba6bf335263285da11a691499a54e80dccd66be";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo launch file for running a MoveGroup setup'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/run-moveit-cpp/default.nix
+++ b/distros/galactic/run-moveit-cpp/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+buildRosPackage {
+  pname = "ros-galactic-run-moveit-cpp";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "5847ea4ab090a5f2243532941f06622e981824196f580242348ce0c6f5777530";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ "TODO: License declaration" ];
+  };
+}

--- a/distros/galactic/run-ompl-constrained-planning/default.nix
+++ b/distros/galactic/run-ompl-constrained-planning/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
+buildRosPackage {
+  pname = "ros-galactic-run-ompl-constrained-planning";
+  version = "2.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.2.0-1.tar.gz";
+    name = "2.2.0-1.tar.gz";
+    sha256 = "dcfb7214f6295e9018619a6e475817cdd4cf37413de50b2e9ad2b9ae8778cc1c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ moveit-ros-planning-interface warehouse-ros-mongo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo ompl constrained planning capabilities'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/tf-transformations/default.nix
+++ b/distros/galactic/tf-transformations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-tf-transformations";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DLu/tf_transformations_release/archive/release/galactic/tf_transformations/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a2c6d18520263bc2c95e8734412d117523ae928f334224beea16ed8bcf823863";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ pythonPackages.numpy ];
+
+  meta = {
+    description = ''Reimplementation of the tf/transformations.py library for common Python spatial operations'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/warehouse-ros/default.nix
+++ b/distros/galactic/warehouse-ros/default.nix
@@ -5,18 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-warehouse-ros";
-  version = "2.0.1-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "5b1009c43e08e064d8b54641762d610784cdb276198a0f69bf2934add794af69";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "5de10f5f42f9a055c0775b226714bd629f9b0b7fcf682a1cb89ce12735217331";
   };
 
   buildType = "ament_cmake";
-  buildInputs = [ openssl ];
   checkInputs = [ ament-cmake-copyright ament-lint-auto ];
-  propagatedBuildInputs = [ boost geometry-msgs pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ boost geometry-msgs openssl pluginlib rclcpp std-msgs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.6.0-3/bota_driver-release-release-melodic-bota_driver-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_driver-0.6.0-3.tar.gz";
-    sha256 = "81a71cc679a7748f57570b6b1593d27c33b504e13a6e80700887e8ff72460a5c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.6.0-5/bota_driver-release-release-melodic-bota_driver-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_driver-0.6.0-5.tar.gz";
+    sha256 = "f127c97547367d82f48c7642730df96011b2bbafbb0460524bac02a1cad6c9f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.6.0-3/bota_driver-release-release-melodic-bota_node-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_node-0.6.0-3.tar.gz";
-    sha256 = "8c742bea9e76ab6a776edb1fb758767ffc1bbfc228c8e1b9bce25c482118c82f";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.6.0-5/bota_driver-release-release-melodic-bota_node-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_node-0.6.0-5.tar.gz";
+    sha256 = "1a4b717128ff061556708ac2099c79e194fcc3f1b518914d9b5082a51de7e607";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.6.0-3/bota_driver-release-release-melodic-bota_signal_handler-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_signal_handler-0.6.0-3.tar.gz";
-    sha256 = "0e7f2a00a6e2103052d38d7c99bf8f5204e175bd7d118dbd055f109cc101d54d";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.6.0-5/bota_driver-release-release-melodic-bota_signal_handler-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_signal_handler-0.6.0-5.tar.gz";
+    sha256 = "54609572eb3d346054a85e8ad3b39a6f31d5dbb2312a7e3d0f7ee92d4de385ef";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.6.0-3/bota_driver-release-release-melodic-bota_worker-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_worker-0.6.0-3.tar.gz";
-    sha256 = "2e2bcd1a6860e2c0a1a58cffa9a06cbaa53640195df9dada6157f38e6dee4e13";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.6.0-5/bota_driver-release-release-melodic-bota_worker-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_worker-0.6.0-5.tar.gz";
+    sha256 = "2717a05a4d971346ab8326f9f10710f05c661951dcecb9e669402624edd5e13a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-core/default.nix
+++ b/distros/melodic/industrial-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-deprecated, industrial-msgs, industrial-robot-client, industrial-robot-simulator, industrial-trajectory-filters, industrial-utils, simple-message }:
 buildRosPackage {
   pname = "ros-melodic-industrial-core";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_core/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "db3b52e778e5cdc9a97854a82b142a6322dd38cb34fce0d57eb16ce208fb4f07";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_core/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "fca1c37d67a9b8133e486c8fd9251d65eaf01bf52cc2577cdcd1c85b1360c212";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-deprecated/default.nix
+++ b/distros/melodic/industrial-deprecated/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-industrial-deprecated";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_deprecated/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "e5b98eb82ac07f838ac0929adb85b15d830460d5e54b52bc92167ae991a213ac";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_deprecated/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "1c2ecfdd2b46177d0d874f24c1daa05e55141a17db32ba238122c29009d79739";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-msgs/default.nix
+++ b/distros/melodic/industrial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "1bda13baa0f9ee548fc5bf8699772ab77543e3fc4ac26a7c46282583bc003531";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "effd2f4ca3973ab57fa500372365179f57492236e63aaf2ff343820d3a1ff545";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-robot-client/default.nix
+++ b/distros/melodic/industrial-robot-client/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, industrial-msgs, industrial-utils, robot-state-publisher, roscpp, rosunit, sensor-msgs, simple-message, std-msgs, trajectory-msgs, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, industrial-msgs, industrial-utils, robot-state-publisher, roscpp, roslaunch, rosunit, sensor-msgs, simple-message, std-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-industrial-robot-client";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_client/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "704f56ecf96f294b7b4805415320179fd1ac6244e309fd0a6d1cc69d4f90c18d";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_client/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "8066fb7a6f027f2d06a3b6641d09fbcd7bc858b677090edf941cbc4fca93ed91";
   };
 
   buildType = "catkin";
-  checkInputs = [ rosunit ];
+  checkInputs = [ roslaunch rosunit ];
   propagatedBuildInputs = [ actionlib actionlib-msgs control-msgs industrial-msgs industrial-utils robot-state-publisher roscpp sensor-msgs simple-message std-msgs trajectory-msgs urdf ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/industrial-robot-simulator/default.nix
+++ b/distros/melodic/industrial-robot-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, industrial-msgs, industrial-robot-client, pythonPackages, roslaunch, rospy, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-robot-simulator";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_simulator/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "2bfbab889523137f608c09ad70ae7f13953e539f7999237d9296648e4d523962";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_simulator/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "4c05ef91e4abaee01a5d477cc2776bff8cf9a5efceff541caf19ce7d7496138e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-trajectory-filters/default.nix
+++ b/distros/melodic/industrial-trajectory-filters/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, moveit-core, moveit-ros-planning, orocos-kdl, pluginlib, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, moveit-core, moveit-ros-planning, orocos-kdl, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-trajectory-filters";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_trajectory_filters/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "d37a9dfc7999bc81e35123f95e305719c7d07330317d7be34c8efd8150f05a22";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_trajectory_filters/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "309487fd3ede43c60b560ba7ab53c62114db02abeab929d819ba8d859de0f75d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ moveit-core moveit-ros-planning orocos-kdl pluginlib trajectory-msgs ];
+  propagatedBuildInputs = [ class-loader moveit-core moveit-ros-planning orocos-kdl pluginlib trajectory-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/industrial-utils/default.nix
+++ b/distros/melodic/industrial-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit, urdf }:
 buildRosPackage {
   pname = "ros-melodic-industrial-utils";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_utils/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "c27a7592fb1c7e08f7b88330936da7dd70647e414514b1e1b2e198324c64916c";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_utils/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "370bac7fd0ecd826d5bdf7e3014d08b5f8de165004ec81b089f1e72b370abd19";
   };
 
   buildType = "catkin";

--- a/distros/melodic/librealsense2/default.nix
+++ b/distros/melodic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-melodic-librealsense2";
-  version = "2.45.0-r1";
+  version = "2.48.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.45.0-1.tar.gz";
-    name = "2.45.0-1.tar.gz";
-    sha256 = "381766c25440e4b4e241110fbbcedfc89139dc47802251e548f3b3f79b8fbce9";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/melodic/librealsense2/2.48.0-1.tar.gz";
+    name = "2.48.0-1.tar.gz";
+    sha256 = "308d0ec8226c4baceeadc7aa65889d25df4901863c2734b23e91403ed0236a2c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "2c8b2835cc189797eac002438990ad47080e21f22556da3d5efb600b7677134c";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "3e6f6dbac65d6f4dfc73586ae9b5d2ff6678a3dbabac789bcf51209f54ac99f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-camera/default.nix
+++ b/distros/melodic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-camera";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "a54563887751fe230e7f4fd9b1f5d62e641f48fb395afcdc2150d4273aad97c0";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_camera/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "0188482ed8dbff76805463de0a0c25cf9e47c63722ec80b4e0d6a76b97f37b4f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/realsense2-description/default.nix
+++ b/distros/melodic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-melodic-realsense2-description";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "e3b1935e077bd1906236929a21f9f2fbd59cc005f8648dc7cd613ca4cd0ba718";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/melodic/realsense2_description/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "a80b157219097f419989219ec949e27a0f47d8f87b9e8cc50f0b84b6027fdd84";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.6.0-3/bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-3.tar.gz";
-    sha256 = "2905cb6d10c6e585b09545c91e2ae4a4c23cf831999d676883b2a71c998e5cce";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.6.0-5/bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-5.tar.gz";
+    sha256 = "1104f46480de718e9b27e97b33edd3f8c6295eb246bc70c1ed0483db97f83dde";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.6.0-3/bota_driver-release-release-melodic-rokubimini_description-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_description-0.6.0-3.tar.gz";
-    sha256 = "0f49d319244e206be84c06269024f338f89c52f485a24b48434666540a8cf3b5";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.6.0-5/bota_driver-release-release-melodic-rokubimini_description-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_description-0.6.0-5.tar.gz";
+    sha256 = "b5e1767ef15b4d7b0948be9abd38396428e3985792c55a668632badb44026d93";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.6.0-3/bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-3.tar.gz";
-    sha256 = "d76813c08f79c6eb52a4528c45e197d87036d71a884da96f2c8637e6be57fb10";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.6.0-5/bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-5.tar.gz";
+    sha256 = "154038dee6f96382a3cb09cc83f62d21da440cd71387c6560cff00418da6d345";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.6.0-3/bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-3.tar.gz";
-    sha256 = "f4a7e27c251f1712d3df98786a7d4ca3147fa635a85927e82770ca730bff59e7";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.6.0-5/bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-5.tar.gz";
+    sha256 = "37925d489e5eafc39d69005070d29aa82bad73ef6a9917e6c3525f09ab639d76";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.6.0-3/bota_driver-release-release-melodic-rokubimini_serial-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_serial-0.6.0-3.tar.gz";
-    sha256 = "bfe09c08763c66553379585efe12994280088c45b3f18cb1f52ea2957006bfe1";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.6.0-5/bota_driver-release-release-melodic-rokubimini_serial-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_serial-0.6.0-5.tar.gz";
+    sha256 = "61f460714694cafafac8cf3f213d1f5fc4a371a4f73bb00d78c39b24d6503625";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.6.0-r3";
+  version = "0.6.0-r5";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.6.0-3/bota_driver-release-release-melodic-rokubimini-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini-0.6.0-3.tar.gz";
-    sha256 = "00816ea9f86db6a9580dd54ffeae8a0066718b451fee9f757d58c2b63efd8cd3";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.6.0-5/bota_driver-release-release-melodic-rokubimini-0.6.0-5.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini-0.6.0-5.tar.gz";
+    sha256 = "4dd066b3dda6c1ea4b79a477bead2b39797e9918fed355b18ef2fbab27491a7c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/simple-message/default.nix
+++ b/distros/melodic/simple-message/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-msgs, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-simple-message";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/simple_message/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "1a173646a6fb15387eea9bb6c7d9225f28c8506e36aebde93667dbefa65c8721";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/simple_message/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "bdc441b65f17935ed7da0dc2690ae4b0654e5169c2109f3cebf1c076eaf49f8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.0-2/bota_driver-release-release-noetic-bota_driver-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_driver-0.6.0-2.tar.gz";
-    sha256 = "feec512fef97f7f40aee864154922d566c7cca17d9aaae565cc28fad60d11fa5";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.0-3/bota_driver-release-release-noetic-bota_driver-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver-0.6.0-3.tar.gz";
+    sha256 = "99624576836ba668531f370c6384d815884e79650549decf44c2b249152dc3a1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-node";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.0-2/bota_driver-release-release-noetic-bota_node-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_node-0.6.0-2.tar.gz";
-    sha256 = "18c7e8a3a7611dfe384e9a1146fc5e208be85c7042423ff15c0b0a8a0c0c22cf";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.0-3/bota_driver-release-release-noetic-bota_node-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_node-0.6.0-3.tar.gz";
+    sha256 = "2dceca17011829a9bbbb383efc59b006b66f9e5e1fcd4042e47d5ecd00f80752";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-signal-handler";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.0-2/bota_driver-release-release-noetic-bota_signal_handler-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.0-2.tar.gz";
-    sha256 = "6d0e411519113c14a3b20a16269f7db2241b7876333705bd8b19c9238580dff6";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.0-3/bota_driver-release-release-noetic-bota_signal_handler-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.0-3.tar.gz";
+    sha256 = "c0ead51c2f2b6c54146f3cdd533d7fe79edff814f43c5e2e9544f3433649aad6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-worker";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.0-2/bota_driver-release-release-noetic-bota_worker-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_worker-0.6.0-2.tar.gz";
-    sha256 = "8c065c81ba508d2dcf5f79064651362233254b5c13b42e9df7e28f3448410ecb";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.0-3/bota_driver-release-release-noetic-bota_worker-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_worker-0.6.0-3.tar.gz";
+    sha256 = "df042edcda3b0ebaab5aa4f5d89ce2b98e633e655108b04ca9bc30971657622d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamixel-workbench-msgs/default.nix
+++ b/distros/noetic/dynamixel-workbench-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-workbench-msgs";
+  version = "2.0.2-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-msgs-release/archive/release/noetic/dynamixel_workbench_msgs/2.0.2-2.tar.gz";
+    name = "2.0.2-2.tar.gz";
+    sha256 = "b77f92bb2a9927cb148b524e5132159fd3f536626b2742116f4b978c7951c088";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package includes ROS messages and services for dynamixel_workbench packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -576,6 +576,8 @@ self: super: {
 
  dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
 
+ dynamixel-workbench-msgs = self.callPackage ./dynamixel-workbench-msgs {};
+
  easy-markers = self.callPackage ./easy-markers {};
 
  ecl-build = self.callPackage ./ecl-build {};
@@ -1050,6 +1052,8 @@ self: super: {
 
  imu-filter-madgwick = self.callPackage ./imu-filter-madgwick {};
 
+ imu-from-ios-sensorlog = self.callPackage ./imu-from-ios-sensorlog {};
+
  imu-monitor = self.callPackage ./imu-monitor {};
 
  imu-pipeline = self.callPackage ./imu-pipeline {};
@@ -1062,11 +1066,23 @@ self: super: {
 
  imu-transformer = self.callPackage ./imu-transformer {};
 
+ industrial-core = self.callPackage ./industrial-core {};
+
+ industrial-deprecated = self.callPackage ./industrial-deprecated {};
+
  industrial-msgs = self.callPackage ./industrial-msgs {};
+
+ industrial-robot-client = self.callPackage ./industrial-robot-client {};
+
+ industrial-robot-simulator = self.callPackage ./industrial-robot-simulator {};
 
  industrial-robot-status-controller = self.callPackage ./industrial-robot-status-controller {};
 
  industrial-robot-status-interface = self.callPackage ./industrial-robot-status-interface {};
+
+ industrial-trajectory-filters = self.callPackage ./industrial-trajectory-filters {};
+
+ industrial-utils = self.callPackage ./industrial-utils {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
@@ -1097,6 +1113,8 @@ self: super: {
  jderobot-drones = self.callPackage ./jderobot-drones {};
 
  joint-limits-interface = self.callPackage ./joint-limits-interface {};
+
+ joint-qualification-controllers = self.callPackage ./joint-qualification-controllers {};
 
  joint-state-controller = self.callPackage ./joint-state-controller {};
 
@@ -1630,6 +1648,16 @@ self: super: {
 
  open-karto = self.callPackage ./open-karto {};
 
+ open-manipulator-gazebo = self.callPackage ./open-manipulator-gazebo {};
+
+ open-manipulator-msgs = self.callPackage ./open-manipulator-msgs {};
+
+ open-manipulator-p-gazebo = self.callPackage ./open-manipulator-p-gazebo {};
+
+ open-manipulator-p-simulations = self.callPackage ./open-manipulator-p-simulations {};
+
+ open-manipulator-simulations = self.callPackage ./open-manipulator-simulations {};
+
  opencv-apps = self.callPackage ./opencv-apps {};
 
  opengm = self.callPackage ./opengm {};
@@ -1806,6 +1834,8 @@ self: super: {
 
  pr2-bringup = self.callPackage ./pr2-bringup {};
 
+ pr2-bringup-tests = self.callPackage ./pr2-bringup-tests {};
+
  pr2-calibration-controllers = self.callPackage ./pr2-calibration-controllers {};
 
  pr2-camera-synchronizer = self.callPackage ./pr2-camera-synchronizer {};
@@ -1827,6 +1857,8 @@ self: super: {
  pr2-controllers = self.callPackage ./pr2-controllers {};
 
  pr2-controllers-msgs = self.callPackage ./pr2-controllers-msgs {};
+
+ pr2-counterbalance-check = self.callPackage ./pr2-counterbalance-check {};
 
  pr2-dashboard-aggregator = self.callPackage ./pr2-dashboard-aggregator {};
 
@@ -1858,6 +1890,8 @@ self: super: {
 
  pr2-mechanism-msgs = self.callPackage ./pr2-mechanism-msgs {};
 
+ pr2-motor-diagnostic-tool = self.callPackage ./pr2-motor-diagnostic-tool {};
+
  pr2-msgs = self.callPackage ./pr2-msgs {};
 
  pr2-position-scripts = self.callPackage ./pr2-position-scripts {};
@@ -1869,6 +1903,10 @@ self: super: {
  pr2-robot = self.callPackage ./pr2-robot {};
 
  pr2-run-stop-auto-restart = self.callPackage ./pr2-run-stop-auto-restart {};
+
+ pr2-self-test = self.callPackage ./pr2-self-test {};
+
+ pr2-self-test-msgs = self.callPackage ./pr2-self-test-msgs {};
 
  pr2-teleop = self.callPackage ./pr2-teleop {};
 
@@ -2013,6 +2051,8 @@ self: super: {
  robot-upstart = self.callPackage ./robot-upstart {};
 
  roboticsgroup-upatras-gazebo-plugins = self.callPackage ./roboticsgroup-upatras-gazebo-plugins {};
+
+ robotis-manipulator = self.callPackage ./robotis-manipulator {};
 
  rokubimini = self.callPackage ./rokubimini {};
 
@@ -2402,6 +2442,8 @@ self: super: {
 
  simple-grasping = self.callPackage ./simple-grasping {};
 
+ simple-message = self.callPackage ./simple-message {};
+
  simulators = self.callPackage ./simulators {};
 
  single-joint-position-action = self.callPackage ./single-joint-position-action {};
@@ -2583,6 +2625,8 @@ self: super: {
  tf-conversions = self.callPackage ./tf-conversions {};
 
  theora-image-transport = self.callPackage ./theora-image-transport {};
+
+ thunder-line-follower-pmr3100 = self.callPackage ./thunder-line-follower-pmr3100 {};
 
  tile-map = self.callPackage ./tile-map {};
 
@@ -2773,6 +2817,22 @@ self: super: {
  vl53l1x = self.callPackage ./vl53l1x {};
 
  voice-text = self.callPackage ./voice-text {};
+
+ volta-base = self.callPackage ./volta-base {};
+
+ volta-control = self.callPackage ./volta-control {};
+
+ volta-description = self.callPackage ./volta-description {};
+
+ volta-localization = self.callPackage ./volta-localization {};
+
+ volta-msgs = self.callPackage ./volta-msgs {};
+
+ volta-navigation = self.callPackage ./volta-navigation {};
+
+ volta-rules = self.callPackage ./volta-rules {};
+
+ volta-teleoperator = self.callPackage ./volta-teleoperator {};
 
  voxel-grid = self.callPackage ./voxel-grid {};
 

--- a/distros/noetic/imu-from-ios-sensorlog/default.nix
+++ b/distros/noetic/imu-from-ios-sensorlog/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, sensor-msgs, std-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-noetic-imu-from-ios-sensorlog";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pietrocolombo/imu_from_ios_sensorlog-release/archive/release/noetic/imu_from_ios_sensorlog/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "de580184eeb098f142326b78523af1340057916f3989a42a7c05a607674ae44d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp rospy sensor-msgs std-msgs tf2 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The imu_from_ios_sensorlog package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/noetic/industrial-core/default.nix
+++ b/distros/noetic/industrial-core/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, industrial-deprecated, industrial-msgs, industrial-robot-client, industrial-robot-simulator, industrial-trajectory-filters, industrial-utils, simple-message }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-core";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_core/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "b7fa93283d893e726a85796b29eec043d65708a23e06d8e2012c05d6454ab6a4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ industrial-deprecated industrial-msgs industrial-robot-client industrial-robot-simulator industrial-trajectory-filters industrial-utils simple-message ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS-Industrial core stack contains packages and libraries for supporing industrial systems'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-deprecated/default.nix
+++ b/distros/noetic/industrial-deprecated/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-deprecated";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_deprecated/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "ab476be2bd0e900ec9c70ef67bae63ce78345d7479ef99a113e49f7195cd7708";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Industrial deprecated package contains nodes, launch files, etc... that are slated for 
+  deprecation.  This package is the last place something will end up before being deleted.  
+  If you are missing a package/node and find it's contents here, then you should consider 
+  a replacement.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-msgs/default.nix
+++ b/distros/noetic/industrial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-industrial-msgs";
-  version = "0.7.1-r1";
+  version = "0.7.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "c1cc02b17cffe63eacfb0ba825cde514478f3c405ced7b8e63c5756085b50554";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_msgs/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "968eeecc295534a4e6fa948a2b3ee8af6b5999ac3b20d4be7130c7fe6a890b4c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/industrial-robot-client/default.nix
+++ b/distros/noetic/industrial-robot-client/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, industrial-msgs, industrial-utils, robot-state-publisher, roscpp, roslaunch, rosunit, sensor-msgs, simple-message, std-msgs, trajectory-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-client";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_client/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "fa50889ec2478a27063557fd79b478bbca8346b55daa8a1998d82423aeb365c7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch rosunit ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs control-msgs industrial-msgs industrial-utils robot-state-publisher roscpp sensor-msgs simple-message std-msgs trajectory-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''industrial robot client contains generic clients for connecting 
+     to industrial robot controllers with servers that adhere to the
+     simple message protocol.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-robot-simulator/default.nix
+++ b/distros/noetic/industrial-robot-simulator/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, industrial-msgs, industrial-robot-client, python3Packages, roslaunch, rospy, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-robot-simulator";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_robot_simulator/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "9b42aed833f10a4293af407e24802a1bac6509abc115b20a2ef25ec7f89ead19";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslaunch ];
+  propagatedBuildInputs = [ control-msgs industrial-msgs industrial-robot-client python3Packages.rospkg rospy sensor-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The industrial robot simulator is a stand in for industrial robot driver node(s).  It adheres to the driver specification for industrial robot controllers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-trajectory-filters/default.nix
+++ b/distros/noetic/industrial-trajectory-filters/default.nix
@@ -1,0 +1,30 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, class-loader, moveit-core, moveit-ros-planning, orocos-kdl, pluginlib, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-trajectory-filters";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_trajectory_filters/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "d4718f6eec2f53f7870a2c873e3d70e40416f30fcb96cdc116c4f5714a2b2e2e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ class-loader moveit-core moveit-ros-planning orocos-kdl pluginlib trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+     ROS Industrial libraries/plugins for filtering trajectories.
+   </p>
+   <p>
+     This package is part of the ROS Industrial program and contains libraries
+     and moveit plugins for filtering robot trajectories.
+   </p>'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/industrial-utils/default.nix
+++ b/distros/noetic/industrial-utils/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-industrial-utils";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/industrial_utils/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "1965c307f351ec1c4df257c92e7d36c6937f2a4b8f279c10155f5bc3cd66308b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ roscpp urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Industrial utils is a library package that captures common funcitonality for the ROS-Industrial distribution.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/joint-qualification-controllers/default.nix
+++ b/distros/noetic/joint-qualification-controllers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, message-generation, message-runtime, pluginlib, pr2-controller-interface, pr2-hardware-interface, pr2-mechanism-model, realtime-tools, robot-mechanism-controllers, roscpp, sensor-msgs, std-msgs, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-joint-qualification-controllers";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/joint_qualification_controllers/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "6f558ae2bd912625a0ca5f95bee94b25369793e70bcaebe6dbff1ed735349479";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ control-toolbox message-runtime pluginlib pr2-controller-interface pr2-hardware-interface pr2-mechanism-model realtime-tools robot-mechanism-controllers roscpp sensor-msgs std-msgs urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers used in PR2 hardware testing. For testing counterbalance of PR2, and for internal WG use.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/librealsense2/default.nix
+++ b/distros/noetic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-noetic-librealsense2";
-  version = "2.45.0-r1";
+  version = "2.48.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.45.0-1.tar.gz";
-    name = "2.45.0-1.tar.gz";
-    sha256 = "431ba3109e26e9fcf8ea32d2fe7b302e59a42304783dfa8dd29eb5c394e1bbf9";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/noetic/librealsense2/2.48.0-1.tar.gz";
+    name = "2.48.0-1.tar.gz";
+    sha256 = "bce0dfe9b6fb802f781aa8f284eb44fb8519dcbed4622564429dbb50f6ed5565";
   };
 
   buildType = "cmake";

--- a/distros/noetic/open-manipulator-gazebo/default.nix
+++ b/distros/noetic/open-manipulator-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros, gazebo-ros-control, roscpp, std-msgs, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-open-manipulator-gazebo";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release/archive/release/noetic/open_manipulator_gazebo/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "997691727a0925b8ec1f3fc0cd8d67a2eb5c5ee18b4fc8d15cc5941d6ec026b8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros gazebo-ros-control roscpp std-msgs urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Gazebo configurations package for OpenManipulator'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/open-manipulator-msgs/default.nix
+++ b/distros/noetic/open-manipulator-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-open-manipulator-msgs";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/open_manipulator_msgs-release/archive/release/noetic/open_manipulator_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "39423343c47cc249fdae4bb7588fc7c6689f49c1374c84e846e7603ea4a09cb3";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages and services package for OpenManipulator to send information about state or pose'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/open-manipulator-p-gazebo/default.nix
+++ b/distros/noetic/open-manipulator-p-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros, gazebo-ros-control, roscpp, std-msgs, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-open-manipulator-p-gazebo";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release/archive/release/noetic/open_manipulator_p_gazebo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3acbf35cfbf201c8008cea6a70e4444a03c8f0f12bbae911a5f601cee074a62e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros gazebo-ros-control roscpp std-msgs urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package for OpenMANIPULATOR-P Gazebo'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/open-manipulator-p-simulations/default.nix
+++ b/distros/noetic/open-manipulator-p-simulations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, open-manipulator-p-gazebo }:
+buildRosPackage {
+  pname = "ros-noetic-open-manipulator-p-simulations";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/open_manipulator_p_simulations-release/archive/release/noetic/open_manipulator_p_simulations/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "6fb11bddc91d991ff81ee705f6ff757641d93eb76343c0ba16e7f176c01b646f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ open-manipulator-p-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for OpenMANIPULATOR-P Simulations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/open-manipulator-simulations/default.nix
+++ b/distros/noetic/open-manipulator-simulations/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, open-manipulator-gazebo }:
+buildRosPackage {
+  pname = "ros-noetic-open-manipulator-simulations";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/open_manipulator_simulations-release/archive/release/noetic/open_manipulator_simulations/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "9d62659b5995a91a4a901e782358bc91c94a237a8c800bdece2cb8a1b8e9a391";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ open-manipulator-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simulation packages for OpenManipulator'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/pr2-bringup-tests/default.nix
+++ b/distros/noetic/pr2-bringup-tests/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, camera-calibration, catkin, ethercat-trigger-controllers, image-view, pr2-bringup, pr2-controller-manager, pr2-mannequin-mode }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-bringup-tests";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/pr2_bringup_tests/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "26850da2346f6960f636510790236c6e1942ccfe83bd4e643d33cc2abe8df1a2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ camera-calibration ethercat-trigger-controllers image-view pr2-bringup pr2-controller-manager pr2-mannequin-mode ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Complete functionality tests for PR2. Contains utilities designed to test and verify devices, mechanicals and sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-counterbalance-check/default.nix
+++ b/distros/noetic/pr2-counterbalance-check/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, catkin, joint-qualification-controllers, pr2-controller-configuration, pr2-controller-manager, pr2-controllers-msgs, pr2-self-test-msgs, rospy, rostest, rosunit, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-counterbalance-check";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/pr2_counterbalance_check/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "fd86f761e8d28ef9a7d5c3633926747fde4c7050758377595afac6914ef4ad92";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rostest ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ actionlib joint-qualification-controllers pr2-controller-configuration pr2-controller-manager pr2-controllers-msgs pr2-self-test-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pr2_counterbalance_check'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-motor-diagnostic-tool/default.nix
+++ b/distros/noetic/pr2-motor-diagnostic-tool/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-hardware, pluginlib, pr2-controller-interface, pr2-mechanism-model, pr2-mechanism-msgs, rospy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-motor-diagnostic-tool";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/pr2_motor_diagnostic_tool/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "b0e0b0abde21ceeda34af122c65c952245a9bc99ecbff3477579504163828801";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ ethercat-hardware pluginlib pr2-controller-interface pr2-mechanism-model pr2-mechanism-msgs rospy rqt-gui rqt-gui-py ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''pr2_motor_diagnostic_tool'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-self-test-msgs/default.nix
+++ b/distros/noetic/pr2-self-test-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-self-test-msgs";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/pr2_self_test_msgs/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "217d79de99304d31c78a25e12a11c81d85496dc3a15eb3c90edbdaae112e7cb9";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages used in PR2 hardware testing.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pr2-self-test/default.nix
+++ b/distros/noetic/pr2-self-test/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, joint-qualification-controllers, pr2-bringup-tests, pr2-counterbalance-check, pr2-self-test-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-pr2-self-test";
+  version = "1.0.15-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pr2-gbp/pr2_self_test-release/archive/release/noetic/pr2_self_test/1.0.15-1.tar.gz";
+    name = "1.0.15-1.tar.gz";
+    sha256 = "16c9ed1182dfb953d741b40605c53ae37e2f1d9fd81394f1a07131040105ee4e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ joint-qualification-controllers pr2-bringup-tests pr2-counterbalance-check pr2-self-test-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The pr2_self_test package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.2.1-r1";
+  version = "0.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.2.1-1.tar.gz";
-    name = "0.2.1-1.tar.gz";
-    sha256 = "343b3172dc3f13850934ccc30ce81e0e7d71c6d4466346f822df87f1856a3026";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.0-1.tar.gz";
+    name = "0.3.0-1.tar.gz";
+    sha256 = "0a5414452789d498da939b00605d3eba9c81fdc327bacbce4bae31a681e73538";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-camera/default.nix
+++ b/distros/noetic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, ddynamic-reconfigure, diagnostic-updater, eigen, genmsg, image-transport, librealsense2, message-runtime, nav-msgs, nodelet, roscpp, sensor-msgs, std-msgs, std-srvs, tf }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-camera";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "2653644627753fb74647c9b6a48ff9f59690e63a709fdffcde1acb97c8c88155";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_camera/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "7a03daf61c66952736ae82144cc88d354ba7a1883b7b59091db5e4cff0bad2fb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/realsense2-description/default.nix
+++ b/distros/noetic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosunit, xacro }:
 buildRosPackage {
   pname = "ros-noetic-realsense2-description";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "eae4d4966849bb5cae78b4fa802085e514a399ffb8232fed5f7cebb17788a4e5";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/noetic/realsense2_description/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "c986f289f83fca204f50e85d2d33f3a2784e5267c8f5aa07bf2b547b1265e8be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robotis-manipulator/default.nix
+++ b/distros/noetic/robotis-manipulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, eigen, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-robotis-manipulator";
+  version = "1.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/robotis_manipulator-release/archive/release/noetic/robotis_manipulator/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "d768b0269636ce2e41c6b4dce982eee5d2363abde6f5172fbadcd8e3f39a7b29";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules eigen roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the manipulation API and functions for controlling the manipulator.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-bus-manager";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.0-2/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-2.tar.gz";
-    sha256 = "7c4b930f7ec8d897d92a7a758d9577f448197a4bf4232685acb8366cc53fe35c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.0-3/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-3.tar.gz";
+    sha256 = "05103139bc34325a0b3cfb2eb67e9730d49ed74da51fd9d8ffd271dfacb88df1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-description";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.0-2/bota_driver-release-release-noetic-rokubimini_description-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.0-2.tar.gz";
-    sha256 = "79460eacaf87f24a5d566e5bb3b8365b1fbbcc57767a6410884078240643eb29";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.0-3/bota_driver-release-release-noetic-rokubimini_description-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.0-3.tar.gz";
+    sha256 = "da529a6ebdaee1693d151b3b60566d2cd69a5fbfdd0bc76c4c089d5a11acee34";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-ethercat";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.0-2/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-2.tar.gz";
-    sha256 = "b321c08a896b365d165b5cd288f5a502aca53bcf9e1a6ea7709a9e52a5ba51e9";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.0-3/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-3.tar.gz";
+    sha256 = "d92e8223000be4d87f5be597201f7f9f574492ea417f41186f8b6469d82ec18b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-msgs";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.0-2/bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-2.tar.gz";
-    sha256 = "1bc8689f8c7c8d3019a7440eafd4a855e90cb8d3332aa920c1be4238f34ca0d3";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.0-3/bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-3.tar.gz";
+    sha256 = "506e071f627848773cd93981e1a6f13f807e83920af9125d3f03eeb874ce3f9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-serial";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.0-2/bota_driver-release-release-noetic-rokubimini_serial-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.0-2.tar.gz";
-    sha256 = "d696a91e061d068923f479437569b4cf007b51f0c2dad69157e3ec7cd01c76c7";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.0-3/bota_driver-release-release-noetic-rokubimini_serial-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.0-3.tar.gz";
+    sha256 = "aad86d31c9a93561c5ba70db388b52aa4bf54661002b866a1f36380b02b984cc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini";
-  version = "0.6.0-r2";
+  version = "0.6.0-r3";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.0-2/bota_driver-release-release-noetic-rokubimini-0.6.0-2.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini-0.6.0-2.tar.gz";
-    sha256 = "0f7e2f207c1d8f139811338f3ccb637338bac932635e4f0be1151f7577c7a502";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.0-3/bota_driver-release-release-noetic-rokubimini-0.6.0-3.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini-0.6.0-3.tar.gz";
+    sha256 = "e18f529bf993ec5cad60b8488a38aa38cd8a9924c4d0c2cc5641048503665986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/simple-message/default.nix
+++ b/distros/noetic/simple-message/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, industrial-msgs, roscpp, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-simple-message";
+  version = "0.7.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/noetic/simple_message/0.7.2-1.tar.gz";
+    name = "0.7.2-1.tar.gz";
+    sha256 = "fc93caccf7044efa6ece2d0bddc9b12d067b3cfee6ed63560a3635aae887829f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ industrial-msgs roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''simple_message defines a simple messaging connection and protocol for communicating 
+	with an industrial robot controller.  Additional handler and manager classes are 
+	included for handling connection limited systems.  This package is part of the ROS-Industrial 
+	program.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/thunder-line-follower-pmr3100/default.nix
+++ b/distros/noetic/thunder-line-follower-pmr3100/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo, gazebo-plugins, gazebo-ros, geometry-msgs, joint-state-publisher, pythonPackages, robot-state-publisher, roscpp, roslaunch, rospy, velocity-controllers, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-thunder-line-follower-pmr3100";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ThundeRatz/thunder_line_follower_pmr3100-release/archive/release/noetic/thunder_line_follower_pmr3100/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "56789b16ded81ee822de841792ecb2d3271008642660ad77580d8de9d088760a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo gazebo-plugins gazebo-ros geometry-msgs joint-state-publisher pythonPackages.pygame robot-state-publisher roscpp roslaunch rospy velocity-controllers xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>Simulation environment for a line follower development</p>
+    <p>Created for the discipline PMR3100 - Intro to Mechatronics from Poli-USP</p>'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/volta-base/default.nix
+++ b/distros/noetic/volta-base/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-volta-base";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_base/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f998233bf5ce9413d482b454c939f5150200d9c18345f2b202645b354fc2bee9";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_base package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-control/default.nix
+++ b/distros/noetic/volta-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, joint-state-controller, twist-mux }:
+buildRosPackage {
+  pname = "ros-noetic-volta-control";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_control/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9a306c8e0223a09f8e40133929368358859632f9e1bc163f3c2ba9b5682dc374";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager diff-drive-controller joint-state-controller twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_control package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-description/default.nix
+++ b/distros/noetic/volta-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-volta-description";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_description/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "43d343a5bdb749a9652a37a2c33b05948199ecddff189420a2bff5478a9b685c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_description package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-localization/default.nix
+++ b/distros/noetic/volta-localization/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, robot-localization }:
+buildRosPackage {
+  pname = "ros-noetic-volta-localization";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_localization/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "b8bbe97255fb5b6bca58879cb9edc7921309051792bce9c2dc35127cb6617263";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ robot-localization ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_localization package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-msgs/default.nix
+++ b/distros/noetic/volta-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-volta-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "33c96cedf001dac8cc8c39cf1a8939eadad9de0d4b500c8632dd457e42683bba";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-generation std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_msgs package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-navigation/default.nix
+++ b/distros/noetic/volta-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, dwa-local-planner, global-planner, gmapping, map-server, move-base }:
+buildRosPackage {
+  pname = "ros-noetic-volta-navigation";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_navigation/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "d42b673b3a6f6830b05c7e584ff4bd07a166784316544e0598797a46d42d3dd0";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ amcl dwa-local-planner global-planner gmapping map-server move-base ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-rules/default.nix
+++ b/distros/noetic/volta-rules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-volta-rules";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_rules/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "f43412c9f11c1bfe36166b924c6a82751da164299b69bf254a5b7dcd9da5160c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.pyusb ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_rules package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/volta-teleoperator/default.nix
+++ b/distros/noetic/volta-teleoperator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, sensor-msgs, teleop-twist-joy, teleop-twist-keyboard, volta-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-volta-teleoperator";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/botsync-gbp/volta-release/archive/release/noetic/volta_teleoperator/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "a3714334e6d6694ea0af0a5c4d41adb229a27be19b38579f52fa6703228e6110";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib-msgs geometry-msgs sensor-msgs teleop-twist-joy teleop-twist-keyboard volta-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The volta_teleoperator package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 97bd4c9cd8da8c4e879c138b1bf0e7f19f031642.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *ament-index-cpp 1.0.2-r1 --> 1.1.0-r1*
* *ament-index-python 1.0.2-r1 --> 1.1.0-r1*
* *diff-drive-controller 0.3.1-r1 --> 0.4.0-r1*
* *effort-controllers 0.3.1-r1 --> 0.4.0-r1*
* *force-torque-sensor-broadcaster 0.4.0-r1*
* *forward-command-controller 0.3.1-r1 --> 0.4.0-r1*
* *gripper-controllers 0.4.0-r1*
* *imu-sensor-broadcaster 0.4.0-r1*
* *joint-state-broadcaster 0.3.1-r1 --> 0.4.0-r1*
* *joint-state-controller 0.3.1-r1 --> 0.4.0-r1*
* *joint-trajectory-controller 0.3.1-r1 --> 0.4.0-r1*
* *launch-pal 0.0.2-r3 --> 0.0.3-r1*
* *librealsense2 2.45.0-r1 --> 2.48.0-r1*
* *massrobotics-amr-sender 1.0.0-r2*
* *moveit 2.1.4-r1 --> 2.2.0-r1*
* *moveit-common 2.1.4-r1 --> 2.2.0-r1*
* *moveit-core 2.1.4-r1 --> 2.2.0-r1*
* *moveit-kinematics 2.1.4-r1 --> 2.2.0-r1*
* *moveit-planners 2.1.4-r1 --> 2.2.0-r1*
* *moveit-planners-ompl 2.1.4-r1 --> 2.2.0-r1*
* *moveit-plugins 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-benchmarks 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-move-group 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-occupancy-map-monitor 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-perception 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-planning 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-planning-interface 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-robot-interaction 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-visualization 2.1.4-r1 --> 2.2.0-r1*
* *moveit-ros-warehouse 2.1.4-r1 --> 2.2.0-r1*
* *moveit-runtime 2.1.4-r1 --> 2.2.0-r1*
* *moveit-servo 2.1.4-r1 --> 2.2.0-r1*
* *moveit-simple-controller-manager 2.1.4-r1 --> 2.2.0-r1*
* *position-controllers 0.3.1-r1 --> 0.4.0-r1*
* *ros2-controllers 0.3.1-r1 --> 0.4.0-r1*
* *rqt-publisher 1.1.2-r1 --> 1.1.3-r1*
* *run-move-group 2.1.4-r1 --> 2.2.0-r1*
* *run-moveit-cpp 2.1.4-r1 --> 2.2.0-r1*
* *run-ompl-constrained-planning 2.1.4-r1 --> 2.2.0-r1*
* *tf-transformations 1.0.2-r1*
* *velocity-controllers 0.3.1-r1 --> 0.4.0-r1*
* *warehouse-ros 2.0.1-r1 --> 2.0.3-r1*

Galactic Changes:
-----------------
* *ament-index-cpp 1.0.6-r1 --> 1.2.0-r1*
* *ament-index-python 1.0.6-r1 --> 1.2.0-r1*
* *geometric-shapes 2.1.0-r1 --> 2.1.0-r2*
* *librealsense2 2.48.0-r1*
* *moveit 2.2.0-r1*
* *moveit-common 2.2.0-r1*
* *moveit-core 2.2.0-r1*
* *moveit-kinematics 2.2.0-r1*
* *moveit-planners 2.2.0-r1*
* *moveit-planners-ompl 2.2.0-r1*
* *moveit-plugins 2.2.0-r1*
* *moveit-ros 2.2.0-r1*
* *moveit-ros-benchmarks 2.2.0-r1*
* *moveit-ros-move-group 2.2.0-r1*
* *moveit-ros-occupancy-map-monitor 2.2.0-r1*
* *moveit-ros-perception 2.2.0-r1*
* *moveit-ros-planning 2.2.0-r1*
* *moveit-ros-planning-interface 2.2.0-r1*
* *moveit-ros-robot-interaction 2.2.0-r1*
* *moveit-ros-visualization 2.2.0-r1*
* *moveit-ros-warehouse 2.2.0-r1*
* *moveit-runtime 2.2.0-r1*
* *moveit-servo 2.2.0-r1*
* *moveit-simple-controller-manager 2.2.0-r1*
* *qpoases-vendor 3.2.3-r1*
* *realsense2-camera 3.2.2-r1*
* *realsense2-camera-msgs 3.2.2-r1*
* *realsense2-description 3.2.2-r1*
* *rmf-traffic 1.3.0-r1*
* *rqt-publisher 1.1.2-r1 --> 1.1.3-r1*
* *run-move-group 2.2.0-r1*
* *run-moveit-cpp 2.2.0-r1*
* *run-ompl-constrained-planning 2.2.0-r1*
* *tf-transformations 1.0.2-r1*
* *warehouse-ros 2.0.1-r1 --> 2.0.3-r1*

Melodic Changes:
----------------
* *bota-driver 0.6.0-r3 --> 0.6.0-r5*
* *bota-node 0.6.0-r3 --> 0.6.0-r5*
* *bota-signal-handler 0.6.0-r3 --> 0.6.0-r5*
* *bota-worker 0.6.0-r3 --> 0.6.0-r5*
* *industrial-core 0.7.1-r1 --> 0.7.2-r1*
* *industrial-deprecated 0.7.1-r1 --> 0.7.2-r1*
* *industrial-msgs 0.7.1-r1 --> 0.7.2-r1*
* *industrial-robot-client 0.7.1-r1 --> 0.7.2-r1*
* *industrial-robot-simulator 0.7.1-r1 --> 0.7.2-r1*
* *industrial-trajectory-filters 0.7.1-r1 --> 0.7.2-r1*
* *industrial-utils 0.7.1-r1 --> 0.7.2-r1*
* *librealsense2 2.45.0-r1 --> 2.48.0-r1*
* *psen-scan-v2 0.2.1-r1 --> 0.3.0-r1*
* *realsense2-camera 2.3.0-r1 --> 2.3.1-r1*
* *realsense2-description 2.3.0-r1 --> 2.3.1-r1*
* *rokubimini 0.6.0-r3 --> 0.6.0-r5*
* *rokubimini-bus-manager 0.6.0-r3 --> 0.6.0-r5*
* *rokubimini-description 0.6.0-r3 --> 0.6.0-r5*
* *rokubimini-ethercat 0.6.0-r3 --> 0.6.0-r5*
* *rokubimini-msgs 0.6.0-r3 --> 0.6.0-r5*
* *rokubimini-serial 0.6.0-r3 --> 0.6.0-r5*
* *simple-message 0.7.1-r1 --> 0.7.2-r1*

Noetic Changes:
---------------
* *bota-driver 0.6.0-r2 --> 0.6.0-r3*
* *bota-node 0.6.0-r2 --> 0.6.0-r3*
* *bota-signal-handler 0.6.0-r2 --> 0.6.0-r3*
* *bota-worker 0.6.0-r2 --> 0.6.0-r3*
* *dynamixel-workbench-msgs 2.0.2-r2*
* *imu-from-ios-sensorlog 0.0.1-r1*
* *industrial-core 0.7.2-r1*
* *industrial-deprecated 0.7.2-r1*
* *industrial-msgs 0.7.1-r1 --> 0.7.2-r1*
* *industrial-robot-client 0.7.2-r1*
* *industrial-robot-simulator 0.7.2-r1*
* *industrial-trajectory-filters 0.7.2-r1*
* *industrial-utils 0.7.2-r1*
* *joint-qualification-controllers 1.0.15-r1*
* *librealsense2 2.45.0-r1 --> 2.48.0-r1*
* *open-manipulator-gazebo 1.1.1-r1*
* *open-manipulator-msgs 1.0.1-r1*
* *open-manipulator-p-gazebo 1.0.1-r1*
* *open-manipulator-p-simulations 1.0.1-r1*
* *open-manipulator-simulations 1.1.1-r1*
* *pr2-bringup-tests 1.0.15-r1*
* *pr2-counterbalance-check 1.0.15-r1*
* *pr2-motor-diagnostic-tool 1.0.15-r1*
* *pr2-self-test 1.0.15-r1*
* *pr2-self-test-msgs 1.0.15-r1*
* *psen-scan-v2 0.2.1-r1 --> 0.3.0-r1*
* *realsense2-camera 2.3.0-r1 --> 2.3.1-r1*
* *realsense2-description 2.3.0-r1 --> 2.3.1-r1*
* *robotis-manipulator 1.1.1-r2*
* *rokubimini 0.6.0-r2 --> 0.6.0-r3*
* *rokubimini-bus-manager 0.6.0-r2 --> 0.6.0-r3*
* *rokubimini-description 0.6.0-r2 --> 0.6.0-r3*
* *rokubimini-ethercat 0.6.0-r2 --> 0.6.0-r3*
* *rokubimini-msgs 0.6.0-r2 --> 0.6.0-r3*
* *rokubimini-serial 0.6.0-r2 --> 0.6.0-r3*
* *simple-message 0.7.2-r1*
* *thunder-line-follower-pmr3100 0.1.1-r1*
* *volta-base 1.2.0-r1*
* *volta-control 1.2.0-r1*
* *volta-description 1.2.0-r1*
* *volta-localization 1.2.0-r1*
* *volta-msgs 1.2.0-r1*
* *volta-navigation 1.2.0-r1*
* *volta-rules 1.2.0-r1*
* *volta-teleoperator 1.2.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

