### PR TITLE
rosdistro sync, Fri Jul 16 13:05:45 2021

### DIFF
--- a/distros/foxy/backward-ros/default.nix
+++ b/distros/foxy/backward-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, elfutils }:
+buildRosPackage {
+  pname = "ros-foxy-backward-ros";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/backward_ros-release/archive/release/foxy/backward_ros/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1482d82dcdf6e056b40c87c27d0f0f29830c5410815ab4e2791178e1c78dd94d";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ elfutils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The backward_ros package is a ros wrapper of backward-cpp from https://github.com/bombela/backward-cpp'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/can-dbc-parser/default.nix
+++ b/distros/foxy/can-dbc-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-msgs }:
 buildRosPackage {
   pname = "ros-foxy-can-dbc-parser";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a03ed6da83ea2a4a5af468c81250a912f5d85ed4d7ec2b463102dc6fdbd1022a";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/can_dbc_parser/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "a42bada40317be633003986455505424957a9378175a2689d57029e1a3ba990a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/cascade-lifecycle-msgs/default.nix
+++ b/distros/foxy/cascade-lifecycle-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-foxy-cascade-lifecycle-msgs";
-  version = "0.0.7-r4";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/cascade_lifecycle_msgs/0.0.7-4.tar.gz";
-    name = "0.0.7-4.tar.gz";
-    sha256 = "efe3b41e8c2b10db244b8bde561b31438dc51b9bbc3fe1d077c6117e6506d360";
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/cascade_lifecycle_msgs/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "f0e734ab6805379d32d941c7358bcbdc82d1774c192a0201be5c7f8fb0168081";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/color-names/default.nix
+++ b/distros/foxy/color-names/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rviz2, std-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-color-names";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/foxy/color_names/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "caf9d1d49ab93d20f75da48ecb9a773f8dbefb13f77fdd9676cf428f3ce774f5";
+    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/foxy/color_names/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "f8ea461dc0e2327076d1c4f082325a5ae4b91996d7906f15873d92e459ba7933";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/compressed-depth-image-transport/default.nix
+++ b/distros/foxy/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-compressed-depth-image-transport";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_depth_image_transport/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "f83ae0dbb7bd2c7efe9dda5589d34ccad3128fae8588fc42d681c2dbdca0cb20";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_depth_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "d8f93971d2fb9d720cd4a88db0e07ea34b205f874b1146fb798906467faf18da";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/compressed-image-transport/default.nix
+++ b/distros/foxy/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-foxy-compressed-image-transport";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_image_transport/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "0a3b2c9d056118fa9f7e5279549c70e773f331ab1d3c2ab52aa535185adab0a4";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/compressed_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "11d25042dff6fbe7f4b9da7757c98c0ca8e25347e2d21e1c5a3c3818569b678a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "3dbce9d3f47b38244c3e435d7379ce6f2fb98d10495d4f278014a8e0212a2763";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "02cbb15dd37364a622699b6b9022e08a33829648bbd1c5d1a9276ea23b25c646";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "06f339b629e3d77118798e3a9b288382a1f6e35239d7aaf2667cf1f33f583a7f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "59b8f1ad9edccc447ba4ea89648351ab712d43891b3325b90814678f19d12205";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/embree-vendor/default.nix
+++ b/distros/foxy/embree-vendor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, glfw3, tbb }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, glfw3, pkg-config }:
 buildRosPackage {
   pname = "ros-foxy-embree-vendor";
-  version = "0.0.6-r1";
+  version = "0.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/embree_vendor-release/archive/release/foxy/embree_vendor/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "257441ebdfee6bc9133e5ebb7bc938b57e8da236b0a1224e5f1b544164c0d120";
+    url = "https://github.com/OUXT-Polaris/embree_vendor-release/archive/release/foxy/embree_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "edb84502c8f4e4c53fe8614daf2e06aa29abcb98c28c87367901a67585e0a8e1";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ glfw3 tbb ];
+  propagatedBuildInputs = [ glfw3 pkg-config ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/filters/default.nix
+++ b/distros/foxy/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-uncrustify, ament-cmake-xmllint, boost, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-filters";
-  version = "2.0.0-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/filters-release/archive/release/foxy/filters/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b44ffe186083a34e1a81ded565c3fec29bb45d43cc9388211fa56928424cc36c";
+    url = "https://github.com/ros2-gbp/filters-release/archive/release/foxy/filters/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "60c7b2e8ac1e208d6c2815a4b468c24cfc739266974bae0a26369b13db8d47d6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "8e9929a8fe0f8631beac16ba54e2fb1474d5567ec1fec8150b45b6dbc35b7d64";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "d57aee6b6fb3338e1b28eb4e5d29ce0343fa001b5db1cbc2d13c2b8e53172511";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "6e4d2636672e89795db672c9e55aa0f9d0aba085c08d9389c3ddb403039ed94d";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "639091192a622a299480d4dfe0ea6fdbc4ab703b97636f36cc90acb79b4a12f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -146,6 +146,8 @@ self: super: {
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
 
+ backward-ros = self.callPackage ./backward-ros {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -598,6 +600,8 @@ self: super: {
 
  logging-demo = self.callPackage ./logging-demo {};
 
+ lua-vendor = self.callPackage ./lua-vendor {};
+
  map-msgs = self.callPackage ./map-msgs {};
 
  map-transformer = self.callPackage ./map-transformer {};
@@ -871,6 +875,20 @@ self: super: {
  plotjuggler-ros = self.callPackage ./plotjuggler-ros {};
 
  pluginlib = self.callPackage ./pluginlib {};
+
+ pmb2-2dnav = self.callPackage ./pmb2-2dnav {};
+
+ pmb2-bringup = self.callPackage ./pmb2-bringup {};
+
+ pmb2-controller-configuration = self.callPackage ./pmb2-controller-configuration {};
+
+ pmb2-description = self.callPackage ./pmb2-description {};
+
+ pmb2-maps = self.callPackage ./pmb2-maps {};
+
+ pmb2-navigation = self.callPackage ./pmb2-navigation {};
+
+ pmb2-robot = self.callPackage ./pmb2-robot {};
 
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
 

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "e16b634fb377dd6c56a57663a00b96234140310785f76324be03d6d0d2df7fb7";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "ffec8c9799c072aa0c817f8cbdb1746aaf45694d33ab1ac7972cb0cd77c48f38";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs control-toolbox controller-interface hardware-interface rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/image-transport-plugins/default.nix
+++ b/distros/foxy/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-foxy-image-transport-plugins";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/image_transport_plugins/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "c37d69a47a288d9f881b7f2b8af86a6c34ceb3d03e36275283cbaefa54a92488";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/image_transport_plugins/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "a8523812ca9d9100d185b1d247003a8a3fa4db17a31c445a80edcff9808abf54";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1dc90effed167877ccc3b5407e7dfc5bbf7c76bda02ec1914c49b048771dd2c2";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "20e14a5f7a76513cd3dac6d214ccd43eae223030d4ec432ada0a863cbd6785da";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "fef5bc8e18b8d14466a17234e9e3d9d487ac6bbd797f92ff6bd86b1f365b3b9f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "19f9b34e3bd1dbafca5ed514f68ad64e3336d9b595f432de80bec800f349635b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1254b40d094fa58ecd2d945179a20fd803a96b597b3bc0ab6ee072edfdc1be3a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "122ab22f91e433c395efa3722fa4c9215125f17b1804db9e67a413d2995ec732";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "5ec2f59ac4dfc1e8f53e8b2bd54b90a1575f9778e619c17d6a32c0fdbab49f30";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "c559585a0b70e30c31d4c3520e634c403fa3562268a905342285929e11dc5e8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/lua-vendor/default.nix
+++ b/distros/foxy/lua-vendor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto }:
+buildRosPackage {
+  pname = "ros-foxy-lua-vendor";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/lua_vendor-release/archive/release/foxy/lua_vendor/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "7708341794178f26d71ce7b6605ba4fc8c37ed4199413ebb85754cf5309ddad0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.6.6-r1";
+  version = "2021.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.6.6-1.tar.gz";
-    name = "2021.6.6-1.tar.gz";
-    sha256 = "5833570b011e6af13b3578edf51d95d5737bc4885a3b21456c0a72ecdaa6351b";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.7.7-1.tar.gz";
+    name = "2021.7.7-1.tar.gz";
+    sha256 = "95dfd40d7b046fdd345d9f135e2d26d0a5fb26c66f3f273bd018090ea443c1ff";
   };
 
   buildType = "cmake";

--- a/distros/foxy/moveit-common/default.nix
+++ b/distros/foxy/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-moveit-common";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "dd6371048f91a3d25b3ca93d0f21aed0a30c606876a1c3d812f592370771898f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_common/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "62688ea5e6548ce5269d20b220cae703282b13692c68db4d336d4a4d206d6be7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-core/default.nix
+++ b/distros/foxy/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-core";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0c9a76c30b1816507dc084b1c854598ed118bf80c3792fd2692582c43bfc41a8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_core/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "92035d8a31eed965e7f897344e6aabfb99b1eddf52c7a2810c11fdcdc76693fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-kinematics/default.nix
+++ b/distros/foxy/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-foxy-moveit-kinematics";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2667dbb97470f68455a61923fa2cea452128c97ef0c768a68113a46ada9d338c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_kinematics/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2204048d999d8fca2ec2ebd3ab75e09d4369198b804bb6c78f5edf4f29900db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners-ompl/default.nix
+++ b/distros/foxy/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners-ompl";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "864dba69ac7966c319314a5155d1c51a9dbb43bf3c9991d5d87ccd7abcc831e0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners_ompl/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "401effdfd12eded28fdbc04f79d50d0fc758faa803ad51ccef263db39d58d6df";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-planners/default.nix
+++ b/distros/foxy/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-foxy-moveit-planners";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e583ba8b7ceb80222b364e02f9524e401f587b76018a955f54a4c068434485bc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_planners/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "4e61882f3d880a4d2a6cdfb6d1afe621740a9b4a0709b50a4fb75708e7ce3133";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-plugins/default.nix
+++ b/distros/foxy/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-foxy-moveit-plugins";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b5b53416d43a88e88a3ccf2c8f55d3785ce0e1cc9905285298a8fd0a5d399c86";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_plugins/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c950632eced55edafc03244652f0b247a23500857db457f052d81d3860f3aa96";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-benchmarks/default.nix
+++ b/distros/foxy/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-benchmarks";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6fca70210286173666efe351972ce675e3ab9cb7a254b493906ff77f305188f9";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_benchmarks/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "f87cd28ea01ab9df58fd5253f114e6a64bea499066f554575adf465cbe6fb20d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-move-group/default.nix
+++ b/distros/foxy/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-move-group";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "58152a8b8852369733595522c1cd558d808d1673e0ec9b713bea18b5eb605190";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_move_group/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "920374d42cbebfbde353d6f8a8d5b443a0895806050486ec63d7cb0290fb3842";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/foxy/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-occupancy-map-monitor";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "604bc1813f9feb88d2a38a8d5b85d5d4925d35dc456d3b7da9efd196c3872c7f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_occupancy_map_monitor/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e2b1055f1d26184da227fd5032becad282d94296bca20a5a370301d09d447ae4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-perception/default.nix
+++ b/distros/foxy/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-perception";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "a1e1e06b700db74f56bdd4b9e61590a9564c950ea0db7083c346c40ae42d4d5f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_perception/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9a4a75bea7adf7b89996685fff3d0a57eb63152718980b9a7ddb99b1ce212b38";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-planning-interface/default.nix
+++ b/distros/foxy/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning-interface";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "26a119b85b03fa0436edc299497b39a8b051eaa02474df5c7cbc45112a7e9b76";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning_interface/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cd72676e502dc113a909cf72ea1f2215424422305d8cb4a1b4ebc0d912c766cb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
   propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/foxy/moveit-ros-planning/default.nix
+++ b/distros/foxy/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-planning";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6709130e688e766f910a85b17eec0b1bfafafcb4740932f3004cefb0685cc403";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_planning/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "4207b5518088adc2942de2178c33a45b398af7491b2c850df56d0f00654d061a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-robot-interaction/default.nix
+++ b/distros/foxy/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-robot-interaction";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "bf050dd6a9b24ec66a40f99524a9349a8c0c6a2fa4de2046784c310a58206f33";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_robot_interaction/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "13bccb8e892f2c9c0c58214d07dd99a79b8d6050325443a3000d042e825bbdab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-visualization/default.nix
+++ b/distros/foxy/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-visualization";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "8ab2372fddf1b7efcf09c0e04967e32b208db9f89526ab668e59a75fd5d95c78";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_visualization/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "8066063d76956eecaa567673a82fc4a7efd41a02945a7cb999757a1470fb28cc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros-warehouse/default.nix
+++ b/distros/foxy/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros-warehouse";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1ef600d5c105cb46c43012aa0c5a1c53e31f571d9a95cf46ae10b6e6b19e15bc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros_warehouse/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "effe9fbc158d5b7567bea99b0ed2bffa5a3a13ca6be05dcb2d96d0eb38394c2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-ros/default.nix
+++ b/distros/foxy/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-ros";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3b316776ba1b0512cf282522c51662b7d801c268589db1a75a79d64bc590434e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_ros/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d991f0af0b7c480235171c04345b7cac794f1e077f1808c5d52680ef8812ded1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-runtime/default.nix
+++ b/distros/foxy/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-foxy-moveit-runtime";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "aa2fa897e7efca15876c0c8ad04811f93082ca2af00a3902bf12879ac6dd458a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_runtime/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c7781b833da0f2b33881acca467de072b41c2348e7922dcd9b24f14d1727e845";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-servo/default.nix
+++ b/distros/foxy/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-moveit-servo";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "adff94dc2e09d4f5d739036fafde598664351b8c95ef68bc5984b915dbc3a4f9";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_servo/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "51b75e062ceee8f4e0053cf9742bb222ff9c695fa7f4dc1efeaea66b292401a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit-simple-controller-manager/default.nix
+++ b/distros/foxy/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-foxy-moveit-simple-controller-manager";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "66681f29c860743607a6c72240541da7b8b3335922dfafb88fbc1a67ce529e19";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit_simple_controller_manager/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "8c63e85a853c872845be336c39133afbf1e8dc1c2e99ce1fa2df675181ee69b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/moveit/default.nix
+++ b/distros/foxy/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-foxy-moveit";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2d50e382d95f563c0e2827ef90da94317e2c446e2e1387f3ae55f40e1ddabf63";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/moveit/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9558e12c8864ce187299ae0b7e5a81b1e846e1451d2b1ef96096d81c322a9f78";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-bringup/default.nix
+++ b/distros/foxy/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-bringup";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bringup/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "2443a7c4806ece4713d9df44b6c69a4c5c577f9a5755c6a056799eccf23f1903";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bringup/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "c05c27d435cd3beca011e03f51702e26024cbf7d88c4797c2650617159fbece4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-bt-actions/default.nix
+++ b/distros/foxy/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-bt-actions";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bt_actions/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "24a95ec8285f690b0d760c6a0c780075665110a9f254e6bf56b03fc749b23977";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_bt_actions/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "4c47a3165b9d70c7a2a7a776adaf1786f24e2f3c15de6e7ec918a4e89e002a2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-core/default.nix
+++ b/distros/foxy/plansys2-core/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rclcpp-lifecycle }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-core";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_core/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "19c9e0a528b22d31a6635489affa5ba4ba006786fbb90b2ca99688502b6b06fc";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_core/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "e38a558254f1f01a694e149466cfaecd2241fc9466cf4ebb0bab96581bcb8661";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-pddl-parser pluginlib rclcpp rclcpp-lifecycle ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-domain-expert/default.nix
+++ b/distros/foxy/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-domain-expert";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_domain_expert/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "35cfe2c7766dc735f2e1fabef276d5e299f8fe9eba8cdb915c94bfbfcf95246c";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_domain_expert/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "04733c12496eb67b36d05f1e0e9bd1b22e278d78647c2f9cd5d2340f02f9b1d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-executor/default.nix
+++ b/distros/foxy/plansys2-executor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-executor";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_executor/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "1926203c16dcb18ebf54a39a5f577db9dc74487438f83939b6f5cf530ad376da";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_executor/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "b9aa39e244b2aa96a088355a3506168e62aabf420007eb2f6dfaf92a4b8f975d";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-lifecycle-manager/default.nix
+++ b/distros/foxy/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-lifecycle-manager";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_lifecycle_manager/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "b95d720d45cac0085d3babc9c160b3a78caa594e87845e848466f2e70635c1b8";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_lifecycle_manager/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "cd6e824d5918fc69ef0453d7fc5d71e982da9784ff13e84d0338272666e6e78c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-msgs/default.nix
+++ b/distros/foxy/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-msgs";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_msgs/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "75665655c8684d4b3bc4fb66b4848bc5a93dc8e37688c7f69ea8e95aa822d16f";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_msgs/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "bc3026589c88fbc30476215b344d1e36aadaa50580164e3049c2f83db593f236";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-pddl-parser/default.nix
+++ b/distros/foxy/plansys2-pddl-parser/default.nix
@@ -2,19 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-pddl-parser";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_pddl_parser/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "a3149ef24c0b6f6a1e3eed4158408365a315f12215abb4624cc590b8b9252ede";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_pddl_parser/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "4fc997f2e7242c21eaa1256424d0ee46227b8d41768a6d69c85586cd89cdd62f";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/plansys2-planner/default.nix
+++ b/distros/foxy/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-planner";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_planner/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "d34f1778874c3a81c8df1c2006e9a6273f3ab7ae8b5a1513a2df07d2f06fb4fa";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_planner/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "f9dcba67f41fb56265d00d62b5f26951a9d74c1ddda535c1807d4b9f0850de07";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-popf-plan-solver/default.nix
+++ b/distros/foxy/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-popf-plan-solver";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_popf_plan_solver/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "244d81b6ca0ba7fd43bcfd39d3acf63a946a26f5d932905fa872330dd7d6b098";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_popf_plan_solver/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "264a5c29013274fc364393da3812d9358fcefcd9334dbd4d4fefea008c434ecd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-problem-expert/default.nix
+++ b/distros/foxy/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-problem-expert";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_problem_expert/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "0707b99cf6f4f1556d497228633e76d18a948cdd27fdfe0c26aaa80620aabec4";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_problem_expert/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "1da192f4ee4b104eb621d37fdefb6e4b4e96b923f38490bc979155db1e858e5d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/plansys2-terminal/default.nix
+++ b/distros/foxy/plansys2-terminal/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-foxy-plansys2-terminal";
-  version = "1.0.9-r1";
+  version = "1.0.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_terminal/1.0.9-1.tar.gz";
-    name = "1.0.9-1.tar.gz";
-    sha256 = "49d62a4000552cbe64469d08693ca6a55f19ec42feea7786a0a3825dff2e1846";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/foxy/plansys2_terminal/1.0.10-1.tar.gz";
+    name = "1.0.10-1.tar.gz";
+    sha256 = "30d6e4330eb95448ff1df959a542a259f474640eb6b3f8663b315aa20d571598";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common lifecycle-msgs ];
-  propagatedBuildInputs = [ plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
+  propagatedBuildInputs = [ plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/pmb2-2dnav/default.nix
+++ b/distros/foxy/pmb2-2dnav/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pmb2-maps }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-2dnav";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/foxy/pmb2_2dnav/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "f43b4e559d4067c33fab92e1be6b98af74e55abd4f7a1030e6cd09144f0e9311";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pmb2-maps ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''PMB2-specific launch files needed to run
+    navigation on the PMB2 robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-bringup/default.nix
+++ b/distros/foxy/pmb2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-bringup";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_bringup/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "2af111ebb9b45c6d67ef871874f8203a7f73dbb5707986d44190603758f5f84d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ joy joy-teleop launch-pal pmb2-controller-configuration pmb2-description robot-state-publisher twist-mux ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Launch files and scripts needed to bring up the ROS nodes of a PMB2 robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-controller-configuration/default.nix
+++ b/distros/foxy/pmb2-controller-configuration/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-controller }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-controller-configuration";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_controller_configuration/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "df7f3da06a7daf015f35ae2bd63c5bd880ae94d492f2c06659656ea45b1618e1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller imu-sensor-broadcaster joint-state-controller ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''Launch files and scripts needed to configure
+    the controllers of the PMB2 robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-description/default.nix
+++ b/distros/foxy/pmb2-description/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-ros, launch-testing-ament-cmake, urdf-test, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-description";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_description/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "dc7291c700d7a875e96fbeefa45fd6d8450f3412bf104321a9c7fc8a6da9ac02";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-pal launch-ros xacro ];
+  nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
+
+  meta = {
+    description = ''Mechanical, kinematic, visual, etc. description of the PMB2 robot.
+      The files in this package are parsed and used by
+      a variety of other components.  Most users will not interact directly
+      with this package.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-maps/default.nix
+++ b/distros/foxy/pmb2-maps/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-maps";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/foxy/pmb2_maps/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ab3f6a6caacdb46babc92db0d073b4e7055474b1c9830f341cc013ec678a304a";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''PMB2-specific maps and launch files.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-navigation/default.nix
+++ b/distros/foxy/pmb2-navigation/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, pmb2-2dnav, pmb2-maps }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-navigation";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_navigation-gbp/archive/release/foxy/pmb2_navigation/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "ab57897df43f10b028519c2e844bf1a03f947be813f42d205cb459d9b24735c9";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ pmb2-2dnav pmb2-maps ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''PMB2 navigation metapackage'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/pmb2-robot/default.nix
+++ b/distros/foxy/pmb2-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-robot";
+  version = "4.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_robot/4.0.2-1.tar.gz";
+    name = "4.0.2-1.tar.gz";
+    sha256 = "93fbb7b4b7f0fc2182c93e8f04fbccfec92c660bd8d740c0806f756f7cec23bb";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ pmb2-bringup pmb2-controller-configuration pmb2-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PMB2 robot description and launch files'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "67fbaceb5a62772eb2e41487682737a3134af52cc5f26b6feca4b9ea3f31a59f";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "6e214f37ed74a9741b5648fefb2e2d90c6366226d275064a2cb4c93953fd46dd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/quaternion-operation/default.nix
+++ b/distros/foxy/quaternion-operation/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, eigen, geometry-msgs, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-quaternion-operation";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "886e171a830e603e12fd3588da6744e0757d9560ecf5394e5d24b4f81ea719c6";
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/foxy/quaternion_operation/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "0923b471cd99eb5c5dd54da8f5f2f113095ab694ebedf17bf73f00d0ba9b4b11";
   };
 
   buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
   propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/raptor-dbw-can/default.nix
+++ b/distros/foxy/raptor-dbw-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, geometry-msgs, raptor-dbw-msgs, raptor-pdu, raptor-pdu-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-can";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "14aa0ceed1d5cbc1d4a6fe871459af434a00f8508c2b4fcba88ebbdca7b32b18";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_can/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "fca24aadcaf1b0e28fdc5862e97c01a2ab5cf29a4a6d9f179153883be35a6cd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-joystick/default.nix
+++ b/distros/foxy/raptor-dbw-joystick/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, raptor-dbw-msgs, rclcpp, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-joystick";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a5d2193047328e26789260f7a2e2c5ab91d44f7cb9a22f7397eccb5578d1c45a";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_joystick/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "179ff82e7809594d36a532b0bccdf072c904ed7a18c66fe58a39d82e90f528cf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-dbw-msgs/default.nix
+++ b/distros/foxy/raptor-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-dbw-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6e998689506478c0289cbb86afa3a4147ee7597e293e4c3d5299a225cf8e406b";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_dbw_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "13bf693aff81e884da8b719805c56c133dbc7407f8206dcd75c470807b030622";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu-msgs/default.nix
+++ b/distros/foxy/raptor-pdu-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "a46bd8710b74a9d51b7b1a3783dd96f3c9b44644d1bb6bc154f71141762e2135";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "bdddcc6534eb4d4c6d8374ba8ca78f7afffd5dd03fa335f214af1c1a833cd4ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/raptor-pdu/default.nix
+++ b/distros/foxy/raptor-pdu/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, can-dbc-parser, can-msgs, raptor-pdu-msgs, rclcpp, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-raptor-pdu";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "4fca165e245f927a38bc945277af34fa6af5884b585a3c0e7bc11e9f16baccd1";
+    url = "https://github.com/NewEagleRaptor/raptor-dbw-ros2-release/archive/release/foxy/raptor_pdu/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "be55a9a3a8fc2ae7a165d70b8142b0af11ebe0f41ba289e60abdabaa4804fa98";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcdiscover/default.nix
+++ b/distros/foxy/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-foxy-rcdiscover";
-  version = "1.1.2-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/foxy/rcdiscover/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "f759212447ad9b29e3be4070e3667135c2e16b4deccbc4c9f330f3c417d5541a";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/foxy/rcdiscover/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "a78655ab6373401ce8b964d495302eec0e23c17da882aab606bb72fc3155985a";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-cascade-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-cascade-lifecycle";
-  version = "0.0.7-r4";
+  version = "0.0.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/rclcpp_cascade_lifecycle/0.0.7-4.tar.gz";
-    name = "0.0.7-4.tar.gz";
-    sha256 = "92bfb8ad368e90dc726a9d815ccaedb91814809efad10f9b70d134733af36cb1";
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/foxy/rclcpp_cascade_lifecycle/0.0.8-1.tar.gz";
+    name = "0.0.8-1.tar.gz";
+    sha256 = "9cbd26130896e20268e8257b232fc9ea9d39b7978445f27d9746aa2fb7dd4aa5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera-msgs/default.nix
+++ b/distros/foxy/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera-msgs";
-  version = "3.2.1-r1";
+  version = "3.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "a48aec95f6ac846e3a420003773f1dc33c794c20ae76a546d5f5bde96e1cf19e";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera_msgs/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "89a37b2dd32f614a9eeba9dc849aa87946ac4523774870f789b42525ee39c184";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-camera/default.nix
+++ b/distros/foxy/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-camera";
-  version = "3.2.1-r1";
+  version = "3.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d3017f181cd72636966fadcf03e71966668353890befe77116b48c3fa91e61a5";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_camera/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "40859a26b5750a72eedcba7fc9fd235f81058129f15f0de00a123416b0869bbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense2-description/default.nix
+++ b/distros/foxy/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-foxy-realsense2-description";
-  version = "3.2.1-r1";
+  version = "3.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "cbc3158f8c918963dab3809980c0560f0f444c5b6c2b80dc47e253bfb2a427a4";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/foxy/realsense2_description/3.2.2-1.tar.gz";
+    name = "3.2.2-1.tar.gz";
+    sha256 = "89a1f38d901e6e973ada9dc9133b6ceb1d7281f979d292305553de4c09d87122";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "1d4aabf7d66422d8a5ffc84306123178f342af63c95b665eccfed9a453f3844a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "57de40e5564783aafa649ec789431c1aa31dedb985d3c04612549c425284b9d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-move-group/default.nix
+++ b/distros/foxy/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-move-group";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "14adab3f57004822bbd01824c22ae77e8e5a5aebe93533833ff6dfe462c782a5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_move_group/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ab5846516a3684bf791cc1e923939afd3b99ded6172f80dcd79b76c4193f7231";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-moveit-cpp/default.nix
+++ b/distros/foxy/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-foxy-run-moveit-cpp";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "6cf13e20dbe99025d9633f74107bcd557b6b6c5dba591bb9b062b509f5e0e526";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_moveit_cpp/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a72717119a52ea030fbccda142e144388e47f8394ba2645acad2eeb2c3bc85d4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/run-ompl-constrained-planning/default.nix
+++ b/distros/foxy/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-foxy-run-ompl-constrained-planning";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "9f4141186c8d7e60b2c110c8639d5d3c0d08d9e006aea35049d1f63821fd830d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/foxy/run_ompl_constrained_planning/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9c20d95494ba163d4f598766232b878dd176d841b12c0d600c9106838c22c725";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/theora-image-transport/default.nix
+++ b/distros/foxy/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, cv-bridge, image-transport, libogg, libtheora, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-theora-image-transport";
-  version = "2.3.0-r1";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/theora_image_transport/2.3.0-1.tar.gz";
-    name = "2.3.0-1.tar.gz";
-    sha256 = "4a2502fef054a44686be2a842714df2f704e4283c22039e5a9f345f3efb74502";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/foxy/theora_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "fdad4bc6a4aac029ae0aad4856aca3f27434997c9b8034d99736cccad3b0f552";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "e80b180d663f1c2a2a92cf387ac06474dc7a3b964d0d43ce29ad46f95cbf0947";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "56cc86d1d3d4d353fe3b221ccd5e071c3c608ba54fb598f17e0582c1c7bb1997";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/cascade-lifecycle-msgs/default.nix
+++ b/distros/galactic/cascade-lifecycle-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, lifecycle-msgs, rclcpp, rosidl-default-generators }:
+buildRosPackage {
+  pname = "ros-galactic-cascade-lifecycle-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/galactic/cascade_lifecycle_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "7e795341e347e8d28b5af6936d4fc613717e8c34d99a90273b177b8b53f6c1c3";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ builtin-interfaces lifecycle-msgs rclcpp rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for rclcpp_cascade_lifecycle package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -168,6 +168,8 @@ self: super: {
 
  cartographer-ros-msgs = self.callPackage ./cartographer-ros-msgs {};
 
+ cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
+
  class-loader = self.callPackage ./class-loader {};
 
  common-interfaces = self.callPackage ./common-interfaces {};
@@ -634,6 +636,30 @@ self: super: {
 
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
+ plansys2-bringup = self.callPackage ./plansys2-bringup {};
+
+ plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
+
+ plansys2-core = self.callPackage ./plansys2-core {};
+
+ plansys2-domain-expert = self.callPackage ./plansys2-domain-expert {};
+
+ plansys2-executor = self.callPackage ./plansys2-executor {};
+
+ plansys2-lifecycle-manager = self.callPackage ./plansys2-lifecycle-manager {};
+
+ plansys2-msgs = self.callPackage ./plansys2-msgs {};
+
+ plansys2-pddl-parser = self.callPackage ./plansys2-pddl-parser {};
+
+ plansys2-planner = self.callPackage ./plansys2-planner {};
+
+ plansys2-popf-plan-solver = self.callPackage ./plansys2-popf-plan-solver {};
+
+ plansys2-problem-expert = self.callPackage ./plansys2-problem-expert {};
+
+ plansys2-terminal = self.callPackage ./plansys2-terminal {};
+
  plotjuggler = self.callPackage ./plotjuggler {};
 
  plotjuggler-msgs = self.callPackage ./plotjuggler-msgs {};
@@ -713,6 +739,8 @@ self: super: {
  rclcpp = self.callPackage ./rclcpp {};
 
  rclcpp-action = self.callPackage ./rclcpp-action {};
+
+ rclcpp-cascade-lifecycle = self.callPackage ./rclcpp-cascade-lifecycle {};
 
  rclcpp-components = self.callPackage ./rclcpp-components {};
 

--- a/distros/galactic/librealsense2/default.nix
+++ b/distros/galactic/librealsense2/default.nix
@@ -10,7 +10,7 @@ buildRosPackage {
   src = fetchurl {
     url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.48.0-1.tar.gz";
     name = "2.48.0-1.tar.gz";
-    sha256 = "adc3306a0b5c9e579605dc01d33162927143145b631778f918be837f587b2525";
+    sha256 = "fb0271473cdad9195ed1a9d457432a416964b1553e518be573e61164289ec8e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2021.6.6-r1";
+  version = "2021.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.6.6-1.tar.gz";
-    name = "2021.6.6-1.tar.gz";
-    sha256 = "946bdffc6db618d635e3ce9f786e7380fe6c5da298a40ee400e2467c501d08dd";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.7.7-1.tar.gz";
+    name = "2021.7.7-1.tar.gz";
+    sha256 = "7dcbfb613334b77ce30cacd37fac4cac9e34cf9a7101f959d1a73371f5e3f10f";
   };
 
   buildType = "cmake";

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-bringup";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "6654a138ee386f155399fd0e02bd640a77e36cdddcd184d56bc5d70e1310b54d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common launch launch-testing ];
+  propagatedBuildInputs = [ launch-ros plansys2-domain-expert plansys2-executor plansys2-lifecycle-manager plansys2-planner plansys2-problem-expert rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Bringup scripts and configurations for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-bt-actions";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "3f956a0509ae0edd056dddf1843fc36c1411c01afeae6d1d5fbe423cf07d4c7b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs plansys2-msgs test-msgs ];
+  propagatedBuildInputs = [ action-msgs behaviortree-cpp-v3 cppzmq plansys2-executor rclcpp rclcpp-action rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-core";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "73d61589075021c24396b945d70e506a7b545e23f190bef9bbffb751384082eb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs plansys2-pddl-parser pluginlib rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based core  for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-domain-expert";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "e03b78e511d38291b1f33e822dd8c30e5ba1f8ded5e643944a981860d5901b9d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Domain Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-executor";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "c6b6d98baa307e0ebcd7c789a3a132c2f3d195fe637e8f287ce5975256f6ee53";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp behaviortree-cpp-v3 cppzmq lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert popf rclcpp rclcpp-action rclcpp-cascade-lifecycle rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Executor module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-lifecycle-manager";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "240072119f822de2d5ca02be285334d01724332f37ed97def04dc9134430a571";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A controller/manager for the lifecycle nodes of the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-msgs";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "4dd6168fab5c756d5dcd85fcf836b161f129d9c4a521708a00024a6ba295b439";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rclcpp rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages and service files for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-pddl-parser";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "631a4c136712ed8ba66ce50ef931553481128acb774975c994eb66083920e5b3";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ plansys2-msgs std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains a library for parsing PDDL domains and problems.
+  
+    This package derives from the work of Anders Jonsson, contained in https://github.com/wisdompoet/universal-pddl-parser.git
+    with many modifications by Francisco Martin:
+      * ROS2 packaging
+      * Source code structure refactor
+      * CMakeLists.txt for cmake compilation
+      * Reading from String instead of files
+      * Licensing'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-planner";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "f711926937f0b76b69edb4286e6aee2a9215707b37a24904f94797f535297fc3";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-core plansys2-domain-expert plansys2-msgs plansys2-pddl-parser plansys2-popf-plan-solver plansys2-problem-expert pluginlib rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-popf-plan-solver";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "4d1e0bc004eefb9f84dcb050e047ff57c57c39ee79f184cc88e71681e5acd548";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp plansys2-core pluginlib popf rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the PDDL-based Planner module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-problem-expert";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "4b60c0db4f9c5eae87c9fad4ba0760d8a5dc244b9deee99a07f29b1f1a4d69f1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp lifecycle-msgs plansys2-domain-expert plansys2-msgs plansys2-pddl-parser rclcpp rclcpp-action rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''This package contains the Problem Expert module for the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
+buildRosPackage {
+  pname = "ros-galactic-plansys2-terminal";
+  version = "2.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.0-2.tar.gz";
+    name = "2.0.0-2.tar.gz";
+    sha256 = "9df8d2fa6f60c9707bfb6fed84eac3a6142e7c90a47d64dc31e0ae2c1fec3581";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common lifecycle-msgs ];
+  propagatedBuildInputs = [ plansys2-domain-expert plansys2-executor plansys2-msgs plansys2-pddl-parser plansys2-planner plansys2-problem-expert rclcpp rclcpp-action rclcpp-lifecycle readline ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A terminal tool for monitor and manage the ROS2 Planning System'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rclcpp-cascade-lifecycle/default.nix
+++ b/distros/galactic/rclcpp-cascade-lifecycle/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, cascade-lifecycle-msgs, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
+buildRosPackage {
+  pname = "ros-galactic-rclcpp-cascade-lifecycle";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fmrico/cascade_lifecycle-release/archive/release/galactic/rclcpp_cascade_lifecycle/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "ac646bf6b93600f497c5cec58ca95ce33c60ea771245c9f19670cfe4f28b2329";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ cascade-lifecycle-msgs lifecycle-msgs rclcpp rclcpp-lifecycle ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides a mechanism to make trees of lifecycle nodes to propagate state changes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/agni-tf-tools/default.nix
+++ b/distros/melodic/agni-tf-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, qt5, roscpp, rviz, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-agni-tf-tools";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/melodic/agni_tf_tools/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "b8554c23840cee7a347399a14df9005003996594067f70319732c5491e1ad154";
+    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/melodic/agni_tf_tools/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "f5d19d9f1dc379c8c62bda3e4a624f18271250442ee76d32fb8d2fe9a9c0f2f9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bev-mavros/default.nix
+++ b/distros/melodic/bev-mavros/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-melodic-bev-mavros";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/bev_mavros/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "cae660a4ee5fc7bc2899162c75c148204d5c149c96fbc179e3ced9d05a01604a";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The heifu mavros package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/collision-avoidance/default.nix
+++ b/distros/melodic/collision-avoidance/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mavros-msgs, nodelet, pluginlib, roscpp, uav-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-collision-avoidance";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/collision_avoidance/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "67854c2391dba2b93578b89672d7aac1b6ea20c8142e3d480746e301b69f136f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mavros-msgs nodelet pluginlib roscpp uav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The CollisionAvoidance package'';
+    license = with lib.licenses; [ "FreeBSD" ];
+  };
+}

--- a/distros/melodic/control-bringup/default.nix
+++ b/distros/melodic/control-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mavros, mavros-commands, priority-manager }:
+buildRosPackage {
+  pname = "ros-melodic-control-bringup";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/control_bringup/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "0314942040884ee88c94308a12954db5d43b35d04655b8a95b8df7f287875d85";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mavros mavros-commands priority-manager ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Bringup of control packages'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/gcs-interface/default.nix
+++ b/distros/melodic/gcs-interface/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, mavros-msgs, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-gcs-interface";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/gcs_interface/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "2af3b879778ebf0fba590a0117165cb0828389b65ab40e332ee3c3f27b1ab514";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geographic-msgs geometry-msgs mavros-msgs rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Ground Control Station Interface'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -200,6 +200,8 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
+ bev-mavros = self.callPackage ./bev-mavros {};
+
  bfl = self.callPackage ./bfl {};
 
  blender-gazebo = self.callPackage ./blender-gazebo {};
@@ -532,6 +534,8 @@ self: super: {
 
  codec-image-transport = self.callPackage ./codec-image-transport {};
 
+ collision-avoidance = self.callPackage ./collision-avoidance {};
+
  color-util = self.callPackage ./color-util {};
 
  combined-robot-hw = self.callPackage ./combined-robot-hw {};
@@ -555,6 +559,8 @@ self: super: {
  concert-workflow-engine-msgs = self.callPackage ./concert-workflow-engine-msgs {};
 
  contact-states-observer = self.callPackage ./contact-states-observer {};
+
+ control-bringup = self.callPackage ./control-bringup {};
 
  control-msgs = self.callPackage ./control-msgs {};
 
@@ -1178,6 +1184,8 @@ self: super: {
 
  gazebo-video-monitors = self.callPackage ./gazebo-video-monitors {};
 
+ gcs-interface = self.callPackage ./gcs-interface {};
+
  gencpp = self.callPackage ./gencpp {};
 
  generic-throttle = self.callPackage ./generic-throttle {};
@@ -1212,6 +1220,8 @@ self: super: {
 
  geos-cmake-module = self.callPackage ./geos-cmake-module {};
 
+ gimbal = self.callPackage ./gimbal {};
+
  gl-dependency = self.callPackage ./gl-dependency {};
 
  global-planner = self.callPackage ./global-planner {};
@@ -1219,6 +1229,8 @@ self: super: {
  global-planner-tests = self.callPackage ./global-planner-tests {};
 
  gmapping = self.callPackage ./gmapping {};
+
+ gnss-utils = self.callPackage ./gnss-utils {};
 
  goal-passer = self.callPackage ./goal-passer {};
 
@@ -1229,6 +1241,8 @@ self: super: {
  gps-umd = self.callPackage ./gps-umd {};
 
  gpsd-client = self.callPackage ./gpsd-client {};
+
+ gpu-voxels-ros = self.callPackage ./gpu-voxels-ros {};
 
  graceful-controller = self.callPackage ./graceful-controller {};
 
@@ -1353,20 +1367,6 @@ self: super: {
  heifu = self.callPackage ./heifu {};
 
  heifu-bringup = self.callPackage ./heifu-bringup {};
-
- heifu-description = self.callPackage ./heifu-description {};
-
- heifu-diagnostic = self.callPackage ./heifu-diagnostic {};
-
- heifu-mavros = self.callPackage ./heifu-mavros {};
-
- heifu-msgs = self.callPackage ./heifu-msgs {};
-
- heifu-safety = self.callPackage ./heifu-safety {};
-
- heifu-simple-waypoint = self.callPackage ./heifu-simple-waypoint {};
-
- heifu-tools = self.callPackage ./heifu-tools {};
 
  heron-control = self.callPackage ./heron-control {};
 
@@ -1990,6 +1990,8 @@ self: super: {
 
  mavros = self.callPackage ./mavros {};
 
+ mavros-commands = self.callPackage ./mavros-commands {};
+
  mavros-extras = self.callPackage ./mavros-extras {};
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
@@ -2368,6 +2370,8 @@ self: super: {
 
  navigation = self.callPackage ./navigation {};
 
+ navigation-controller = self.callPackage ./navigation-controller {};
+
  navigation-experimental = self.callPackage ./navigation-experimental {};
 
  navigation-layers = self.callPackage ./navigation-layers {};
@@ -2708,9 +2712,13 @@ self: super: {
 
  pinocchio = self.callPackage ./pinocchio {};
 
+ planner = self.callPackage ./planner {};
+
  planner-cspace = self.callPackage ./planner-cspace {};
 
  planner-cspace-msgs = self.callPackage ./planner-cspace-msgs {};
+
+ planners-manager = self.callPackage ./planners-manager {};
 
  play-motion = self.callPackage ./play-motion {};
 
@@ -2918,6 +2926,8 @@ self: super: {
 
  prbt-support = self.callPackage ./prbt-support {};
 
+ priority-manager = self.callPackage ./priority-manager {};
+
  prosilica-camera = self.callPackage ./prosilica-camera {};
 
  prosilica-gige-sdk = self.callPackage ./prosilica-gige-sdk {};
@@ -3013,6 +3023,8 @@ self: super: {
  qt-ros = self.callPackage ./qt-ros {};
 
  qt-tutorials = self.callPackage ./qt-tutorials {};
+
+ quanergy-client = self.callPackage ./quanergy-client {};
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
@@ -3636,6 +3648,8 @@ self: super: {
 
  rr-rover-zero-driver = self.callPackage ./rr-rover-zero-driver {};
 
+ rrt = self.callPackage ./rrt {};
+
  rslidar = self.callPackage ./rslidar {};
 
  rslidar-driver = self.callPackage ./rslidar-driver {};
@@ -3864,6 +3878,8 @@ self: super: {
 
  statistics-msgs = self.callPackage ./statistics-msgs {};
 
+ status-diagnostic = self.callPackage ./status-diagnostic {};
+
  std-capabilities = self.callPackage ./std-capabilities {};
 
  std-msgs = self.callPackage ./std-msgs {};
@@ -3951,6 +3967,8 @@ self: super: {
  tf = self.callPackage ./tf {};
 
  tf2 = self.callPackage ./tf2 {};
+
+ tf2-2d = self.callPackage ./tf2-2d {};
 
  tf2-bullet = self.callPackage ./tf2-bullet {};
 
@@ -4119,6 +4137,8 @@ self: super: {
  twist-mux-msgs = self.callPackage ./twist-mux-msgs {};
 
  twist-recovery = self.callPackage ./twist-recovery {};
+
+ uav-msgs = self.callPackage ./uav-msgs {};
 
  ubiquity-motor = self.callPackage ./ubiquity-motor {};
 
@@ -4373,6 +4393,8 @@ self: super: {
  wave-gazebo = self.callPackage ./wave-gazebo {};
 
  wave-gazebo-plugins = self.callPackage ./wave-gazebo-plugins {};
+
+ waypoints-manager = self.callPackage ./waypoints-manager {};
 
  web-video-server = self.callPackage ./web-video-server {};
 

--- a/distros/melodic/gimbal/default.nix
+++ b/distros/melodic/gimbal/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mavros-msgs, roscpp, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-gimbal";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/gimbal/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "f8ee728287cd3dc2aa763e267bdf778f87a8f99bae10a5d4e2940e6f3a3a28da";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mavros-msgs roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The gimbal package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/melodic/gnss-utils/default.nix
+++ b/distros/melodic/gnss-utils/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geographic-msgs, mavros-msgs, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-gnss-utils";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/gnss_utils/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "675d7215ba226273960df07af39b3dcd69fd8d3c99a587da8952f298be682e35";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geographic-msgs mavros-msgs roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The GNSS_utils package'';
+    license = with lib.licenses; [ "TODO" ];
+  };
+}

--- a/distros/melodic/gpu-voxels-ros/default.nix
+++ b/distros/melodic/gpu-voxels-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nodelet, pcl-ros, pluginlib, tf }:
+buildRosPackage {
+  pname = "ros-melodic-gpu-voxels-ros";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/gpu_voxels_ros/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "73293c29cad9643173c6c62b245025f45cce4fd5707ff35f9432262b5998b878";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs nodelet pcl-ros pluginlib tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The gpu_voxels package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/heifu-bringup/default.nix
+++ b/distros/melodic/heifu-bringup/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, heifu-description, heifu-mavros, heifu-msgs, heifu-safety, heifu-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, control-bringup, gcs-interface, waypoints-manager }:
 buildRosPackage {
   pname = "ros-melodic-heifu-bringup";
-  version = "0.7.7-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu_bringup/0.7.7-2.tar.gz";
-    name = "0.7.7-2.tar.gz";
-    sha256 = "6798c1d532a30c3c156470eaeb00c13c680f33de1ebe5af1dc7a0b8daeff3c2b";
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu-bringup/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "280568e8c2f0b548046ff3b0d4a51bc3208704665a62d3697ad4830b0409cac3";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ heifu-description heifu-mavros heifu-msgs heifu-safety heifu-tools ];
+  propagatedBuildInputs = [ control-bringup gcs-interface waypoints-manager ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''Heifu is a ROS driver for PDMFC and BEV drone'';
+    description = ''The heifu-bringup package'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/heifu/default.nix
+++ b/distros/melodic/heifu/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, heifu-bringup, heifu-description, heifu-mavros, heifu-msgs, heifu-safety, heifu-simple-waypoint, heifu-tools }:
+{ lib, buildRosPackage, fetchurl, catkin, collision-avoidance, control-bringup, gcs-interface, gimbal, gnss-utils, gpu-voxels-ros, heifu-bringup, libmavconn, mavros, mavros-commands, mavros-extras, mavros-msgs, navigation-controller, planner, planners-manager, priority-manager, rrt, status-diagnostic, test-mavros, uav-msgs, waypoints-manager }:
 buildRosPackage {
   pname = "ros-melodic-heifu";
-  version = "0.7.7-r2";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu/0.7.7-2.tar.gz";
-    name = "0.7.7-2.tar.gz";
-    sha256 = "8436cf31ff37312589400f124aeaeed1aacb9093847ea92546287d8e1147c909";
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "9d924036981d7bc4aec3b2205d86dddcf7e7c4b9dd48696841acb679945aec60";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ heifu-bringup heifu-description heifu-mavros heifu-msgs heifu-safety heifu-simple-waypoint heifu-tools ];
+  propagatedBuildInputs = [ collision-avoidance control-bringup gcs-interface gimbal gnss-utils gpu-voxels-ros heifu-bringup libmavconn mavros mavros-commands mavros-extras mavros-msgs navigation-controller planner planners-manager priority-manager rrt status-diagnostic test-mavros uav-msgs waypoints-manager ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "1acc7ae7628526e6f65aef5f99345c0670d444994c8d226d3d50ef36d98aebf8";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "27a800321014707c3ba056d8071b451eeeb62e166ec5c9180e4caedd7cfeb5ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "7ca1a5cafd841c64ebc73d17ad950d6061f6603055f1c8c31d971fb2ca9bde25";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "3711bc5572b8d7c9f007973a55120682e24326359e43fba62824d1b0f756a2b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "cc7eb4d05e4646b29090f534cdff8a5b8013bc09eec293f4bce2f974c4733732";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "ea1e85ad9be394c1e98c62b4ca0199866568e9a1bf7efefa1aa62df3a402b3f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "fec9dcfe37abad1289f3aad1d19fe693f1baa9c0e31f214c7a037b80b9c7345a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "7f98a40d620a10e68c17008954a7b058986fc4528c61825b4b61e6c62af1d0cd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "8f2aa10c17706972c6d8754cdf7a35b732acb9caa0451c6b7da1fb532c8ee0a3";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "ab402fa3c2ea108e9edbb1e079726d4baeea18903c7c3ab485f08335b8b073b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "2f30ad759790288db741fc9acbfbf6764b7079fa57ddceb5abcbea6be6fb1f41";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "92b98dd7bdce139683bf6e2983554419bff54c57b4d3ec4f3effeb2be0105a1b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "faa4b679592efe31ba883df2eda2e44f3942c5fd285ef35a4c88c93c558c0cb0";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "54242466b9d297d728b21ace8770719e5043e4895f63a54d73c1eef1c328bfdd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "cc409eaf5d68321a1dcdc37c8f281e1d6c31639bdec8e467a8178f69537e42d1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "7bba4afef96c0588624e695e70cfe849a712352f5bee88bad56c8dde20d6e12a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "2827892b52a7344ebe70821d9728e45bf0f3aa1c5d432aa599fbef7ffb7a25ee";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "63dd260f50a32ae88bde89cd67830aa913a333b445b0650d8eb0b70269050928";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "2f3532b926034c6710efd7c4f4028bb9da5d47e717380ea70f8ef3c78b6bb1a4";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "34f4590997ab7a51c29e2f09dcaa27a08799eec6e0df288f45346277cadbbc1a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.8-r1";
+  version = "0.4.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.8-1.tar.gz";
-    name = "0.4.8-1.tar.gz";
-    sha256 = "c2f389bcdb67c45d87e769e866a59aa3fa416e21d73d8279ae5efadf062dd841";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.9-1.tar.gz";
+    name = "0.4.9-1.tar.gz";
+    sha256 = "715e1619570f076cda9aee2feb315ea89eee38918b3a6fd0fe9cc5b9dc0fe19f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-core/default.nix
+++ b/distros/melodic/industrial-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-deprecated, industrial-msgs, industrial-robot-client, industrial-robot-simulator, industrial-trajectory-filters, industrial-utils, simple-message }:
 buildRosPackage {
   pname = "ros-melodic-industrial-core";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_core/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "fca1c37d67a9b8133e486c8fd9251d65eaf01bf52cc2577cdcd1c85b1360c212";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_core/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "b37cab9d1669956c8a3d7314314cb3b54e0e4b1a4ac9a231416e89f5b1bfa266";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-deprecated/default.nix
+++ b/distros/melodic/industrial-deprecated/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-industrial-deprecated";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_deprecated/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "1c2ecfdd2b46177d0d874f24c1daa05e55141a17db32ba238122c29009d79739";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_deprecated/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "32ee44d4411020c706eb55523f8dffb857ec94615f83d78c44fc90d8310a9d87";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-msgs/default.nix
+++ b/distros/melodic/industrial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-msgs";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_msgs/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "effd2f4ca3973ab57fa500372365179f57492236e63aaf2ff343820d3a1ff545";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_msgs/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "ea2f9d7bed6e3bfd7c2a3fe74718d450c5b886f20904bc5b222f14848fb02110";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-robot-client/default.nix
+++ b/distros/melodic/industrial-robot-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, industrial-msgs, industrial-utils, robot-state-publisher, roscpp, roslaunch, rosunit, sensor-msgs, simple-message, std-msgs, trajectory-msgs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-industrial-robot-client";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_client/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "8066fb7a6f027f2d06a3b6641d09fbcd7bc858b677090edf941cbc4fca93ed91";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_client/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "752478205c90b5ca1bfb45a88e14ad235f773377af99444ef9a42ad23bb015e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-robot-simulator/default.nix
+++ b/distros/melodic/industrial-robot-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, industrial-msgs, industrial-robot-client, pythonPackages, roslaunch, rospy, sensor-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-robot-simulator";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_simulator/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "4c05ef91e4abaee01a5d477cc2776bff8cf9a5efceff541caf19ce7d7496138e";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_robot_simulator/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "56f07602a4716e5c0a328cb37a4f7f9c976a9e1e1f331f8569422999e3122f33";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-trajectory-filters/default.nix
+++ b/distros/melodic/industrial-trajectory-filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, class-loader, moveit-core, moveit-ros-planning, orocos-kdl, pluginlib, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-industrial-trajectory-filters";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_trajectory_filters/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "309487fd3ede43c60b560ba7ab53c62114db02abeab929d819ba8d859de0f75d";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_trajectory_filters/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "a9e5f67a1156a469a399a90351db828360728b186e0d1bb287991cc4b74ffbae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/industrial-utils/default.nix
+++ b/distros/melodic/industrial-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, rosunit, urdf }:
 buildRosPackage {
   pname = "ros-melodic-industrial-utils";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_utils/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "370bac7fd0ecd826d5bdf7e3014d08b5f8de165004ec81b089f1e72b370abd19";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/industrial_utils/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "82705cad368cb6995c9d75f3045802d2a86aae8de325ee517d8f066e3ad19c58";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kvh-geo-fog-3d-driver/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, kvh-geo-fog-3d-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, sensor-msgs, std-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-kvh-geo-fog-3d-driver";
-  version = "1.3.3-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_driver/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "f52b0818c830b2b5d5e441e36374e801844fe9ba36a8880a94be6abf7e45e7ef";
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_driver/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "c2556efa67c6dfa7ad60406fc08a3d8a618f1838a25259dd9f32794ee6792ebd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kvh-geo-fog-3d-msgs/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-kvh-geo-fog-3d-msgs";
-  version = "1.3.3-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_msgs/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "0ea3ac9d0959826daed2ff9fe600c80939b2529744e74f1ebd0d96c6c24c1b37";
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "80c23203e375105bd7e99139b21ddce46d251c4ce43709ef3c1f80f91ef65107";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kvh-geo-fog-3d-rviz/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d-rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, kvh-geo-fog-3d-msgs, qt5, roslint, rviz }:
 buildRosPackage {
   pname = "ros-melodic-kvh-geo-fog-3d-rviz";
-  version = "1.3.3-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_rviz/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "e83f6fca4f5fea627273634cc6a32b1cd72f6afde9120ef2d57b319b4c9e7265";
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d_rviz/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "8921cdefb404c9c8b7d73830499c7a912d256da57d643a44e7e77dabe8027227";
   };
 
   buildType = "catkin";

--- a/distros/melodic/kvh-geo-fog-3d/default.nix
+++ b/distros/melodic/kvh-geo-fog-3d/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, kvh-geo-fog-3d-driver, kvh-geo-fog-3d-msgs, kvh-geo-fog-3d-rviz }:
 buildRosPackage {
   pname = "ros-melodic-kvh-geo-fog-3d";
-  version = "1.3.3-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d/1.3.3-1.tar.gz";
-    name = "1.3.3-1.tar.gz";
-    sha256 = "014ddc8b7bf8a2239353b8aa0b6bce023d2b809d407284eb8ef4de6e505149b1";
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/melodic/kvh_geo_fog_3d/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "dd37181032cc101a812e169099344c177d61c29e3942d071063bd83c90a6f0cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.6.6-r1";
+  version = "2021.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.6.6-1.tar.gz";
-    name = "2021.6.6-1.tar.gz";
-    sha256 = "6a3a62f5f8411d44573b85888788be5e174a9611e76ad5a8ce021e692a1129f2";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.7.7-1.tar.gz";
+    name = "2021.7.7-1.tar.gz";
+    sha256 = "ae5288afecde7eee8d675b9897c61d1c73c21c636ed87b9c9e08b6b7a022d018";
   };
 
   buildType = "cmake";

--- a/distros/melodic/mavros-commands/default.nix
+++ b/distros/melodic/mavros-commands/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, mavros, mavros-msgs, roscpp, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-mavros-commands";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/mavros_commands/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "a40f4d531e6cd9533318af167c1f13f62d858811653b1054c16ed9131924f14f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ mavros mavros-msgs roscpp std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Mavros Common Commands'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/navigation-controller/default.nix
+++ b/distros/melodic/navigation-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, mavros-commands, mavros-msgs, roscpp, std-msgs, uav-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-navigation-controller";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/navigation_controller/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "76d99b2662a3d0eac4b9caa7e7a2eb22947ee9955c44669a7349238e0967f1fd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs mavros-commands mavros-msgs roscpp std-msgs uav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Navigation Controller package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/pilz-control/default.nix
+++ b/distros/melodic/pilz-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, geometry-msgs, joint-trajectory-controller, moveit-core, moveit-ros-planning, pilz-msgs, pilz-testutils, pilz-utils, roscpp, roslint, rostest, rosunit, std-srvs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-control";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "acfb911d647d5da6c87d8978a750cacb69d5a8c8a254a79d5da4c7874c9603af";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "b4acd60ba92e7f02256597e3a24f113fecf107f7b3163b35cd94162a10c6ec1e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-robots/default.nix
+++ b/distros/melodic/pilz-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-control, pilz-status-indicator-rqt, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robots";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "95c8c9a4ca0a3abd271bf81046bde74047a66a35447973255cddead2e5f5170f";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "f11816e0e36ce2e491e5a10e0e73fe3cb0ff96a04fe9ecd78911e249e551f590";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-status-indicator-rqt/default.nix
+++ b/distros/melodic/pilz-status-indicator-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-msgs, pythonPackages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-status-indicator-rqt";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "7aba436d2831b15c5cf14acefd26f47ab503eb7796ea40ba70727ad922793b79";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "633935da676a42a110587f86080532a57089df1be0dacfbfd2a406d5702c96a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner/default.nix
+++ b/distros/melodic/planner/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gpu-voxels-ros, roscpp, uav-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-planner";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/planner/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "bd7505bbb9cd6eef0c6815645aef588ff2af29b01be556e82b83ad1bb15f50a7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gpu-voxels-ros roscpp uav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Planner package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/planners-manager/default.nix
+++ b/distros/melodic/planners-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, planner, pluginlib, roscpp, rrt }:
+buildRosPackage {
+  pname = "ros-melodic-planners-manager";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/planners_manager/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "eb119fee19273de3112ab71db31e0224cbde919a6f7e6293f172bbc87cc52672";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet planner pluginlib roscpp rrt ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Planners_Manager package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/prbt-gazebo/default.nix
+++ b/distros/melodic/prbt-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-gazebo";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "73ba5d420bdd4ad68df6cac7447bacadd79744ff07bb2cf21eb2026ed0f731de";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "4c5c287328b685b4ec776b56838b18f48f1080113d974a5d842fdf772a487bd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-hardware-support/default.nix
+++ b/distros/melodic/prbt-hardware-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rosservice, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-prbt-hardware-support";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "54326a18bffb1d069a8a881c333e08fc4d961c5fcfe7b2119945cd3146aaecbf";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "e8ca0b6497b3a97cd45ac3fa8a8d0a774b78ff73c999a7686d132a7d1a297448";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-prbt-ikfast-manipulator-plugin";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "ff71bec173cefb6fe53df8d3776f3986ba0fe67c72ae549dbdfa5d45e2da8e2f";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "ecc5584dcdd97f1359cf783c846da4c7a9a54d8628b1a51966ef49f88f5f289b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-moveit-config/default.nix
+++ b/distros/melodic/prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-core, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-planning, moveit-ros-visualization, moveit-simple-controller-manager, pluginlib, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roscpp, roslaunch, rostest, rosunit, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-moveit-config";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "634605197400d4950fd7c9214f7f5ee041f5a241ad673cf25779ff66d2a6593c";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "8f5c72376e73c65209791789aa74baec4186b4f5f90129d701c2f16d350c8af8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-support/default.nix
+++ b/distros/melodic/prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, pilz-status-indicator-rqt, pilz-testutils, pilz-utils, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-support";
-  version = "0.5.21-r1";
+  version = "0.5.22-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.21-1.tar.gz";
-    name = "0.5.21-1.tar.gz";
-    sha256 = "932983411971aadf5b2d14dd2fdc7ca6c2712165bc32a1fd97db731330a0f5ef";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.22-1.tar.gz";
+    name = "0.5.22-1.tar.gz";
+    sha256 = "0375123ea08ac4a8e1dc528f9e71c64c48c091c1d25e5921e3c86a9911075477";
   };
 
   buildType = "catkin";

--- a/distros/melodic/priority-manager/default.nix
+++ b/distros/melodic/priority-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, tf2, uav-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-priority-manager";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/priority_manager/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "e17aba178a484d90ececd91d1d42239b8bac2c3e943a9753b9d2d6f28b48e637";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs roscpp tf2 uav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Priority Manager'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/python-qt-binding/default.nix
+++ b/distros/melodic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-melodic-python-qt-binding";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "e4da2117e4480a5f73a6cd256f7f66777bc95e90977c01450adb53befff30236";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/melodic/python_qt_binding/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "81666239682642c2c08f0a507f113efe4df1cd7f2cb778d3d02d913bcfa68478";
   };
 
   buildType = "catkin";

--- a/distros/melodic/quanergy-client/default.nix
+++ b/distros/melodic/quanergy-client/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, pcl }:
+buildRosPackage {
+  pname = "ros-melodic-quanergy-client";
+  version = "5.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/QuanergySystems/quanergy_client-release/archive/release/melodic/quanergy_client/5.0.0-2.tar.gz";
+    name = "5.0.0-2.tar.gz";
+    sha256 = "f9374cfdbfd688147cc1135673f55a7935a746ef8376123c3be4133c353d5c5d";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin pcl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Quanergy Sensor SDK'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/rcdiscover/default.nix
+++ b/distros/melodic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-melodic-rcdiscover";
-  version = "1.1.2-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "b8c4bb1f6fe20b91777d783f6863eeae11f45f42a081a56f168fee1c2ef52c6f";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/melodic/rcdiscover/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "ea2fa0724a29e95475715069e2e149ed146fa7f9c6b60b15ed8a578c89ba7ee8";
   };
 
   buildType = "cmake";

--- a/distros/melodic/rrt/default.nix
+++ b/distros/melodic/rrt/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, mavros-msgs, planner, roscpp, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rrt";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/rrt/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b1219689bd9895c4a2b29d43a34f29f6d02ef1904ab23dbb667b4ec21c0a7edd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs mavros-msgs planner roscpp tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The RRT package'';
+    license = with lib.licenses; [ "BCD" ];
+  };
+}

--- a/distros/melodic/simple-message/default.nix
+++ b/distros/melodic/simple-message/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, industrial-msgs, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-simple-message";
-  version = "0.7.2-r1";
+  version = "0.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/simple_message/0.7.2-1.tar.gz";
-    name = "0.7.2-1.tar.gz";
-    sha256 = "bdc441b65f17935ed7da0dc2690ae4b0654e5169c2109f3cebf1c076eaf49f8c";
+    url = "https://github.com/ros-industrial-release/industrial_core-release/archive/release/melodic/simple_message/0.7.3-1.tar.gz";
+    name = "0.7.3-1.tar.gz";
+    sha256 = "e3dcc3297fef3c238c0f9e63c80aa7be89329cc927c414de96bfca435db50075";
   };
 
   buildType = "catkin";

--- a/distros/melodic/status-diagnostic/default.nix
+++ b/distros/melodic/status-diagnostic/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, mavros, roscpp, std-msgs, topic-tools }:
+buildRosPackage {
+  pname = "ros-melodic-status-diagnostic";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/status_diagnostic/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "6329f09a2950677ec3e3d0b7816cf90c8d69fd616a5b421ff060ce7946f81924";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-msgs mavros roscpp std-msgs topic-tools ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Status messages for diagnostic'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tf2-2d/default.nix
+++ b/distros/melodic/tf2-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, roslint, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-tf2-2d";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/tf2_2d-release/archive/release/melodic/tf2_2d/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "1d4a60de80ea7adfb5894381d0b16e8d7257230a93caa3eaa9411e248a154847";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ eigen roscpp tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A set of 2D geometry classes modeled after the 3D geometry classes in tf2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/turtlebot3-fake/default.nix
+++ b/distros/melodic/turtlebot3-fake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, robot-state-publisher, roscpp, sensor-msgs, std-msgs, tf, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-melodic-turtlebot3-fake";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_fake/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "4a55cbdb39090ea375189f1a39c407a88e8293de5e4f0798a7208a5cd54cebcb";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_fake/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "f7974e0d8015e3a089be733f06c7155d83ec20dd103c54330d6a65cebc352de9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/turtlebot3-gazebo/default.nix
+++ b/distros/melodic/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, geometry-msgs, nav-msgs, roscpp, sensor-msgs, std-msgs, tf, turtlebot3-description }:
 buildRosPackage {
   pname = "ros-melodic-turtlebot3-gazebo";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_gazebo/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "4904798c2d4fedc19ac522a53ed69a7b46ea2ce61e01fbfc741088a3cbe28055";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_gazebo/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "6c2fcf64534c1bf2c45e1525b6ace892fecb354cc998985f969a55755b6e7857";
   };
 
   buildType = "catkin";

--- a/distros/melodic/turtlebot3-simulations/default.nix
+++ b/distros/melodic/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, turtlebot3-fake, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-turtlebot3-simulations";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_simulations/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "9a37b9826f45018669604a4c0d3fd205f36303f3182c787d4d6d54c174afb6a4";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/melodic/turtlebot3_simulations/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "cd6e3fdbe9a6e53715475eee65bf1a0aff709ac94b41567e7c1cb198f7300e96";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uav-msgs/default.nix
+++ b/distros/melodic/uav-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-runtime }:
+buildRosPackage {
+  pname = "ros-melodic-uav-msgs";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/uav_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "15428ad920e7797529fb238cfdfef4a8dd7fe7fc0b0bd48edbd9429fe12c7bc5";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''UAV messages package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.11-r1";
+  version = "0.0.12-r2";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.11-1.tar.gz";
-    name = "0.0.11-1.tar.gz";
-    sha256 = "f8009574969c5c35909be73d0fb7730c597be54ef02d9d511e9586dc2aa409df";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.12-2.tar.gz";
+    name = "0.0.12-2.tar.gz";
+    sha256 = "6c47c85970feb0713ca00ae6fc35c5c6d2d0f43ada2fce002e70b5ddc632fb8f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/waypoints-manager/default.nix
+++ b/distros/melodic/waypoints-manager/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, gnss-utils, mavros, mavros-commands, mavros-msgs, roscpp, sensor-msgs, std-msgs, uav-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-waypoints-manager";
+  version = "0.8.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/waypoints_manager/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "875bd4a481d14f56b28fbe5091662f207643f64a6ef1c9492db6c73c7ee173e1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs gnss-utils mavros mavros-commands mavros-msgs roscpp sensor-msgs std-msgs uav-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The Waypoints Manager package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/agni-tf-tools/default.nix
+++ b/distros/noetic/agni-tf-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, qt5, roscpp, rviz, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-agni-tf-tools";
-  version = "0.1.5-r1";
+  version = "0.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/noetic/agni_tf_tools/0.1.5-1.tar.gz";
-    name = "0.1.5-1.tar.gz";
-    sha256 = "e7f0cdd3041fb904419c86f6b0c7639b32ac05b9adfd158464a38f62bfa1bcf8";
+    url = "https://github.com/ubi-agni-gbp/agni_tf_tools-release/archive/release/noetic/agni_tf_tools/0.1.6-1.tar.gz";
+    name = "0.1.6-1.tar.gz";
+    sha256 = "43daaec7c8cc80d4b4114d5f6401947f23c7a2ae8a1f8661bfb9ded96c435392";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cv-camera/default.nix
+++ b/distros/noetic/cv-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-info-manager, catkin, cv-bridge, image-transport, nodelet, opencv3, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-cv-camera";
-  version = "0.5.0-r3";
+  version = "0.6.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/OTL/cv_camera-release/archive/release/noetic/cv_camera/0.5.0-3.tar.gz";
-    name = "0.5.0-3.tar.gz";
-    sha256 = "d28ff8d89e6f26235c50b2bc1a60d712378bd2b5085b71ff2b21f5a330dc15f8";
+    url = "https://github.com/OTL/cv_camera-release/archive/release/noetic/cv_camera/0.6.0-1.tar.gz";
+    name = "0.6.0-1.tar.gz";
+    sha256 = "fe2a15b06ca996cdf5eb2272ec070d5b6e7cc442abb7d17e48ced7c3bc73afa4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -896,6 +896,8 @@ self: super: {
 
  gmapping = self.callPackage ./gmapping {};
 
+ gmcl = self.callPackage ./gmcl {};
+
  goal-passer = self.callPackage ./goal-passer {};
 
  gpp-interface = self.callPackage ./gpp-interface {};
@@ -1962,6 +1964,8 @@ self: super: {
 
  qt-gui-py-common = self.callPackage ./qt-gui-py-common {};
 
+ quanergy-client = self.callPackage ./quanergy-client {};
+
  qwt-dependency = self.callPackage ./qwt-dependency {};
 
  radar-msgs = self.callPackage ./radar-msgs {};
@@ -2601,6 +2605,8 @@ self: super: {
  tf = self.callPackage ./tf {};
 
  tf2 = self.callPackage ./tf2 {};
+
+ tf2-2d = self.callPackage ./tf2-2d {};
 
  tf2-bullet = self.callPackage ./tf2-bullet {};
 

--- a/distros/noetic/gmcl/default.nix
+++ b/distros/noetic/gmcl/default.nix
@@ -1,0 +1,35 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, map-server, message-filters, nav-msgs, python3Packages, rosbag, roscpp, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-gmcl";
+  version = "1.0.1-r3";
+
+  src = fetchurl {
+    url = "https://github.com/adler-1994/gmcl-release/archive/release/noetic/gmcl/1.0.1-3.tar.gz";
+    name = "1.0.1-3.tar.gz";
+    sha256 = "46c797852514b8f68fdfed022818e139bc7384323891013e3fee1deb9c7428c2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-filters tf2-geometry-msgs ];
+  checkInputs = [ map-server python3Packages.pykdl rostest ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure geometry-msgs nav-msgs rosbag roscpp sensor-msgs std-srvs tf2 tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+         gmcl, which stands for general monte carlo localization,
+         is a probabilistic-based localization technique for mobile robots in
+         2D-known map. It integrates the adaptive monte carlo localization
+         - amcl - approach with three different particle filter algorithms (Optimal, Intelligent,
+         Self-adaptive) to improve the performance while working in real time.                       
+        </p>
+        <p>
+         Main node structure and amcl-algorithms’s code was derived, with thanks, from Brian Gerkey's amcl package.     
+        </p>'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.6.6-r1";
+  version = "2021.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.6.6-1.tar.gz";
-    name = "2021.6.6-1.tar.gz";
-    sha256 = "b241b889ea2d0d3cd3bef3e3bdf6944b54cf18f9d98293ee5d1d2284166f2ff2";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.7.7-1.tar.gz";
+    name = "2021.7.7-1.tar.gz";
+    sha256 = "df50afc1cc68b86bff65cffb3da256e38574487ad86b4cdb7efa6a0e5c93a43d";
   };
 
   buildType = "cmake";

--- a/distros/noetic/python-qt-binding/default.nix
+++ b/distros/noetic/python-qt-binding/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, qt5, rosbuild }:
 buildRosPackage {
   pname = "ros-noetic-python-qt-binding";
-  version = "0.4.3-r1";
+  version = "0.4.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.3-1.tar.gz";
-    name = "0.4.3-1.tar.gz";
-    sha256 = "743d59d0e39c3c139521050628ea45a0f2cef9b9e5e536d93eb04062974c3868";
+    url = "https://github.com/ros-gbp/python_qt_binding-release/archive/release/noetic/python_qt_binding/0.4.4-1.tar.gz";
+    name = "0.4.4-1.tar.gz";
+    sha256 = "d4db9983e7df47036a7afa16aac5db9e5c3de0de0c9a203fd0a2419456d035a7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/quanergy-client/default.nix
+++ b/distros/noetic/quanergy-client/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, cmake, pcl }:
+buildRosPackage {
+  pname = "ros-noetic-quanergy-client";
+  version = "5.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/QuanergySystems/quanergy_client-release/archive/release/noetic/quanergy_client/5.0.0-1.tar.gz";
+    name = "5.0.0-1.tar.gz";
+    sha256 = "213f76e7975be608547c5459b9ddcea593993460236800dfd5e1fd90fd821f29";
+  };
+
+  buildType = "cmake";
+  propagatedBuildInputs = [ boost catkin pcl ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Quanergy Sensor SDK'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/rcdiscover/default.nix
+++ b/distros/noetic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-noetic-rcdiscover";
-  version = "1.1.2-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "785cfe918435b1998ff3f646859706eb18dd0bf52e985881c0dedaa426594c8b";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/noetic/rcdiscover/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "77c6f9fdff80705af1ad973d107c1ae7e1ec6e2920687c26e2e2a7f1161c1266";
   };
 
   buildType = "cmake";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.9-r2";
+  version = "0.2.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.9-2.tar.gz";
-    name = "0.2.9-2.tar.gz";
-    sha256 = "52b25332e4bd2139fadeb6c89f6a2d385f8f49a765d841c0486a6580965941a5";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.11-1.tar.gz";
+    name = "0.2.11-1.tar.gz";
+    sha256 = "4471935a9ef992e8830fc007517492889d9867367285d3bf542eb22156440178";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-common/default.nix
+++ b/distros/noetic/tesseract-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, clang, cmake, console-bridge, eigen, gtest, lcov, ros-industrial-cmake-boilerplate, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-common";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "12589f5eb9062c63c204e4f84aec7b60bfb0053fa572f122584da80093306d0a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_common/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "d4a329fa5a25f252231d486ebcbfed44e6054f5ee39ed0b157639564fb8664cc";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-environment/default.nix
+++ b/distros/noetic/tesseract-environment/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, llvmPackages, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-kinematics, tesseract-scene-graph, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-environment";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "f8c7e24e93543b4f207aef1eab68fe04b9fd2d4ed3d573cc52643131734f51d1";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_environment/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "720aaf4a9e72f27db13c17d5ba5dd2e8e1c448a2d3cdb0f3451396ba2271bead";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-geometry/default.nix
+++ b/distros/noetic/tesseract-geometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, cmake, console-bridge, eigen, gtest, octomap, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-geometry";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "1e8f31eb932060813644a450d0d0a9ca79c2d2486799232b7c478adaee7a2c55";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_geometry/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "9db968bdfab05f4a3ef50c1ddeb07570904d04bee48637626eb52fb858525b56";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-kinematics/default.nix
+++ b/distros/noetic/tesseract-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, opw-kinematics, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-srdf, tesseract-support, tesseract-urdf }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-kinematics";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "894c1ac51131eff63bc7f00cd7ce10d8dbd8915a6b6daccd442d53cc8e67732a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_kinematics/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "5178a5136b7e754f1ab5501188d7775b75a9a48b1affd7c5dc537e020739c6c5";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-scene-graph/default.nix
+++ b/distros/noetic/tesseract-scene-graph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cmake, console-bridge, eigen, gtest, orocos-kdl, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-geometry, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-scene-graph";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "a7a541a6ce27b49ddcf204c7f20d69ad5715f6ccc174abaae4f2468038ab5e7a";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_scene_graph/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "a95645e2ad86a287ef369a55a090b0f2e481c6bc4ac733fa824a302370c35e75";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-srdf/default.nix
+++ b/distros/noetic/tesseract-srdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, ros-industrial-cmake-boilerplate, tesseract-common, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-srdf";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "cf57cada98437d0d63ca98423ea8f224063f1bd918272b782e9011f673a8ae00";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_srdf/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "c4f83af8cab478fb477dfdc90d489286a1021b48ddedec7a8fe7f09c0d1b4e5b";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-support/default.nix
+++ b/distros/noetic/tesseract-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, ros-industrial-cmake-boilerplate, tesseract-common }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-support";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "5879c2ed8ca4cd121fc6bd12f7c77f0627671bc1a20aa0638dae541637700075";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_support/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "43b191a57fab811b834548cd682e6ae35210695df2aab878bf269ce7f3bac0ea";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-urdf/default.nix
+++ b/distros/noetic/tesseract-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, gtest, pcl, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-geometry, tesseract-scene-graph, tesseract-support }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-urdf";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "03b865ec55cc9b8313a3d39836c6cbc71de226467139681013fa563638dd3501";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_urdf/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "ba643d52b30db1078aa4c9acf6672360c61e0ed6f97bf0880b602e3bfe5135b7";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tesseract-visualization/default.nix
+++ b/distros/noetic/tesseract-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, console-bridge, eigen, ros-industrial-cmake-boilerplate, tesseract-collision, tesseract-common, tesseract-environment, tesseract-scene-graph }:
 buildRosPackage {
   pname = "ros-noetic-tesseract-visualization";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "74d9c636fc34d36cd104069989ed084953d8a15d7e9abe10d9b560ed623e52d5";
+    url = "https://github.com/ros-industrial-release/tesseract-release/archive/release/noetic/tesseract_visualization/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "4cfe4b588e833cc2b89069ae42776ff2ca588dff37cc5b38a579b79c89076974";
   };
 
   buildType = "cmake";

--- a/distros/noetic/tf2-2d/default.nix
+++ b/distros/noetic/tf2-2d/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, roscpp, roslint, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-tf2-2d";
+  version = "0.6.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/tf2_2d-release/archive/release/noetic/tf2_2d/0.6.4-1.tar.gz";
+    name = "0.6.4-1.tar.gz";
+    sha256 = "e6391d874cb244f062336064435ca13899bd50f71657ad6b3f928b0f85aa212a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ eigen roscpp tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A set of 2D geometry classes modeled after the 3D geometry classes in tf2.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/turtlebot3-fake/default.nix
+++ b/distros/noetic/turtlebot3-fake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, nav-msgs, robot-state-publisher, roscpp, sensor-msgs, std-msgs, tf, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-fake";
-  version = "1.3.1-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_fake/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "60cd6b07fe5a640176d4e24e75ab0abacc81de40a4aa8dafd0ad02221a80b96c";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_fake/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "092140ac011b733db80dd95dfdff2a6fbc4cb5423811ab72c1262be5089d4532";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-gazebo/default.nix
+++ b/distros/noetic/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, geometry-msgs, nav-msgs, roscpp, sensor-msgs, std-msgs, tf, turtlebot3-description }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-gazebo";
-  version = "1.3.1-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_gazebo/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "c424f455e4425a8c810fb321a397492169366cc8cfeb0ea926cc79f0e611bf6f";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_gazebo/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "97f6e5a041d1edd6a549e8c696331ece95e96f285ae4dd595d29cf8a4c1d29a8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/turtlebot3-simulations/default.nix
+++ b/distros/noetic/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, turtlebot3-fake, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-noetic-turtlebot3-simulations";
-  version = "1.3.1-r1";
+  version = "1.3.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_simulations/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "717bedf9950d6e1238d8892074d91aef195ee9f8f351f98e7348b0ccb03bb2b3";
+    url = "https://github.com/ROBOTIS-GIT-release/turtlebot3_simulations-release/archive/release/noetic/turtlebot3_simulations/1.3.2-2.tar.gz";
+    name = "1.3.2-2.tar.gz";
+    sha256 = "aa1474452ef725257bb52b83f2bce1284a5cabccdbb070b2b920732c522cc78e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.11-r1";
+  version = "0.0.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.11-1.tar.gz";
-    name = "0.0.11-1.tar.gz";
-    sha256 = "598bb427682aea7eecfb4199526685dbebe5bd4a6ddb958614c51667f42d2a86";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.12-1.tar.gz";
+    name = "0.0.12-1.tar.gz";
+    sha256 = "3dfd5522e271282f93d381ba0c6ca25f104ff51a79253fd1e908685eba57f75d";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit e90355503d47d9a6a5907673bb5c1939fa124d7d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *backward-ros 1.0.1-r1*
* *can-dbc-parser 1.1.0-r1 --> 1.1.1-r1*
* *cascade-lifecycle-msgs 0.0.7-r4 --> 0.0.8-r1*
* *color-names 0.0.1-r1 --> 0.0.2-r1*
* *compressed-depth-image-transport 2.3.0-r1 --> 2.3.1-r1*
* *compressed-image-transport 2.3.0-r1 --> 2.3.1-r1*
* *diff-drive-controller 0.4.0-r1 --> 0.4.1-r1*
* *effort-controllers 0.4.0-r1 --> 0.4.1-r1*
* *embree-vendor 0.0.6-r1 --> 0.1.0-r1*
* *filters 2.0.0-r1 --> 2.0.2-r1*
* *force-torque-sensor-broadcaster 0.4.0-r1 --> 0.4.1-r1*
* *forward-command-controller 0.4.0-r1 --> 0.4.1-r1*
* *gripper-controllers 0.4.0-r1 --> 0.4.1-r1*
* *image-transport-plugins 2.3.0-r1 --> 2.3.1-r1*
* *imu-sensor-broadcaster 0.4.0-r1 --> 0.4.1-r1*
* *joint-state-broadcaster 0.4.0-r1 --> 0.4.1-r1*
* *joint-state-controller 0.4.0-r1 --> 0.4.1-r1*
* *joint-trajectory-controller 0.4.0-r1 --> 0.4.1-r1*
* *lua-vendor 0.0.1-r2*
* *mavlink 2021.6.6-r1 --> 2021.7.7-r1*
* *moveit 2.2.0-r1 --> 2.2.1-r1*
* *moveit-common 2.2.0-r1 --> 2.2.1-r1*
* *moveit-core 2.2.0-r1 --> 2.2.1-r1*
* *moveit-kinematics 2.2.0-r1 --> 2.2.1-r1*
* *moveit-planners 2.2.0-r1 --> 2.2.1-r1*
* *moveit-planners-ompl 2.2.0-r1 --> 2.2.1-r1*
* *moveit-plugins 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-benchmarks 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-move-group 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-occupancy-map-monitor 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-perception 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-planning 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-planning-interface 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-robot-interaction 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-visualization 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-warehouse 2.2.0-r1 --> 2.2.1-r1*
* *moveit-runtime 2.2.0-r1 --> 2.2.1-r1*
* *moveit-servo 2.2.0-r1 --> 2.2.1-r1*
* *moveit-simple-controller-manager 2.2.0-r1 --> 2.2.1-r1*
* *plansys2-bringup 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-bt-actions 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-core 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-domain-expert 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-executor 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-lifecycle-manager 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-msgs 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-pddl-parser 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-planner 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-popf-plan-solver 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-problem-expert 1.0.9-r1 --> 1.0.10-r1*
* *plansys2-terminal 1.0.9-r1 --> 1.0.10-r1*
* *pmb2-2dnav 3.0.1-r1*
* *pmb2-bringup 4.0.2-r1*
* *pmb2-controller-configuration 4.0.2-r1*
* *pmb2-description 4.0.2-r1*
* *pmb2-maps 3.0.1-r1*
* *pmb2-navigation 3.0.1-r1*
* *pmb2-robot 4.0.2-r1*
* *position-controllers 0.4.0-r1 --> 0.4.1-r1*
* *quaternion-operation 0.0.5-r1 --> 0.0.6-r1*
* *raptor-dbw-can 1.1.0-r1 --> 1.1.1-r1*
* *raptor-dbw-joystick 1.1.0-r1 --> 1.1.1-r1*
* *raptor-dbw-msgs 1.1.0-r1 --> 1.1.1-r1*
* *raptor-pdu 1.1.0-r1 --> 1.1.1-r1*
* *raptor-pdu-msgs 1.1.0-r1 --> 1.1.1-r1*
* *rcdiscover 1.1.2-r1 --> 1.1.4-r1*
* *rclcpp-cascade-lifecycle 0.0.7-r4 --> 0.0.8-r1*
* *realsense2-camera 3.2.1-r1 --> 3.2.2-r1*
* *realsense2-camera-msgs 3.2.1-r1 --> 3.2.2-r1*
* *realsense2-description 3.2.1-r1 --> 3.2.2-r1*
* *ros2-controllers 0.4.0-r1 --> 0.4.1-r1*
* *run-move-group 2.2.0-r1 --> 2.2.1-r1*
* *run-moveit-cpp 2.2.0-r1 --> 2.2.1-r1*
* *run-ompl-constrained-planning 2.2.0-r1 --> 2.2.1-r1*
* *theora-image-transport 2.3.0-r1 --> 2.3.1-r1*
* *velocity-controllers 0.4.0-r1 --> 0.4.1-r1*

Galactic Changes:
-----------------
* *cascade-lifecycle-msgs 1.0.0-r2*
* *mavlink 2021.6.6-r1 --> 2021.7.7-r1*
* *plansys2-bringup 2.0.0-r2*
* *plansys2-bt-actions 2.0.0-r2*
* *plansys2-core 2.0.0-r2*
* *plansys2-domain-expert 2.0.0-r2*
* *plansys2-executor 2.0.0-r2*
* *plansys2-lifecycle-manager 2.0.0-r2*
* *plansys2-msgs 2.0.0-r2*
* *plansys2-pddl-parser 2.0.0-r2*
* *plansys2-planner 2.0.0-r2*
* *plansys2-popf-plan-solver 2.0.0-r2*
* *plansys2-problem-expert 2.0.0-r2*
* *plansys2-terminal 2.0.0-r2*
* *rclcpp-cascade-lifecycle 1.0.0-r2*

Melodic Changes:
----------------
* *agni-tf-tools 0.1.5-r1 --> 0.1.6-r1*
* *bev-mavros 0.8.1-r1*
* *collision-avoidance 0.8.1-r1*
* *control-bringup 0.8.1-r1*
* *gcs-interface 0.8.1-r1*
* *gimbal 0.8.1-r1*
* *gnss-utils 0.8.1-r1*
* *gpu-voxels-ros 0.8.1-r1*
* *heifu 0.7.7-r2 --> 0.8.1-r1*
* *heifu-bringup 0.7.7-r2 --> 0.8.1-r1*
* *husky-base 0.4.8-r1 --> 0.4.9-r1*
* *husky-bringup 0.4.8-r1 --> 0.4.9-r1*
* *husky-control 0.4.8-r1 --> 0.4.9-r1*
* *husky-description 0.4.8-r1 --> 0.4.9-r1*
* *husky-desktop 0.4.8-r1 --> 0.4.9-r1*
* *husky-gazebo 0.4.8-r1 --> 0.4.9-r1*
* *husky-msgs 0.4.8-r1 --> 0.4.9-r1*
* *husky-navigation 0.4.8-r1 --> 0.4.9-r1*
* *husky-robot 0.4.8-r1 --> 0.4.9-r1*
* *husky-simulator 0.4.8-r1 --> 0.4.9-r1*
* *husky-viz 0.4.8-r1 --> 0.4.9-r1*
* *industrial-core 0.7.2-r1 --> 0.7.3-r1*
* *industrial-deprecated 0.7.2-r1 --> 0.7.3-r1*
* *industrial-msgs 0.7.2-r1 --> 0.7.3-r1*
* *industrial-robot-client 0.7.2-r1 --> 0.7.3-r1*
* *industrial-robot-simulator 0.7.2-r1 --> 0.7.3-r1*
* *industrial-trajectory-filters 0.7.2-r1 --> 0.7.3-r1*
* *industrial-utils 0.7.2-r1 --> 0.7.3-r1*
* *kvh-geo-fog-3d 1.3.3-r1 --> 1.5.1-r1*
* *kvh-geo-fog-3d-driver 1.3.3-r1 --> 1.5.1-r1*
* *kvh-geo-fog-3d-msgs 1.3.3-r1 --> 1.5.1-r1*
* *kvh-geo-fog-3d-rviz 1.3.3-r1 --> 1.5.1-r1*
* *mavlink 2021.6.6-r1 --> 2021.7.7-r1*
* *mavros-commands 0.8.1-r1*
* *navigation-controller 0.8.1-r1*
* *pilz-control 0.5.21-r1 --> 0.5.22-r1*
* *pilz-robots 0.5.21-r1 --> 0.5.22-r1*
* *pilz-status-indicator-rqt 0.5.21-r1 --> 0.5.22-r1*
* *planner 0.8.1-r1*
* *planners-manager 0.8.1-r1*
* *prbt-gazebo 0.5.21-r1 --> 0.5.22-r1*
* *prbt-hardware-support 0.5.21-r1 --> 0.5.22-r1*
* *prbt-ikfast-manipulator-plugin 0.5.21-r1 --> 0.5.22-r1*
* *prbt-moveit-config 0.5.21-r1 --> 0.5.22-r1*
* *prbt-support 0.5.21-r1 --> 0.5.22-r1*
* *priority-manager 0.8.1-r1*
* *python-qt-binding 0.4.3-r1 --> 0.4.4-r1*
* *quanergy-client 5.0.0-r2*
* *rcdiscover 1.1.2-r1 --> 1.1.4-r1*
* *rrt 0.8.1-r1*
* *simple-message 0.7.2-r1 --> 0.7.3-r1*
* *status-diagnostic 0.8.1-r1*
* *tf2-2d 0.6.4-r1*
* *turtlebot3-fake 1.3.1-r1 --> 1.3.2-r1*
* *turtlebot3-gazebo 1.3.1-r1 --> 1.3.2-r1*
* *turtlebot3-simulations 1.3.1-r1 --> 1.3.2-r1*
* *uav-msgs 0.8.1-r1*
* *urg-stamped 0.0.11-r1 --> 0.0.12-r2*
* *waypoints-manager 0.8.1-r1*

Noetic Changes:
---------------
* *agni-tf-tools 0.1.5-r1 --> 0.1.6-r1*
* *cv-camera 0.5.0-r3 --> 0.6.0-r1*
* *gmcl 1.0.1-r3*
* *mavlink 2021.6.6-r1 --> 2021.7.7-r1*
* *python-qt-binding 0.4.3-r1 --> 0.4.4-r1*
* *quanergy-client 5.0.0-r1*
* *rcdiscover 1.1.2-r1 --> 1.1.4-r1*
* *ros-industrial-cmake-boilerplate 0.2.9-r2 --> 0.2.11-r1*
* *tesseract-common 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-environment 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-geometry 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-kinematics 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-scene-graph 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-srdf 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-support 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-urdf 0.4.1-r1 --> 0.5.0-r1*
* *tesseract-visualization 0.4.1-r1 --> 0.5.0-r1*
* *tf2-2d 0.6.4-r1*
* *turtlebot3-fake 1.3.1-r1 --> 1.3.2-r2*
* *turtlebot3-gazebo 1.3.1-r1 --> 1.3.2-r2*
* *turtlebot3-simulations 1.3.1-r1 --> 1.3.2-r2*
* *urg-stamped 0.0.11-r1 --> 0.0.12-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

