### PR TITLE
rosdistro sync, Fri Jul 23 13:01:27 2021

### DIFF
--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "198862ab0d43504568c8129df228af3bea299c162b0ff095dd7872fb3c66d143";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "588323f3c1fda3430d1c31efcda9a121a2f37946e842d38d1232065647fe2436";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''The bosch_locator_bridge package'';
+    description = ''ROS interface to Rexroth ROKIT Locator'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -878,17 +878,23 @@ self: super: {
 
  pmb2-2dnav = self.callPackage ./pmb2-2dnav {};
 
+ pmb2-2dnav-gazebo = self.callPackage ./pmb2-2dnav-gazebo {};
+
  pmb2-bringup = self.callPackage ./pmb2-bringup {};
 
  pmb2-controller-configuration = self.callPackage ./pmb2-controller-configuration {};
 
  pmb2-description = self.callPackage ./pmb2-description {};
 
+ pmb2-gazebo = self.callPackage ./pmb2-gazebo {};
+
  pmb2-maps = self.callPackage ./pmb2-maps {};
 
  pmb2-navigation = self.callPackage ./pmb2-navigation {};
 
  pmb2-robot = self.callPackage ./pmb2-robot {};
+
+ pmb2-simulation = self.callPackage ./pmb2-simulation {};
 
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
 
@@ -1002,6 +1008,8 @@ self: super: {
 
  realsense-examples = self.callPackage ./realsense-examples {};
 
+ realsense-hardware-interface = self.callPackage ./realsense-hardware-interface {};
+
  realsense-msgs = self.callPackage ./realsense-msgs {};
 
  realsense-node = self.callPackage ./realsense-node {};
@@ -1108,9 +1116,9 @@ self: super: {
 
  ros-ign-bridge = self.callPackage ./ros-ign-bridge {};
 
- ros-ign-gazebo = self.callPackage ./ros-ign-gazebo {};
-
  ros-ign-image = self.callPackage ./ros-ign-image {};
+
+ ros-ign-interfaces = self.callPackage ./ros-ign-interfaces {};
 
  ros-testing = self.callPackage ./ros-testing {};
 
@@ -1504,6 +1512,8 @@ self: super: {
 
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
 
+ usb-cam = self.callPackage ./usb-cam {};
+
  v4l2-camera = self.callPackage ./v4l2-camera {};
 
  velocity-controllers = self.callPackage ./velocity-controllers {};
@@ -1534,13 +1544,19 @@ self: super: {
 
  webots-ros2-abb = self.callPackage ./webots-ros2-abb {};
 
+ webots-ros2-control = self.callPackage ./webots-ros2-control {};
+
  webots-ros2-core = self.callPackage ./webots-ros2-core {};
 
  webots-ros2-demos = self.callPackage ./webots-ros2-demos {};
 
+ webots-ros2-driver = self.callPackage ./webots-ros2-driver {};
+
  webots-ros2-epuck = self.callPackage ./webots-ros2-epuck {};
 
  webots-ros2-examples = self.callPackage ./webots-ros2-examples {};
+
+ webots-ros2-mavic = self.callPackage ./webots-ros2-mavic {};
 
  webots-ros2-msgs = self.callPackage ./webots-ros2-msgs {};
 

--- a/distros/foxy/launch-pal/default.nix
+++ b/distros/foxy/launch-pal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-pal";
-  version = "0.0.3-r1";
+  version = "0.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "3487c6fbe6e9af8269bca39c514bc141151d850a89d20e6fd6362faa6694f8e0";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.4-1.tar.gz";
+    name = "0.0.4-1.tar.gz";
+    sha256 = "0e27a958c5f16e0f0ad950baeeee1d39750522c20bbe43d20524589c756c9e22";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-system-modes/default.nix
+++ b/distros/foxy/launch-system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages, rclpy, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/launch_system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "0d3fe2eeb111a4a4b22a1925d117d6fd1f0276a4f137ad9f6f1713dcdd747473";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/launch_system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c85d6dcc92090c918b9d4f3858bfb1c31a3269e584e30f59106808812085d5b7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/pmb2-2dnav-gazebo/default.nix
+++ b/distros/foxy/pmb2-2dnav-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-2dnav, pmb2-gazebo }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-2dnav-gazebo";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_2dnav_gazebo/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "56118dc7d7b3b94c719e39cadd23a7d26eac0a31b4e2c285505dcb939b5d9c36";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pmb2-2dnav pmb2-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PMB2-specific launch files needed to run
+    navigation on the PMB2 robot.'';
+    license = with lib.licenses; [ "Modified BSD" ];
+  };
+}

--- a/distros/foxy/pmb2-gazebo/default.nix
+++ b/distros/foxy/pmb2-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, launch-pal, pal-gazebo-worlds, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-gazebo";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_gazebo/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "7a3aaa8eff3f11c4dda34dc3719adbbaca5d685e0055f6abfeee6b0fd1893ea0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros launch-pal pal-gazebo-worlds pmb2-bringup pmb2-controller-configuration pmb2-description ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Simulation files for the PMB2 robot.'';
+    license = with lib.licenses; [ "Modified BSD" ];
+  };
+}

--- a/distros/foxy/pmb2-simulation/default.nix
+++ b/distros/foxy/pmb2-simulation/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-2dnav-gazebo, pmb2-gazebo }:
+buildRosPackage {
+  pname = "ros-foxy-pmb2-simulation";
+  version = "3.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_simulation/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "faec313fca6e74a7636b1ca4137e45ff779038041e30e9ce097b70269aa08ed7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pmb2-2dnav-gazebo pmb2-gazebo ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''PMB2-specific simulation components. These include plugins
+               and launch scripts necessary for running PMB2 in simulation.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rclc-examples/default.nix
+++ b/distros/foxy/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclc-examples";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_examples/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "095d08ea05eb55fe47eb587f0768c8d2eff9c913a1fa955bc774092e1d02f945";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_examples/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ab1af227dc3c33d8fbef878125743a3b1df22459c42741608d486043cc44bc7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclc-lifecycle/default.nix
+++ b/distros/foxy/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-foxy-rclc-lifecycle";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_lifecycle/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "15b2a1f47b2f5f47acb4041352525b7d73b64206b2cd4a2c79ffc501d8089d70";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc_lifecycle/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c75cac0a9e09f2a2073e621597df14be3e8c3b22ca0c274146fd9ce498a31244";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclc/default.nix
+++ b/distros/foxy/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclc";
-  version = "1.0.0-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "1a910dedc390f603316b41c67f01a0d2361b247430a9de6cc86ebd5b70596044";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/foxy/rclc/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "c779af82a8faf121daa84efcad6f33f47e6445fb9cdbbeb500e66a4f0ec2f11e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/realsense-hardware-interface/default.nix
+++ b/distros/foxy/realsense-hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-clang-format, ament-cmake-copyright, ament-cmake-flake8, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-xmllint, ament-lint-auto, controller-interface, cv-bridge, hardware-interface, image-transport, librealsense2, nav-msgs, pluginlib, poco, quaternion-operation, rclcpp, rclcpp-components, realtime-tools, ros2-control, rviz2, sensor-msgs, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-realsense-hardware-interface";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/realsense_hardware_interface-release/archive/release/foxy/realsense_hardware_interface/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "3119bf7e88139e500a4bd18dcf79db6296723057fb1b8c0406799f37aa0834c3";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-clang-format ament-cmake-copyright ament-cmake-flake8 ament-cmake-gtest ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ controller-interface cv-bridge hardware-interface image-transport librealsense2 nav-msgs pluginlib poco quaternion-operation rclcpp rclcpp-components realtime-tools ros2-control rviz2 sensor-msgs tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2 hardware interface for realsense camera'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ros-ign-bridge/default.nix
+++ b/distros/foxy/ros-ign-bridge/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, ignition, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rosgraph-msgs, sensor-msgs, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, ignition, launch-ros, launch-testing, launch-testing-ament-cmake, nav-msgs, pkg-config, rclcpp, rosgraph-msgs, sensor-msgs, std-msgs, tf2-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros-ign-bridge";
-  version = "0.221.1-r1";
+  version = "0.221.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign_bridge/0.221.1-1.tar.gz";
-    name = "0.221.1-1.tar.gz";
-    sha256 = "10227a32dcb13cdff499d6705f9958c02d4fd0eae7264238d978c22442a44504";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign_bridge/0.221.2-1.tar.gz";
+    name = "0.221.2-1.tar.gz";
+    sha256 = "ec186272bbfc483e9ef0d1d12767e7f1e6fa8a246da048bfc38866779da54b74";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common launch-ros launch-testing launch-testing-ament-cmake ];
-  propagatedBuildInputs = [ geometry-msgs ignition.msgs5 ignition.transport8 nav-msgs rclcpp rosgraph-msgs sensor-msgs std-msgs ];
+  propagatedBuildInputs = [ geometry-msgs ignition.msgs5 ignition.transport8 nav-msgs rclcpp rosgraph-msgs sensor-msgs std-msgs tf2-msgs trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake pkg-config ];
 
   meta = {

--- a/distros/foxy/ros-ign-image/default.nix
+++ b/distros/foxy/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ignition, image-transport, pkg-config, rclcpp, ros-ign-bridge, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros-ign-image";
-  version = "0.221.1-r1";
+  version = "0.221.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign_image/0.221.1-1.tar.gz";
-    name = "0.221.1-1.tar.gz";
-    sha256 = "9d0cf6e57d9352e0d172dd102beae3777a63656641112db424dc6aa1ca463548";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign_image/0.221.2-1.tar.gz";
+    name = "0.221.2-1.tar.gz";
+    sha256 = "e749b6739d04888ba97f79ee5f7b819563bda26e617e9334a7671ecdc5872c45";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros-ign-interfaces/default.nix
+++ b/distros/foxy/ros-ign-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-ros-ign-interfaces";
+  version = "0.221.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign_interfaces/0.221.2-1.tar.gz";
+    name = "0.221.2-1.tar.gz";
+    sha256 = "a7a55eb2c8bc0bca95d13563ffa43e77f86aa8984b0816bc12858153cf32aaa7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service data structures for interacting with Ignition from ROS2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ros-ign/default.nix
+++ b/distros/foxy/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-foxy-ros-ign";
-  version = "0.221.1-r1";
+  version = "0.221.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign/0.221.1-1.tar.gz";
-    name = "0.221.1-1.tar.gz";
-    sha256 = "c947e01a17d76bc3871d5e8a6d6eef0eb182d3421d89e7d14d886db289724899";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/foxy/ros_ign/0.221.2-1.tar.gz";
+    name = "0.221.2-1.tar.gz";
+    sha256 = "e16c78fd9bf2039ea9a3b36b5c7dca8154894910bc4423ce8d82cfddc311279e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2bag/default.nix
+++ b/distros/foxy/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-foxy-ros2bag";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "c1f119bc19d6aaec54d67f22543f4194184cc0e8e9691ab5bc45277fac9ec1c8";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/ros2bag/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "314d56fc958c8a3d4340d89e95148955722bae77e146f1952ad44c22f74d4231";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosbag2-compression/default.nix
+++ b/distros/foxy/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-compression";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "4e5ad66b1101e9033790c0de6176592224306da2b2baa4b16616305af2628212";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_compression/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "2cad09b9bde49dad3031f280746729213f9f3facc0da10efaa4f8ef32ef3e53c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-converter-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-converter-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rmw, rmw-fastrtps-cpp, rosbag2-cpp, rosbag2-test-common, rosidl-runtime-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-converter-default-plugins";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "cdc8e0eb24507b17d35901dcbef059ddfe5fd0693d4ed4a05f479411cb9fa9dd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_converter_default_plugins/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "20bfa740b28fb280ceed092eb2ac7079131e570dc5fa6f78fa8ad93d2384ccbd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-cpp/default.nix
+++ b/distros/foxy/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-cpp";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "44f309ee0baa98bb78e1a3671157c1f277dc7fe5dfcd3f4b4ddedd087ebdd7b1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_cpp/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "129df1f3b7f0f0628a7962411c73deef20b571ad9d8238ce6a1fe19c4f43fb8a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage-default-plugins/default.nix
+++ b/distros/foxy/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage-default-plugins";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "c85a806a2d9993d37c1a2fe9d3a4d44eee50500a68edd1f8ed7af759ee7a33d2";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage_default_plugins/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "9d479aae173b6e6b4f2a203b76df720d1e10d575b901932e9c9868a687b62ef6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-storage/default.nix
+++ b/distros/foxy/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-storage";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "adfc0c2cdc07d5d5e217106eeae1045fc8784754893571f246be540ceaa7a10f";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_storage/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "531c1a385e67cd6cbd54188f0b2b844b4552e687b9a82c317ca4e704dea56315";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-test-common/default.nix
+++ b/distros/foxy/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-test-common";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "31801b834882ef8140cad8a72b4e8c550797087d3972119cf0a3a8f9b9fda48b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_test_common/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "15520db6ed09c3a231ac1317443a372e079aa13b0144dc63016ff1904e73352c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-tests/default.nix
+++ b/distros/foxy/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-tests";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "1821b3f30a46de5947f6e5e241b0e472d07cf61043a152d05634da675ee88985";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_tests/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "811ded9fac8a0bad80e6bd6135031e7d3b67925bd40576cbb837db7332fcdab6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2-transport/default.nix
+++ b/distros/foxy/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, python-cmake-module, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-test-common, rpyutils, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2-transport";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "b60ba321facfe5c320a584f0be99f8ee610a24d5a8ba30e8461882ffcc5c7d30";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2_transport/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "68d7c95ab20930794b4263eaf21e1bdc9f0c1ecac8ba02b0067ab744d1632a8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosbag2/default.nix
+++ b/distros/foxy/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-converter-default-plugins, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rosbag2";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "3615c2633742f8fb39d2515ce258d17331c794661142e6e4135643621418a2fd";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/rosbag2/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "b21e5dfa6fb8ce2016f930ea8e444585bc55141f04171a904a466111f60beed9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/shared-queues-vendor/default.nix
+++ b/distros/foxy/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-shared-queues-vendor";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "edc644c9982602ab644b676900819cd3ae7d318d9877a352a9dc01186a463afa";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/shared_queues_vendor/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "97e124a84c70bc9af3a73480702e81cd3a742724c049761a9aeaf4b4fddd058f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/sqlite3-vendor/default.nix
+++ b/distros/foxy/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-foxy-sqlite3-vendor";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "5fecf846cf536ebf09b6463103e80e99d3b2f2abae683dc7b19f98037df0b8af";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/sqlite3_vendor/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "747946eb57d96eefa6f3322ee3392470bcdd0a848538285e730469d2e7e429ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-examples/default.nix
+++ b/distros/foxy/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, launch, launch-system-modes, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-examples";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "f5c987719f72ddddd37fa64bd20a3417170df8e7a7ff4695a7a59d645c83fada";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_examples/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "a74870f22ec802c61895f8330ef7b6a10cb6697dc5629c2bc75abc3a4bef4d13";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes-msgs/default.nix
+++ b/distros/foxy/system-modes-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-system-modes-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "605a3f2af6338ee36fec057cbcf36d7460224a4867b633f23664d36024978cfb";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "8eebfd37f1f9def3dbb28119bbfd4bd10776cb35c4ccd1857910b451a84211a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/system-modes/default.nix
+++ b/distros/foxy/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "70b6fc15164dbc46963b104b0dfd873bddc5527e5500693c8ffe93511ebdb605";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "50250aec9316d66a8e53e429cea7f4988f4005a23c60e28a60637201b6bda8ac";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/test-launch-system-modes/default.nix
+++ b/distros/foxy/test-launch-system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-pep257, ament-index-python, ament-lint-auto, builtin-interfaces, launch-system-modes, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, rclcpp, rclcpp-lifecycle, system-modes, system-modes-examples, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-foxy-test-launch-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/test_launch_system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "bb6ab84bd048b0fd43202dd0e4d0bd006b8b8979bd27c45a20720c04b0d62dd5";
+    url = "https://github.com/microROS/system_modes-release/archive/release/foxy/test_launch_system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "700fc5b26ae1dbfe58891f793a8c64ebbfe6d3a2dfbb94c7729ae2428f2f1bb3";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/usb-cam/default.nix
+++ b/distros/foxy/usb-cam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+buildRosPackage {
+  pname = "ros-foxy-usb-cam";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/foxy/usb_cam/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "80afcf551cfac0d60fde305ac68ad73ce18ae1036e44311c56f567b42ac9a840";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
+  nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
+
+  meta = {
+    description = ''A ROS2 Driver for V4L USB Cameras'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/webots-ros2-abb/default.nix
+++ b/distros/foxy/webots-ros2-abb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-abb";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "e22314d520c51d584175334ca2cdfc1b28203dca43c2abc4c0a461a543849640";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "f9df46ac4aff1710bb6b7d3db376253463b79f0806b0039f08d9bba3855453b0";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-control";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "fd7ba06d9e6f734e9e26f9d214c5eab3e730ab85b28ea53348d123c8a967d664";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager hardware-interface pluginlib rclcpp webots-ros2-driver ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros2_control plugin for Webots'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "fc0e2e0ea1887ebf46ee6bde6bc478c9fc2a69c3c7da0ec69e0e0d6c59810175";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c225e143811d0fdd1bbd446dfb5823d9927901ad862a573167f674906c93272e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-demos/default.nix
+++ b/distros/foxy/webots-ros2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-demos";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "15e7d5de283aebca8c07a9e8eac11eead02db6c97a1eabb0b863845be6217d79";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ad584e5cfdadbfef7084c20bc14b2e75bbbb6b793e1eb204e68ce89904eb8396";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-driver";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "90447cc5fc8f193da2b04132fa1c9990ec91f2f9701338b31aad85a1255f8f03";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of the Webots - ROS 2 interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "4a9279a3a5cf7805f067bde7d9a03c9a07359d1008d50ae3e369dfe28a82308d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "aa1948024f639ae31b3d1e88331695b89653b3d510149121e31b59cde1bf4641";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-examples/default.nix
+++ b/distros/foxy/webots-ros2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-examples";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "cccba5cfdffd2a8629dd90ac70ea7cfc271568754124587fcd667e3a49bad0b5";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "c7d8c918efe307d95f38674b140271d432982068279c02903dec3bc999fa692d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-mavic";
+  version = "1.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "6e15bd7a48cc96f6e55e16df9072678c722aff1a3c6be6e4254b77c87c8d9fe9";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy webots-ros2-core ];
+
+  meta = {
+    description = ''Mavic 2 Pro robot ROS2 interface for Webots.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "17253b5b61585f5f10236278c32e2c57df54ec41ad54425fd866db6f52e13154";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "2dcfc0c0f332a1156d1a463914c296a5761441470619f82427efd151d10290be";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "07382ffb899d4f4d495d9e626031e7c8c069223072bd4cbce004b1068e618d40";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "ea2c7a201cb2ac8fd573635af2cc6be7cf3abd45e11c5960bb50ac174e16d38f";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "ae5537db12cc491ced97b3edcd7a704baa0267b51c4386dbc92d2bacd8e12700";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "9bb1fc1c4b60d23b2498f5569bc7ce951648128d751e9d4dc66b3f757c974351";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, webots-ros2-control, webots-ros2-core, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "d9db73b50f52c6539e22f007d6e9937e2915d9ac75f7a714d48eb8ac55faa690";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d3d54543e2109afae75dcceb695d0f77ff39062c418f6f72e8be607e9159e6bb";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy webots-ros2-core ];
+  propagatedBuildInputs = [ builtin-interfaces diff-drive-controller joint-state-broadcaster rclpy webots-ros2-control webots-ros2-core webots-ros2-driver ];
 
   meta = {
     description = ''TurtleBot3 Burger robot ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2-tutorials/default.nix
+++ b/distros/foxy/webots-ros2-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, std-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tutorials";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "82525e7e5094857e6008e3171c292fa55632ab0c93abaeaae067e5defc51ad7c";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "e8366d01eac65cf95e113001924dd41cf78ec037c5dcd519c8fc8ae32a04c420";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "c41d298bdd75040f38155519eddbb3047de1e78381865f4ac7488da507060790";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "33a9555b2abcd5b0571931cf52f86b8b7556a347a73035cbe727d01d9fa7b9c9";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-ur-e-description/default.nix
+++ b/distros/foxy/webots-ros2-ur-e-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, urdf }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-ur-e-description";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "cc98e500bb007ee224c8ae03b4fe5547ef8e42a788de7da4dae950d044484e12";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "d06876fabec2f6d602fd85aa994209aed7e2dca43240dca983b3dcc3d73c6999";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "45cf583827a91c1a26a970443b56dbe6841d709ad6c60c98494db0d8e274d518";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "5673c38f65b4b1444b6a06f78e3c7b04ae337b5a80aba3c2c0def2cd8df05f4d";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-demos webots-ros2-epuck webots-ros2-examples webots-ros2-importer webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-tutorials webots-ros2-universal-robot ];
+  propagatedBuildInputs = [ builtin-interfaces rclpy std-msgs webots-ros2-abb webots-ros2-core webots-ros2-demos webots-ros2-epuck webots-ros2-examples webots-ros2-importer webots-ros2-mavic webots-ros2-msgs webots-ros2-tesla webots-ros2-tiago webots-ros2-turtlebot webots-ros2-tutorials webots-ros2-universal-robot ];
 
   meta = {
     description = ''Interface between Webots and ROS2'';

--- a/distros/foxy/zstd-vendor/default.nix
+++ b/distros/foxy/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-foxy-zstd-vendor";
-  version = "0.3.7-r1";
+  version = "0.3.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.7-1.tar.gz";
-    name = "0.3.7-1.tar.gz";
-    sha256 = "4768326423dccd4ac7d044447a78c89cf71acfc2d4840d64c3fffc12c9daa4b7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/foxy/zstd_vendor/0.3.8-1.tar.gz";
+    name = "0.3.8-1.tar.gz";
+    sha256 = "894765acd5f917266e4702d03d6eb765454e5e01f635072e4858de71700ec60e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ackermann-msgs/default.nix
+++ b/distros/galactic/ackermann-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ackermann-msgs";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/ackermann_msgs-release/archive/release/galactic/ackermann_msgs/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "1ca419db4958f61417579aaf5761bfc5d0f6b668eff119673e2efaedca35d396";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS2 messages for robots using Ackermann steering.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/backward-ros/default.nix
+++ b/distros/galactic/backward-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, elfutils }:
+buildRosPackage {
+  pname = "ros-galactic-backward-ros";
+  version = "1.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/backward_ros-release/archive/release/galactic/backward_ros/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "0471b6be0d5e661af0b0e943c576d8ae9cfef99c8b69ebc28d376b4080a6ff8c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ elfutils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The backward_ros package is a ros wrapper of backward-cpp from https://github.com/bombela/backward-cpp'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/color-names/default.nix
+++ b/distros/galactic/color-names/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rviz2, std-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-color-names";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/color_names-release/archive/release/galactic/color_names/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "f0eb7edaf3aa63d6beb7597d22ad05df2244f3667c61764dcc5bf504b0fd4306";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp rviz2 std-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The color_names package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/compressed-depth-image-transport/default.nix
+++ b/distros/galactic/compressed-depth-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-compressed-depth-image-transport";
-  version = "2.3.0-r5";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_depth_image_transport/2.3.0-5.tar.gz";
-    name = "2.3.0-5.tar.gz";
-    sha256 = "040987efb61cdb93928c788485906699abd8d4344c6081b84606885486ef2611";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_depth_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "65640347a63e52460e4cf0d66a6112951840bcdabf34ce54260775c9126c405e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/compressed-image-transport/default.nix
+++ b/distros/galactic/compressed-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cv-bridge, image-transport }:
 buildRosPackage {
   pname = "ros-galactic-compressed-image-transport";
-  version = "2.3.0-r5";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_image_transport/2.3.0-5.tar.gz";
-    name = "2.3.0-5.tar.gz";
-    sha256 = "0a728a4f31448127f9ec7a4faa119f7676d9ffc2b287af9253ca07db298eaa27";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/compressed_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "def53261c78f0c5506df72d3c2aecce2b7f2d898c3465c3e7013dda512aae7be";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/embree-vendor/default.nix
+++ b/distros/galactic/embree-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, glfw3, pkg-config }:
+buildRosPackage {
+  pname = "ros-galactic-embree-vendor";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/embree_vendor-release/archive/release/galactic/embree_vendor/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "4728e8d270a86c188c40695ce56bf7fbae1eeaf2b8adb6112b6662883c7fd701";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ glfw3 pkg-config ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''vendor packages for intel raytracing kernel library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/filters/default.nix
+++ b/distros/galactic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gtest, ament-cmake-uncrustify, ament-cmake-xmllint, boost, pluginlib, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-filters";
-  version = "2.0.0-r3";
+  version = "2.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/filters-release/archive/release/galactic/filters/2.0.0-3.tar.gz";
-    name = "2.0.0-3.tar.gz";
-    sha256 = "23fa210e8ab8625a1f8517e8143b5f50b34091f4ee217645fc5a6a0bb5b7ff84";
+    url = "https://github.com/ros2-gbp/filters-release/archive/release/galactic/filters/2.1.0-1.tar.gz";
+    name = "2.1.0-1.tar.gz";
+    sha256 = "2a6c14d40944d30277c034fd6b83c3e7bcbb5d1c53797881a342f50fb55aff72";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/four-wheel-steering-msgs/default.nix
+++ b/distros/galactic/four-wheel-steering-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-four-wheel-steering-msgs";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/four_wheel_steering_msgs-release/archive/release/galactic/four_wheel_steering_msgs/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "d9ba5c5eb9c12d18fab4b8a043dda5f32eb8505e7ac43868b9496e1ff44e92d0";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS messages for robots using FourWheelSteering.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -6,6 +6,8 @@ self: super: {
 
  acado-vendor = self.callPackage ./acado-vendor {};
 
+ ackermann-msgs = self.callPackage ./ackermann-msgs {};
+
  action-msgs = self.callPackage ./action-msgs {};
 
  action-tutorials-cpp = self.callPackage ./action-tutorials-cpp {};
@@ -142,6 +144,8 @@ self: super: {
 
  autoware-auto-msgs = self.callPackage ./autoware-auto-msgs {};
 
+ backward-ros = self.callPackage ./backward-ros {};
+
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
  bno055 = self.callPackage ./bno055 {};
@@ -171,6 +175,8 @@ self: super: {
  cascade-lifecycle-msgs = self.callPackage ./cascade-lifecycle-msgs {};
 
  class-loader = self.callPackage ./class-loader {};
+
+ color-names = self.callPackage ./color-names {};
 
  common-interfaces = self.callPackage ./common-interfaces {};
 
@@ -242,6 +248,8 @@ self: super: {
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
 
+ embree-vendor = self.callPackage ./embree-vendor {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-cbg-executor = self.callPackage ./examples-rclcpp-cbg-executor {};
@@ -300,6 +308,8 @@ self: super: {
 
  foonathan-memory-vendor = self.callPackage ./foonathan-memory-vendor {};
 
+ four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
+
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
@@ -337,6 +347,8 @@ self: super: {
  grbl-ros = self.callPackage ./grbl-ros {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
+
+ hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
  iceoryx-binding-c = self.callPackage ./iceoryx-binding-c {};
 
@@ -510,7 +522,11 @@ self: super: {
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
- nao-interfaces = self.callPackage ./nao-interfaces {};
+ nao-button-sim = self.callPackage ./nao-button-sim {};
+
+ nao-command-msgs = self.callPackage ./nao-command-msgs {};
+
+ nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
 
@@ -694,6 +710,8 @@ self: super: {
 
  quality-of-service-demo-py = self.callPackage ./quality-of-service-demo-py {};
 
+ quaternion-operation = self.callPackage ./quaternion-operation {};
+
  radar-msgs = self.callPackage ./radar-msgs {};
 
  random-numbers = self.callPackage ./random-numbers {};
@@ -736,6 +754,8 @@ self: super: {
 
  rclc-lifecycle = self.callPackage ./rclc-lifecycle {};
 
+ rclc-parameter = self.callPackage ./rclc-parameter {};
+
  rclcpp = self.callPackage ./rclcpp {};
 
  rclcpp-action = self.callPackage ./rclcpp-action {};
@@ -750,6 +770,8 @@ self: super: {
 
  rcpputils = self.callPackage ./rcpputils {};
 
+ rcss3d-agent = self.callPackage ./rcss3d-agent {};
+
  rcutils = self.callPackage ./rcutils {};
 
  realsense2-camera = self.callPackage ./realsense2-camera {};
@@ -762,7 +784,11 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ rmf-battery = self.callPackage ./rmf-battery {};
+
  rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
+
+ rmf-building-map-tools = self.callPackage ./rmf-building-map-tools {};
 
  rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
 
@@ -781,6 +807,12 @@ self: super: {
  rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
 
  rmf-traffic = self.callPackage ./rmf-traffic {};
+
+ rmf-traffic-editor = self.callPackage ./rmf-traffic-editor {};
+
+ rmf-traffic-editor-assets = self.callPackage ./rmf-traffic-editor-assets {};
+
+ rmf-traffic-editor-test-maps = self.callPackage ./rmf-traffic-editor-test-maps {};
 
  rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
 
@@ -871,6 +903,8 @@ self: super: {
  ros-environment = self.callPackage ./ros-environment {};
 
  ros-ign = self.callPackage ./ros-ign {};
+
+ ros-ign-interfaces = self.callPackage ./ros-ign-interfaces {};
 
  ros-testing = self.callPackage ./ros-testing {};
 
@@ -1160,11 +1194,19 @@ self: super: {
 
  ublox = self.callPackage ./ublox {};
 
+ ublox-dgnss = self.callPackage ./ublox-dgnss {};
+
+ ublox-dgnss-node = self.callPackage ./ublox-dgnss-node {};
+
  ublox-gps = self.callPackage ./ublox-gps {};
 
  ublox-msgs = self.callPackage ./ublox-msgs {};
 
  ublox-serialization = self.callPackage ./ublox-serialization {};
+
+ ublox-ubx-interfaces = self.callPackage ./ublox-ubx-interfaces {};
+
+ ublox-ubx-msgs = self.callPackage ./ublox-ubx-msgs {};
 
  udp-driver = self.callPackage ./udp-driver {};
 
@@ -1190,7 +1232,11 @@ self: super: {
 
  urg-node-msgs = self.callPackage ./urg-node-msgs {};
 
+ usb-cam = self.callPackage ./usb-cam {};
+
  v4l2-camera = self.callPackage ./v4l2-camera {};
+
+ vision-msgs = self.callPackage ./vision-msgs {};
 
  vision-opencv = self.callPackage ./vision-opencv {};
 

--- a/distros/galactic/hls-lfcd-lds-driver/default.nix
+++ b/distros/galactic/hls-lfcd-lds-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-hls-lfcd-lds-driver";
+  version = "2.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robotis-ros2-release/hls_lfcd_lds_driver-release/archive/release/galactic/hls_lfcd_lds_driver/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "87af426f16a85710b87c4bc7e179110f05d1b47c71006974479e684d61d462a5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS package for LDS(HLS-LFCD2).
+    The LDS (Laser Distance Sensor) is a sensor sending the data to Host for the simultaneous localization and mapping (SLAM). Simultaneously the detecting obstacle data can also be sent to Host. HLDS(Hitachi-LG Data Storage) is developing the technology for the moving platform sensor such as Robot Vacuum Cleaners, Home Robot, Robotics Lawn Mower Sensor, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/image-transport-plugins/default.nix
+++ b/distros/galactic/image-transport-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, compressed-depth-image-transport, compressed-image-transport, theora-image-transport }:
 buildRosPackage {
   pname = "ros-galactic-image-transport-plugins";
-  version = "2.3.0-r5";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/image_transport_plugins/2.3.0-5.tar.gz";
-    name = "2.3.0-5.tar.gz";
-    sha256 = "2b5138bf52dbb1d5f8376346191f6482e0cb3d4eb9664ca0c12d720da3d3a085";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/image_transport_plugins/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "f771323208546bf66408b6d662b19010c19e3aa84d42968c5e778d4ba7957469";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/launch-system-modes/default.nix
+++ b/distros/galactic/launch-system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages, rclpy, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-launch-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/launch_system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ca94791d4296fac35774317ed0d3abff02930392a8f45b6f03dc7f610998b3ce";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/launch_system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "d744b53f51d8495bdc8e7ed7a585a780bb9d02a4a59990dd72640ba97e8f1a9f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/librealsense2/default.nix
+++ b/distros/galactic/librealsense2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1, openssl, pkg-config, udev }:
 buildRosPackage {
   pname = "ros-galactic-librealsense2";
-  version = "2.48.0-r1";
+  version = "2.48.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.48.0-1.tar.gz";
-    name = "2.48.0-1.tar.gz";
-    sha256 = "fb0271473cdad9195ed1a9d457432a416964b1553e518be573e61164289ec8e9";
+    url = "https://github.com/IntelRealSense/librealsense2-release/archive/release/galactic/librealsense2/2.48.0-2.tar.gz";
+    name = "2.48.0-2.tar.gz";
+    sha256 = "a041d44b269f2ef41485eebefb5264bf8910df794c07e831120ec0f55a68208d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "8d9346d9e219da36d8a6a1ae34a28599eb77c4e7bfe3b33c19a2752fcfa009f4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "4c31ac5c4d676f4359da29b8e1f474cf29d5354ec3a0215c0528ce0b9d19a3e8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "86dad4e9ae13874f7f0a52f0f8837130d908a05a3854338d52275d989213b986";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "5cc16a50baaa0bcf203412f25e4ff711d879d0566740f9c1c6fa32b4bbe0c5b5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d7db0fcd41b664836a3e00a42ffe97a95918196a57d4072bd7869b4e33618ffc";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "59aafca8938975ab28d77fa66a70031a6334610957ff86cde37a5bf36b48c413";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5f6fa8e2d29ac7e6c5cc62e64ad882f7981e4f86407b3f1cf9f3b31ae3419284";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9df49e6a7e9ac04a38384acae4eca45556fd480d04f295891366920f9ccacd82";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "038dab70bba47b262821b759a2cc4004c037eb94484a2c10223730704e734a10";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a6fe405d45026ad8baf0ebe2328e46d77eac67820dbedee52447d866367f9ab2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1f0b0c8b913a40b7c7e789ffde59819dc574ac8903ce0554ee54994735d17e88";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2029cc947e7d5475c8331d9db037f8ffca1c6ab6104ef8623a8fe890702dc31f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "46714294f3bdef60fba8b986dce85f6d0a406977ec45564bacd3f4f479cbfa99";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "5b51ee65c8cc3f59b3781c183447a67d0a7e0da49d072edc2338c10a2780c27c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "12559c70e3b9e5703563f84e9a36b786b65f2808da869417276f707ea214a742";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "707758332928010cc691bcad596f3ebc4a5a7229d5184708107dd7b27bd028ba";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d1d56a698d8718558b38380b338d3aeb38fb5278dd8e83e592dcd30f7f8db191";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1a781133b06a0116b809796d550368ebd617f448c524ababad29649cf080cad4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f6dd9a6cbe95dac9f04c7d222c158e0029a36f83408933b317919ad3a032e77b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "00b31598f20c410627d74a4fca7d92f50884c9e8ebb34c6cce5a87fa47e72b76";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d93670f52b4424617992d758a121a78b9ecd1951ee446a896acaacb350a1de20";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "ce71992ce90db93e0343df991614c4a628bbb3b640fe9ff28175cd066e5e7d1b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ eigen moveit-common ];
-  checkInputs = [ moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
+  checkInputs = [ ament-cmake-gtest ament-lint-auto moveit-planners-ompl moveit-resources-fanuc-moveit-config moveit-resources-panda-moveit-config moveit-simple-controller-manager ros-testing rviz2 ];
   propagatedBuildInputs = [ geometry-msgs moveit-core moveit-msgs moveit-ros-move-group moveit-ros-planning moveit-ros-warehouse python3 rclcpp rclcpp-action rclpy tf2 tf2-eigen tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "82d768c61b59150571dcf2bd328290ce3d0e72e457c52ee2a23f9b895f04823d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "444941c55f8dad7a854ac19c58cfba10a80157e8935cdbdf3717fb1b39f56b7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0ce64dcc4bc3db1c2a6d1189b75d3fd7943ec7682046713c590d911fcf76bbeb";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "853f8505107e186be829df34b912aea8563320cd59e0bb39bbfc035a6791eace";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d6b25ca30a9a4595490c40157848d22b778f55865224421d9486db02aaace325";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7d55bfacdfce11470b243df4feefe1f751ceab19714c20262fc88b0448079f3a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "d94845bee9e43e5444a0d0e565379099449cf5761b82272c2005d1c4250daaf4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a760de0684ad98e7f73d3e344cf716ab56bdbc9798277bb47711dfb0c6970412";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "847aabc9299d352ea45aee4d0382e99b606a2a8923c8e751963cd06735fa933b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d534a57cb5ce32682d8f7a46d15618106cffd882a2be838c99d66384ff04b11b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "e38f7b7b588fb46b379023a0f57f583ebbeeb44c4ccd0364f06ae201445d68f7";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "89e2063e90e8003cee6c2fe99e4ab933e1f41980d779abe87dc2d3043a64b8db";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "ad9a7b980c6b0aa145dba1a4810c4356e8d21c225f79cec68fa3db7baa23fa3d";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "582ad27bf9605bcf6d4eac6360dbd61913719d46dd0d0d0fe833f23d5789611f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "ebc7c2448d230125be11e1a414b7655ab4ec6868b126c585086fa63dbfcb5b87";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "e53081d26a7d9c5e76d6501f4e58c63ac519d0bee51e3aabc6873ac2bc54b922";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "f200e9b10018aef20c2f3657079a126a0e6d1d689e00ef96d72bf8b8c482dd70";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "62618f2c1090c3372152f3e333b4dbdd1a59ed0ad76c499a1c5d3cd9076ae61e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/nao-button-sim/default.nix
+++ b/distros/galactic/nao-button-sim/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, nao-sensor-msgs, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-nao-button-sim";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/naosoccer_sim-release/archive/release/galactic/nao_button_sim/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "db559559fecfacc104af37bfb9bf8e451a3cc28ed71927b3c069513ebc2f7cba";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ nao-sensor-msgs ];
+
+  meta = {
+    description = ''Allows simulating button presses through command line interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/nao-command-msgs/default.nix
+++ b/distros/galactic/nao-command-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-nao-command-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/nao_interfaces-release/archive/release/galactic/nao_command_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c3fa99b82e75f19a7d80eb378857f1359ed6260f15ea2de0574b7364798959fd";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing sensor msgs to be used with a NAO robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/nao-sensor-msgs/default.nix
+++ b/distros/galactic/nao-sensor-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-nao-sensor-msgs";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/nao_interfaces-release/archive/release/galactic/nao_sensor_msgs/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "3609ad9a77e2d17cc31ea5b3d67142230ef654003305b4b2759326226c79195c";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing sensor msgs to be used with a NAO robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plansys2-bringup/default.nix
+++ b/distros/galactic/plansys2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch, launch-ros, launch-testing, plansys2-domain-expert, plansys2-executor, plansys2-lifecycle-manager, plansys2-planner, plansys2-problem-expert, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bringup";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "6654a138ee386f155399fd0e02bd640a77e36cdddcd184d56bc5d70e1310b54d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bringup/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "f27337bd6f14fe943c27eb4e9981601aecff9cd8ff3a49bf1669cb195946e8a2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-bt-actions/default.nix
+++ b/distros/galactic/plansys2-bt-actions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, geometry-msgs, plansys2-executor, plansys2-msgs, rclcpp, rclcpp-action, rclcpp-lifecycle, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-bt-actions";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "3f956a0509ae0edd056dddf1843fc36c1411c01afeae6d1d5fbe423cf07d4c7b";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_bt_actions/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "064682f8cbe19b1d1465b8cd8eebb052143da0cff3393258ec30a20b132a3fd3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-core/default.nix
+++ b/distros/galactic/plansys2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, plansys2-pddl-parser, pluginlib, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-core";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "73d61589075021c24396b945d70e506a7b545e23f190bef9bbffb751384082eb";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_core/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "8fab0723c02c0a4834eaaac9eb1b5f96dc114ff7ec2ffe42086ce9e16cd6852e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-domain-expert/default.nix
+++ b/distros/galactic/plansys2-domain-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-domain-expert";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "e03b78e511d38291b1f33e822dd8c30e5ba1f8ded5e643944a981860d5901b9d";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_domain_expert/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "cbc3f9de79636e7f4b436ce6a439aa929d31d94ad3b5e01c05e0fad27add4388";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-executor/default.nix
+++ b/distros/galactic/plansys2-executor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, behaviortree-cpp-v3, cppzmq, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, popf, rclcpp, rclcpp-action, rclcpp-cascade-lifecycle, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-executor";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "c6b6d98baa307e0ebcd7c789a3a132c2f3d195fe637e8f287ce5975256f6ee53";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_executor/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "da697a96a162902d34ca1d95ec6ef0a83e0411858eecd4019b1ab49e1cad0238";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-lifecycle-manager/default.nix
+++ b/distros/galactic/plansys2-lifecycle-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, lifecycle-msgs, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-lifecycle-manager";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "240072119f822de2d5ca02be285334d01724332f37ed97def04dc9134430a571";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_lifecycle_manager/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "734bbc926c1c482c8b60b4dd7867143f3ee7b13a5266bdb7b3a667704a67e5e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-msgs/default.nix
+++ b/distros/galactic/plansys2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, builtin-interfaces, rclcpp, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-msgs";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "4dd6168fab5c756d5dcd85fcf836b161f129d9c4a521708a00024a6ba295b439";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_msgs/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "6018ae43d84ee057bb4baa1335d83cf74154b31ccb763ef3d6d2412131b10105";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-pddl-parser/default.nix
+++ b/distros/galactic/plansys2-pddl-parser/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, plansys2-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-pddl-parser";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "631a4c136712ed8ba66ce50ef931553481128acb774975c994eb66083920e5b3";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_pddl_parser/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "5b8173f01fbf026a608db04c72fb166a4028bada383c4ef4f961c3761722df2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-planner/default.nix
+++ b/distros/galactic/plansys2-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-core, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, plansys2-popf-plan-solver, plansys2-problem-expert, pluginlib, rclcpp, rclcpp-action, rclcpp-lifecycle, ros2run, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-planner";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "f711926937f0b76b69edb4286e6aee2a9215707b37a24904f94797f535297fc3";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_planner/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "4057270815e06cb5dbd99e31fc9c87d7d6eaa64a9b12bbc948c3dae03318345e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-popf-plan-solver/default.nix
+++ b/distros/galactic/plansys2-popf-plan-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, plansys2-core, pluginlib, popf, rclcpp, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-popf-plan-solver";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "4d1e0bc004eefb9f84dcb050e047ff57c57c39ee79f184cc88e71681e5acd548";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_popf_plan_solver/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "e92ce6b8dcae208e040038120cf38a9f2b7e5674922ce1d25424493df48563f0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-problem-expert/default.nix
+++ b/distros/galactic/plansys2-problem-expert/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-msgs, plansys2-pddl-parser, rclcpp, rclcpp-action, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-problem-expert";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "4b60c0db4f9c5eae87c9fad4ba0760d8a5dc244b9deee99a07f29b1f1a4d69f1";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_problem_expert/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "3eee9d8f027ee60b44f393578bd3df16586508eb6cd279e62be2bb1001408d48";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plansys2-terminal/default.nix
+++ b/distros/galactic/plansys2-terminal/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, lifecycle-msgs, plansys2-domain-expert, plansys2-executor, plansys2-msgs, plansys2-pddl-parser, plansys2-planner, plansys2-problem-expert, rclcpp, rclcpp-action, rclcpp-lifecycle, readline }:
 buildRosPackage {
   pname = "ros-galactic-plansys2-terminal";
-  version = "2.0.0-r2";
+  version = "2.0.0-r3";
 
   src = fetchurl {
-    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.0-2.tar.gz";
-    name = "2.0.0-2.tar.gz";
-    sha256 = "9df8d2fa6f60c9707bfb6fed84eac3a6142e7c90a47d64dc31e0ae2c1fec3581";
+    url = "https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release/archive/release/galactic/plansys2_terminal/2.0.0-3.tar.gz";
+    name = "2.0.0-3.tar.gz";
+    sha256 = "c4129ea8a5db8b1522f560b3289404088b9fa9935040fcfc73760ad1edc4e26a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/quaternion-operation/default.nix
+++ b/distros/galactic/quaternion-operation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-auto, ament-cmake-gtest, eigen, geometry-msgs, rclcpp, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-quaternion-operation";
+  version = "0.0.6-r1";
+
+  src = fetchurl {
+    url = "https://github.com/OUXT-Polaris/quaternion_operation-release/archive/release/galactic/quaternion_operation/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "2000adee827cb2b8cdea6dd0ad31d7d4abf6fd13669da21f5ff2b2eb02e39866";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ ament-cmake-auto eigen geometry-msgs rclcpp tf2-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The quaternion_operation package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rcdiscover/default.nix
+++ b/distros/galactic/rcdiscover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-galactic-rcdiscover";
-  version = "1.1.2-r1";
+  version = "1.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/galactic/rcdiscover/1.1.2-1.tar.gz";
-    name = "1.1.2-1.tar.gz";
-    sha256 = "47f99b85a9a3a1d6961519a3931b020a49add3eae431d5244354f0944ae7925a";
+    url = "https://github.com/roboception-gbp/rcdiscover-release/archive/release/galactic/rcdiscover/1.1.4-1.tar.gz";
+    name = "1.1.4-1.tar.gz";
+    sha256 = "8141f60a4d3709f63556e0328676effc7355fe9a93093e62d16f706476dc15c1";
   };
 
   buildType = "cmake";

--- a/distros/galactic/rclc-examples/default.nix
+++ b/distros/galactic/rclc-examples/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-examples";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "e58654729a943c915aa94c72e20025ded5ccd42b02bce2f2ae51881d76de9b80";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e300c2cf54f3bfdb4382cdfc4f9ec66106d946612aa61f02c249513a231f3bc8";
   };
 
   buildType = "ament_cmake";
-  propagatedBuildInputs = [ example-interfaces lifecycle-msgs rcl rclc rclc-lifecycle std-msgs ];
+  propagatedBuildInputs = [ example-interfaces lifecycle-msgs rcl rclc rclc-lifecycle rclc-parameter std-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/galactic/rclc-lifecycle/default.nix
+++ b/distros/galactic/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-galactic-rclc-lifecycle";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "253afaa0e4e52438aba95a0acd9b229fef3c16c984dcb6056c32d27ed5ec8180";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "e516b2e98ed24c012eddf05dc2313cce7a39888da078b6cb75fba9ad797ae721";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-parameter/default.nix
+++ b/distros/galactic/rclc-parameter/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c }:
+buildRosPackage {
+  pname = "ros-galactic-rclc-parameter";
+  version = "2.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "22009a785628d01e27162122acab22aea2c602807a32256518907e966e3031ee";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common rclcpp ];
+  propagatedBuildInputs = [ builtin-interfaces rcl rcl-interfaces rclc rcutils rosidl-runtime-c ];
+  nativeBuildInputs = [ ament-cmake-ros ];
+
+  meta = {
+    description = ''Parameter server implementation for micro-ROS nodes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rclc/default.nix
+++ b/distros/galactic/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc";
-  version = "2.0.1-r1";
+  version = "2.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.1-1.tar.gz";
-    name = "2.0.1-1.tar.gz";
-    sha256 = "30361aba8605c1fd1e7761086a1ee61265aa6a2ea0fc6a5698251608cc9ba141";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.2-1.tar.gz";
+    name = "2.0.2-1.tar.gz";
+    sha256 = "86d91bff183d45375a7a0ed57ee82c8c95595b555828f4ea194eae702a2f7198";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rcss3d-agent/default.nix
+++ b/distros/galactic/rcss3d-agent/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, nao-command-msgs, nao-sensor-msgs, rclcpp, soccer-vision-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rcss3d-agent";
+  version = "0.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/naosoccer_sim-release/archive/release/galactic/rcss3d_agent/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "d1621aaeab74babcfaee0701f9231488d0927c9bd70f86af03d675a51b25d65e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs nao-command-msgs nao-sensor-msgs rclcpp soccer-vision-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''TODO: Package description'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-battery/default.nix
+++ b/distros/galactic/rmf-battery/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, eigen, rmf-cmake-uncrustify, rmf-traffic, rmf-utils }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-battery";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_battery-release/archive/release/galactic/rmf_battery/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "f35acb0a973133f680546c728f0c2ae25092d9780ad10a5b14216d85a7b3773e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ eigen rmf-traffic rmf-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package for modelling battery life of robots'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-building-map-tools/default.nix
+++ b/distros/galactic/rmf-building-map-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-index-python, python3Packages, pythonPackages, rclpy, rmf-building-map-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-building-map-tools";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_building_map_tools/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "fc079670b32cedbd394597fbd7506af719c0e9403c8bcaec2c37c760a6fa80d4";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs std-msgs ];
+
+  meta = {
+    description = ''RMF Building map tools'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-editor-assets/default.nix
+++ b/distros/galactic/rmf-traffic-editor-assets/default.nix
@@ -1,0 +1,22 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl,  }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-editor-assets";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_assets/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "1060a5ea3cc4e0a2ff51bf8cada19c1badbe7dc6a679715b32e9139123595d39";
+  };
+
+  buildType = "ament_python";
+
+  meta = {
+    description = ''Assets for use with traffic_editor.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/galactic/rmf-traffic-editor-test-maps/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-editor-test-maps";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_test_maps/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "fd5f1248fa859db07e7eddc744a72258337a7e79027abe21841d39880bb07d4a";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake rmf-building-map-tools ros2run ];
+
+  meta = {
+    description = ''Some test maps for traffic_editor and rmf_building_map_tools.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-editor/default.nix
+++ b/distros/galactic/rmf-traffic-editor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ceres-solver, eigen, glog, libyamlcpp, qt5 }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-editor";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "07a2a5cb5e86765880732a46a69a715c0fa1792ff62b21d172ee14956d82c840";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake ament-index-cpp eigen libyamlcpp qt5.qtbase ];
+  propagatedBuildInputs = [ ceres-solver glog ];
+
+  meta = {
+    description = ''traffic editor'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros-ign-interfaces/default.nix
+++ b/distros/galactic/ros-ign-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ros-ign-interfaces";
+  version = "0.233.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign_interfaces/0.233.2-1.tar.gz";
+    name = "0.233.2-1.tar.gz";
+    sha256 = "d150df575a1846f69dfb53712a099e3c99cea23c039dd576bc9fbe36773e98ea";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Message and service data structures for interacting with Ignition from ROS2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros-ign/default.nix
+++ b/distros/galactic/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ros-ign-bridge, ros-ign-gazebo, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-galactic-ros-ign";
-  version = "0.233.1-r5";
+  version = "0.233.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.1-5.tar.gz";
-    name = "0.233.1-5.tar.gz";
-    sha256 = "ec1b36512b032c9887f59594e708055976f6222ac4fc4d71b2d09459ea062ae8";
+    url = "https://github.com/ros2-gbp/ros_ign-release/archive/release/galactic/ros_ign/0.233.2-1.tar.gz";
+    name = "0.233.2-1.tar.gz";
+    sha256 = "6c9b66374a40bf4cdf6e761fed4802d51205de651ec61d0aaafa05886b1615d0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2bag/default.nix
+++ b/distros/galactic/ros2bag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-testing, launch-testing-ros, pythonPackages, ros2cli, rosbag2-py, rosbag2-transport }:
 buildRosPackage {
   pname = "ros-galactic-ros2bag";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/ros2bag/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e4b56d82794ac62ae5805ef73c2993a5dad9f4d7fe747c60c876907ab5e6291a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/ros2bag/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "ed14a055798affc082d89a29b3c7b25c9eb67ac0d3c730712fdef79c7368439e";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rosbag2-compression-zstd/default.nix
+++ b/distros/galactic/rosbag2-compression-zstd/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rosbag2-compression, rosbag2-test-common, zstd-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-compression-zstd";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_compression_zstd/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "6fbab389053527673746af80a79f6a437363a7a07723658e7064f4208d999861";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_compression_zstd/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "c4a4a6475aa99bfa0251c5bbd303f0b412cc9a5f9695204d2327fe373b46674a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-compression/default.nix
+++ b/distros/galactic/rosbag2-compression/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, rcutils, rosbag2-cpp, rosbag2-storage, rosbag2-test-common }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-compression";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_compression/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "95d7212fa1fd162b707f6df0983e267bb3ff55822b89e1f4344c1134d7cdaea6";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_compression/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "41853ea09c6d159a1a342af90d336a5db91e7ba028d0a7e976f33a5dbe0efa04";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-cpp/default.nix
+++ b/distros/galactic/rosbag2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rcpputils, rcutils, rmw, rmw-implementation, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-cpp, rosidl-typesupport-introspection-cpp, shared-queues-vendor, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-cpp";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_cpp/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "1f2b96eae0140292151f4faf6b956ec739b8e3684557509b7b5f7d0ebfa46380";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_cpp/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "bf2d4dfbb8a0eb031ec0fbbfcdcb87da6ca6e0201065828adf2b69d08b9a1183";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-interfaces/default.nix
+++ b/distros/galactic/rosbag2-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-interfaces";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_interfaces/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "ce14168f6fbcc950362e8d97251d58711e3862e1fcd59a46569830decedc4987";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_interfaces/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "01faeaca9fcef14e3a0083afd8c7d8fded8944e07b062ac4d4cfcb741ed3e1b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-performance-benchmarking/default.nix
+++ b/distros/galactic/rosbag2-performance-benchmarking/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rmw, rosbag2-compression, rosbag2-cpp, rosbag2-storage, std-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-performance-benchmarking";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_performance_benchmarking/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "794613557460e583d58f79cfba43f8ff2e5bf9f8d27f120a0c0e3968b8e0b806";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_performance_benchmarking/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "f0c2a88fcbdd379a38971c9d3dac015aa80390e4cc3ee1d7c8fcc8378f7a48bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-py/default.nix
+++ b/distros/galactic/rosbag2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-python, ament-cmake-ros, ament-lint-auto, ament-lint-common, pybind11-vendor, python-cmake-module, pythonPackages, rcl-interfaces, rclpy, rosbag2-compression, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-transport, rosidl-runtime-py, rpyutils, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-py";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_py/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "3ba1f57e462c851821f42a178dcd86a2f93f2d0f6402ddb8100af5137985a50b";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_py/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "2f007b77b8d7c38bff8f4a90e8624992a2b47238e1392f610ab7c999609666bc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-storage-default-plugins/default.nix
+++ b/distros/galactic/rosbag2-storage-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-storage, rosbag2-test-common, sqlite3-vendor, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-storage-default-plugins";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_storage_default_plugins/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "1fabafdc26ee1ff7d5624b3ccfcf6604dc9a432a6922d15c5f8e67cf2cb9066c";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_storage_default_plugins/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "27099ae95291f3c5290e5fe7ced4554fd780cb0e21ba1e0b2df0a755e9490bd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-storage/default.nix
+++ b/distros/galactic/rosbag2-storage/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, pluginlib, rcpputils, rcutils, rosbag2-test-common, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-storage";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_storage/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e3a5beb54ae29d55f730dcf1380bc50dd6a337a855fd5fe4c351da0deece1bde";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_storage/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "8f6cf0dac17220bbbdf6d6a72bc66146d3944a78e769dea6c6e171869c257769";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-test-common/default.nix
+++ b/distros/galactic/rosbag2-test-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rcutils }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-test-common";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_test_common/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "5b16f1782352d04ea2cdc8ad56b932b4d69276136768c37aa5d541290d624c29";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_test_common/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "51e874be18cacd0b6fd8634382a2dfdd9ac207b24ef04b661e33230b5ae0b616";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-tests/default.nix
+++ b/distros/galactic/rosbag2-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rcpputils, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-tests";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_tests/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "0b7f0396eb6fc0b02b823f1ad8cca18cc708099837495311e978a5716ac9a0d9";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_tests/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "b13864084f13d385d81441fadce6ffa549850400edbc62f825168ea343f257a8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2-transport/default.nix
+++ b/distros/galactic/rosbag2-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, rclcpp, rmw, rmw-implementation-cmake, rosbag2-compression, rosbag2-cpp, rosbag2-interfaces, rosbag2-storage, rosbag2-test-common, shared-queues-vendor, test-msgs, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2-transport";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_transport/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "ce6b19f3c07cae71145571a36e7a3e3cf7cf2555c8199269a134cf245dd2101a";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2_transport/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "7a4d806b918baf5efcbd2c5154f651c403e35b808cb71876612635567a60c5fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosbag2/default.nix
+++ b/distros/galactic/rosbag2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ros2bag, rosbag2-compression, rosbag2-compression-zstd, rosbag2-cpp, rosbag2-py, rosbag2-storage, rosbag2-storage-default-plugins, rosbag2-test-common, rosbag2-tests, rosbag2-transport, shared-queues-vendor, sqlite3-vendor }:
 buildRosPackage {
   pname = "ros-galactic-rosbag2";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "19e5a86021a3278545f8400025291017ec7154cfa3143e26fa9559d9833bc61d";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/rosbag2/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "7769aa273049cfefb80e9b03c0470a86e2583c8f1a3d8aef8b4e0bb901665a5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/run-move-group/default.nix
+++ b/distros/galactic/run-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-galactic-run-move-group";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "762f994116876259c9b776090ba6bf335263285da11a691499a54e80dccd66be";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a3efb1e1b57a30f40e63982e472e691faf653c8c0d54a62c15e2494a76fd679e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/run-moveit-cpp/default.nix
+++ b/distros/galactic/run-moveit-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
 buildRosPackage {
   pname = "ros-galactic-run-moveit-cpp";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "5847ea4ab090a5f2243532941f06622e981824196f580242348ce0c6f5777530";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cb2228caaea30ec8199d0a1efad1107c438f00294f1327900d1e57a2f231e043";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/run-ompl-constrained-planning/default.nix
+++ b/distros/galactic/run-ompl-constrained-planning/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-ompl-constrained-planning";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "dcfb7214f6295e9018619a6e475817cdd4cf37413de50b2e9ad2b9ae8778cc1c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b6f251d9c8dad11feb8677dab6e291f53a257455955f8ab4741b70524b6b8db0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/shared-queues-vendor/default.nix
+++ b/distros/galactic/shared-queues-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-shared-queues-vendor";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/shared_queues_vendor/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "90dc2c7420d8c671080403277fb2c731e172744395127a371ad38ac993f2d8e1";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/shared_queues_vendor/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "60e2698b9a59dd811f9fe4c84a11371b202df1a4c866090c8f1e8817661ccaaa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-vision-msgs/default.nix
+++ b/distros/galactic/soccer-vision-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-soccer-vision-msgs";
-  version = "0.0.1-r1";
+  version = "0.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/galactic/soccer_vision_msgs/0.0.1-1.tar.gz";
-    name = "0.0.1-1.tar.gz";
-    sha256 = "45ecaf07aa73795b72c927bf264a8a628a0319dcedd4955ffc73021b549e05e4";
+    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/galactic/soccer_vision_msgs/0.0.2-1.tar.gz";
+    name = "0.0.2-1.tar.gz";
+    sha256 = "aded059455744e4dec01b420d64aca707f1db55901a85b190c2cb0d318be217b";
   };
 
   buildType = "ament_cmake";
@@ -20,7 +20,7 @@ buildRosPackage {
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {
-    description = ''TODO: Package description'';
+    description = ''Package providing interfaces to be used in a soccer domain.'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/sqlite3-vendor/default.nix
+++ b/distros/galactic/sqlite3-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, sqlite }:
 buildRosPackage {
   pname = "ros-galactic-sqlite3-vendor";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/sqlite3_vendor/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "e4c860aac2ae36fb195643d8a0461eacdf819104339713408263514dfc518052";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/sqlite3_vendor/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "c22e6164716c8eb44383f4fa9040927ede18bf5d9a966bcc6644f17c1a4eb84b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/system-modes-examples/default.nix
+++ b/distros/galactic/system-modes-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-lint-auto, launch, launch-system-modes, rclcpp, rclcpp-lifecycle, ros2launch, system-modes, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-examples";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "ada88f621f2ae43f067d76a68f0250f98458f879c035589136defc701536a119";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_examples/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "ae86cbab4c20fd863025b3648168c9438de1c3d8e2549b6ca6221f77e3f94da4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/system-modes-msgs/default.nix
+++ b/distros/galactic/system-modes-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-system-modes-msgs";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "219aa913637105060717a8be60115acb01422ddf310ef1cdaa84038e99f12320";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes_msgs/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "b5c5facf63578d34743d262b34b5ec6c925bf5b2bfb694f8a58ac547f646f096";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/system-modes/default.nix
+++ b/distros/galactic/system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-pep257, ament-cmake-uncrustify, ament-index-python, ament-lint-auto, builtin-interfaces, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-lifecycle, ros2run, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "2863caf47d437d34ec5adc17cdd8703039c08628fb0e17b57a1f4caa707708eb";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c0f26b88f4d179629df59d588307b0fedb9de70d1965b58ab4ac7953db37e8c0";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/test-launch-system-modes/default.nix
+++ b/distros/galactic/test-launch-system-modes/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-flake8, ament-cmake-pep257, ament-index-python, ament-lint-auto, builtin-interfaces, launch-system-modes, launch-testing-ament-cmake, launch-testing-ros, lifecycle-msgs, rclcpp, rclcpp-lifecycle, system-modes, system-modes-examples, system-modes-msgs }:
 buildRosPackage {
   pname = "ros-galactic-test-launch-system-modes";
-  version = "0.8.0-r1";
+  version = "0.9.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/test_launch_system_modes/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "e11602477c88318215d55fb1ee8e4bbcfd62b83ddc40311d1c6524c16bf87712";
+    url = "https://github.com/ros2-gbp/system_modes-release/archive/release/galactic/test_launch_system_modes/0.9.0-1.tar.gz";
+    name = "0.9.0-1.tar.gz";
+    sha256 = "c617b50142fc21d186c541bd152f32bd05dc637ddd553c2d96e27b7c03054ac9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/theora-image-transport/default.nix
+++ b/distros/galactic/theora-image-transport/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, cv-bridge, image-transport, libogg, libtheora, pluginlib, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-theora-image-transport";
-  version = "2.3.0-r5";
+  version = "2.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/theora_image_transport/2.3.0-5.tar.gz";
-    name = "2.3.0-5.tar.gz";
-    sha256 = "a0deb31f2e95b09e06ea963b3cb6b06ff39df1ea4fe1b3b9b61de71799448360";
+    url = "https://github.com/ros2-gbp/image_transport_plugins-release/archive/release/galactic/theora_image_transport/2.3.1-1.tar.gz";
+    name = "2.3.1-1.tar.gz";
+    sha256 = "f1ff380ed47fa07afc04a90138f5787165056e7da5352b06a7be6ebf7ff91154";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-dgnss-node/default.nix
+++ b/distros/galactic/ublox-dgnss-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, libusb1, rclcpp, rclcpp-components, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ublox-dgnss-node";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss_node/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "03e5a6fb5441e08c467aae38ac8e06636e97e58ab109ba122dc10ca94b2b6630";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-cppcheck ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ libusb1 rclcpp rclcpp-components std-msgs ublox-ubx-interfaces ublox-ubx-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides a ublox_gnss node for a u-blox GPS GNSS receiver using Gen 9 UBX Protocol'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ublox-dgnss/default.nix
+++ b/distros/galactic/ublox-dgnss/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ublox-dgnss-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ublox-dgnss";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "9da16db3d434301072bd352f54bb2bce8df5ffc42cb2e48f494d27f7ddea3e65";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ublox-dgnss-node ublox-ubx-interfaces ublox-ubx-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Provides a ublox_dgnss node for a u-blox GPS DGNSS receiver using Gen 9 UBX Protocol'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ublox-ubx-interfaces/default.nix
+++ b/distros/galactic/ublox-ubx-interfaces/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
+buildRosPackage {
+  pname = "ros-galactic-ublox-ubx-interfaces";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_interfaces/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "fe19666de3d72e3f92446587579f1ffbedc934f72d141cb7634a4527a038af22";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-generators ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''UBLOX UBX Interfaces'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ublox-ubx-msgs/default.nix
+++ b/distros/galactic/ublox-ubx-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-ublox-ubx-msgs";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_msgs/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "2365b8e3b8d8d71469e43f0beb050e557d0c20266f503503ad187a273c97302c";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-generators std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''UBLOX UBX ROS2 Msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/usb-cam/default.nix
+++ b/distros/galactic/usb-cam/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+buildRosPackage {
+  pname = "ros-galactic-usb-cam";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/galactic/usb_cam/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "3d526bb3a8559d357e5a30c58a6dbeff14e43ffd52a552210b0dd70b54d5af45";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
+  nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
+
+  meta = {
+    description = ''A ROS2 Driver for V4L USB Cameras'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/vision-msgs/default.nix
+++ b/distros/galactic/vision-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-vision-msgs";
+  version = "3.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/vision_msgs-release/archive/release/galactic/vision_msgs/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "0d88b18a42337465c8bd4a4967505d7bc868e892011e6a9725d5d32d331997a0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages for interfacing with various computer vision pipelines, such as
+    object detectors.'';
+    license = with lib.licenses; [ asl20 asl20 ];
+  };
+}

--- a/distros/galactic/zstd-vendor/default.nix
+++ b/distros/galactic/zstd-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, zstd }:
 buildRosPackage {
   pname = "ros-galactic-zstd-vendor";
-  version = "0.9.0-r1";
+  version = "0.9.1-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/zstd_vendor/0.9.0-1.tar.gz";
-    name = "0.9.0-1.tar.gz";
-    sha256 = "458b4123b36ab48b26f9f7f34c28aaf973807b8df5a095aad98fd1b02c683db7";
+    url = "https://github.com/ros2-gbp/rosbag2-release/archive/release/galactic/zstd_vendor/0.9.1-3.tar.gz";
+    name = "0.9.1-3.tar.gz";
+    sha256 = "08637d6df6372281da5a340b09e07cdc9c73400530f8748519bff32b70a73428";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-aques-talk";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "a537e5c2bd122d9506710191541a9660a88daa1129f35b974d0fa9bce60a31e4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "44a514bca2a5779849875e31040927929d95f8c70b24752092a983f4cc4e4d88";
   };
 
   buildType = "catkin";

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "afc880a08df6dd79c65228e3950bf1fccd18d0e14c393d2da6b191049ec67188";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "c9f2a223e497f623dba9b3bf0a57d0e537ba8dbeb684dcacbe91cf6078e4146d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "370b4226ab5afc3841f17e1a36cd266910dae6941ff0b6006272d8f03d279732";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "e538b2fede05a71b2a1484d912092f76d877211de2856ad5fb74bb35262fa21f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-chaplus-ros";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "c37f88ea93357f57bf6caeddff4a99565b08d9b95285552c849f7c7e0a0f8917";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "63b92b40839313bd535feaaa8fc4897a0201ac550da2a2e0ca986c5e838d7018";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-control/default.nix
+++ b/distros/melodic/dingo-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, ridgeback-control, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-dingo-control";
-  version = "0.1.8-r1";
+  version = "0.1.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.8-1.tar.gz";
-    name = "0.1.8-1.tar.gz";
-    sha256 = "0a8a8916fa8261163f36a177dc778ed9174a9966dc4ab23d69a97a44bf8760c0";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_control/0.1.9-2.tar.gz";
+    name = "0.1.9-2.tar.gz";
+    sha256 = "8729ac9bb598c995a6a01e228a209c00e166fa08d516202dad6cbc308b982db2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-description/default.nix
+++ b/distros/melodic/dingo-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, robot-state-publisher, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dingo-description";
-  version = "0.1.8-r1";
+  version = "0.1.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.8-1.tar.gz";
-    name = "0.1.8-1.tar.gz";
-    sha256 = "2923afb18b143779f1c2ffdd59b3dbdd31e8bd5c8bc57290bb182a44ebdc3db0";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_description/0.1.9-2.tar.gz";
+    name = "0.1.9-2.tar.gz";
+    sha256 = "476fe53fb38033437fd450852107c6f910cf693bba7b43fefe9e0c28eab3d32a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-msgs/default.nix
+++ b/distros/melodic/dingo-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dingo-msgs";
-  version = "0.1.8-r1";
+  version = "0.1.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.8-1.tar.gz";
-    name = "0.1.8-1.tar.gz";
-    sha256 = "568173a34a38a8529b14142c2fb209679b137c3b5fdd378b07320859aa80523a";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_msgs/0.1.9-2.tar.gz";
+    name = "0.1.9-2.tar.gz";
+    sha256 = "149b26e9f04cae21c9f3e5947a908cada8d0be81e71d76881e2a259429b81155";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dingo-navigation/default.nix
+++ b/distros/melodic/dingo-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-dingo-navigation";
-  version = "0.1.8-r1";
+  version = "0.1.9-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.8-1.tar.gz";
-    name = "0.1.8-1.tar.gz";
-    sha256 = "033992ccc8bede53c74e4343a7f9d0476b785e8e511884c8d79f0e40efc37800";
+    url = "https://github.com/clearpath-gbp/dingo-release/archive/release/melodic/dingo_navigation/0.1.9-2.tar.gz";
+    name = "0.1.9-2.tar.gz";
+    sha256 = "c9c7acc5177110ea5ee6ef69241bb8e2dc42d1131a02de8d4166ac352add1f38";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "a961d1f9b2b9f6af11ea5272feb72e89c58b76f6f73fb1847d13814f07b1661c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "f46fd8cba49ba79dbec02b9ab7cf087970723798d5d906f1bcd7fbfbfdb74d67";
   };
 
   buildType = "catkin";

--- a/distros/melodic/er-public-msgs/default.nix
+++ b/distros/melodic/er-public-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-er-public-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/enabled-robotics/er_public_msgs-release/archive/release/melodic/er_public_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3cf914fbbab8f498ab045542807b3f94f4179c46a469847ef92a9172b9f35f83";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Enabled Robotics public messages package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "21ca5326b82e1c975ac432a9b41892a51a0fa90706fe15fd6cbe590deb8409d6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "0bb3abb6c5d7105e7904ac76487dd0a5b5139496906ee319c25e3ca6bf22457c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "cba733bea85d8ca6709f41e90560571d6caafac0f265a15777399e9a0c101a47";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "ba6aa626677012ae042dd37863eba71088fb9b8b11305a34e530fe5d3c2ea646";
   };
 
   buildType = "catkin";

--- a/distros/melodic/fuse-core/default.nix
+++ b/distros/melodic/fuse-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, eigen, fuse-msgs, pluginlib, rosconsole, roscpp, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-core";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_core/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "c77b8eaf22b5a011e67d962b57a7b59833a909f0fd4388b0438974879bb3f8c6";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ ceres-solver eigen fuse-msgs pluginlib rosconsole roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_core package provides the base class interfaces for the various fuse components. Concrete implementations of these
+    interfaces are provided in other packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-doc/default.nix
+++ b/distros/melodic/fuse-doc/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pythonPackages }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-doc";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_doc/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "57e9290fc5658904228e2729d9ffbb7da66253d78b4c09c615c3bdb17fea7987";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin pythonPackages.catkin-pkg ];
+
+  meta = {
+    description = ''The fuse_doc package provides documentation and examples for the fuse package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-loss/default.nix
+++ b/distros/melodic/fuse-loss/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, fuse-core, libsForQt5, pluginlib, qt5, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-loss";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_loss/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "6978e2c311fb7736a5afe5f373c7d2b178df364f4f9745eb15dd7b25956002f7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ libsForQt5.qwt qt5.qtbase roslint ];
+  propagatedBuildInputs = [ ceres-solver fuse-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_loss package provides a set of commonly used loss functions, such as the basic ones provided by Ceres.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-msgs/default.nix
+++ b/distros/melodic/fuse-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-msgs";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "c9cd309c4090cf1d964e26b231c118cd290263d5d44ac2b19c1e3b850db780c4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_msgs package contains messages capable of holding serialized fuse objects'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-optimizers/default.nix
+++ b/distros/melodic/fuse-optimizers/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-variables, geometry-msgs, nav-msgs, pluginlib, roscpp, roslint, rostest, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-optimizers";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_optimizers/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "19db2d9a282a84189f9ad5ce940c4079f5d6bda5a93864fb128a4f5a41caa459";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ fuse-models geometry-msgs nav-msgs roslint rostest ];
+  propagatedBuildInputs = [ diagnostic-updater fuse-constraints fuse-core fuse-graphs fuse-variables pluginlib roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_optimizers package provides a set of optimizer implementations. An optimizer is the object responsible
+    for coordinating the sensors and motion model inputs, computing the optimal state values, and providing access to
+    to the optimal state via the publishers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-publishers/default.nix
+++ b/distros/melodic/fuse-publishers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fuse-constraints, fuse-core, fuse-graphs, fuse-variables, geometry-msgs, nav-msgs, pluginlib, roscpp, roslint, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-publishers";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_publishers/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "b9be70663b6edafeb4f05cb24ad1ed84cf5298b36a6c3fc1a627ebea77437579";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ fuse-constraints fuse-graphs roslint rostest ];
+  propagatedBuildInputs = [ fuse-core fuse-variables geometry-msgs nav-msgs pluginlib roscpp tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_publishers package provides a set of common publisher plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-variables/default.nix
+++ b/distros/melodic/fuse-variables/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, fuse-core, pluginlib, roscpp, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-variables";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_variables/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "98776b63e33317a449abc8ac1060982454f76d81722f3d8b52c79fbe2f346d4a";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ ceres-solver fuse-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_variables package provides a set of commonly used variable types, such as 2D and 3D positions,
+    orientations, velocities, and accelerations.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse-viz/default.nix
+++ b/distros/melodic/fuse-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, qt5, roslint, rviz, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-fuse-viz";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse_viz/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "344e5b335b0d41ae4b1eef9e3a7e0d26efefdbd1e9db412d9a41106673fa1d23";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ eigen fuse-constraints fuse-core fuse-msgs fuse-variables geometry-msgs rviz tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_viz package provides visualization tools for fuse.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/fuse/default.nix
+++ b/distros/melodic/fuse/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz }:
+buildRosPackage {
+  pname = "ros-melodic-fuse";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/melodic/fuse/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "1b4c234605c45fb56e982e84cf9bf59947af23db2659eb7c038a94b5c3062d4a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fuse-constraints fuse-core fuse-doc fuse-graphs fuse-models fuse-msgs fuse-optimizers fuse-publishers fuse-variables fuse-viz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -200,8 +200,6 @@ self: super: {
 
  behaviortree-cpp-v3 = self.callPackage ./behaviortree-cpp-v3 {};
 
- bev-mavros = self.callPackage ./bev-mavros {};
-
  bfl = self.callPackage ./bfl {};
 
  blender-gazebo = self.callPackage ./blender-gazebo {};
@@ -534,8 +532,6 @@ self: super: {
 
  codec-image-transport = self.callPackage ./codec-image-transport {};
 
- collision-avoidance = self.callPackage ./collision-avoidance {};
-
  color-util = self.callPackage ./color-util {};
 
  combined-robot-hw = self.callPackage ./combined-robot-hw {};
@@ -559,8 +555,6 @@ self: super: {
  concert-workflow-engine-msgs = self.callPackage ./concert-workflow-engine-msgs {};
 
  contact-states-observer = self.callPackage ./contact-states-observer {};
-
- control-bringup = self.callPackage ./control-bringup {};
 
  control-msgs = self.callPackage ./control-msgs {};
 
@@ -936,6 +930,8 @@ self: super: {
 
  eml = self.callPackage ./eml {};
 
+ er-public-msgs = self.callPackage ./er-public-msgs {};
+
  ethercat-grant = self.callPackage ./ethercat-grant {};
 
  ethercat-hardware = self.callPackage ./ethercat-hardware {};
@@ -1164,6 +1160,24 @@ self: super: {
 
  fsrobo-r-trajectory-filters = self.callPackage ./fsrobo-r-trajectory-filters {};
 
+ fuse = self.callPackage ./fuse {};
+
+ fuse-core = self.callPackage ./fuse-core {};
+
+ fuse-doc = self.callPackage ./fuse-doc {};
+
+ fuse-loss = self.callPackage ./fuse-loss {};
+
+ fuse-msgs = self.callPackage ./fuse-msgs {};
+
+ fuse-optimizers = self.callPackage ./fuse-optimizers {};
+
+ fuse-publishers = self.callPackage ./fuse-publishers {};
+
+ fuse-variables = self.callPackage ./fuse-variables {};
+
+ fuse-viz = self.callPackage ./fuse-viz {};
+
  gateway-msgs = self.callPackage ./gateway-msgs {};
 
  gazebo-dev = self.callPackage ./gazebo-dev {};
@@ -1183,8 +1197,6 @@ self: super: {
  gazebo-video-monitor-plugins = self.callPackage ./gazebo-video-monitor-plugins {};
 
  gazebo-video-monitors = self.callPackage ./gazebo-video-monitors {};
-
- gcs-interface = self.callPackage ./gcs-interface {};
 
  gencpp = self.callPackage ./gencpp {};
 
@@ -1220,8 +1232,6 @@ self: super: {
 
  geos-cmake-module = self.callPackage ./geos-cmake-module {};
 
- gimbal = self.callPackage ./gimbal {};
-
  gl-dependency = self.callPackage ./gl-dependency {};
 
  global-planner = self.callPackage ./global-planner {};
@@ -1229,8 +1239,6 @@ self: super: {
  global-planner-tests = self.callPackage ./global-planner-tests {};
 
  gmapping = self.callPackage ./gmapping {};
-
- gnss-utils = self.callPackage ./gnss-utils {};
 
  goal-passer = self.callPackage ./goal-passer {};
 
@@ -1241,8 +1249,6 @@ self: super: {
  gps-umd = self.callPackage ./gps-umd {};
 
  gpsd-client = self.callPackage ./gpsd-client {};
-
- gpu-voxels-ros = self.callPackage ./gpu-voxels-ros {};
 
  graceful-controller = self.callPackage ./graceful-controller {};
 
@@ -1367,6 +1373,20 @@ self: super: {
  heifu = self.callPackage ./heifu {};
 
  heifu-bringup = self.callPackage ./heifu-bringup {};
+
+ heifu-description = self.callPackage ./heifu-description {};
+
+ heifu-diagnostic = self.callPackage ./heifu-diagnostic {};
+
+ heifu-mavros = self.callPackage ./heifu-mavros {};
+
+ heifu-msgs = self.callPackage ./heifu-msgs {};
+
+ heifu-safety = self.callPackage ./heifu-safety {};
+
+ heifu-simple-waypoint = self.callPackage ./heifu-simple-waypoint {};
+
+ heifu-tools = self.callPackage ./heifu-tools {};
 
  heron-control = self.callPackage ./heron-control {};
 
@@ -1990,8 +2010,6 @@ self: super: {
 
  mavros = self.callPackage ./mavros {};
 
- mavros-commands = self.callPackage ./mavros-commands {};
-
  mavros-extras = self.callPackage ./mavros-extras {};
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
@@ -2370,8 +2388,6 @@ self: super: {
 
  navigation = self.callPackage ./navigation {};
 
- navigation-controller = self.callPackage ./navigation-controller {};
-
  navigation-experimental = self.callPackage ./navigation-experimental {};
 
  navigation-layers = self.callPackage ./navigation-layers {};
@@ -2712,13 +2728,9 @@ self: super: {
 
  pinocchio = self.callPackage ./pinocchio {};
 
- planner = self.callPackage ./planner {};
-
  planner-cspace = self.callPackage ./planner-cspace {};
 
  planner-cspace-msgs = self.callPackage ./planner-cspace-msgs {};
-
- planners-manager = self.callPackage ./planners-manager {};
 
  play-motion = self.callPackage ./play-motion {};
 
@@ -2926,8 +2938,6 @@ self: super: {
 
  prbt-support = self.callPackage ./prbt-support {};
 
- priority-manager = self.callPackage ./priority-manager {};
-
  prosilica-camera = self.callPackage ./prosilica-camera {};
 
  prosilica-gige-sdk = self.callPackage ./prosilica-gige-sdk {};
@@ -3025,6 +3035,8 @@ self: super: {
  qt-tutorials = self.callPackage ./qt-tutorials {};
 
  quanergy-client = self.callPackage ./quanergy-client {};
+
+ quanergy-client-ros = self.callPackage ./quanergy-client-ros {};
 
  quaternion-operation = self.callPackage ./quaternion-operation {};
 
@@ -3648,8 +3660,6 @@ self: super: {
 
  rr-rover-zero-driver = self.callPackage ./rr-rover-zero-driver {};
 
- rrt = self.callPackage ./rrt {};
-
  rslidar = self.callPackage ./rslidar {};
 
  rslidar-driver = self.callPackage ./rslidar-driver {};
@@ -3878,17 +3888,19 @@ self: super: {
 
  statistics-msgs = self.callPackage ./statistics-msgs {};
 
- status-diagnostic = self.callPackage ./status-diagnostic {};
-
  std-capabilities = self.callPackage ./std-capabilities {};
 
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
 
+ steering-functions = self.callPackage ./steering-functions {};
+
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
+
+ switchbot-ros = self.callPackage ./switchbot-ros {};
 
  swri-console = self.callPackage ./swri-console {};
 
@@ -4137,8 +4149,6 @@ self: super: {
  twist-mux-msgs = self.callPackage ./twist-mux-msgs {};
 
  twist-recovery = self.callPackage ./twist-recovery {};
-
- uav-msgs = self.callPackage ./uav-msgs {};
 
  ubiquity-motor = self.callPackage ./ubiquity-motor {};
 
@@ -4393,8 +4403,6 @@ self: super: {
  wave-gazebo = self.callPackage ./wave-gazebo {};
 
  wave-gazebo-plugins = self.callPackage ./wave-gazebo-plugins {};
-
- waypoints-manager = self.callPackage ./waypoints-manager {};
 
  web-video-server = self.callPackage ./web-video-server {};
 

--- a/distros/melodic/heifu-bringup/default.nix
+++ b/distros/melodic/heifu-bringup/default.nix
@@ -2,23 +2,23 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-bringup, gcs-interface, waypoints-manager }:
+{ lib, buildRosPackage, fetchurl, catkin, heifu-description, heifu-mavros, heifu-msgs, heifu-safety, heifu-tools }:
 buildRosPackage {
   pname = "ros-melodic-heifu-bringup";
-  version = "0.8.1-r1";
+  version = "0.7.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu-bringup/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "280568e8c2f0b548046ff3b0d4a51bc3208704665a62d3697ad4830b0409cac3";
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu_bringup/0.7.7-2.tar.gz";
+    name = "0.7.7-2.tar.gz";
+    sha256 = "6798c1d532a30c3c156470eaeb00c13c680f33de1ebe5af1dc7a0b8daeff3c2b";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ control-bringup gcs-interface waypoints-manager ];
+  propagatedBuildInputs = [ heifu-description heifu-mavros heifu-msgs heifu-safety heifu-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The heifu-bringup package'';
+    description = ''Heifu is a ROS driver for PDMFC and BEV drone'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/heifu/default.nix
+++ b/distros/melodic/heifu/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, collision-avoidance, control-bringup, gcs-interface, gimbal, gnss-utils, gpu-voxels-ros, heifu-bringup, libmavconn, mavros, mavros-commands, mavros-extras, mavros-msgs, navigation-controller, planner, planners-manager, priority-manager, rrt, status-diagnostic, test-mavros, uav-msgs, waypoints-manager }:
+{ lib, buildRosPackage, fetchurl, catkin, heifu-bringup, heifu-description, heifu-mavros, heifu-msgs, heifu-safety, heifu-simple-waypoint, heifu-tools }:
 buildRosPackage {
   pname = "ros-melodic-heifu";
-  version = "0.8.1-r1";
+  version = "0.7.7-r2";
 
   src = fetchurl {
-    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu/0.8.1-1.tar.gz";
-    name = "0.8.1-1.tar.gz";
-    sha256 = "9d924036981d7bc4aec3b2205d86dddcf7e7c4b9dd48696841acb679945aec60";
+    url = "https://github.com/BV-OpenSource/heifu-release/archive/release/melodic/heifu/0.7.7-2.tar.gz";
+    name = "0.7.7-2.tar.gz";
+    sha256 = "8436cf31ff37312589400f124aeaeed1aacb9093847ea92546287d8e1147c909";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ collision-avoidance control-bringup gcs-interface gimbal gnss-utils gpu-voxels-ros heifu-bringup libmavconn mavros mavros-commands mavros-extras mavros-msgs navigation-controller planner planners-manager priority-manager rrt status-diagnostic test-mavros uav-msgs waypoints-manager ];
+  propagatedBuildInputs = [ heifu-bringup heifu-description heifu-mavros heifu-msgs heifu-safety heifu-simple-waypoint heifu-tools ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/husky-base/default.nix
+++ b/distros/melodic/husky-base/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-aggregator, diagnostic-msgs, diagnostic-updater, diff-drive-controller, geometry-msgs, hardware-interface, husky-control, husky-description, husky-msgs, roscpp, roslaunch, roslint, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-husky-base";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "27a800321014707c3ba056d8071b451eeeb62e166ec5c9180e4caedd7cfeb5ce";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_base/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "dc77e8ea9b79913b0d79f4640e0b1833e72be611f2f759796ac425c16ca31904";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-bringup/default.nix
+++ b/distros/melodic/husky-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-control, husky-description, imu-filter-madgwick, imu-transformer, lms1xx, microstrain-3dmgx2-imu, microstrain-mips, nmea-comms, nmea-navsat-driver, pythonPackages, realsense2-camera, robot-localization, robot-upstart, roslaunch, tf, tf2-ros, um6, um7, velodyne-pointcloud }:
 buildRosPackage {
   pname = "ros-melodic-husky-bringup";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "3711bc5572b8d7c9f007973a55120682e24326359e43fba62824d1b0f756a2b8";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_bringup/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "46bad79d296bc55882200607ea60f6e9b7f025a9826a394314a6f72ba72d0b55";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-control/default.nix
+++ b/distros/melodic/husky-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, multimaster-launch, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-husky-control";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "ea1e85ad9be394c1e98c62b4ca0199866568e9a1bf7efefa1aa62df3a402b3f1";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_control/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "c5c5813986a35fb0068e2e450ef1c30f2d95839933a992f9913d855c5e12020b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-description/default.nix
+++ b/distros/melodic/husky-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-husky-description";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "7f98a40d620a10e68c17008954a7b058986fc4528c61825b4b61e6c62af1d0cd";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_description/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "ed1b31abad1d0184c6b4ebeef0a4c4130d5190e4113d8b2743f9ba889f160251";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-desktop/default.nix
+++ b/distros/melodic/husky-desktop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
 buildRosPackage {
   pname = "ros-melodic-husky-desktop";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "ab402fa3c2ea108e9edbb1e079726d4baeea18903c7c3ab485f08335b8b073b7";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_desktop/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "3805d7f4f820955e23429335d4ddfe6fd4e565d277f8c4aa4c011d04022bb0e1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-gazebo/default.nix
+++ b/distros/melodic/husky-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, multimaster-launch, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
 buildRosPackage {
   pname = "ros-melodic-husky-gazebo";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "92b98dd7bdce139683bf6e2983554419bff54c57b4d3ec4f3effeb2be0105a1b";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_gazebo/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "42b5cd143ee7d44aab60c380172a3e2f635ae0687af64bd28613ef54f7606194";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-msgs/default.nix
+++ b/distros/melodic/husky-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-husky-msgs";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "54242466b9d297d728b21ace8770719e5043e4895f63a54d73c1eef1c328bfdd";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_msgs/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "c32e1a1b78bb2bfce1bd122c01669fcf09dcc43d005885266aad4345acd9f240";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-navigation/default.nix
+++ b/distros/melodic/husky-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
 buildRosPackage {
   pname = "ros-melodic-husky-navigation";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "7bba4afef96c0588624e695e70cfe849a712352f5bee88bad56c8dde20d6e12a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_navigation/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "02427a982d0723d543215e63a7998533cf3360f0a6c9f092da64554fb9bfcd0a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-robot/default.nix
+++ b/distros/melodic/husky-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-base, husky-bringup }:
 buildRosPackage {
   pname = "ros-melodic-husky-robot";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "63dd260f50a32ae88bde89cd67830aa913a333b445b0650d8eb0b70269050928";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_robot/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "ca4b293cdcc7046b3e8914f663d525a65a98af8b5bcf1dc0115d0b6d8b5a667a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-simulator/default.nix
+++ b/distros/melodic/husky-simulator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
 buildRosPackage {
   pname = "ros-melodic-husky-simulator";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "34f4590997ab7a51c29e2f09dcaa27a08799eec6e0df288f45346277cadbbc1a";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_simulator/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "b38959be7e5874e7dc7b699e231b1781252d551303fea791f8faf83cb66890b7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/husky-viz/default.nix
+++ b/distros/melodic/husky-viz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
 buildRosPackage {
   pname = "ros-melodic-husky-viz";
-  version = "0.4.9-r1";
+  version = "0.4.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.9-1.tar.gz";
-    name = "0.4.9-1.tar.gz";
-    sha256 = "715e1619570f076cda9aee2feb315ea89eee38918b3a6fd0fe9cc5b9dc0fe19f";
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/melodic/husky_viz/0.4.10-1.tar.gz";
+    name = "0.4.10-1.tar.gz";
+    sha256 = "2d6cef1ceed85bb50de7f008fdacf8785b04a8609f9c53d721fba4c5873fe9f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "9c642d9a09b6a715c5196f0e33705cd24a4c9c871beca6ecb9fcade14e2e3045";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "9e30cadcad73a39729b96fc7bc702fee43d71cc20317b0e4d92cbf5d58a119ec";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "768484a6fb6f87871c0be6797b6221ed34a03b1551afb802293f506fdbfe3edf";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "2fcd30f53b30cef383f0758b1d8c96db2b8e26bdba15788708e81b5c449b26ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "dc08cfbdf9bf1f20caea56319ab430d01d89e5392500162d7cd23fca3e812952";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "3cf501c738d0f9b33bd7c744277110bcf206eeaf5116f57794ecfa339e3b9e2b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "cc76816ecda61789ec304e12571067c01ce409597f12b07d0e48fa25c83b836d";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "09a22aad9574fe03bd81b4352a87aff8a0629043367dd957ce6c9d1a0d804a7b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.5-r1";
+  version = "0.7.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.5-1.tar.gz";
-    name = "0.7.5-1.tar.gz";
-    sha256 = "ff1b92b42798a58eb68710c93ecb9bfcd8fda8ecad3304cbe3c43b19a5abcaa9";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.6-1.tar.gz";
+    name = "0.7.6-1.tar.gz";
+    sha256 = "f3b43616ea52bf0b0e8bd0c1ac11269b06f6e7779f356143bfaf5acdad5514ad";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "e9462eb12a7dc81c6a47e9dca701ab7aee844b6c5d74d0ae28adfafd3e029af2";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "ade47b4f901130802a6ef28ac05b243edbf2a3d7e4fc484687d916eaca0cef16";
   };
 
   buildType = "catkin";

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "645cbcb2d731344c20ab293169104e821495c49eb8b0ffdecc0844c0f2603c34";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "daac96404772a43ebf280700478b94a28fc6cd19ce0a61e2d2ffac7da36adfbf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters-jsk-patch/default.nix
+++ b/distros/melodic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters-jsk-patch";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "5fb7cc733051f087d74e9345de022ecbacdc5d7ce500cfe084d2b79614c7e533";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "7f4583a260f42817fe55cd2bb350d4b3c95045a7a1b89f05f54ca56f159e3aa1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "6b51e5fbe7ae691b329f8ff19de65617a9d694ebf06011832d043c8a2101290c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "1562ae8d15a3bfea334c3425bc626435a30091fbc6236763533a5de8bef517d4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "9a6b98bf3366af7e8fcd205dc09ec3976243037f5c4eeccbe5045740aaa76421";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "10a93f313edcba25f77830470cb771c60d9777a10ac9952d26659f4187a30346";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "b0c9074c493b4ce9237e2668b87ed95a8a9389537a8fe3bafd1bf7d98afe329e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "0a03508ba0e0e77d6258e0350ca3aefb60e737e7204aad5a643efcf6a5d277be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "e3fff426221703d58aca43e821fade1f92dda4fb60472c77aed6b966827a6b9c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "60259edb460635615e74bf90f754856e96f8e666d2d0d7b3d01de983364b9cbe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "a952ba2d8e901984ee14bfb07058fab067bc6a277ac8d7c08b4a66a3f9930cd6";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "cc6fed393b73f40891a72caf215da19a50c48c4545c53e27d3f6882f3e59b8e4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "5f89bc3505223a68f915e106d6cf319cb5deabeae6d1cc403b6de5a5a4645402";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "ad1c05c658939b82195e49003be1ab09c90d0d9e9bcbaaffb65875035de24fbd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-control/default.nix
+++ b/distros/melodic/pilz-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, controller-interface, controller-manager, geometry-msgs, joint-trajectory-controller, moveit-core, moveit-ros-planning, pilz-msgs, pilz-testutils, pilz-utils, roscpp, roslint, rostest, rosunit, std-srvs, tf2, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-control";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "b4acd60ba92e7f02256597e3a24f113fecf107f7b3163b35cd94162a10c6ec1e";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_control/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "f686fe3565c832940c04e14e35771028368963b4a88857ebeefc524b6d7f1b09";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-extensions/default.nix
+++ b/distros/melodic/pilz-extensions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, joint-limits-interface, roscpp, rostest }:
 buildRosPackage {
   pname = "ros-melodic-pilz-extensions";
-  version = "0.4.12-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_extensions/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "dcb194f8272aebfcd2dd22e55a04984790b1f5e33bfab667a8f1c7215f70f9c2";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_extensions/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "0c750d40f8d7e22e93f8fa7c4376001989b441e5cf55fa0bc173c011697787f0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-industrial-motion/default.nix
+++ b/distros/melodic/pilz-industrial-motion/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-extensions, pilz-robot-programming, pilz-trajectory-generation }:
 buildRosPackage {
   pname = "ros-melodic-pilz-industrial-motion";
-  version = "0.4.12-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "601db0a28cf0e8b77acc2652c08c010cb78bde4becb004e4f3d4711f2bf331e4";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_industrial_motion/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "d934fc24dca066e31c7c49f2d59c4ee22d52e38b4afb0b10fedaca0418c3ee63";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-robot-programming/default.nix
+++ b/distros/melodic/pilz-robot-programming/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, code-coverage, moveit-commander, pilz-industrial-motion-testutils, pilz-msgs, pilz-trajectory-generation, prbt-hardware-support, prbt-moveit-config, prbt-pg70-support, pythonPackages, roslint, rospy, rostest, rosunit, tf-conversions, tf2-geometry-msgs, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, catkin, code-coverage, moveit-commander, pilz-industrial-motion-planner, pilz-industrial-motion-testutils, pilz-msgs, prbt-hardware-support, prbt-moveit-config, prbt-pg70-support, pythonPackages, roslint, rospy, rostest, rosunit, tf-conversions, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robot-programming";
-  version = "0.4.12-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_robot_programming/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "1062a86b989d434525385cab9278543a3144929d2320beae795f546494e2f086";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_robot_programming/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "746fc5780070faca34e79c98fcf856245f241f32748529f7a7eda3474549b18c";
   };
 
   buildType = "catkin";
   buildInputs = [ roslint ];
   checkInputs = [ code-coverage pilz-industrial-motion-testutils prbt-hardware-support prbt-moveit-config prbt-pg70-support pythonPackages.coverage pythonPackages.docopt pythonPackages.mock rostest rosunit ];
-  propagatedBuildInputs = [ moveit-commander pilz-msgs pilz-trajectory-generation pythonPackages.psutil rospy tf-conversions tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ moveit-commander pilz-industrial-motion-planner pilz-msgs pythonPackages.psutil rospy tf-conversions tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/pilz-robots/default.nix
+++ b/distros/melodic/pilz-robots/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-control, pilz-status-indicator-rqt, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-moveit-config, prbt-support }:
 buildRosPackage {
   pname = "ros-melodic-pilz-robots";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "f11816e0e36ce2e491e5a10e0e73fe3cb0ff96a04fe9ecd78911e249e551f590";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_robots/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "ab98a25dedb5a104fecaaf4ed3631f09764186a5e1c5da9e87f32b8a7fb73e5a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-status-indicator-rqt/default.nix
+++ b/distros/melodic/pilz-status-indicator-rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pilz-msgs, pythonPackages, rospy, rostest, rosunit, rqt-gui, rqt-gui-py, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-status-indicator-rqt";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "633935da676a42a110587f86080532a57089df1be0dacfbfd2a406d5702c96a2";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/pilz_status_indicator_rqt/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "6665eb85e1a85d1e33bf9f3611435a209a21cc418c96d5fcae88c4faeb58970a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-store-positions/default.nix
+++ b/distros/melodic/pilz-store-positions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, geometry-msgs, libyaml, pythonPackages, ros-pytest, roslint, rospy, rostest, std-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-store-positions";
-  version = "0.4.12-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_store_positions/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "8bf6b8c834bf6cca1b16bf3d2c9b4dbe7c1df801f3bcdcf646dc04eb0bff12c3";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_store_positions/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "e5b3f77c5955899145e6fd06dc5ba7fab918b651d543aeb27e7b90e4987293f8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pilz-trajectory-generation/default.nix
+++ b/distros/melodic/pilz-trajectory-generation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, code-coverage, eigen-conversions, kdl-conversions, moveit-core, moveit-msgs, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, orocos-kdl, pilz-extensions, pilz-industrial-motion-testutils, pilz-msgs, pilz-testutils, pluginlib, prbt-moveit-config, prbt-pg70-support, prbt-support, roscpp, rostest, rosunit, tf2, tf2-eigen, tf2-geometry-msgs }:
 buildRosPackage {
   pname = "ros-melodic-pilz-trajectory-generation";
-  version = "0.4.12-r1";
+  version = "0.4.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_trajectory_generation/0.4.12-1.tar.gz";
-    name = "0.4.12-1.tar.gz";
-    sha256 = "8217cdbc41e2624c351a48c380a574ff6ba026a818713053ccf557f1b911faa4";
+    url = "https://github.com/PilzDE/pilz_industrial_motion-release/archive/release/melodic/pilz_trajectory_generation/0.4.14-1.tar.gz";
+    name = "0.4.14-1.tar.gz";
+    sha256 = "55c630f7cee97d09abb77f22ef40b4aebdebcccf56fa6bcc93363bbc9bfc4c97";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-gazebo/default.nix
+++ b/distros/melodic/prbt-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, gazebo-ros, gazebo-ros-control, prbt-moveit-config, prbt-support, roscpp, roslaunch, rostest, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-gazebo";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "4c5c287328b685b4ec776b56838b18f48f1080113d974a5d842fdf772a487bd8";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_gazebo/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "fd6264498b55c274405e379cb95641be0598b418512a6311012e69d5060b02a2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-hardware-support/default.nix
+++ b/distros/melodic/prbt-hardware-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, catkin, cmake-modules, code-coverage, dynamic-reconfigure, libmodbus, message-filters, message-generation, message-runtime, pilz-msgs, pilz-testutils, pilz-utils, roscpp, rosservice, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-melodic-prbt-hardware-support";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "e8ca0b6497b3a97cd45ac3fa8a8d0a774b78ff73c999a7686d132a7d1a297448";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_hardware_support/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "cae651e8cca5fb59f8a85526191d845a1096a967859de5e70847eedf4892bef4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
+++ b/distros/melodic/prbt-ikfast-manipulator-plugin/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, pluginlib, roscpp, tf2-eigen, tf2-kdl }:
 buildRosPackage {
   pname = "ros-melodic-prbt-ikfast-manipulator-plugin";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "ecc5584dcdd97f1359cf783c846da4c7a9a54d8628b1a51966ef49f88f5f289b";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_ikfast_manipulator_plugin/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "aab1ab20938b11048170850f082682fef0fd4fb6e7895712a9875080cbbb7bb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-moveit-config/default.nix
+++ b/distros/melodic/prbt-moveit-config/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, joint-state-publisher, moveit-core, moveit-fake-controller-manager, moveit-kinematics, moveit-planners-ompl, moveit-ros-move-group, moveit-ros-planning, moveit-ros-visualization, moveit-simple-controller-manager, pluginlib, prbt-hardware-support, prbt-ikfast-manipulator-plugin, prbt-support, robot-state-publisher, roscpp, roslaunch, rostest, rosunit, rviz, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-moveit-config";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "8f5c72376e73c65209791789aa74baec4186b4f5f90129d701c2f16d350c8af8";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_moveit_config/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "ac90dce368fc651dfcd6ae85eeddbba21c982e95ae556d85602d8322069d22ea";
   };
 
   buildType = "catkin";

--- a/distros/melodic/prbt-support/default.nix
+++ b/distros/melodic/prbt-support/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, canopen-chain-node, canopen-motor-node, catkin, cmake-modules, code-coverage, controller-manager, eigen, joint-state-controller, joint-state-publisher, moveit-core, moveit-ros-planning, pilz-control, pilz-status-indicator-rqt, pilz-testutils, pilz-utils, prbt-hardware-support, robot-state-publisher, roscpp, roslaunch, roslint, rosservice, rostest, rosunit, rviz, sensor-msgs, topic-tools, xacro }:
 buildRosPackage {
   pname = "ros-melodic-prbt-support";
-  version = "0.5.22-r1";
+  version = "0.5.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.22-1.tar.gz";
-    name = "0.5.22-1.tar.gz";
-    sha256 = "0375123ea08ac4a8e1dc528f9e71c64c48c091c1d25e5921e3c86a9911075477";
+    url = "https://github.com/PilzDE/pilz_robots-release/archive/release/melodic/prbt_support/0.5.23-1.tar.gz";
+    name = "0.5.23-1.tar.gz";
+    sha256 = "ab99d8c017856a4e336cf0ee323f428b148400317422ae3c1ec3e33cd4156a5c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/psen-scan-v2/default.nix
+++ b/distros/melodic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-psen-scan-v2";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "3e6f6dbac65d6f4dfc73586ae9b5d2ff6678a3dbabac789bcf51209f54ac99f8";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/melodic/psen_scan_v2/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "666e966bcf43a1aa041fa5f8c91c97c7144e3eebf8ddc6376bc34fc61156fae0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/quanergy-client-ros/default.nix
+++ b/distros/melodic/quanergy-client-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl-ros, quanergy-client, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-quanergy-client-ros";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/melodic/quanergy_client_ros/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "95707f54940cf7aad18f6fe8d4d49c869486715393d6608b0b44beaa3ba60bcb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pcl-ros quanergy-client roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The quanergy_client_ros package provides a ROS driver for Quanergy sensors'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "76924e3f260093adae48bffbe2b49222ca2c00707bfb33483285a0c2c22cb4a1";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "5e01ad253087b8dab1501f343d49c26e26797a75ae2f748592331032935534f0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "4dcc5cac04ce4650df0d01835a074f4211f217b8532be1b4fd9ed5e28512afc9";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "f70fded13077a3232c6b01219c538151b3ec329c49071c8434ef23d2d4ee823d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "2af99e9bce75677ce360cf070170595c53cac6a59d20fe8c84dc57dd3a5cff68";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "54c6a98ad8fd96458951922cad11a0479c9d2896aa446eeeed3d105ea124a97e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "2f989a35ecf0d095454620fefa76fe0802d71806cdd834011595436a1c5c42a7";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "565be41ab0971e1307cd57d5852aab77d4e2af710931e325b83026528ad4968c";
   };
 
   buildType = "cmake";

--- a/distros/melodic/steering-functions/default.nix
+++ b/distros/melodic/steering-functions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, eigen, geometry-msgs, nav-msgs, roscpp, roslib, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-steering-functions";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/steering_functions-release/archive/release/melodic/steering_functions/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "800bb9121a562af00f81e20262a34e5263d9f28e99bd91bd6af68a1203341d09";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ costmap-2d eigen geometry-msgs nav-msgs roscpp roslib tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The steering_functions package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/switchbot-ros/default.nix
+++ b/distros/melodic/switchbot-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-runtime, pythonPackages, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-switchbot-ros";
+  version = "2.1.23-r1";
+
+  src = fetchurl {
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "1a8c29d7ac6f11009a88d3110b30613fcbdc80aab88b4b8aa57db63e4bf5b0ef";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime pythonPackages.requests rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''use switchbot with ros'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/udp-com/default.nix
+++ b/distros/melodic/udp-com/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nodelet, roscpp, roslint, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-udp-com";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/udp_com-release/archive/release/melodic/udp_com/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "8f844c3da576c2b248db9f6e4cc2ef8b17e4a5014492be84a5378998827ac6ec";
+    url = "https://github.com/flynneva/udp_com-release/archive/release/melodic/udp_com/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "2a27e17103618c78691b9d353174c16fb4565148e8be0825fc629dc55ebbb068";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The udp_com package'';
+    description = ''Generic UDP communication ROS package'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/melodic/view-controller-msgs/default.nix
+++ b/distros/melodic/view-controller-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-view-controller-msgs";
-  version = "0.1.3";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/melodic/view_controller_msgs/0.1.3-0.tar.gz";
-    name = "0.1.3-0.tar.gz";
-    sha256 = "9ee90391a7604f99bcc5ee9ef5f0dd0d7585247c3fd1c59f871eeee5f8cb739f";
+    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/melodic/view_controller_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "cec91dd973a711c951445740ee4d743fb4907de310411e62bbd9796d3fcf54fe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.22-r1";
+  version = "2.1.23-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.22-1.tar.gz";
-    name = "2.1.22-1.tar.gz";
-    sha256 = "eed24d2b0ae5c11193df2589df08da92ed66e159030ed07fb6f63ebcde03ca5d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.23-1.tar.gz";
+    name = "2.1.23-1.tar.gz";
+    sha256 = "84f279188041134b65566a09eb9720eb944003f0360995f4e94c6b4d56383d4b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-control/default.nix
+++ b/distros/melodic/warthog-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-warthog-control";
-  version = "0.1.3-r1";
+  version = "0.1.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "5d0aa4fa339942dbed6eb901307332befc8ce052f1d01eef3c74439b7622dad6";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_control/0.1.4-2.tar.gz";
+    name = "0.1.4-2.tar.gz";
+    sha256 = "e15ff240c247e0733b5f319f25e7847d83c99d7807143b26261c1bc3a1af69fc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-description/default.nix
+++ b/distros/melodic/warthog-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-warthog-description";
-  version = "0.1.3-r1";
+  version = "0.1.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "7fb3fe0903dfeed8112c5c68854e6952136d1588d495a85d902d92a46f3e82af";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_description/0.1.4-2.tar.gz";
+    name = "0.1.4-2.tar.gz";
+    sha256 = "980542ca1871b6455b04b5b65038126f5c8441a9415fe2432852f8391b96b3df";
   };
 
   buildType = "catkin";

--- a/distros/melodic/warthog-msgs/default.nix
+++ b/distros/melodic/warthog-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-warthog-msgs";
-  version = "0.1.3-r1";
+  version = "0.1.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "bf3be025e0b3929028832d7220b11ecc76957a37db0dd553909ca706f8bf8896";
+    url = "https://github.com/clearpath-gbp/warthog-release/archive/release/melodic/warthog_msgs/0.1.4-2.tar.gz";
+    name = "0.1.4-2.tar.gz";
+    sha256 = "3df0ba916742d200c6f69b1abd42bf3d5f258783b25df029bb6aba3a41b7f76f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/webots-ros/default.nix
+++ b/distros/melodic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-webots-ros";
-  version = "4.0.1-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "30d11297e55c1a268ce53d9cc3fcec78cffb57d0846a5105c1736e2fdf1af650";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/melodic/webots_ros/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "4c1930c9dfedcadd5d279e06072d97e04e61dea98e6dc49122923aa41d5b726e";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.11-r1";
+  version = "1.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.11-1.tar.gz";
-    name = "1.13.11-1.tar.gz";
-    sha256 = "8a429e9085339ad44d05b10729d51efc5393f28e357d5362c26f689264331cba";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.12-1.tar.gz";
+    name = "1.13.12-1.tar.gz";
+    sha256 = "8b727673a70f77dbdc4ac44544c2e39724cd37b49246998a7e954fa790817ab5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/fuse-core/default.nix
+++ b/distros/noetic/fuse-core/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, eigen, fuse-msgs, pluginlib, rosconsole, roscpp, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-core";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_core/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "e3028de21273ab389dbb85c93b28c01ab7a24009d44ea407bb30b2b9ea04d36f";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ ceres-solver eigen fuse-msgs pluginlib rosconsole roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_core package provides the base class interfaces for the various fuse components. Concrete implementations of these
+    interfaces are provided in other packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-doc/default.nix
+++ b/distros/noetic/fuse-doc/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-doc";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_doc/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "f4bffab22c2f7c9098058c2edf9b44482885aa8dced53a4e6c625dc8107eb699";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin python3Packages.catkin-pkg ];
+
+  meta = {
+    description = ''The fuse_doc package provides documentation and examples for the fuse package.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-loss/default.nix
+++ b/distros/noetic/fuse-loss/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, fuse-core, libsForQt5, pluginlib, qt5, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-loss";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_loss/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "ad517f3b405c32d529e1c487d3ee77cf556386ac519de01a929b792ff227375c";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ libsForQt5.qwt qt5.qtbase roslint ];
+  propagatedBuildInputs = [ ceres-solver fuse-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_loss package provides a set of commonly used loss functions, such as the basic ones provided by Ceres.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-msgs/default.nix
+++ b/distros/noetic/fuse-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-msgs";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_msgs/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "0b575230410d4bc65a862f7b7d99aa324a5f9d1e7d804ab5ec945af88bf38efd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_msgs package contains messages capable of holding serialized fuse objects'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-optimizers/default.nix
+++ b/distros/noetic/fuse-optimizers/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, fuse-constraints, fuse-core, fuse-graphs, fuse-models, fuse-variables, geometry-msgs, nav-msgs, pluginlib, roscpp, roslint, rostest, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-optimizers";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_optimizers/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "7327fd3bd1de8a049b782e839bf4c0878467ed38693e249c845a9d004e6bb5a9";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ fuse-models geometry-msgs nav-msgs roslint rostest ];
+  propagatedBuildInputs = [ diagnostic-updater fuse-constraints fuse-core fuse-graphs fuse-variables pluginlib roscpp std-srvs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_optimizers package provides a set of optimizer implementations. An optimizer is the object responsible
+    for coordinating the sensors and motion model inputs, computing the optimal state values, and providing access to
+    to the optimal state via the publishers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-publishers/default.nix
+++ b/distros/noetic/fuse-publishers/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fuse-constraints, fuse-core, fuse-graphs, fuse-variables, geometry-msgs, nav-msgs, pluginlib, roscpp, roslint, rostest, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-publishers";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_publishers/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "1939abba76b170966680595857a504b304f86b0ed514fa8416f1b920b9366b8b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ fuse-constraints fuse-graphs roslint rostest ];
+  propagatedBuildInputs = [ fuse-core fuse-variables geometry-msgs nav-msgs pluginlib roscpp tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_publishers package provides a set of common publisher plugins.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-variables/default.nix
+++ b/distros/noetic/fuse-variables/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, ceres-solver, fuse-core, pluginlib, roscpp, roslint, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-variables";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_variables/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "28e692927f5dabf2818df89960abefa75669bf8ec16de14cf3626a581d77308b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ roslint rostest ];
+  propagatedBuildInputs = [ ceres-solver fuse-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_variables package provides a set of commonly used variable types, such as 2D and 3D positions,
+    orientations, velocities, and accelerations.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse-viz/default.nix
+++ b/distros/noetic/fuse-viz/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen, fuse-constraints, fuse-core, fuse-msgs, fuse-variables, geometry-msgs, qt5, roslint, rviz, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fuse-viz";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse_viz/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "579487efe209c56eb45f26119de0668e07254377b28bca28cae46660decba942";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase ];
+  checkInputs = [ roslint ];
+  propagatedBuildInputs = [ eigen fuse-constraints fuse-core fuse-msgs fuse-variables geometry-msgs rviz tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse_viz package provides visualization tools for fuse.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fuse/default.nix
+++ b/distros/noetic/fuse/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, fuse-constraints, fuse-core, fuse-doc, fuse-graphs, fuse-models, fuse-msgs, fuse-optimizers, fuse-publishers, fuse-variables, fuse-viz }:
+buildRosPackage {
+  pname = "ros-noetic-fuse";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/locusrobotics/fuse-release/archive/release/noetic/fuse/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "00717f86ddb50dde32843f9907ada284b9f55a9cb250a5e509a26f67bd68614e";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ fuse-constraints fuse-core fuse-doc fuse-graphs fuse-models fuse-msgs fuse-optimizers fuse-publishers fuse-variables fuse-viz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The fuse metapackage'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -836,6 +836,24 @@ self: super: {
 
  freight-bringup = self.callPackage ./freight-bringup {};
 
+ fuse = self.callPackage ./fuse {};
+
+ fuse-core = self.callPackage ./fuse-core {};
+
+ fuse-doc = self.callPackage ./fuse-doc {};
+
+ fuse-loss = self.callPackage ./fuse-loss {};
+
+ fuse-msgs = self.callPackage ./fuse-msgs {};
+
+ fuse-optimizers = self.callPackage ./fuse-optimizers {};
+
+ fuse-publishers = self.callPackage ./fuse-publishers {};
+
+ fuse-variables = self.callPackage ./fuse-variables {};
+
+ fuse-viz = self.callPackage ./fuse-viz {};
+
  gazebo-dev = self.callPackage ./gazebo-dev {};
 
  gazebo-msgs = self.callPackage ./gazebo-msgs {};
@@ -1086,6 +1104,8 @@ self: super: {
 
  industrial-utils = self.callPackage ./industrial-utils {};
 
+ inorbit-republisher = self.callPackage ./inorbit-republisher {};
+
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};
 
  interactive-marker-twist-server = self.callPackage ./interactive-marker-twist-server {};
@@ -1201,6 +1221,14 @@ self: super: {
  kobuki-ftdi = self.callPackage ./kobuki-ftdi {};
 
  kobuki-msgs = self.callPackage ./kobuki-msgs {};
+
+ kvh-geo-fog-3d = self.callPackage ./kvh-geo-fog-3d {};
+
+ kvh-geo-fog-3d-driver = self.callPackage ./kvh-geo-fog-3d-driver {};
+
+ kvh-geo-fog-3d-msgs = self.callPackage ./kvh-geo-fog-3d-msgs {};
+
+ kvh-geo-fog-3d-rviz = self.callPackage ./kvh-geo-fog-3d-rviz {};
 
  label-manager = self.callPackage ./label-manager {};
 
@@ -1966,6 +1994,8 @@ self: super: {
 
  quanergy-client = self.callPackage ./quanergy-client {};
 
+ quanergy-client-ros = self.callPackage ./quanergy-client-ros {};
+
  qwt-dependency = self.callPackage ./qwt-dependency {};
 
  radar-msgs = self.callPackage ./radar-msgs {};
@@ -2517,6 +2547,8 @@ self: super: {
  std-msgs = self.callPackage ./std-msgs {};
 
  std-srvs = self.callPackage ./std-srvs {};
+
+ steering-functions = self.callPackage ./steering-functions {};
 
  stereo-image-proc = self.callPackage ./stereo-image-proc {};
 

--- a/distros/noetic/inorbit-republisher/default.nix
+++ b/distros/noetic/inorbit-republisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-inorbit-republisher";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/noetic/inorbit_republisher/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8b0247307350809ca7eef2d3cac5a07af1393260bee6c3df7d40cb27d7d08e1f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.pyyaml roslib rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS to InOrbit topic republisher'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/kvh-geo-fog-3d-driver/default.nix
+++ b/distros/noetic/kvh-geo-fog-3d-driver/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, geometry-msgs, kvh-geo-fog-3d-msgs, message-generation, message-runtime, nav-msgs, roscpp, roslint, rosunit, sensor-msgs, std-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-kvh-geo-fog-3d-driver";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/noetic/kvh_geo_fog_3d_driver/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "a4b21fb5cea577af79ef19fd9feb96625daba8af93b5c10fd57158f9d50ed6b2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  checkInputs = [ rosunit ];
+  propagatedBuildInputs = [ diagnostic-updater dynamic-reconfigure geometry-msgs kvh-geo-fog-3d-msgs message-generation message-runtime nav-msgs roscpp sensor-msgs std-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A ROS driver for the KVH Geo Fog 3D INS family of systems.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/kvh-geo-fog-3d-msgs/default.nix
+++ b/distros/noetic/kvh-geo-fog-3d-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-kvh-geo-fog-3d-msgs";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/noetic/kvh_geo_fog_3d_msgs/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "20eb1568add8a3edfefaea64ad4675cf00511945ae10cad9c6ff5dcf2aaf4477";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin message-generation ];
+
+  meta = {
+    description = ''kvh_geo_fog_3d_msgs contains raw messages for the KVH GEO FOG 3D INS devices.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/kvh-geo-fog-3d-rviz/default.nix
+++ b/distros/noetic/kvh-geo-fog-3d-rviz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-msgs, kvh-geo-fog-3d-msgs, qt5, roslint, rviz }:
+buildRosPackage {
+  pname = "ros-noetic-kvh-geo-fog-3d-rviz";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/noetic/kvh_geo_fog_3d_rviz/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e1fa880c67be39646d09d36eb4707c89429ae39fc544e7d931770f8eddd422e1";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ qt5.qtbase qt5.qtdeclarative qt5.qtmultimedia qt5.qtsvg roslint ];
+  propagatedBuildInputs = [ diagnostic-msgs kvh-geo-fog-3d-msgs rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The KVH GEO FOG 3D rviz plugin package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/kvh-geo-fog-3d/default.nix
+++ b/distros/noetic/kvh-geo-fog-3d/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, kvh-geo-fog-3d-driver, kvh-geo-fog-3d-msgs, kvh-geo-fog-3d-rviz }:
+buildRosPackage {
+  pname = "ros-noetic-kvh-geo-fog-3d";
+  version = "1.5.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/MITRE/kvh_geo_fog_3d-release/archive/release/noetic/kvh_geo_fog_3d/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "e2722ed45a72e67d54c1ae3ee3c474a5ae1e682c21bfd049bf4d6a44ae146061";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ kvh-geo-fog-3d-driver kvh-geo-fog-3d-msgs kvh-geo-fog-3d-rviz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a driver node for KVH GEO FOG 3D INS sensors, messages, and rviz plugins.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/psen-scan-v2/default.nix
+++ b/distros/noetic/psen-scan-v2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, code-coverage, fmt, pilz-testutils, robot-state-publisher, rosbag, rosconsole-bridge, roscpp, roslaunch, rostest, rosunit, rviz, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-psen-scan-v2";
-  version = "0.3.0-r1";
+  version = "0.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.0-1.tar.gz";
-    name = "0.3.0-1.tar.gz";
-    sha256 = "0a5414452789d498da939b00605d3eba9c81fdc327bacbce4bae31a681e73538";
+    url = "https://github.com/PilzDE/psen_scan_v2-release/archive/release/noetic/psen_scan_v2/0.3.1-1.tar.gz";
+    name = "0.3.1-1.tar.gz";
+    sha256 = "4e3b72c3a89fe3bb5d62bf2028a1022129a580479f26d2a62100c9474f217435";
   };
 
   buildType = "catkin";

--- a/distros/noetic/quanergy-client-ros/default.nix
+++ b/distros/noetic/quanergy-client-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, pcl-ros, quanergy-client, roscpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-quanergy-client-ros";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/noetic/quanergy_client_ros/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "bb1bbcd771601402b9bc57f6f0032561ef127d45c4e6424a91b483d54c3c93a7";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ pcl-ros quanergy-client roscpp sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The quanergy_client_ros package provides a ROS driver for Quanergy sensors'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/ros-ign-bridge/default.nix
+++ b/distros/noetic/ros-ign-bridge/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, ignition, message-generation, message-runtime, nav-msgs, rosconsole, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, std-srvs, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, ignition, message-generation, message-runtime, nav-msgs, rosconsole, roscpp, rosgraph-msgs, rostest, sensor-msgs, std-msgs, std-srvs, tf2-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-ign-bridge";
-  version = "0.111.0-r1";
+  version = "0.111.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign_bridge/0.111.0-1.tar.gz";
-    name = "0.111.0-1.tar.gz";
-    sha256 = "4fe215b92ebb32ae9b97f25fb6f615643c989990e8feb91972365cb5b5cbf613";
+    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign_bridge/0.111.1-2.tar.gz";
+    name = "0.111.1-2.tar.gz";
+    sha256 = "a5b27966c6d1f327aa12e551ac9ef8c87f0c9ab8f3c9f1ea4891ff2ffe62ecda";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ rostest ];
-  propagatedBuildInputs = [ geometry-msgs ignition.msgs5 ignition.transport8 message-runtime nav-msgs rosconsole roscpp rosgraph-msgs sensor-msgs std-msgs std-srvs tf2-msgs ];
+  propagatedBuildInputs = [ geometry-msgs ignition.msgs5 ignition.transport8 message-runtime nav-msgs rosconsole roscpp rosgraph-msgs sensor-msgs std-msgs std-srvs tf2-msgs visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-ign-image/default.nix
+++ b/distros/noetic/ros-ign-image/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ignition, image-transport, ros-ign-bridge, roscpp, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-ros-ign-image";
-  version = "0.111.0-r1";
+  version = "0.111.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign_image/0.111.0-1.tar.gz";
-    name = "0.111.0-1.tar.gz";
-    sha256 = "689bdefbecb3826cb6c2fcea4191b7fe23545635f9be4e184e0090f81112f5f0";
+    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign_image/0.111.1-2.tar.gz";
+    name = "0.111.1-2.tar.gz";
+    sha256 = "d03bede505b6f6e15a966cec96d398f3b95e9a14c02890b96dbc89edd14d6786";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-ign/default.nix
+++ b/distros/noetic/ros-ign/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ros-ign-bridge, ros-ign-gazebo-demos, ros-ign-image }:
 buildRosPackage {
   pname = "ros-noetic-ros-ign";
-  version = "0.111.0-r1";
+  version = "0.111.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign/0.111.0-1.tar.gz";
-    name = "0.111.0-1.tar.gz";
-    sha256 = "21beeed679e05614595d381e55753bb6de4596921da96d621f53fb3c018e64ff";
+    url = "https://github.com/ros-gbp/ros_ign-release/archive/release/noetic/ros_ign/0.111.1-2.tar.gz";
+    name = "0.111.1-2.tar.gz";
+    sha256 = "84789b6bdd9557c10bf47b65f855476e15db0ff69de6541857b93ffee9e54470";
   };
 
   buildType = "catkin";

--- a/distros/noetic/steering-functions/default.nix
+++ b/distros/noetic/steering-functions/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, costmap-2d, eigen, geometry-msgs, nav-msgs, roscpp, roslib, tf, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-steering-functions";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/steering_functions-release/archive/release/noetic/steering_functions/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "b5c609ae4d3cc7ac00530c7ef805d9cc9f0313dd3b3be10dca6cf8481ceb052e";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ cmake-modules ];
+  propagatedBuildInputs = [ costmap-2d eigen geometry-msgs nav-msgs roscpp roslib tf visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The steering_functions package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/udp-com/default.nix
+++ b/distros/noetic/udp-com/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, nodelet, roscpp, roslint, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-udp-com";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/udp_com-release/archive/release/noetic/udp_com/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "732b025c28622d1bfe03947eb273dabf9a8d5f63dd7ae331eed3c01d674a2f8b";
+    url = "https://github.com/flynneva/udp_com-release/archive/release/noetic/udp_com/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "aac456e8ac59b6a472358d527eebd3be84021964c48e602adf85d9a1100a9909";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The udp_com package'';
+    description = ''Generic UDP communication ROS package'';
     license = with lib.licenses; [ bsdOriginal ];
   };
 }

--- a/distros/noetic/webots-ros/default.nix
+++ b/distros/noetic/webots-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, sensor-msgs, std-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, moveit-ros-planning-interface, robot-state-publisher, ros-control, ros-controllers, roscpp, rospy, sensor-msgs, std-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-webots-ros";
-  version = "4.0.1-r1";
+  version = "4.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "b25e1e22d3cc28cd480e1c22f2d9c05f0f31767149cd8572b69b8f302f793ae8";
+    url = "https://github.com/cyberbotics/webots_ros-release/archive/release/noetic/webots_ros/4.1.0-1.tar.gz";
+    name = "4.1.0-1.tar.gz";
+    sha256 = "4175499066cf217586c057a5c6a81945abcfb491eeec7b753c72068a0f871914";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ message-runtime roscpp rospy sensor-msgs std-msgs tf ];
+  propagatedBuildInputs = [ message-runtime moveit-ros-planning-interface robot-state-publisher ros-control ros-controllers roscpp rospy sensor-msgs std-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.7-r1";
+  version = "1.14.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.7-1.tar.gz";
-    name = "1.14.7-1.tar.gz";
-    sha256 = "e49a02c2868315b91934b9c8037d3a57e5949825fb38a4f7c7959321c68651b1";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.8-1.tar.gz";
+    name = "1.14.8-1.tar.gz";
+    sha256 = "eaf183c11a4feb2dcb79f6320fc443ad08cb395045c2a8ae53dd4c86f3370e8a";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit be22697212debf9912e75bb5424285bfbbfbbe41.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *bosch-locator-bridge 2.0.1-r1 --> 2.0.2-r1*
* *launch-pal 0.0.3-r1 --> 0.0.4-r1*
* *launch-system-modes 0.8.0-r1 --> 0.9.0-r1*
* *pmb2-2dnav-gazebo 3.0.0-r1*
* *pmb2-gazebo 3.0.0-r1*
* *pmb2-simulation 3.0.0-r1*
* *rclc 1.0.0-r1 --> 1.0.2-r1*
* *rclc-examples 1.0.0-r1 --> 1.0.2-r1*
* *rclc-lifecycle 1.0.0-r1 --> 1.0.2-r1*
* *realsense-hardware-interface 0.0.1-r1*
* *ros-ign 0.221.1-r1 --> 0.221.2-r1*
* *ros-ign-bridge 0.221.1-r1 --> 0.221.2-r1*
* *ros-ign-image 0.221.1-r1 --> 0.221.2-r1*
* *ros-ign-interfaces 0.221.2-r1*
* *ros2bag 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-compression 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-converter-default-plugins 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-cpp 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-storage 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-storage-default-plugins 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-test-common 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-tests 0.3.7-r1 --> 0.3.8-r1*
* *rosbag2-transport 0.3.7-r1 --> 0.3.8-r1*
* *shared-queues-vendor 0.3.7-r1 --> 0.3.8-r1*
* *sqlite3-vendor 0.3.7-r1 --> 0.3.8-r1*
* *system-modes 0.8.0-r1 --> 0.9.0-r1*
* *system-modes-examples 0.8.0-r1 --> 0.9.0-r1*
* *system-modes-msgs 0.8.0-r1 --> 0.9.0-r1*
* *test-launch-system-modes 0.8.0-r1 --> 0.9.0-r1*
* *usb-cam 0.4.0-r1*
* *webots-ros2 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-abb 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-control 1.1.0-r1*
* *webots-ros2-core 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-demos 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-driver 1.1.0-r1*
* *webots-ros2-epuck 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-examples 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-mavic 1.1.0-r1*
* *webots-ros2-msgs 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-tesla 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-tiago 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-turtlebot 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-tutorials 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-universal-robot 1.0.6-r1 --> 1.1.0-r1*
* *webots-ros2-ur-e-description 1.0.6-r1 --> 1.1.0-r1*
* *zstd-vendor 0.3.7-r1 --> 0.3.8-r1*

Galactic Changes:
-----------------
* *ackermann-msgs 2.0.2-r1*
* *backward-ros 1.0.1-r2*
* *color-names 0.0.2-r1*
* *compressed-depth-image-transport 2.3.0-r5 --> 2.3.1-r1*
* *compressed-image-transport 2.3.0-r5 --> 2.3.1-r1*
* *embree-vendor 0.1.0-r1*
* *filters 2.0.0-r3 --> 2.1.0-r1*
* *four-wheel-steering-msgs 2.0.1-r1*
* *hls-lfcd-lds-driver 2.0.4-r1*
* *image-transport-plugins 2.3.0-r5 --> 2.3.1-r1*
* *launch-system-modes 0.8.0-r1 --> 0.9.0-r1*
* *librealsense2 2.48.0-r1 --> 2.48.0-r2*
* *moveit 2.2.0-r1 --> 2.2.1-r1*
* *moveit-common 2.2.0-r1 --> 2.2.1-r1*
* *moveit-core 2.2.0-r1 --> 2.2.1-r1*
* *moveit-kinematics 2.2.0-r1 --> 2.2.1-r1*
* *moveit-planners 2.2.0-r1 --> 2.2.1-r1*
* *moveit-planners-ompl 2.2.0-r1 --> 2.2.1-r1*
* *moveit-plugins 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-benchmarks 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-move-group 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-occupancy-map-monitor 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-perception 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-planning 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-planning-interface 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-robot-interaction 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-visualization 2.2.0-r1 --> 2.2.1-r1*
* *moveit-ros-warehouse 2.2.0-r1 --> 2.2.1-r1*
* *moveit-runtime 2.2.0-r1 --> 2.2.1-r1*
* *moveit-servo 2.2.0-r1 --> 2.2.1-r1*
* *moveit-simple-controller-manager 2.2.0-r1 --> 2.2.1-r1*
* *nao-button-sim 0.0.2-r1*
* *nao-command-msgs 0.0.3-r1*
* *nao-sensor-msgs 0.0.3-r1*
* *plansys2-bringup 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-bt-actions 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-core 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-domain-expert 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-executor 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-lifecycle-manager 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-msgs 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-pddl-parser 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-planner 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-popf-plan-solver 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-problem-expert 2.0.0-r2 --> 2.0.0-r3*
* *plansys2-terminal 2.0.0-r2 --> 2.0.0-r3*
* *quaternion-operation 0.0.6-r1*
* *rcdiscover 1.1.2-r1 --> 1.1.4-r1*
* *rclc 2.0.1-r1 --> 2.0.2-r1*
* *rclc-examples 2.0.1-r1 --> 2.0.2-r1*
* *rclc-lifecycle 2.0.1-r1 --> 2.0.2-r1*
* *rclc-parameter 2.0.2-r1*
* *rcss3d-agent 0.0.2-r1*
* *rmf-battery 0.1.0-r1*
* *rmf-building-map-tools 1.3.0-r1*
* *rmf-traffic-editor 1.3.0-r1*
* *rmf-traffic-editor-assets 1.3.0-r1*
* *rmf-traffic-editor-test-maps 1.3.0-r1*
* *ros-ign 0.233.1-r5 --> 0.233.2-r1*
* *ros-ign-interfaces 0.233.2-r1*
* *ros2bag 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-compression 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-compression-zstd 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-cpp 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-interfaces 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-performance-benchmarking 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-py 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-storage 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-storage-default-plugins 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-test-common 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-tests 0.9.0-r1 --> 0.9.1-r3*
* *rosbag2-transport 0.9.0-r1 --> 0.9.1-r3*
* *run-move-group 2.2.0-r1 --> 2.2.1-r1*
* *run-moveit-cpp 2.2.0-r1 --> 2.2.1-r1*
* *run-ompl-constrained-planning 2.2.0-r1 --> 2.2.1-r1*
* *shared-queues-vendor 0.9.0-r1 --> 0.9.1-r3*
* *soccer-vision-msgs 0.0.1-r1 --> 0.0.2-r1*
* *sqlite3-vendor 0.9.0-r1 --> 0.9.1-r3*
* *system-modes 0.8.0-r1 --> 0.9.0-r1*
* *system-modes-examples 0.8.0-r1 --> 0.9.0-r1*
* *system-modes-msgs 0.8.0-r1 --> 0.9.0-r1*
* *test-launch-system-modes 0.8.0-r1 --> 0.9.0-r1*
* *theora-image-transport 2.3.0-r5 --> 2.3.1-r1*
* *ublox-dgnss 0.2.2-r1*
* *ublox-dgnss-node 0.2.2-r1*
* *ublox-ubx-interfaces 0.2.2-r1*
* *ublox-ubx-msgs 0.2.2-r1*
* *usb-cam 0.4.0-r1*
* *vision-msgs 3.0.1-r1*
* *zstd-vendor 0.9.0-r1 --> 0.9.1-r3*

Melodic Changes:
----------------
* *aques-talk 2.1.22-r1 --> 2.1.23-r1*
* *assimp-devel 2.1.22-r1 --> 2.1.23-r1*
* *bayesian-belief-networks 2.1.22-r1 --> 2.1.23-r1*
* *chaplus-ros 2.1.22-r1 --> 2.1.23-r1*
* *dingo-control 0.1.8-r1 --> 0.1.9-r2*
* *dingo-description 0.1.8-r1 --> 0.1.9-r2*
* *dingo-msgs 0.1.8-r1 --> 0.1.9-r2*
* *dingo-navigation 0.1.8-r1 --> 0.1.9-r2*
* *downward 2.1.22-r1 --> 2.1.23-r1*
* *er-public-msgs 1.0.0-r1*
* *ff 2.1.22-r1 --> 2.1.23-r1*
* *ffha 2.1.22-r1 --> 2.1.23-r1*
* *fuse 0.4.2-r1*
* *fuse-core 0.4.2-r1*
* *fuse-doc 0.4.2-r1*
* *fuse-loss 0.4.2-r1*
* *fuse-msgs 0.4.2-r1*
* *fuse-optimizers 0.4.2-r1*
* *fuse-publishers 0.4.2-r1*
* *fuse-variables 0.4.2-r1*
* *fuse-viz 0.4.2-r1*
* *heifu 0.8.1-r1 --> 0.7.7-r2*
* *heifu-bringup 0.8.1-r1 --> 0.7.7-r2*
* *husky-base 0.4.9-r1 --> 0.4.10-r1*
* *husky-bringup 0.4.9-r1 --> 0.4.10-r1*
* *husky-control 0.4.9-r1 --> 0.4.10-r1*
* *husky-description 0.4.9-r1 --> 0.4.10-r1*
* *husky-desktop 0.4.9-r1 --> 0.4.10-r1*
* *husky-gazebo 0.4.9-r1 --> 0.4.10-r1*
* *husky-msgs 0.4.9-r1 --> 0.4.10-r1*
* *husky-navigation 0.4.9-r1 --> 0.4.10-r1*
* *husky-robot 0.4.9-r1 --> 0.4.10-r1*
* *husky-simulator 0.4.9-r1 --> 0.4.10-r1*
* *husky-viz 0.4.9-r1 --> 0.4.10-r1*
* *jackal-control 0.7.5-r1 --> 0.7.6-r1*
* *jackal-description 0.7.5-r1 --> 0.7.6-r1*
* *jackal-msgs 0.7.5-r1 --> 0.7.6-r1*
* *jackal-navigation 0.7.5-r1 --> 0.7.6-r1*
* *jackal-tutorials 0.7.5-r1 --> 0.7.6-r1*
* *jsk-3rdparty 2.1.22-r1 --> 2.1.23-r1*
* *julius 2.1.22-r1 --> 2.1.23-r1*
* *laser-filters-jsk-patch 2.1.22-r1 --> 2.1.23-r1*
* *libcmt 2.1.22-r1 --> 2.1.23-r1*
* *libsiftfast 2.1.22-r1 --> 2.1.23-r1*
* *lpg-planner 2.1.22-r1 --> 2.1.23-r1*
* *mini-maxwell 2.1.22-r1 --> 2.1.23-r1*
* *nlopt 2.1.22-r1 --> 2.1.23-r1*
* *opt-camera 2.1.22-r1 --> 2.1.23-r1*
* *pilz-control 0.5.22-r1 --> 0.5.23-r1*
* *pilz-extensions 0.4.12-r1 --> 0.4.14-r1*
* *pilz-industrial-motion 0.4.12-r1 --> 0.4.14-r1*
* *pilz-robot-programming 0.4.12-r1 --> 0.4.14-r1*
* *pilz-robots 0.5.22-r1 --> 0.5.23-r1*
* *pilz-status-indicator-rqt 0.5.22-r1 --> 0.5.23-r1*
* *pilz-store-positions 0.4.12-r1 --> 0.4.14-r1*
* *pilz-trajectory-generation 0.4.12-r1 --> 0.4.14-r1*
* *prbt-gazebo 0.5.22-r1 --> 0.5.23-r1*
* *prbt-hardware-support 0.5.22-r1 --> 0.5.23-r1*
* *prbt-ikfast-manipulator-plugin 0.5.22-r1 --> 0.5.23-r1*
* *prbt-moveit-config 0.5.22-r1 --> 0.5.23-r1*
* *prbt-support 0.5.22-r1 --> 0.5.23-r1*
* *psen-scan-v2 0.3.0-r1 --> 0.3.1-r1*
* *quanergy-client-ros 4.0.0-r1*
* *rospatlite 2.1.22-r1 --> 2.1.23-r1*
* *rosping 2.1.22-r1 --> 2.1.23-r1*
* *sesame-ros 2.1.22-r1 --> 2.1.23-r1*
* *slic 2.1.22-r1 --> 2.1.23-r1*
* *steering-functions 0.1.0-r1*
* *switchbot-ros 2.1.23-r1*
* *udp-com 1.1.1-r1 --> 1.1.2-r1*
* *view-controller-msgs 0.1.3 --> 0.2.0-r1*
* *voice-text 2.1.22-r1 --> 2.1.23-r1*
* *warthog-control 0.1.3-r1 --> 0.1.4-r2*
* *warthog-description 0.1.3-r1 --> 0.1.4-r2*
* *warthog-msgs 0.1.3-r1 --> 0.1.4-r2*
* *webots-ros 4.0.1-r1 --> 4.1.0-r1*
* *xacro 1.13.11-r1 --> 1.13.12-r1*

Noetic Changes:
---------------
* *fuse 0.4.2-r1*
* *fuse-core 0.4.2-r1*
* *fuse-doc 0.4.2-r1*
* *fuse-loss 0.4.2-r1*
* *fuse-msgs 0.4.2-r1*
* *fuse-optimizers 0.4.2-r1*
* *fuse-publishers 0.4.2-r1*
* *fuse-variables 0.4.2-r1*
* *fuse-viz 0.4.2-r1*
* *inorbit-republisher 0.2.1-r1*
* *kvh-geo-fog-3d 1.5.1-r1*
* *kvh-geo-fog-3d-driver 1.5.1-r1*
* *kvh-geo-fog-3d-msgs 1.5.1-r1*
* *kvh-geo-fog-3d-rviz 1.5.1-r1*
* *psen-scan-v2 0.3.0-r1 --> 0.3.1-r1*
* *quanergy-client-ros 4.0.0-r1*
* *ros-ign 0.111.0-r1 --> 0.111.1-r2*
* *ros-ign-bridge 0.111.0-r1 --> 0.111.1-r2*
* *ros-ign-image 0.111.0-r1 --> 0.111.1-r2*
* *steering-functions 0.1.0-r1*
* *udp-com 1.1.1-r1 --> 1.1.2-r1*
* *webots-ros 4.0.1-r1 --> 4.1.0-r1*
* *xacro 1.14.7-r1 --> 1.14.8-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

