### PR TITLE
rosdistro sync, Fri Jul 30 13:17:18 2021

### DIFF
--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -526,6 +526,8 @@ self: super: {
 
  nao-command-msgs = self.callPackage ./nao-command-msgs {};
 
+ nao-lola = self.callPackage ./nao-lola {};
+
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 
  nav2-amcl = self.callPackage ./nav2-amcl {};
@@ -1081,6 +1083,8 @@ self: super: {
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
  smclib = self.callPackage ./smclib {};
+
+ soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
 

--- a/distros/galactic/nao-lola/default.nix
+++ b/distros/galactic/nao-lola/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-nao-lola";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c61ff7eb66fc2a791f130688ab751f11b8170dadf57d7a7a0788988db1e97a87";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost nao-command-msgs nao-sensor-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Packages that allow communicating with the NAO’s Lola middle-ware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rclc-examples/default.nix
+++ b/distros/galactic/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-examples";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e300c2cf54f3bfdb4382cdfc4f9ec66106d946612aa61f02c249513a231f3bc8";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "d82f4d21f48d2d31a954b2ca54ea2b91569579affb1675e197dc94cad15be8c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-lifecycle/default.nix
+++ b/distros/galactic/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-galactic-rclc-lifecycle";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e516b2e98ed24c012eddf05dc2313cce7a39888da078b6cb75fba9ad797ae721";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "7d96192d941fa8f07210cc102081bd47e49f34c8ef014449cb415785e798eefa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-parameter/default.nix
+++ b/distros/galactic/rclc-parameter/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-parameter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "22009a785628d01e27162122acab22aea2c602807a32256518907e966e3031ee";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "f317ae6ac85fba3b4959cb6b39a7d6b0880ed2c23692ddb2bb1677d3318405a3";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common rclcpp ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common example-interfaces osrf-testing-tools-cpp rclcpp std-msgs ];
   propagatedBuildInputs = [ builtin-interfaces rcl rcl-interfaces rclc rcutils rosidl-runtime-c ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/galactic/rclc/default.nix
+++ b/distros/galactic/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "86d91bff183d45375a7a0ed57ee82c8c95595b555828f4ea194eae702a2f7198";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "e366a239f16ed2c18057bebeb7a230befff7d8390931c87d34f91f84599be9a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera-msgs/default.nix
+++ b/distros/galactic/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera-msgs";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "1444eae3dbc9ba23a62666cfb7aa917afcb31ec00edd27f21e7b7355d0977a70";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "5a4b1627446662459a841a631d59d7a8d4b7d82a926ecba4f481c75b7e693cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera/default.nix
+++ b/distros/galactic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "a0e416884327da905b9a66ebf1215fe77d84f4424933cc37c1861d86f3bc2d14";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "790f619dc14c37640238117073c0c51982db4f94a4ea4e65e6397fdbcef1d08a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-description/default.nix
+++ b/distros/galactic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-description";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "fd73bf268ec673aa2d0d3440672b7b1ffd8bb2d9c0617577d6fe0bf6855e5e75";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "394c8ad4e49ca3e8ca8fcc6fa50c64689ffcb2de83f1b3c0e0864799e2d2ee24";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-marker-generation/default.nix
+++ b/distros/galactic/soccer-marker-generation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, soccer-vision-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-soccer-marker-generation";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "189d3289374ddeb5078718359cd67e205eab040437466f23015f633fe821c452";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp soccer-vision-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generates rviz display markers from soccer msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtlebot3-fake-node/default.nix
+++ b/distros/galactic/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-fake-node";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "74dd61d7ca8495e2c42dc03a06e148b6ada531ad091c0357d2010bf882c1e1e4";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "746cda6a901994dee688ec957bc7d1b5372e7e9366f63a8e6f7e9a6b49100db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-gazebo/default.nix
+++ b/distros/galactic/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-gazebo";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "865093b702e896467230cca014ebd7f24f318bd335b76f9853cdd08864ab5832";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "e76517cb5f513868ea7a76963666d5d9e7ef03b4c25611b0bdfed12c5e6f1036";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-simulations/default.nix
+++ b/distros/galactic/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-simulations";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "6fe67cb191ca2dcab6dd76a8266296360f6f71a55b8370d55f9f0fedb71550c0";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "0faeea177c3ad970753b5c1dae3fdee66a2ff2a646e7eb895d33454d1a0efeb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-dgnss-node/default.nix
+++ b/distros/galactic/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, libusb1, rclcpp, rclcpp-components, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-dgnss-node";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss_node/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "03e5a6fb5441e08c467aae38ac8e06636e97e58ab109ba122dc10ca94b2b6630";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss_node/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "60b17ae2ba4bde43e0d62112076fd53b7db39172a001a95648f8e90b636c899c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-dgnss/default.nix
+++ b/distros/galactic/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ublox-dgnss-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-dgnss";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "9da16db3d434301072bd352f54bb2bce8df5ffc42cb2e48f494d27f7ddea3e65";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "f78bd221cef424ca70fbf61ec88bdbfa2c7eb37990d92317595515450bc1fd5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-ubx-interfaces/default.nix
+++ b/distros/galactic/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-galactic-ublox-ubx-interfaces";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_interfaces/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "fe19666de3d72e3f92446587579f1ffbedc934f72d141cb7634a4527a038af22";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_interfaces/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "df6264657cba012ac0fdce496118a5eac34bbcd4738c3f5330686ae22e0c3be5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-ubx-msgs/default.nix
+++ b/distros/galactic/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-ubx-msgs";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_msgs/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "2365b8e3b8d8d71469e43f0beb050e557d0c20266f503503ad187a273c97302c";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_msgs/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "eb69525840403fb60e8661a4fbbe4032825ceba682b34df96293c869ee8fec2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-aques-talk";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "44a514bca2a5779849875e31040927929d95f8c70b24752092a983f4cc4e4d88";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "82869afa17eba0e36a858850f810ec92304ee2332d37868e5c03cd20fa399fe6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "c9f2a223e497f623dba9b3bf0a57d0e537ba8dbeb684dcacbe91cf6078e4146d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "f1fc13d561d14a433023f924c829f39097608b7aa28f3947214cc89c3fb176b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "e538b2fede05a71b2a1484d912092f76d877211de2856ad5fb74bb35262fa21f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e1b42c1dfb5284eed1db5beb5ea6c769ebc2cbef17b89674d95eed6e15936f12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-chaplus-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "63b92b40839313bd535feaaa8fc4897a0201ac550da2a2e0ca986c5e838d7018";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "39bb3f7e562d4f135fd6281b7abf4b71e20bdbf7559aa56909093bb446fba75e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "f46fd8cba49ba79dbec02b9ab7cf087970723798d5d906f1bcd7fbfbfdb74d67";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "2ff442d942c92ae15b01fe6a41549dde0ad83877bafd1ae83e5a28c2431f32b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ac0e2a251ead84bb783513f3354eb333bf404e74c1283bd677c855ff43589e4e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "511627d7c2c811f3a189c91ffd4b33f37f368dd6be00d2522332ed1a7cd6455d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "22a4a1aae5d1536c2e7329cec6f323b1de1be125c99908a220aed6eb0ba35821";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "70c082510ca9a1838c04f7de893251a0a510ba195d9078d2b1b9cfd9a8abae9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "f5326db87a0809d9993ab137529de2f7b11f87b33e1d1afe4214343d758291ae";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a13d9ae11fd68e80daa62c8ac6aab85dca5111015468953b667be858c9d25606";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "b5ff1a3d74784b2d09348927b5d9068f6b1ab9822d469438ec5eddf1f915d71b";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4610912d61cec611e4bd7f438d605168f5fa0ac976ff1f7aacbfb6ca92daf20b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "45fb404fa156fc75d8172b49cd9ce04a452d4ba33bcbee50c0d77b3e67e6e395";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4223cfdf3dafcab1632b16847e289582f004d5adc9bdd9ad3d2cbf0eddda4240";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5527b22452856b9e6ff7430263b974141e9ee6495e6b9949776a6da91e41c8cc";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "778875f473020668f70d8fd46ccd6b3438dce9ff3ab747a0929232b0ae07d963";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "9c20edbcde360d6c12286f1c52743507875a93fcf8907008ea72f48e7f4045ec";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "fddc1c35f30e38eb033e4e5627e21fb699c1fb226cff4f676976fa8a25bb84d2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "15687b033af6ef1400a62138edbd9960298580f2ae98e9a9393f93c36cbe8361";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "bb7f1c96594f7789b8cac978571a23a8b28e629f2a14554e891a4cea90db7ab9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5ab0d4451557df8f78135d08278417f25a7e413285b1de737849fcc761d5e236";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e6b7a37a6c16fd636cfa279dbeb2540418e6404b2a35e64c4c6e9529ceb6ef3d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "cfb1c394e27648d2cc230d5b39a7a0885a31fb9e9203311e80101518c07166f2";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "7242987a28dd17b8d11486e1d1e15f65b8324c897de3e9be200213a60d875b36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "f3bf96ebabbafc95cd3b9703cc4e80cbee578d1f0f5655da0a2abb92954fe697";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "628e317c178e94728ee4d18fcc75ec83b68c2f0c9429773d69ff0040be3a6868";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "7a80f10763837b95e286f9d76bbc79297b66a92521adc43cddedd63bbac9a3d6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "77e2f28159e77ccf37e4b88696682ab05232697588f64039c2dba3182b8c9692";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "abe360ac8db24541295ce7abcb1d0f428af7ffcb07b24f248d73330db55b39df";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5c6f06ce4d3fd4a069477fd994f0b31c61adc48bc4b2709b955e1a784721879a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "364c26a4ab3d976f715e435fc2a2f9227a3b7837dc6c8e584aa1619b1deb0d88";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a62b78136c92e9db002785b9be5c3eeb1da0867063dc64233a009f36ccf45b91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ca209926dde27acfb2bbf3259da7c6d17182805b02ed05a7d0c3ec0baa46e8d6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "38782932d1b6e6107f2bbafbd10c63357e23a9e771b1a208eb6372130c2aa67c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ddd9d3c39477c96547e64ddacf8030ee86bb1845240d87ea02660fd7f9512153";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "8a80eee1ef29f578cc6ccf406b01044127ed46c988dab54484779b2b2b9963f0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, clang, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "891d50bcb28862ee30c7f7091774dfc8a5d24ae30cc68b5e5eeaff40a1595f7a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e2fc909514d0a8eaf1272099e10ae0972da901271abd99cbc6bccf193720c5ce";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  propagatedBuildInputs = [ clang exotica-core pinocchio roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8eb98c390ec797d3fb47134a653675628af1a681002fdc1d6175a27abbe53f65";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "398c1c4340b857108543536ae16b2502b6d79ba70ed820b6ae9cdc863cd36fc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6d0694bfcf35e952ea6097b850d2824e4bc4d967c277007d138bcc0d866db00a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e8ab625926e85331b7926c49e3849f636b7d39a95e6a6662eec83c16ee5664b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "d4a48b82251ed4cf276e8bd6e2d6f0682fed1e327a9c4f7e439c8e241314aca1";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "bae5bdda0839de66c99c8b800877103ed50863f2b4e3899f8bf135c68de9c213";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5a613ad20d20c954823d70cecebd17036b2a6c9b0cf09e92caada64edb20604e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "20efa697c52405088af5188ee7e119d6492f1272efe15849ae20c059fbba2880";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "0bb3abb6c5d7105e7904ac76487dd0a5b5139496906ee319c25e3ca6bf22457c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "4009d2758aa8c4dde3c4a850ab68854d90928c8bd8f0033c8c323597339de767";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ba6aa626677012ae042dd37863eba71088fb9b8b11305a34e530fe5d3c2ea646";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "dd6a5b76ff585b5fcd82a8f2b641f9ed35d0787535866027d563cb1ea312f8e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ade47b4f901130802a6ef28ac05b243edbf2a3d7e4fc484687d916eaca0cef16";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "1450a9afeb52fdb7ef609eb251583bfd59ea3986b4388fd915f1e89e6bbb69a6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "daac96404772a43ebf280700478b94a28fc6cd19ce0a61e2d2ffac7da36adfbf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e9584e6b499d9efac760ae114e921b80a72304897d4ccb4d1e41fb6521d460ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters-jsk-patch/default.nix
+++ b/distros/melodic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters-jsk-patch";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "7f4583a260f42817fe55cd2bb350d4b3c95045a7a1b89f05f54ca56f159e3aa1";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "3efd3a7b0b31928f8ee41e047b5a212c766bf2ad3bd8c1d7607fd13d5cfb2a28";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "1562ae8d15a3bfea334c3425bc626435a30091fbc6236763533a5de8bef517d4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e0ece8617dc15630f1584003705c73484db1f27123b3dc943d31d2878bd0cfc4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "10a93f313edcba25f77830470cb771c60d9777a10ac9952d26659f4187a30346";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "87761a5a4f4feb68f17e309768ff3868e1b3f2a24f06885671321a289406bbaa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "0a03508ba0e0e77d6258e0350ca3aefb60e737e7204aad5a643efcf6a5d277be";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "ddb8d29035bc8e74460123650bc23d69b87b9802fe1f9fcfd20249e784bd7fd0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "60259edb460635615e74bf90f754856e96f8e666d2d0d7b3d01de983364b9cbe";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "ba44f36b1f096aae97a143170235999f251fb121b66792fe6d05106722b9d8c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "cc6fed393b73f40891a72caf215da19a50c48c4545c53e27d3f6882f3e59b8e4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "738644a604b580b7ee9fe3df9332558d7fe29559e68d7d4ab3d4c129dcda8ae0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ad1c05c658939b82195e49003be1ab09c90d0d9e9bcbaaffb65875035de24fbd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "bb1aedce31c9f6efeca26bbe59e5139fae1218d0b1591d6e4fd34646cea4020f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.1-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d6bcb86336ec895fd8752c13fd9d4b1ff75821b38c54388c03c775a717d36b24";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "a2a4f78cec9aebbb7284b51ed82afcabe1e98b082cbfc97eb4e2a4ce56cff404";
   };
 
   buildType = "cmake";

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.10-r1";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "6c29f8412e50f60f391ff48c25e591363661ee99456f70383896617c990c32d5";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "460ae8491dd7487f761ebb69e2bc052d836502abcf682f9174b28c6493828693";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "5e01ad253087b8dab1501f343d49c26e26797a75ae2f748592331032935534f0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "26cb5bd321426b71aa3e2f6c1818ee7a029422a6818b9e47bd39896c76cad17d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "f70fded13077a3232c6b01219c538151b3ec329c49071c8434ef23d2d4ee823d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "bc920068e908068eea5789b1cfbacda7e48872836c845c47cae6e7aff6b27334";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "54c6a98ad8fd96458951922cad11a0479c9d2896aa446eeeed3d105ea124a97e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "d066f569e031178d47310e1b7761bd1f7e9d038843876838cb1fdc167e7b99ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "565be41ab0971e1307cd57d5852aab77d4e2af710931e325b83026528ad4968c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e007e40244375ee5d06d9d254db91c142349edfb218b6b12fe76fd84297eb9bf";
   };
 
   buildType = "cmake";

--- a/distros/melodic/switchbot-ros/default.nix
+++ b/distros/melodic/switchbot-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-runtime, pythonPackages, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-switchbot-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "1a8c29d7ac6f11009a88d3110b30613fcbdc80aab88b4b8aa57db63e4bf5b0ef";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "328df93d029dd75726982089e88ce3112d497a3ec7c2df4bfd5e8c8b8035ff08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "84f279188041134b65566a09eb9720eb944003f0360995f4e94c6b4d56383d4b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "8e17878d8972cc45282d3d10ff334d242e8e49c568bf02e01960d8bd13a911e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "a20e31870dd97fa3a0ee9c51a2328eaf4bd5788a46a2ce59e938a0ff3bd61457";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "8d122dad07b506b904befd65db6d44d6f90b9c0c2306ac75fdd77dc58b70546f";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The bosch_locator_bridge package'';
+    description = ''ROS interface to Rexroth ROKIT Locator'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/exotica-aico-solver/default.nix
+++ b/distros/noetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-aico-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6d67b24bfb99a327e10b7a747fbb7f8e08add8b3cd200ded7de136255e37e583";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "8c868d4729ae7b7d00eef65fd4f9ab60bf97e1321f39d0583dfaff92754e0e3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-cartpole-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "2e79cd3d9dde38e0530e96af9f3a4658d3ff5c0f875cb6e4d9109403efb75059";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "baa1d842aa76a78e30f715e34ee6c7875ed6fbe1c303f7da57967671c6bef9bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl, geometric-shapes }:
 buildRosPackage {
   pname = "ros-noetic-exotica-collision-scene-fcl-latest";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "0683e6d99bdbec936deb6384b70d3092e9e0d889b45a3a0a889d59372bc57684";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4498a661edc5aaf4f04f356ad9a44b69a2e16b3767cf37a3b4bd605dbc8145d0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core fcl-catkin geometric-shapes ];
+  propagatedBuildInputs = [ exotica-core fcl geometric-shapes ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/exotica-core-task-maps/default.nix
+++ b/distros/noetic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core-task-maps";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "0e0bf5274381e2264b216f5d8ced4e6018d939210c1bf29b8214324bbc8cf689";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "0da5ac478efdaa7523c292c1332139d33b948a4df6297e4324ca9d142fbf45aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-core/default.nix
+++ b/distros/noetic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "156815433c405fca51fe552806eb98b8f3f3e67ee047f8511a43f01315c2bd34";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e5a0d4c3011d40a110dacdbb595f0bc0cbfb55eab42da9d5bfdb644453aab6ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ddp-solver/default.nix
+++ b/distros/noetic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ddp-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "908c2fe22aedbb0c111a59bc582b2699dd0aec961be5128eb72652da14dec224";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a77f9751667bcd8e6acdb7b058fd64a05fbf34d02ede8af7076ddafb18a980cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-double-integrator-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5eb8f652c5e6d3c0afa8b317830c16b3dbe4978e52715c7a273a57564583b23f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "1f923cb14c5b1610f7496c4af3ca5d7d60aadef736263ab72e9859d0bfeb33d4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-dynamics-solvers/default.nix
+++ b/distros/noetic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica-dynamics-solvers";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8b5857927f5f082ca115a3a4d9087621d3830e152cc5138b926e882128a25876";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "91c483689f74df47d811b385156a14d06d7f984346f1d0b998e37265314b185b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-examples/default.nix
+++ b/distros/noetic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python3Packages, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-exotica-examples";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "fc82861ba5e048f0ba3ff5f40b53bd2d1d1288069221db60385299b4e69fec32";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "253c541a3cb1eb6215226dd062360c131ef478065abdcde75455d25b8213d262";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ik-solver/default.nix
+++ b/distros/noetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ik-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "a0363e76e27e36305c850ecee6adcf2133512620422c2e7fc25b1a177594d2b5";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "c6537d5896dac76ac90cd8db8de863cb719204259d3c363b40ecc54f978569b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqg-solver/default.nix
+++ b/distros/noetic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqg-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "fa454d463b1194649ba097acf518b4b02c725b1e2bcfc5706833919bc7ab2f30";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e3c7a828a6cf965a2f2c18c88b77aec879ca003460497d3be6ba712d8226830d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqr-solver/default.nix
+++ b/distros/noetic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqr-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "554ea850f68fcaafac94a4718236d025309bd54ad626a43083485e917f256473";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a796cfef3920486d26caf201e22191c2663dd97f846c52c6344faf8649f5441a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-levenberg-marquardt-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "80d2b90056cdd0091f4dac19b30a62412e601421c9087d7a508621c7c60864c8";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "135bb1e8166b3f10b61c15be56718dc1249b6555404e6026a61df817911e4ef3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-control-solver/default.nix
+++ b/distros/noetic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-control-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5f81f6301c8695bc50b0f584d8c85bc372b3ebdc295dc86531b20e57f3aa74de";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "3192ddfc51623872b292eafbbc53cebe5be603e22f4b3101f9b448dd24b5263e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-solver/default.nix
+++ b/distros/noetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8bc6472bb6b4ea8f4e23b5b7e204f973cc483acb24f0556ac6b7aeabd0759c70";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "88d6418dd0dac08307b2e982c670a614b11bbd6a2b6a5fb2ccc57fcc8860d4e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pendulum-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "e05f33d8f25fdc020cfea09f277c2416170d3c57fd344738fa3eb61923b8bea4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5b6d3e637a7df464ee506bdf7a47da647041035bc2686e0f12a8654764a8ac14";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, clang, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pinocchio-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6f34d0014013026de5d84d11fc1e5d48c3131c3edcfaa460887a1fd5ba5e4d33";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "f4d67d2e53282319f64a1cafb9d9077180a7dec2c5e5b2dac253ff0b922456aa";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  propagatedBuildInputs = [ clang exotica-core pinocchio roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-quadrotor-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "baeae64d957184984aa276e6205aea214b36099c6f737ae9630f5eea18adafa4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "821f8955a1087becabaa394797ae9a9e28b27f1fa3f9f46a71863e2325fecb42";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-scipy-solver/default.nix
+++ b/distros/noetic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-exotica-scipy-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "12ee73b924ddc37144fa88801d21a33b675cceaf2d208002a1915a6ab6496f35";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "46dae74a65ba823ea0ba88ab9bd99d21cd57b130064c1b30ac0a0b0b02ac0c26";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "89b36aca5ec996c3a5b4ec9e564c92f9350a2e1f300c3234de75094420b87b85";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5cc72e41ed448ea01febaf17af48dcffe19d498e3fda230c16b83263491069f7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica/default.nix
+++ b/distros/noetic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "9deeee658d9b2d94c241500dab6d9a216f07f97d3bf3fa3d8a5131a2526b49a7";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "c574f23e46c5d676c8ac7b41ea7a37ee616990700048b4047eead4b362aab87f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2882,6 +2882,8 @@ self: super: {
 
  wave-front-planner = self.callPackage ./wave-front-planner {};
 
+ web-video-server = self.callPackage ./web-video-server {};
+
  webots-ros = self.callPackage ./webots-ros {};
 
  wfov-camera-msgs = self.callPackage ./wfov-camera-msgs {};

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "061d5bb2377d741b1b574f845b3f538ec202ec58fb484ac923da673e88b6062d";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "6e570970ed335eace1b1b4ed1f2cdf9b079c31a1a61bd6e73fe794f53ca17bdc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.1-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e3cbc64999563f286763e321db3b76957ad10d34b30a6c63aed1e1544140fced";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "6af15f1ded6714909c0a7999b73016b1646f32dfa7ff93ab11e98384d0147121";
   };
 
   buildType = "cmake";

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9ee850a4e0d2db4656976d527e25e35bf5af9fbb742b5b034061d08aa0dc89d5";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "8698f935ea320a63e0e4c8ec45938e6d7ee2067b163dcda0fd0c67bb9d2e4b60";
   };
 
   buildType = "catkin";
-  buildInputs = [ geographiclib message-generation python3Packages.catkin-pkg roslint ];
+  buildInputs = [ message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "8a5a5c9371b115c2ba61093a714d50d30d6ba306d813046e3ebfea95bcfdb770";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "84a51b386e543407cdf8fe3e318adc5dbffeebd7ec9f1eda709b7d64d3ead11f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ae342273fce13575f5b3c8b29355fc0cd70a0b36cfb7aef0b83391732acbcb13";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "9e29d79829b5a974db4142d1d8f1bc5ed0e412d85694cf707316c503bce81af5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "7785199b2fb11f649e2783d683b05cc1627213e9f14acece52ddb55e0d4dfe8c";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "7560041d65a39dc786a1202318395c866af0b7b17a5eb8839e4c485f7679c7eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "b823264a4d9061dfad8bd240161be7a8976f6ea8c14dfd8936fa5b5df51cfd3c";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "0c84f212ce86cdfe61726e3bfd304ca257c1ae4d113bd0524c8f9d7dd6529c43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "07f10331747829275619412337672b65f1718fdf2c29fdb3239b29afa186ee2d";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "6ce03bce22e1009aa43f3f74f99efd6026702e7d775aac15a1800c7305857086";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ee8eadf161fe8bb931ee07b2611c74613bdd5488a9713c5f42af61ffffd54434";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "0cd12e40b3e5c68ccd1576f6b0f34be6fa0d98744105bb545d26f41b738d5ca6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "1dc142fe4396e3edfcd75777bf049cae4daa6d88ae445d8a08211c33ec277468";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "920854f983ee43f4eda52a44e2e318f1db47ffd36f74af6cd43c9139c0d5f053";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "0655caaa3dd5b82f6255c4b61c3c50244785f4ca8ef4ae352485fbdfc2ac208e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "5842542a7518a694e1e339fb3d59d4807bf15382d0393c4dab077d67f1458148";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ccf86e352c39bdf203c0465e1a154021e06d8f3b4face37269b1b01e3cba521e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "03ed121f2231478045cdb983ccbca247f214322acf67d9553d78f78a558c3ffb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "37e53948063c7b37e461483fe40ae12168dc83f0a4211a40adc9aa8a809ed45f";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "8a8a32d9a5b42badd7cae613892b2db4a72035923a4e2a369e34e1877b2fa433";
   };
 
   buildType = "catkin";

--- a/distros/noetic/view-controller-msgs/default.nix
+++ b/distros/noetic/view-controller-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-view-controller-msgs";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/noetic/view_controller_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "2790e733c8c9880af8643f5b59523aa1a7a82d562901fc14b307ccfa3b4411bd";
+    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/noetic/view_controller_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "2157172387b8868d01b73a0cf00fb1425748b9707b54b40f97eb1ef40505aadf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/web-video-server/default.nix
+++ b/distros/noetic/web-video-server/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, ffmpeg, image-transport, roscpp, roslib, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-web-video-server";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/web_video_server-release/archive/release/noetic/web_video_server/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "7ae5dbf920030dd13a5d7d6010ba398db9efad78a6b382630f7095db0467e467";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ async-web-server-cpp cv-bridge ffmpeg image-transport roscpp roslib sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''HTTP Streaming of ROS Image Topics in Multiple Formats'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 591fd6fea1df4a28e70ddd8f3e9c317a3c661c68.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Galactic Changes:
-----------------
* *nao-lola 0.0.3-r1*
* *rclc 2.0.2-r1 --> 2.0.3-r3*
* *rclc-examples 2.0.2-r1 --> 2.0.3-r3*
* *rclc-lifecycle 2.0.2-r1 --> 2.0.3-r3*
* *rclc-parameter 2.0.2-r1 --> 2.0.3-r3*
* *realsense2-camera 3.2.2-r1 --> 3.2.2-r2*
* *realsense2-camera-msgs 3.2.2-r1 --> 3.2.2-r2*
* *realsense2-description 3.2.2-r1 --> 3.2.2-r2*
* *soccer-marker-generation 0.0.1-r1*
* *turtlebot3-fake-node 2.2.4-r1 --> 2.2.4-r2*
* *turtlebot3-gazebo 2.2.4-r1 --> 2.2.4-r2*
* *turtlebot3-simulations 2.2.4-r1 --> 2.2.4-r2*
* *ublox-dgnss 0.2.2-r1 --> 0.2.3-r4*
* *ublox-dgnss-node 0.2.2-r1 --> 0.2.3-r4*
* *ublox-ubx-interfaces 0.2.2-r1 --> 0.2.3-r4*
* *ublox-ubx-msgs 0.2.2-r1 --> 0.2.3-r4*

Melodic Changes:
----------------
* *aques-talk 2.1.23-r1 --> 2.1.24-r1*
* *assimp-devel 2.1.23-r1 --> 2.1.24-r1*
* *bayesian-belief-networks 2.1.23-r1 --> 2.1.24-r1*
* *chaplus-ros 2.1.23-r1 --> 2.1.24-r1*
* *downward 2.1.23-r1 --> 2.1.24-r1*
* *exotica 6.1.1-r1 --> 6.2.0-r1*
* *exotica-aico-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-cartpole-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-collision-scene-fcl-latest 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core-task-maps 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ddp-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-double-integrator-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-dynamics-solvers 6.1.1-r1 --> 6.2.0-r1*
* *exotica-examples 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ik-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqg-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqr-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-levenberg-marquardt-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-control-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pendulum-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pinocchio-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-quadrotor-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-scipy-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.1.1-r1 --> 6.2.0-r1*
* *ff 2.1.23-r1 --> 2.1.24-r1*
* *ffha 2.1.23-r1 --> 2.1.24-r1*
* *jsk-3rdparty 2.1.23-r1 --> 2.1.24-r1*
* *julius 2.1.23-r1 --> 2.1.24-r1*
* *laser-filters-jsk-patch 2.1.23-r1 --> 2.1.24-r1*
* *libcmt 2.1.23-r1 --> 2.1.24-r1*
* *libsiftfast 2.1.23-r1 --> 2.1.24-r1*
* *lpg-planner 2.1.23-r1 --> 2.1.24-r1*
* *mini-maxwell 2.1.23-r1 --> 2.1.24-r1*
* *nlopt 2.1.23-r1 --> 2.1.24-r1*
* *opt-camera 2.1.23-r1 --> 2.1.24-r1*
* *pinocchio 2.6.1-r1 --> 2.6.3-r1*
* *robot-localization 2.6.10-r1 --> 2.6.11-r1*
* *rospatlite 2.1.23-r1 --> 2.1.24-r1*
* *rosping 2.1.23-r1 --> 2.1.24-r1*
* *sesame-ros 2.1.23-r1 --> 2.1.24-r1*
* *slic 2.1.23-r1 --> 2.1.24-r1*
* *switchbot-ros 2.1.23-r1 --> 2.1.24-r1*
* *voice-text 2.1.23-r1 --> 2.1.24-r1*

Noetic Changes:
---------------
* *bosch-locator-bridge 1.0.1-r2 --> 1.0.2-r1*
* *exotica 6.1.1-r1 --> 6.2.0-r1*
* *exotica-aico-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-cartpole-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-collision-scene-fcl-latest 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core-task-maps 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ddp-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-double-integrator-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-dynamics-solvers 6.1.1-r1 --> 6.2.0-r1*
* *exotica-examples 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ik-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqg-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqr-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-levenberg-marquardt-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-control-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pendulum-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pinocchio-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-quadrotor-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-scipy-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.1.1-r1 --> 6.2.0-r1*
* *mk 1.15.7-r1 --> 1.15.8-r1*
* *pinocchio 2.6.1-r1 --> 2.6.3-r1*
* *robot-localization 2.7.2-r1 --> 2.7.3-r1*
* *ros 1.15.7-r1 --> 1.15.8-r1*
* *rosbash 1.15.7-r1 --> 1.15.8-r1*
* *rosboost-cfg 1.15.7-r1 --> 1.15.8-r1*
* *rosbuild 1.15.7-r1 --> 1.15.8-r1*
* *rosclean 1.15.7-r1 --> 1.15.8-r1*
* *roscreate 1.15.7-r1 --> 1.15.8-r1*
* *roslang 1.15.7-r1 --> 1.15.8-r1*
* *roslib 1.15.7-r1 --> 1.15.8-r1*
* *rosmake 1.15.7-r1 --> 1.15.8-r1*
* *rosunit 1.15.7-r1 --> 1.15.8-r1*
* *view-controller-msgs 0.1.3-r1 --> 0.2.0-r1*
* *web-video-server 0.2.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

