### PR TITLE
rosdistro sync, Fri Aug  6 13:28:56 2021

### DIFF
--- a/distros/foxy/diagnostic-aggregator/default.nix
+++ b/distros/foxy/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-aggregator";
-  version = "2.0.7-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "36f9ceeb869ae722d3f1ba5c8c486fe7165e4b963d8a28e17d653a3049795c43";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_aggregator/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "7d666fe6d9592908b132b560e02fbc213f9808c628cd0e06cc101a1f1d48e47b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/diagnostic-updater/default.nix
+++ b/distros/foxy/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diagnostic-updater";
-  version = "2.0.7-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "83d7525f87936c881a6328abb045af63d9de7a91e71ddd185207be85b0ea7601";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/diagnostic_updater/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "08abc22cf49ec9740af6ee857e2491213aeb78ffac9f589e14ab1faaa9b0c3ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rc-genicam-api/default.nix
+++ b/distros/foxy/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-api";
-  version = "2.5.0-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "bb26ba22885c4fa58e28dfb71fb879cf703761eab6d789efb4daff2d22a08b1e";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/foxy/rc_genicam_api/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "20a621c8649a6f5b336f6237f9c635cde01fc8ae280a91d472658414bc404e2a";
   };
 
   buildType = "cmake";

--- a/distros/foxy/rc-genicam-driver/default.nix
+++ b/distros/foxy/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, image-transport, rc-common-msgs, rc-genicam-api, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rc-genicam-driver";
-  version = "0.1.2-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros2-release/archive/release/foxy/rc_genicam_driver/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "20794b66cd597e94c850f0bf264d43a425a9db7f67910e7b7ca918a7f406d734";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros2-release/archive/release/foxy/rc_genicam_driver/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "277dbe5453658c31c06dacba050321e1927191291d447b211bf6a8476ea1a3ab";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/robot-state-publisher/default.nix
+++ b/distros/foxy/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-foxy-robot-state-publisher";
-  version = "2.4.2-r1";
+  version = "2.4.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "59f69893fc4e810209db9c569c6d0826a230428a936690303884c03d61f7aba7";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/foxy/robot_state_publisher/2.4.5-1.tar.gz";
+    name = "2.4.5-1.tar.gz";
+    sha256 = "515d5f18cb4937f9854bd46d62731d394c72fe81f4ddcc26b900726eff45ab02";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/self-test/default.nix
+++ b/distros/foxy/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-self-test";
-  version = "2.0.7-r1";
+  version = "2.0.8-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.7-1.tar.gz";
-    name = "2.0.7-1.tar.gz";
-    sha256 = "a65c4f1449ab6dfecfe242367fe13ec976c74487b279ad1550c971ea572c4ac8";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/foxy/self_test/2.0.8-2.tar.gz";
+    name = "2.0.8-2.tar.gz";
+    sha256 = "7a59d918b7b2ce03ad3496b1b8bcc79ac6eecbb35fed93a450fb7f5a6c56bcde";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/teleop-twist-joy/default.nix
+++ b/distros/foxy/teleop-twist-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, joy, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-teleop-twist-joy";
-  version = "2.4.2-r1";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.2-1.tar.gz";
-    name = "2.4.2-1.tar.gz";
-    sha256 = "47c018a6195d9e8bae6cad5f537105657b2a3cbe209f669a0aceccadbf0443c9";
+    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/foxy/teleop_twist_joy/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "8496be1929173bdf1d2a11b56e2b25eda3d2072f6551cac6d18f0a4e6a845b2b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diagnostic-aggregator/default.nix
+++ b/distros/galactic/diagnostic-aggregator/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, launch-testing-ament-cmake, launch-testing-ros, pluginlib, rclcpp, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diagnostic-aggregator";
-  version = "2.1.2-r2";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/diagnostic_aggregator/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "6320fb6619b2879c4fc6b66de644115176eae622aa8687693b1bd8fb778fe3e2";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/diagnostic_aggregator/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "d22fc5fb0cc86d4279d1b44af1d7975fb15003fa8dd81e39b1a314390ab1e6b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/diagnostic-updater/default.nix
+++ b/distros/galactic/diagnostic-updater/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-common, diagnostic-msgs, rclcpp, rclcpp-lifecycle, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-diagnostic-updater";
-  version = "2.1.2-r2";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/diagnostic_updater/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "6a2b5660984eb30b0c3221c9b760b8caca5b1c5183998fd9ec8ea7b353dcb188";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/diagnostic_updater/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "25dfbe1434610f9dc4b2c1f6f91006c5c1b0a214da7995be59bcf637a4e85f2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/fastrtps/default.nix
+++ b/distros/galactic/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-galactic-fastrtps";
-  version = "2.3.1-r1";
+  version = "2.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/galactic/fastrtps/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "78fdec7c410caa774b0a82ce8cd7c1e5068224ef0ed9a5a465f5308f5d4ff6f6";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/galactic/fastrtps/2.3.4-1.tar.gz";
+    name = "2.3.4-1.tar.gz";
+    sha256 = "eddb31f507208251544e87541ec323e776d6094cb42bbfa2fb38aff6c9b6a82b";
   };
 
   buildType = "cmake";

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -394,6 +394,24 @@ self: super: {
 
  key-teleop = self.callPackage ./key-teleop {};
 
+ lanelet2 = self.callPackage ./lanelet2 {};
+
+ lanelet2-core = self.callPackage ./lanelet2-core {};
+
+ lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-maps = self.callPackage ./lanelet2-maps {};
+
+ lanelet2-projection = self.callPackage ./lanelet2-projection {};
+
+ lanelet2-python = self.callPackage ./lanelet2-python {};
+
+ lanelet2-routing = self.callPackage ./lanelet2-routing {};
+
+ lanelet2-traffic-rules = self.callPackage ./lanelet2-traffic-rules {};
+
+ lanelet2-validation = self.callPackage ./lanelet2-validation {};
+
  laser-geometry = self.callPackage ./laser-geometry {};
 
  laser-proc = self.callPackage ./laser-proc {};
@@ -522,9 +540,13 @@ self: super: {
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
+ mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
+
  nao-button-sim = self.callPackage ./nao-button-sim {};
 
  nao-command-msgs = self.callPackage ./nao-command-msgs {};
+
+ nao-lola = self.callPackage ./nao-lola {};
 
  nao-sensor-msgs = self.callPackage ./nao-sensor-msgs {};
 
@@ -1081,6 +1103,8 @@ self: super: {
  slam-toolbox = self.callPackage ./slam-toolbox {};
 
  smclib = self.callPackage ./smclib {};
+
+ soccer-marker-generation = self.callPackage ./soccer-marker-generation {};
 
  soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
 

--- a/distros/galactic/lanelet2-core/default.nix
+++ b/distros/galactic/lanelet2-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, eigen, gtest, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-core";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_core/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b0a84915cf69ef9b1886a93a83134713406811826944225f9350154fbb812ac2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost eigen mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Lanelet2 core module'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-examples/default.nix
+++ b/distros/galactic/lanelet2-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, ros2cli }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-examples";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_examples/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c5255625ce3f14ecc64570a7591f0e1f90b332e0c4afe2f02e987b0ba824b0df";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ros2cli ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Examples for working with Lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-maps/default.nix
+++ b/distros/galactic/lanelet2-maps/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-maps";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_maps/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "beb9f2699c15c12a195402848416527a1fe399aa2f8948401ef4e51f43de513d";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lanelet2-core mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Example maps in the lanelet2-format'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-projection/default.nix
+++ b/distros/galactic/lanelet2-projection/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, geographiclib, gtest, lanelet2-io, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-projection";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_projection/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "cd528b555940160b5aac2bfeaff8038e54c04c28df03de6d8d46c74189a6f4e2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ geographiclib lanelet2-io mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Lanelet2 projection library for lat/lon to local x/y conversion'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-python/default.nix
+++ b/distros/galactic/lanelet2-python/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-python";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_python/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "12adb6188fed913af61e6f1fc95ab2b58db3c467f3388eac7584c356a4b68cdc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core lanelet2-io lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Python bindings for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-routing/default.nix
+++ b/distros/galactic/lanelet2-routing/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-routing";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_routing/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "1d2a5eee38ad730e4013a15851eece4b235850df3ffc97f869b0f61cf659ffd2";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Routing module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-traffic-rules/default.nix
+++ b/distros/galactic/lanelet2-traffic-rules/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-traffic-rules";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_traffic_rules/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "58952f01ce2ee3d971e77f278eff800fb1c79e89e81a3942f1c6e3f3779e8cfc";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ lanelet2-core mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Package for interpreting traffic rules in a lanelet map'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2-validation/default.nix
+++ b/distros/galactic/lanelet2-validation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-validation";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_validation/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "2e583f252ed48deadb29ae7844d25408f60604abe1aab510e6d99eb50769d173";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest lanelet2-maps ];
+  propagatedBuildInputs = [ lanelet2-core lanelet2-io lanelet2-projection lanelet2-routing lanelet2-traffic-rules mrt-cmake-modules ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Package for sanitizing lanelet maps'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/lanelet2/default.nix
+++ b/distros/galactic/lanelet2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "813163ba02b4f4b155e0bf27d4fb524b3d6dc9ed2e31d6b66c91056de5d957a2";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ lanelet2-core lanelet2-examples lanelet2-io lanelet2-maps lanelet2-projection lanelet2-python lanelet2-routing lanelet2-traffic-rules lanelet2-validation ];
+  nativeBuildInputs = [ ament-cmake-core ros-environment ];
+
+  meta = {
+    description = ''Meta-package for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/libphidget22/default.nix
+++ b/distros/galactic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-libphidget22";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4cf358789470c53020d6f4130f530c49d2744f606796a8623cd18c866662d85c";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/libphidget22/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "8f8ee29321775752a5053b28770844bb68c7ce2820652ab3bae4e549a8d0ace7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mrt-cmake-modules/default.nix
+++ b/distros/galactic/mrt-cmake-modules/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, gtest-vendor, lcov, python3Packages, ros-environment }:
+buildRosPackage {
+  pname = "ros-galactic-mrt-cmake-modules";
+  version = "1.0.8-r3";
+
+  src = fetchurl {
+    url = "https://github.com/KIT-MRT/mrt_cmake_modules-release/archive/release/galactic/mrt_cmake_modules/1.0.8-3.tar.gz";
+    name = "1.0.8-3.tar.gz";
+    sha256 = "8d00dd6c383e08e96b6af38bc88bd6f7b7e02c1402950cdeba102cdcd06edb62";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gtest-vendor lcov python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+  nativeBuildInputs = [ ament-cmake-core python3Packages.catkin-pkg python3Packages.pyyaml python3Packages.rospkg python3Packages.setuptools ros-environment ];
+
+  meta = {
+    description = ''CMake Functions and Modules for automating CMake'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/nao-lola/default.nix
+++ b/distros/galactic/nao-lola/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, nao-command-msgs, nao-sensor-msgs, rclcpp }:
+buildRosPackage {
+  pname = "ros-galactic-nao-lola";
+  version = "0.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/nao_lola-release/archive/release/galactic/nao_lola/0.0.3-1.tar.gz";
+    name = "0.0.3-1.tar.gz";
+    sha256 = "c61ff7eb66fc2a791f130688ab751f11b8170dadf57d7a7a0788988db1e97a87";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost nao-command-msgs nao-sensor-msgs rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Packages that allow communicating with the NAO’s Lola middle-ware.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/phidgets-accelerometer/default.nix
+++ b/distros/galactic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-accelerometer";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "2d00849f42e93186935e94bb709f1d26b56ff48fc04de9548b34fa348a0d30ee";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_accelerometer/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7719bd584b0d7a8e1e827aaf859198a27cb6857852ec2b172c8399638e1ee07e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-analog-inputs/default.nix
+++ b/distros/galactic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-analog-inputs";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "214dc638b381a79066de744e83b81b479890b2a5ce904629819fe716a7f6bf50";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_analog_inputs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "3eb96e768e7d4bc6379e38600a9c818b80cc3a8133e1f52c42a2db9461a47946";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-api/default.nix
+++ b/distros/galactic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, libphidget22 }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-api";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0ac7122fa0d3d8cdc16b21c3dd63493ab73516b8aa8c61b487585c06e8cfe7c8";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_api/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2aa42b9ddbdbf95550722a7032943cad7319a9170e284133359b2b503e69c4de";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-inputs/default.nix
+++ b/distros/galactic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-inputs";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4524f0881302c1b3927af44e71c1eaaf645cf78477f73b0897ac1d5740b73b5e";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_inputs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2360d0df777522513aa3746f02ee74a803e10157f59a2cd7e1629c7b8f61c4ee";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-digital-outputs/default.nix
+++ b/distros/galactic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-digital-outputs";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b44fe76181b39e966785e5f0c7c5e04f2144f02559aac4d48b43b005a6195be7";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_digital_outputs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "96f686b37d6765153991b900204a3e545b4f78c13ed51d51d7bd6efed2841f75";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-drivers/default.nix
+++ b/distros/galactic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-drivers";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "1658cc97336b4da0bff84744fe565fd4b0648b971508092be82fced68e7b26fb";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_drivers/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c065f41350a72f2c24d853f9990b5bda4fde2e0c43d302926d3dbe59f835decb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-gyroscope/default.nix
+++ b/distros/galactic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-gyroscope";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "3c27edf14b2eb9ccf92189d2246b5cf72eb5377eaf6731c9151f03e233cefdc1";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_gyroscope/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "3a69f6739a74c52e8d4f62ef09a972625a00347640158580ee0b0979a41cf473";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-high-speed-encoder/default.nix
+++ b/distros/galactic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-high-speed-encoder";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b56a14cebb4dc02cd3f4dce5f3caf619a4cb2f10ed0e59d744ec4686c8e7aa8b";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_high_speed_encoder/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b34fb8948fca836dec78b1b7ef46011e32e168ac7e0ad8cfe7fbff0581840a63";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-ik/default.nix
+++ b/distros/galactic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, launch, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-ik";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "7ce81805829c98773b85991a1cda3c081f0ea5a5bd2f12987ce27e1a9889c285";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_ik/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9f9ac59d39b5d5c6a30e2b6112c673b865180d1231d1157e05e3fe1b33869be8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-magnetometer/default.nix
+++ b/distros/galactic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-magnetometer";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0a267a515931dc608a344ef0ad49c5ae3e7f25326c72413270ca7d5c45684f83";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_magnetometer/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "58725896a43537cc2e322bf1c47a06ac696106611a6d063c4b716076240eed03";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-motors/default.nix
+++ b/distros/galactic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, phidgets-msgs, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-motors";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "b2b8301cdf54d7e15a557cea23c637b481666f2033366f9ee8793709a28432d9";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_motors/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7706b1f736d8fa2056f4f5158d68357f8aa520a90613a652139bd445d388b13f";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-msgs/default.nix
+++ b/distros/galactic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-msgs";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "4550572daedcc1c4d8265678ee3b53e7d6b9dcb8248e8ec07f8473573f103381";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_msgs/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "8b514cbb4815b072df8208cf07cda9ace0e2a576d844b5ac3357d5fd1411e646";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-spatial/default.nix
+++ b/distros/galactic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-spatial";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "89554b8d7e4b10251a27eb71824ebf29d471acddbaff5fe7815d53c2def8ed99";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_spatial/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "c4f94483c2b62da8f65ef9e4d6d4e7ff7f8d8a60fe02f1d88004eca366fa8618";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/phidgets-temperature/default.nix
+++ b/distros/galactic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, launch, phidgets-api, rclcpp, rclcpp-components, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-phidgets-temperature";
-  version = "2.2.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.0-1.tar.gz";
-    name = "2.2.0-1.tar.gz";
-    sha256 = "0300042ea7afd951a3b30f58c2d681b3999fa04f468b60a86d5935724d4db708";
+    url = "https://github.com/ros2-gbp/phidgets_drivers-release/archive/release/galactic/phidgets_temperature/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "0afa3df6ea213b0baf1ccfa3b502efd0ab1ef65115bafcce8cf2a84ed5398a4d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/plotjuggler-ros/default.nix
+++ b/distros/galactic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler-ros";
-  version = "1.5.0-r1";
+  version = "1.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/galactic/plotjuggler_ros/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "5de2877f63666b5f7dfa3b5c3b4bbc2e0baf54f86420faecd78b82bb4609239c";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/galactic/plotjuggler_ros/1.5.1-1.tar.gz";
+    name = "1.5.1-1.tar.gz";
+    sha256 = "be0bcdd99993ddd30072c1a8150db442141a53ae5d2fc39fb17d6bcd7b054640";
   };
 
   buildType = "catkin";

--- a/distros/galactic/rclc-examples/default.nix
+++ b/distros/galactic/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-examples";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e300c2cf54f3bfdb4382cdfc4f9ec66106d946612aa61f02c249513a231f3bc8";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "d82f4d21f48d2d31a954b2ca54ea2b91569579affb1675e197dc94cad15be8c9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-lifecycle/default.nix
+++ b/distros/galactic/rclc-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
 buildRosPackage {
   pname = "ros-galactic-rclc-lifecycle";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e516b2e98ed24c012eddf05dc2313cce7a39888da078b6cb75fba9ad797ae721";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "7d96192d941fa8f07210cc102081bd47e49f34c8ef014449cb415785e798eefa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-parameter/default.nix
+++ b/distros/galactic/rclc-parameter/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-parameter";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "22009a785628d01e27162122acab22aea2c602807a32256518907e966e3031ee";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "f317ae6ac85fba3b4959cb6b39a7d6b0880ed2c23692ddb2bb1677d3318405a3";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common rclcpp ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-common example-interfaces osrf-testing-tools-cpp rclcpp std-msgs ];
   propagatedBuildInputs = [ builtin-interfaces rcl rcl-interfaces rclc rcutils rosidl-runtime-c ];
   nativeBuildInputs = [ ament-cmake-ros ];
 

--- a/distros/galactic/rclc/default.nix
+++ b/distros/galactic/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc";
-  version = "2.0.2-r1";
+  version = "2.0.3-r3";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "86d91bff183d45375a7a0ed57ee82c8c95595b555828f4ea194eae702a2f7198";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.3-3.tar.gz";
+    name = "2.0.3-3.tar.gz";
+    sha256 = "e366a239f16ed2c18057bebeb7a230befff7d8390931c87d34f91f84599be9a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera-msgs/default.nix
+++ b/distros/galactic/realsense2-camera-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera-msgs";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "1444eae3dbc9ba23a62666cfb7aa917afcb31ec00edd27f21e7b7355d0977a70";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera_msgs/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "5a4b1627446662459a841a631d59d7a8d4b7d82a926ecba4f481c75b7e693cfc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-camera/default.nix
+++ b/distros/galactic/realsense2-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, cv-bridge, eigen, geometry-msgs, image-transport, launch-ros, librealsense2, nav-msgs, opencv3, rclcpp, rclcpp-components, realsense2-camera-msgs, ros-environment, sensor-msgs, std-msgs, std-srvs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-camera";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "a0e416884327da905b9a66ebf1215fe77d84f4424933cc37c1861d86f3bc2d14";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_camera/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "790f619dc14c37640238117073c0c51982db4f94a4ea4e65e6397fdbcef1d08a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/realsense2-description/default.nix
+++ b/distros/galactic/realsense2-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, launch-ros, rclcpp, rclcpp-components, realsense2-camera-msgs, xacro }:
 buildRosPackage {
   pname = "ros-galactic-realsense2-description";
-  version = "3.2.2-r1";
+  version = "3.2.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-1.tar.gz";
-    name = "3.2.2-1.tar.gz";
-    sha256 = "fd73bf268ec673aa2d0d3440672b7b1ffd8bb2d9c0617577d6fe0bf6855e5e75";
+    url = "https://github.com/IntelRealSense/realsense-ros-release/archive/release/galactic/realsense2_description/3.2.2-2.tar.gz";
+    name = "3.2.2-2.tar.gz";
+    sha256 = "394c8ad4e49ca3e8ca8fcc6fa50c64689ffcb2de83f1b3c0e0864799e2d2ee24";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/robot-state-publisher/default.nix
+++ b/distros/galactic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, kdl-parser, launch-ros, launch-testing-ament-cmake, orocos-kdl, rclcpp, rclcpp-components, sensor-msgs, std-msgs, tf2-ros, urdf, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-galactic-robot-state-publisher";
-  version = "2.4.3-r2";
+  version = "2.5.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.4.3-2.tar.gz";
-    name = "2.4.3-2.tar.gz";
-    sha256 = "bc7e9eb0e41d0da37afdd0f55fb98ce54d3cf28bb6a620e8618944acf9de8aaa";
+    url = "https://github.com/ros2-gbp/robot_state_publisher-release/archive/release/galactic/robot_state_publisher/2.5.1-1.tar.gz";
+    name = "2.5.1-1.tar.gz";
+    sha256 = "b0428425ce47d88be2465f64ab2bc4c2b848e73401cccc07186e1d13b0aa9232";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/self-test/default.nix
+++ b/distros/galactic/self-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, diagnostic-msgs, diagnostic-updater, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-self-test";
-  version = "2.1.2-r2";
+  version = "2.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/self_test/2.1.2-2.tar.gz";
-    name = "2.1.2-2.tar.gz";
-    sha256 = "4890d07b7830f284c0a3126a29433bf27bb69996301fc91d4ff8d6fbaf0a4d58";
+    url = "https://github.com/ros2-gbp/diagnostics-release/archive/release/galactic/self_test/2.1.3-1.tar.gz";
+    name = "2.1.3-1.tar.gz";
+    sha256 = "a196cb520454949b043a71882dec129b447274c5073d7f7ea14a3180546e2807";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/soccer-marker-generation/default.nix
+++ b/distros/galactic/soccer-marker-generation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, soccer-vision-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-soccer-marker-generation";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_visualization-release/archive/release/galactic/soccer_marker_generation/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "189d3289374ddeb5078718359cd67e205eab040437466f23015f633fe821c452";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp soccer-vision-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generates rviz display markers from soccer msgs'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/teleop-twist-joy/default.nix
+++ b/distros/galactic/teleop-twist-joy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, joy, launch-ros, launch-testing-ament-cmake, launch-testing-ros, rclcpp, rclcpp-components, sensor-msgs }:
 buildRosPackage {
   pname = "ros-galactic-teleop-twist-joy";
-  version = "2.4.2-r2";
+  version = "2.4.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/galactic/teleop_twist_joy/2.4.2-2.tar.gz";
-    name = "2.4.2-2.tar.gz";
-    sha256 = "17724fe71a5a9b8a5e0bc4e5ba03ee4809201076c4d0b50cfa3bb498de88df52";
+    url = "https://github.com/ros2-gbp/teleop_twist_joy-release/archive/release/galactic/teleop_twist_joy/2.4.3-1.tar.gz";
+    name = "2.4.3-1.tar.gz";
+    sha256 = "7a9597cf0ffa9c77a30f7f01c04d66420ccba8a2ed9f61463bacb42d64607abf";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-fake-node/default.nix
+++ b/distros/galactic/turtlebot3-fake-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, nav-msgs, rclcpp, robot-state-publisher, sensor-msgs, tf2, tf2-msgs, turtlebot3-msgs }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-fake-node";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "74dd61d7ca8495e2c42dc03a06e148b6ada531ad091c0357d2010bf882c1e1e4";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_fake_node/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "746cda6a901994dee688ec957bc7d1b5372e7e9366f63a8e6f7e9a6b49100db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-gazebo/default.nix
+++ b/distros/galactic/turtlebot3-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros-pkgs, geometry-msgs, nav-msgs, rclcpp, sensor-msgs, tf2 }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-gazebo";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "865093b702e896467230cca014ebd7f24f318bd335b76f9853cdd08864ab5832";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_gazebo/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "e76517cb5f513868ea7a76963666d5d9e7ef03b4c25611b0bdfed12c5e6f1036";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtlebot3-simulations/default.nix
+++ b/distros/galactic/turtlebot3-simulations/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, turtlebot3-fake-node, turtlebot3-gazebo }:
 buildRosPackage {
   pname = "ros-galactic-turtlebot3-simulations";
-  version = "2.2.4-r1";
+  version = "2.2.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-1.tar.gz";
-    name = "2.2.4-1.tar.gz";
-    sha256 = "6fe67cb191ca2dcab6dd76a8266296360f6f71a55b8370d55f9f0fedb71550c0";
+    url = "https://github.com/robotis-ros2-release/turtlebot3_simulations-release/archive/release/galactic/turtlebot3_simulations/2.2.4-2.tar.gz";
+    name = "2.2.4-2.tar.gz";
+    sha256 = "0faeea177c3ad970753b5c1dae3fdee66a2ff2a646e7eb895d33454d1a0efeb1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-dgnss-node/default.nix
+++ b/distros/galactic/ublox-dgnss-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-cppcheck, ament-lint-auto, ament-lint-common, libusb1, rclcpp, rclcpp-components, std-msgs, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-dgnss-node";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss_node/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "03e5a6fb5441e08c467aae38ac8e06636e97e58ab109ba122dc10ca94b2b6630";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss_node/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "60b17ae2ba4bde43e0d62112076fd53b7db39172a001a95648f8e90b636c899c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-dgnss/default.nix
+++ b/distros/galactic/ublox-dgnss/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ublox-dgnss-node, ublox-ubx-interfaces, ublox-ubx-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-dgnss";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "9da16db3d434301072bd352f54bb2bce8df5ffc42cb2e48f494d27f7ddea3e65";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_dgnss/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "f78bd221cef424ca70fbf61ec88bdbfa2c7eb37990d92317595515450bc1fd5e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-ubx-interfaces/default.nix
+++ b/distros/galactic/ublox-ubx-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators }:
 buildRosPackage {
   pname = "ros-galactic-ublox-ubx-interfaces";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_interfaces/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "fe19666de3d72e3f92446587579f1ffbedc934f72d141cb7634a4527a038af22";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_interfaces/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "df6264657cba012ac0fdce496118a5eac34bbcd4738c3f5330686ae22e0c3be5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ublox-ubx-msgs/default.nix
+++ b/distros/galactic/ublox-ubx-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-ublox-ubx-msgs";
-  version = "0.2.2-r1";
+  version = "0.2.3-r4";
 
   src = fetchurl {
-    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_msgs/0.2.2-1.tar.gz";
-    name = "0.2.2-1.tar.gz";
-    sha256 = "2365b8e3b8d8d71469e43f0beb050e557d0c20266f503503ad187a273c97302c";
+    url = "https://github.com/aussierobots/ublox_dgnss-release/archive/release/galactic/ublox_ubx_msgs/0.2.3-4.tar.gz";
+    name = "0.2.3-4.tar.gz";
+    sha256 = "eb69525840403fb60e8661a4fbbe4032825ceba682b34df96293c869ee8fec2e";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/aques-talk/default.nix
+++ b/distros/melodic/aques-talk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, kakasi, nkf, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-aques-talk";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "44a514bca2a5779849875e31040927929d95f8c70b24752092a983f4cc4e4d88";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/aques_talk/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "82869afa17eba0e36a858850f810ec92304ee2332d37868e5c03cd20fa399fe6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/aruco-pose/default.nix
+++ b/distros/melodic/aruco-pose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-publisher, image-transport, message-generation, message-runtime, nodelet, ros-pytest, roscpp, rostest, sensor-msgs, std-msgs, tf, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-aruco-pose";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/aruco_pose/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "56de0156088bf874c4adbc573265f2a5416cf102692e44256a6d10bdae5e7bdd";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/aruco_pose/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "2506649647c6e2372fe659fe72c03888aefe3fa5a395c765a4d381def7be84ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/assimp-devel/default.nix
+++ b/distros/melodic/assimp-devel/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, cacert, catkin, git, mk, openssl, rosboost-cfg, rosbuild, unzip, zlib }:
 buildRosPackage {
   pname = "ros-melodic-assimp-devel";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "c9f2a223e497f623dba9b3bf0a57d0e537ba8dbeb684dcacbe91cf6078e4146d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/assimp_devel/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "f1fc13d561d14a433023f924c829f39097608b7aa28f3947214cc89c3fb176b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bayesian-belief-networks/default.nix
+++ b/distros/melodic/bayesian-belief-networks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, git, message-generation, message-runtime, mk, rospy, std-msgs, unzip }:
 buildRosPackage {
   pname = "ros-melodic-bayesian-belief-networks";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "e538b2fede05a71b2a1484d912092f76d877211de2856ad5fb74bb35262fa21f";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/bayesian_belief_networks/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e1b42c1dfb5284eed1db5beb5ea6c769ebc2cbef17b89674d95eed6e15936f12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/chaplus-ros/default.nix
+++ b/distros/melodic/chaplus-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-chaplus-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "63b92b40839313bd535feaaa8fc4897a0201ac550da2a2e0ca986c5e838d7018";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/chaplus_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "39bb3f7e562d4f135fd6281b7abf4b71e20bdbf7559aa56909093bb446fba75e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/clover-blocks/default.nix
+++ b/distros/melodic/clover-blocks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, rospy }:
 buildRosPackage {
   pname = "ros-melodic-clover-blocks";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_blocks/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "14a77b30e6f765ca68bc9d3be75f38ff8396695b509d1e9487226973e4deeb23";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_blocks/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "e239ebc11090127ed61030db7fa8c71e9218c00dadfb86328d0204ee0412a651";
   };
 
   buildType = "catkin";

--- a/distros/melodic/clover-description/default.nix
+++ b/distros/melodic/clover-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, xacro }:
 buildRosPackage {
   pname = "ros-melodic-clover-description";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_description/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "a9c169ffff5118a6bb54ffa2fcc3a50278547a9cad575b887b0c1f289d71e1f2";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_description/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "343e10bb269be05deb36111a2ca4bbdb6adde31de38df4ff7d660bd35a2fa77e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/clover-simulation/default.nix
+++ b/distros/melodic/clover-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, gazebo-ros, led-msgs, rospy, xacro }:
 buildRosPackage {
   pname = "ros-melodic-clover-simulation";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_simulation/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "b99255dcb946b46ece99e2858c913e7eedbe8ffd9e92945884b9cc8d2d52da89";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover_simulation/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "a3ae1cd0f1898d8b65411101dd012b63f7441b3e8b948ef3b3b6acfdf1b77f39";
   };
 
   buildType = "catkin";

--- a/distros/melodic/clover/default.nix
+++ b/distros/melodic/clover/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, cv-bridge, cv-camera, geographiclib, geometry-msgs, led-msgs, mavros, mavros-extras, message-generation, nodelet, pythonPackages, ros-pytest, rosbridge-server, roscpp, rospy, sensor-msgs, std-msgs, std-srvs, tf, tf2, tf2-geometry-msgs, tf2-ros, tf2-web-republisher, visualization-msgs, web-video-server }:
 buildRosPackage {
   pname = "ros-melodic-clover";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "65905f65df78466fe585a3417d513ba448fb2d2d55fe86f4b1649084fe14c4cc";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/clover/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "778f01196b1c57d7b4b622146a5e72757fc97d1dda17fbc0bca67c2b11a6465b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/downward/default.nix
+++ b/distros/melodic/downward/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, gawk, python, rostest, time }:
 buildRosPackage {
   pname = "ros-melodic-downward";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "f46fd8cba49ba79dbec02b9ab7cf087970723798d5d906f1bcd7fbfbfdb74d67";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/downward/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "2ff442d942c92ae15b01fe6a41549dde0ad83877bafd1ae83e5a28c2431f32b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-aico-solver/default.nix
+++ b/distros/melodic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-aico-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ac0e2a251ead84bb783513f3354eb333bf404e74c1283bd677c855ff43589e4e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_aico_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "511627d7c2c811f3a189c91ffd4b33f37f368dd6be00d2522332ed1a7cd6455d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-cartpole-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "22a4a1aae5d1536c2e7329cec6f323b1de1be125c99908a220aed6eb0ba35821";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_cartpole_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "70c082510ca9a1838c04f7de893251a0a510ba195d9078d2b1b9cfd9a8abae9f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/melodic/exotica-collision-scene-fcl-latest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
 buildRosPackage {
   pname = "ros-melodic-exotica-collision-scene-fcl-latest";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "f5326db87a0809d9993ab137529de2f7b11f87b33e1d1afe4214343d758291ae";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_collision_scene_fcl_latest/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a13d9ae11fd68e80daa62c8ac6aab85dca5111015468953b667be858c9d25606";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core-task-maps/default.nix
+++ b/distros/melodic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core-task-maps";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "b5ff1a3d74784b2d09348927b5d9068f6b1ab9822d469438ec5eddf1f915d71b";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core_task_maps/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4610912d61cec611e4bd7f438d605168f5fa0ac976ff1f7aacbfb6ca92daf20b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-core/default.nix
+++ b/distros/melodic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-melodic-exotica-core";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "45fb404fa156fc75d8172b49cd9ce04a452d4ba33bcbee50c0d77b3e67e6e395";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_core/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4223cfdf3dafcab1632b16847e289582f004d5adc9bdd9ad3d2cbf0eddda4240";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ddp-solver/default.nix
+++ b/distros/melodic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ddp-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5527b22452856b9e6ff7430263b974141e9ee6495e6b9949776a6da91e41c8cc";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ddp_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "778875f473020668f70d8fd46ccd6b3438dce9ff3ab747a0929232b0ae07d963";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-double-integrator-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "9c20edbcde360d6c12286f1c52743507875a93fcf8907008ea72f48e7f4045ec";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_double_integrator_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "fddc1c35f30e38eb033e4e5627e21fb699c1fb226cff4f676976fa8a25bb84d2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-dynamics-solvers/default.nix
+++ b/distros/melodic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica-dynamics-solvers";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "15687b033af6ef1400a62138edbd9960298580f2ae98e9a9393f93c36cbe8361";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_dynamics_solvers/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "bb7f1c96594f7789b8cac978571a23a8b28e629f2a14554e891a4cea90db7ab9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-examples/default.nix
+++ b/distros/melodic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-exotica-examples";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5ab0d4451557df8f78135d08278417f25a7e413285b1de737849fcc761d5e236";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_examples/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e6b7a37a6c16fd636cfa279dbeb2540418e6404b2a35e64c4c6e9529ceb6ef3d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ik-solver/default.nix
+++ b/distros/melodic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ik-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "cfb1c394e27648d2cc230d5b39a7a0885a31fb9e9203311e80101518c07166f2";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ik_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "7242987a28dd17b8d11486e1d1e15f65b8324c897de3e9be200213a60d875b36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqg-solver/default.nix
+++ b/distros/melodic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqg-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "f3bf96ebabbafc95cd3b9703cc4e80cbee578d1f0f5655da0a2abb92954fe697";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqg_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "628e317c178e94728ee4d18fcc75ec83b68c2f0c9429773d69ff0040be3a6868";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ilqr-solver/default.nix
+++ b/distros/melodic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ilqr-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "7a80f10763837b95e286f9d76bbc79297b66a92521adc43cddedd63bbac9a3d6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ilqr_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "77e2f28159e77ccf37e4b88696682ab05232697588f64039c2dba3182b8c9692";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/melodic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-melodic-exotica-levenberg-marquardt-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "abe360ac8db24541295ce7abcb1d0f428af7ffcb07b24f248d73330db55b39df";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_levenberg_marquardt_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5c6f06ce4d3fd4a069477fd994f0b31c61adc48bc4b2709b955e1a784721879a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-control-solver/default.nix
+++ b/distros/melodic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-control-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "364c26a4ab3d976f715e435fc2a2f9227a3b7837dc6c8e584aa1619b1deb0d88";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_control_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a62b78136c92e9db002785b9be5c3eeb1da0867063dc64233a009f36ccf45b91";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-ompl-solver/default.nix
+++ b/distros/melodic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-ompl-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ca209926dde27acfb2bbf3259da7c6d17182805b02ed05a7d0c3ec0baa46e8d6";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_ompl_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "38782932d1b6e6107f2bbafbd10c63357e23a9e771b1a208eb6372130c2aa67c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pendulum-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "ddd9d3c39477c96547e64ddacf8030ee86bb1845240d87ea02660fd7f9512153";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pendulum_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "8a80eee1ef29f578cc6ccf406b01044127ed46c988dab54484779b2b2b9963f0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-pinocchio-dynamics-solver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, clang, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-pinocchio-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "891d50bcb28862ee30c7f7091774dfc8a5d24ae30cc68b5e5eeaff40a1595f7a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_pinocchio_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e2fc909514d0a8eaf1272099e10ae0972da901271abd99cbc6bccf193720c5ce";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  propagatedBuildInputs = [ clang exotica-core pinocchio roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/melodic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-exotica-quadrotor-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8eb98c390ec797d3fb47134a653675628af1a681002fdc1d6175a27abbe53f65";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_quadrotor_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "398c1c4340b857108543536ae16b2502b6d79ba70ed820b6ae9cdc863cd36fc9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-scipy-solver/default.nix
+++ b/distros/melodic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-exotica-scipy-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6d0694bfcf35e952ea6097b850d2824e4bc4d967c277007d138bcc0d866db00a";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_scipy_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e8ab625926e85331b7926c49e3849f636b7d39a95e6a6662eec83c16ee5664b4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/melodic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-melodic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "d4a48b82251ed4cf276e8bd6e2d6f0682fed1e327a9c4f7e439c8e241314aca1";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica_time_indexed_rrt_connect_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "bae5bdda0839de66c99c8b800877103ed50863f2b4e3899f8bf135c68de9c213";
   };
 
   buildType = "catkin";

--- a/distros/melodic/exotica/default.nix
+++ b/distros/melodic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-melodic-exotica";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5a613ad20d20c954823d70cecebd17036b2a6c9b0cf09e92caada64edb20604e";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/melodic/exotica/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "20efa697c52405088af5188ee7e119d6492f1272efe15849ae20c059fbba2880";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ff/default.nix
+++ b/distros/melodic/ff/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, cacert, catkin, flex, mk, openssl, rosbash, rosbuild, roslib, rospack, unzip }:
 buildRosPackage {
   pname = "ros-melodic-ff";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "0bb3abb6c5d7105e7904ac76487dd0a5b5139496906ee319c25e3ca6bf22457c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ff/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "4009d2758aa8c4dde3c4a850ab68854d90928c8bd8f0033c8c323597339de767";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ffha/default.nix
+++ b/distros/melodic/ffha/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bison, catkin, flex, gawk, mk, rosbuild, roslib, rospack }:
 buildRosPackage {
   pname = "ros-melodic-ffha";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ba6aa626677012ae042dd37863eba71088fb9b8b11305a34e530fe5d3c2ea646";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/ffha/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "dd6a5b76ff585b5fcd82a8f2b641f9ed35d0787535866027d563cb1ea312f8e0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-control/default.nix
+++ b/distros/melodic/franka-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, tf, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-control";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "cec412f212461dffb69f6b584da38f86a0d4e792a46f9765d220e39c34e0422e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "50a9759027ad8342c024da2c531baad88c49daa30b9c1fa76ba757e745cc4150";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ controller-interface controller-manager franka-description franka-gripper franka-hw franka-msgs geometry-msgs joint-state-publisher libfranka pluginlib realtime-tools robot-state-publisher roscpp sensor-msgs tf tf2-msgs ];
+  propagatedBuildInputs = [ controller-interface controller-manager franka-description franka-gripper franka-hw franka-msgs geometry-msgs joint-state-publisher libfranka pluginlib realtime-tools robot-state-publisher roscpp sensor-msgs std-srvs tf tf2-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/franka-description/default.nix
+++ b/distros/melodic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-description";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "900aafe7e265eded57bf5912dea22a166ff95047fa108a92e7d8d599dfd43d0e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "2be5aadd4d6ad6b77207e4d024570f7d70c588eeb6d565106008339b8a03732b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-example-controllers/default.nix
+++ b/distros/melodic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-franka-example-controllers";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "c407028f4462054ee5691943cb401fd0b79285a8217c7f2f51b361d5feb991b1";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "0ad67a6533256a467a61b6bed080a1d982a5246ae198f5050d65ec8934c53444";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-gazebo/default.nix
+++ b/distros/melodic/franka-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, std-msgs, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-melodic-franka-gazebo";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gazebo/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "596ca26ce1a567d664f987fc7caf9dfc085fd5ba4134551f05a3506a17d81f33";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gazebo-dev ];
+  checkInputs = [ gtest rostest ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp std-msgs transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package offers the FrankaHWSim Class to simulate a Franka Robot in Gazebo'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/franka-gripper/default.nix
+++ b/distros/melodic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-franka-gripper";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "44fbcb55b400f1f358660d1ddc0e36ab7bada81561e0d825ba98de11cb8e04df";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "a9e109dc85ed5886534c0696892a29572b8c6eae07225297ce97105b7f5708ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-hw/default.nix
+++ b/distros/melodic/franka-hw/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-franka-hw";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "9d5e7b500096de8c99d98d528c46e570fc8a48dee4913a703e8a7f8d8c7f64ce";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "7b0688fc23757b0169ad5e90ff363cb67462b6ebc70d394a0ae8b42a5aabc52a";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ franka-description gtest rostest ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs combined-robot-hw controller-interface franka-msgs hardware-interface joint-limits-interface libfranka pluginlib roscpp urdf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs combined-robot-hw controller-interface franka-msgs hardware-interface joint-limits-interface libfranka pluginlib roscpp std-srvs urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/franka-msgs/default.nix
+++ b/distros/melodic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-msgs";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "c48fe771b14182e46d47ab9d093d00e3ecce4788544b10ea6bd108753c156e67";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "a9ad6ea5c30756f51c72134b4530c4352c1cdd8cdd4f3493bdc4d0c4ff67bd0c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-ros/default.nix
+++ b/distros/melodic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-melodic-franka-ros";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "5aceda597b81953bf15928a7e9f26fa1607d561b29b7b18d7f5ee38bc9807a21";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "e48f2cd6f6aea7e68e81d3a11325cbf04a1030f1dc7db0e4be5f1812d398778e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-visualization/default.nix
+++ b/distros/melodic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-visualization";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "62372338af371f5c7004669c4b19a37a544a9753df8d0d8905837a82fd8d57b3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "3505398ec199018247dcce2fd60284336ddf1a6856a939d08e4b70ae9cac4188";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1128,6 +1128,8 @@ self: super: {
 
  franka-example-controllers = self.callPackage ./franka-example-controllers {};
 
+ franka-gazebo = self.callPackage ./franka-gazebo {};
+
  franka-gripper = self.callPackage ./franka-gripper {};
 
  franka-hw = self.callPackage ./franka-hw {};
@@ -3681,6 +3683,8 @@ self: super: {
  rt-usb-9axisimu-driver = self.callPackage ./rt-usb-9axisimu-driver {};
 
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
+
+ rtcm-msgs = self.callPackage ./rtcm-msgs {};
 
  rtmbuild = self.callPackage ./rtmbuild {};
 

--- a/distros/melodic/jsk-3rdparty/default.nix
+++ b/distros/melodic/jsk-3rdparty/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp-devel, bayesian-belief-networks, catkin, dialogflow-task-executive, downward, ff, ffha, gdrive-ros, google-cloud-texttospeech, julius, julius-ros, libcmt, libsiftfast, mini-maxwell, nlopt, opt-camera, pgm-learner, rospatlite, rosping, rostwitter, sesame-ros, slic, voice-text }:
 buildRosPackage {
   pname = "ros-melodic-jsk-3rdparty";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ade47b4f901130802a6ef28ac05b243edbf2a3d7e4fc484687d916eaca0cef16";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/jsk_3rdparty/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "1450a9afeb52fdb7ef609eb251583bfd59ea3986b4388fd915f1e89e6bbb69a6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/julius/default.nix
+++ b/distros/melodic/julius/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, roslib, rospack, rsync, unzip, wget }:
 buildRosPackage {
   pname = "ros-melodic-julius";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "daac96404772a43ebf280700478b94a28fc6cd19ce0a61e2d2ffac7da36adfbf";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/julius/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e9584e6b499d9efac760ae114e921b80a72304897d4ccb4d1e41fb6521d460ce";
   };
 
   buildType = "catkin";

--- a/distros/melodic/laser-filters-jsk-patch/default.nix
+++ b/distros/melodic/laser-filters-jsk-patch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, filters, git, laser-filters, laser-geometry, mk }:
 buildRosPackage {
   pname = "ros-melodic-laser-filters-jsk-patch";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "7f4583a260f42817fe55cd2bb350d4b3c95045a7a1b89f05f54ca56f159e3aa1";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/laser_filters_jsk_patch/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "3efd3a7b0b31928f8ee41e047b5a212c766bf2ad3bd8c1d7607fd13d5cfb2a28";
   };
 
   buildType = "catkin";

--- a/distros/melodic/libcmt/default.nix
+++ b/distros/melodic/libcmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cv-bridge, git, openssl }:
 buildRosPackage {
   pname = "ros-melodic-libcmt";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "1562ae8d15a3bfea334c3425bc626435a30091fbc6236763533a5de8bef517d4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libcmt/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e0ece8617dc15630f1584003705c73484db1f27123b3dc943d31d2878bd0cfc4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/libsiftfast/default.nix
+++ b/distros/melodic/libsiftfast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, mk, pythonPackages, rosboost-cfg, roslib, rospack, subversion }:
 buildRosPackage {
   pname = "ros-melodic-libsiftfast";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "10a93f313edcba25f77830470cb771c60d9777a10ac9952d26659f4187a30346";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/libsiftfast/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "87761a5a4f4feb68f17e309768ff3868e1b3f2a24f06885671321a289406bbaa";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lpg-planner/default.nix
+++ b/distros/melodic/lpg-planner/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-lpg-planner";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "0a03508ba0e0e77d6258e0350ca3aefb60e737e7204aad5a643efcf6a5d277be";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/lpg_planner/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "ddb8d29035bc8e74460123650bc23d69b87b9802fe1f9fcfd20249e784bd7fd0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mini-maxwell/default.nix
+++ b/distros/melodic/mini-maxwell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamic-reconfigure, roslib }:
 buildRosPackage {
   pname = "ros-melodic-mini-maxwell";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "60259edb460635615e74bf90f754856e96f8e666d2d0d7b3d01de983364b9cbe";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/mini_maxwell/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "ba44f36b1f096aae97a143170235999f251fb121b66792fe6d05106722b9d8c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/nlopt/default.nix
+++ b/distros/melodic/nlopt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, libtool, mk, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-melodic-nlopt";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "cc6fed393b73f40891a72caf215da19a50c48c4545c53e27d3f6882f3e59b8e4";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/nlopt/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "738644a604b580b7ee9fe3df9332558d7fe29559e68d7d4ab3d4c129dcda8ae0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/opt-camera/default.nix
+++ b/distros/melodic/opt-camera/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, camera-calibration-parsers, catkin, compressed-image-transport, cv-bridge, dynamic-reconfigure, image-proc, roslang, rospack, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-opt-camera";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "ad1c05c658939b82195e49003be1ab09c90d0d9e9bcbaaffb65875035de24fbd";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/opt_camera/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "bb1aedce31c9f6efeca26bbe59e5139fae1218d0b1591d6e4fd34646cea4020f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/pinocchio/default.nix
+++ b/distros/melodic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python, pythonPackages, urdfdom }:
 buildRosPackage {
   pname = "ros-melodic-pinocchio";
-  version = "2.6.1-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "d6bcb86336ec895fd8752c13fd9d4b1ff75821b38c54388c03c775a717d36b24";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/melodic/pinocchio/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "a2a4f78cec9aebbb7284b51ed82afcabe1e98b082cbfc97eb4e2a4ce56cff404";
   };
 
   buildType = "cmake";

--- a/distros/melodic/rc-genicam-api/default.nix
+++ b/distros/melodic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-api";
-  version = "2.5.0-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "b4dc36dd3b80e25866b175147f4af04b29988efc97f6441bf3dc7bed1d4ca9e5";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/melodic/rc_genicam_api/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "902f6cc0d8a886664bca7e2e0b9301991d986aa632945975df5d794a57c171a4";
   };
 
   buildType = "cmake";

--- a/distros/melodic/rc-genicam-driver/default.nix
+++ b/distros/melodic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-rc-genicam-driver";
-  version = "0.5.2-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "061603525595b683a2f6042b84a7daf4fc040d935996abc31d76006e83d51207";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/melodic/rc_genicam_driver/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "649606695422e7f7cdbe614404434dcf60e2922abfe7d839aa463a3fa6096fae";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/melodic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-rc-hand-eye-calibration-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "6977a56aa6ebd55c2fdd9a5b5a771e54de1ce04d734fe55ea605e6219d7fa753";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_hand_eye_calibration_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "0fc4ed0f1cf427c040ec7db8387f9d07404b3edc68ef2802b6bfcce2ab466105";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-pick-client/default.nix
+++ b/distros/melodic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-pick-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "ba1922684317bf4cd72559f403dbe777539f958a3b98e22456a80652c1160af4";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_pick_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "e3f5296e818834456cd6faa979a2f2e18370cddb81600cb8ac28ebfaf3227bd6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-roi-manager-gui/default.nix
+++ b/distros/melodic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-melodic-rc-roi-manager-gui";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "1646a238a2c14cfd93358afadb2562feccc3f9397335495a40858dcc9a251cd1";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_roi_manager_gui/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "3ffa307c635080207ddb6c8a90ce0e65135e501b849059199b093b4aa4edd19d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-silhouettematch-client/default.nix
+++ b/distros/melodic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-silhouettematch-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "60d93f70770b054b9369410ead8a14dd5401a326e7f1ab28c26f04deae035c5d";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_silhouettematch_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "b4a5d4ccd2301e171b489be4002b073b2d7140b254f62cb43cf977050e1d4c7f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-tagdetect-client/default.nix
+++ b/distros/melodic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-tagdetect-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "0ba875889282dbc31b58d4b3808e71e7a01eeaa6653dc78725cba4f94befbda7";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_tagdetect_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "03afbb41710552ab519ed2b284f24a1d7cf501b153661cc25994fa21ea85dc3c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-description/default.nix
+++ b/distros/melodic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-description";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "dfcb05e9b5046061e9059414ee2399a7429494f203014d8c0ab0f92ecf2d8c5a";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_description/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "80596819b33dabed21c77e73233ce9b4879908bfe7771b371901c8b6954b4832";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard-driver/default.nix
+++ b/distros/melodic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard-driver";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "2fd6fc988d8687feff0b5393c5e392814a7bfc6a6fd6d22c9645b85db71a2575";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard_driver/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "31ebf811e9c8d660b4e12e592cb17812ddea22251755070df2981bf3655e2ea0";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rc-visard/default.nix
+++ b/distros/melodic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-melodic-rc-visard";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "b6985c1ce05e26b49d2893d1718449b6a166e9766aa66e3996e7904d80235733";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/melodic/rc_visard/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "888b202662f7d7e64f86933f50f6f1df5b04e0497634e7b3de2e88798e147e47";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-body-filter/default.nix
+++ b/distros/melodic/robot-body-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-body-filter";
-  version = "1.1.9-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/peci1/robot_body_filter-release/archive/release/melodic/robot_body_filter/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "d16cb56b66e5add7d8c5f35951a7e357ad59eab88a5f89149d4b18ef432afb96";
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/melodic/robot_body_filter/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "d51b48b1688bcf9d53181d592d1f346f3adb017bc1995143bb144d98a87b992f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-localization/default.nix
+++ b/distros/melodic/robot-localization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, pythonPackages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-robot-localization";
-  version = "2.6.10-r1";
+  version = "2.6.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.10-1.tar.gz";
-    name = "2.6.10-1.tar.gz";
-    sha256 = "6c29f8412e50f60f391ff48c25e591363661ee99456f70383896617c990c32d5";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/melodic/robot_localization/2.6.11-1.tar.gz";
+    name = "2.6.11-1.tar.gz";
+    sha256 = "460ae8491dd7487f761ebb69e2bc052d836502abcf682f9174b28c6493828693";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rospatlite/default.nix
+++ b/distros/melodic/rospatlite/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rospatlite";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "5e01ad253087b8dab1501f343d49c26e26797a75ae2f748592331032935534f0";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rospatlite/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "26cb5bd321426b71aa3e2f6c1818ee7a029422a6818b9e47bd39896c76cad17d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosping/default.nix
+++ b/distros/melodic/rosping/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosboost-cfg, rosbuild, roscpp, rostest, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rosping";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "f70fded13077a3232c6b01219c538151b3ec329c49071c8434ef23d2d4ee823d";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/rosping/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "bc920068e908068eea5789b1cfbacda7e48872836c845c47cae6e7aff6b27334";
   };
 
   buildType = "catkin";

--- a/distros/melodic/roswww-static/default.nix
+++ b/distros/melodic/roswww-static/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-roswww-static";
-  version = "0.21.3-r1";
+  version = "0.21.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/roswww_static/0.21.3-1.tar.gz";
-    name = "0.21.3-1.tar.gz";
-    sha256 = "2420681ba2278f0aeb622e54220d0add26cf00b0d9d8606dbad1d698e11fe058";
+    url = "https://github.com/CopterExpress/clover-release/archive/release/melodic/roswww_static/0.21.2-1.tar.gz";
+    name = "0.21.2-1.tar.gz";
+    sha256 = "d15218175c9d6ccaac2489434e083d4cac54ff6403af7b69e76560f3a9712cbd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtcm-msgs/default.nix
+++ b/distros/melodic/rtcm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rtcm-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rtcm_msgs-release/archive/release/melodic/rtcm_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "7ca84d7bd226e0121ad7d2952c793ba4ac818538e5b377bb35cf6febc9a8f64a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rtcm_msgs package contains messages related to data in the RTCM format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/sesame-ros/default.nix
+++ b/distros/melodic/sesame-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, catkin-virtualenv, libffi, message-generation, message-runtime, openssl }:
 buildRosPackage {
   pname = "ros-melodic-sesame-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "54c6a98ad8fd96458951922cad11a0479c9d2896aa446eeeed3d105ea124a97e";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/sesame_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "d066f569e031178d47310e1b7761bd1f7e9d038843876838cb1fdc167e7b99ac";
   };
 
   buildType = "catkin";

--- a/distros/melodic/slic/default.nix
+++ b/distros/melodic/slic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cacert, cmake, cmake-modules, git, opencv3, openssl }:
 buildRosPackage {
   pname = "ros-melodic-slic";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "565be41ab0971e1307cd57d5852aab77d4e2af710931e325b83026528ad4968c";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/slic/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "e007e40244375ee5d06d9d254db91c142349edfb218b6b12fe76fd84297eb9bf";
   };
 
   buildType = "cmake";

--- a/distros/melodic/switchbot-ros/default.nix
+++ b/distros/melodic/switchbot-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-runtime, pythonPackages, rospy, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-switchbot-ros";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "1a8c29d7ac6f11009a88d3110b30613fcbdc80aab88b4b8aa57db63e4bf5b0ef";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/switchbot_ros/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "328df93d029dd75726982089e88ce3112d497a3ec7c2df4bfd5e8c8b8035ff08";
   };
 
   buildType = "catkin";

--- a/distros/melodic/voice-text/default.nix
+++ b/distros/melodic/voice-text/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, message-generation, message-runtime, nkf, roscpp, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-voice-text";
-  version = "2.1.23-r1";
+  version = "2.1.24-r1";
 
   src = fetchurl {
-    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.23-1.tar.gz";
-    name = "2.1.23-1.tar.gz";
-    sha256 = "84f279188041134b65566a09eb9720eb944003f0360995f4e94c6b4d56383d4b";
+    url = "https://github.com/tork-a/jsk_3rdparty-release/archive/release/melodic/voice_text/2.1.24-1.tar.gz";
+    name = "2.1.24-1.tar.gz";
+    sha256 = "8e17878d8972cc45282d3d10ff334d242e8e49c568bf02e01960d8bd13a911e0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.1-r2";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.1-2.tar.gz";
-    name = "1.0.1-2.tar.gz";
-    sha256 = "a20e31870dd97fa3a0ee9c51a2328eaf4bd5788a46a2ce59e938a0ff3bd61457";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "8d122dad07b506b904befd65db6d44d6f90b9c0c2306ac75fdd77dc58b70546f";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The bosch_locator_bridge package'';
+    description = ''ROS interface to Rexroth ROKIT Locator'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/noetic/cartesian-interface/default.nix
+++ b/distros/noetic/cartesian-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-interface";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "5fdd869842258eab6342f8fa8f0f41206e30fbfdc706c46b042a7ca708a84f30";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_interface/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "68ec44c6147522d337527352ba97241fc7b71484cb9d7557e939c36ec7da5df3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-controller/default.nix
+++ b/distros/noetic/cartesian-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-controller";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "882ca6abac1e790866c7bdf43fdb0b41bda431666b6383628a293eab1ad32835";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_controller/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "b62ba5575808a6cf1c140840e9fc23b39cef01344ddee77af7bcecf53ab0295d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/noetic/cartesian-trajectory-interpolation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
 buildRosPackage {
   pname = "ros-noetic-cartesian-trajectory-interpolation";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "3b56a4850e1c23e5a796710e962aa0c46649a9a6af4df6161b67a5cef6d8917f";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/cartesian_trajectory_interpolation/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "8a54f18bd64bb3aa82c13fc0bf695030c01db3d05b757ab1ea21ef32e941f45f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dynamixel-workbench-controllers/default.nix
+++ b/distros/noetic/dynamixel-workbench-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, dynamixel-workbench-msgs, dynamixel-workbench-toolbox, eigen, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-workbench-controllers";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/noetic/dynamixel_workbench_controllers/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "0191c29aaa977c0ec9407d4743da05968a15cc97415f24bb845cc67e237bd6ab";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules dynamixel-workbench-msgs dynamixel-workbench-toolbox eigen geometry-msgs libyamlcpp roscpp sensor-msgs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains examples of applying the 'dynamixel_workbench_toolbox' library developed on the basis of dynamixel_sdk to various operating modes of Dynamixel.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/dynamixel-workbench-operators/default.nix
+++ b/distros/noetic/dynamixel-workbench-operators/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, geometry-msgs, libyamlcpp, roscpp, sensor-msgs, std-srvs, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-workbench-operators";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/noetic/dynamixel_workbench_operators/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "7a36a609437d621c5194faf13c738bad9d30721ca9d835d6be4f70b5e1a8e0fc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules geometry-msgs libyamlcpp roscpp sensor-msgs std-srvs trajectory-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains nodes that control the Dynamixel by communicating with the server registered in the 'dynamixel_workbench_controllers' package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/dynamixel-workbench-toolbox/default.nix
+++ b/distros/noetic/dynamixel-workbench-toolbox/default.nix
@@ -1,0 +1,28 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-sdk, roscpp }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-workbench-toolbox";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/noetic/dynamixel_workbench_toolbox/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2c3513d9e4e8d1ac52e5c230c63ef6661cc74c97bd0cc1f71281fa11d2f56777";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamixel-sdk roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package is composed of 'dynamixel_item', 'dynamixel_tool', 'dynamixel_driver' and 'dynamixel_workbench' class.
+    The 'dynamixel_item' is saved as control table item and information of Dynamixels.
+    The 'dynamixel_tool' class loads its by model number of Dynamixels.
+    The 'dynamixel_driver' class includes wraped function used in DYNAMIXEL SDK.
+    The 'dynamixel_workbench' class make simple to use Dynamixels'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/dynamixel-workbench/default.nix
+++ b/distros/noetic/dynamixel-workbench/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, dynamixel-workbench-controllers, dynamixel-workbench-operators, dynamixel-workbench-toolbox }:
+buildRosPackage {
+  pname = "ros-noetic-dynamixel-workbench";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ROBOTIS-GIT-release/dynamixel-workbench-release/archive/release/noetic/dynamixel_workbench/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "d9ab814b23da7f58a8ef012d3c93c3c225340c5dd19d810b67a2093d6aac0b54";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ dynamixel-workbench-controllers dynamixel-workbench-operators dynamixel-workbench-toolbox ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Dynamixel-Workbench is dynamixel solution for ROS.
+    This metapackage allows you to easily change the ID, baudrate and operating mode of the Dynamixel.
+    Furthermore, it supports various controllers based on operating mode and Dynamixel SDK.
+    These controllers are commanded by operators.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/exotica-aico-solver/default.nix
+++ b/distros/noetic/exotica-aico-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-aico-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6d67b24bfb99a327e10b7a747fbb7f8e08add8b3cd200ded7de136255e37e583";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_aico_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "8c868d4729ae7b7d00eef65fd4f9ab60bf97e1321f39d0583dfaff92754e0e3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-cartpole-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-cartpole-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "2e79cd3d9dde38e0530e96af9f3a4658d3ff5c0f875cb6e4d9109403efb75059";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_cartpole_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "baa1d842aa76a78e30f715e34ee6c7875ed6fbe1c303f7da57967671c6bef9bb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
+++ b/distros/noetic/exotica-collision-scene-fcl-latest/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl-catkin, geometric-shapes }:
+{ lib, buildRosPackage, fetchurl, catkin, exotica-core, fcl, geometric-shapes }:
 buildRosPackage {
   pname = "ros-noetic-exotica-collision-scene-fcl-latest";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "0683e6d99bdbec936deb6384b70d3092e9e0d889b45a3a0a889d59372bc57684";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_collision_scene_fcl_latest/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "4498a661edc5aaf4f04f356ad9a44b69a2e16b3767cf37a3b4bd605dbc8145d0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core fcl-catkin geometric-shapes ];
+  propagatedBuildInputs = [ exotica-core fcl geometric-shapes ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/exotica-core-task-maps/default.nix
+++ b/distros/noetic/exotica-core-task-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen-conversions, exotica-collision-scene-fcl-latest, exotica-core, exotica-python, geometry-msgs, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core-task-maps";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "0e0bf5274381e2264b216f5d8ced4e6018d939210c1bf29b8214324bbc8cf689";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core_task_maps/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "0da5ac478efdaa7523c292c1332139d33b948a4df6297e4324ca9d142fbf45aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-core/default.nix
+++ b/distros/noetic/exotica-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, cppzmq, eigen-conversions, geometry-msgs, kdl-parser, moveit-core, moveit-msgs, moveit-ros-planning, msgpack, orocos-kdl, pluginlib, roscpp, rosunit, std-msgs, tf, tf-conversions, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-noetic-exotica-core";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "156815433c405fca51fe552806eb98b8f3f3e67ee047f8511a43f01315c2bd34";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_core/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e5a0d4c3011d40a110dacdbb595f0bc0cbfb55eab42da9d5bfdb644453aab6ab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ddp-solver/default.nix
+++ b/distros/noetic/exotica-ddp-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ddp-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "908c2fe22aedbb0c111a59bc582b2699dd0aec961be5128eb72652da14dec224";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ddp_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a77f9751667bcd8e6acdb7b058fd64a05fbf34d02ede8af7076ddafb18a980cb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-double-integrator-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-double-integrator-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5eb8f652c5e6d3c0afa8b317830c16b3dbe4978e52715c7a273a57564583b23f";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_double_integrator_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "1f923cb14c5b1610f7496c4af3ca5d7d60aadef736263ab72e9859d0bfeb33d4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-dynamics-solvers/default.nix
+++ b/distros/noetic/exotica-dynamics-solvers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-cartpole-dynamics-solver, exotica-double-integrator-dynamics-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-quadrotor-dynamics-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica-dynamics-solvers";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8b5857927f5f082ca115a3a4d9087621d3830e152cc5138b926e882128a25876";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_dynamics_solvers/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "91c483689f74df47d811b385156a14d06d7f984346f1d0b998e37265314b185b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-examples/default.nix
+++ b/distros/noetic/exotica-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-cartpole-dynamics-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ddp-solver, exotica-double-integrator-dynamics-solver, exotica-ik-solver, exotica-ilqg-solver, exotica-ilqr-solver, exotica-levenberg-marquardt-solver, exotica-ompl-control-solver, exotica-ompl-solver, exotica-pendulum-dynamics-solver, exotica-pinocchio-dynamics-solver, exotica-python, exotica-quadrotor-dynamics-solver, exotica-scipy-solver, exotica-time-indexed-rrt-connect-solver, exotica-val-description, geometry-msgs, interactive-markers, python3Packages, robot-state-publisher, rostest, rosunit, rviz, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-exotica-examples";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "fc82861ba5e048f0ba3ff5f40b53bd2d1d1288069221db60385299b4e69fec32";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_examples/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "253c541a3cb1eb6215226dd062360c131ef478065abdcde75455d25b8213d262";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ik-solver/default.nix
+++ b/distros/noetic/exotica-ik-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ik-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "a0363e76e27e36305c850ecee6adcf2133512620422c2e7fc25b1a177594d2b5";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ik_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "c6537d5896dac76ac90cd8db8de863cb719204259d3c363b40ecc54f978569b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqg-solver/default.nix
+++ b/distros/noetic/exotica-ilqg-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqg-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "fa454d463b1194649ba097acf518b4b02c725b1e2bcfc5706833919bc7ab2f30";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqg_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "e3c7a828a6cf965a2f2c18c88b77aec879ca003460497d3be6ba712d8226830d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ilqr-solver/default.nix
+++ b/distros/noetic/exotica-ilqr-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ilqr-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "554ea850f68fcaafac94a4718236d025309bd54ad626a43083485e917f256473";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ilqr_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "a796cfef3920486d26caf201e22191c2663dd97f846c52c6344faf8649f5441a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
+++ b/distros/noetic/exotica-levenberg-marquardt-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, exotica-core }:
 buildRosPackage {
   pname = "ros-noetic-exotica-levenberg-marquardt-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "80d2b90056cdd0091f4dac19b30a62412e601421c9087d7a508621c7c60864c8";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_levenberg_marquardt_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "135bb1e8166b3f10b61c15be56718dc1249b6555404e6026a61df817911e4ef3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-control-solver/default.nix
+++ b/distros/noetic/exotica-ompl-control-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-control-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "5f81f6301c8695bc50b0f584d8c85bc372b3ebdc295dc86531b20e57f3aa74de";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_control_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "3192ddfc51623872b292eafbbc53cebe5be603e22f4b3101f9b448dd24b5263e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-ompl-solver/default.nix
+++ b/distros/noetic/exotica-ompl-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, exotica-python, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-ompl-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "8bc6472bb6b4ea8f4e23b5b7e204f973cc483acb24f0556ac6b7aeabd0759c70";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_ompl_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "88d6418dd0dac08307b2e982c670a614b11bbd6a2b6a5fb2ccc57fcc8860d4e4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pendulum-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pendulum-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "e05f33d8f25fdc020cfea09f277c2416170d3c57fd344738fa3eb61923b8bea4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pendulum_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5b6d3e637a7df464ee506bdf7a47da647041035bc2686e0f12a8654764a8ac14";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-pinocchio-dynamics-solver/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, exotica-core, pinocchio, roscpp }:
+{ lib, buildRosPackage, fetchurl, catkin, clang, exotica-core, pinocchio, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-pinocchio-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "6f34d0014013026de5d84d11fc1e5d48c3131c3edcfaa460887a1fd5ba5e4d33";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_pinocchio_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "f4d67d2e53282319f64a1cafb9d9077180a7dec2c5e5b2dac253ff0b922456aa";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ exotica-core pinocchio roscpp ];
+  propagatedBuildInputs = [ clang exotica-core pinocchio roscpp ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
+++ b/distros/noetic/exotica-quadrotor-dynamics-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-exotica-quadrotor-dynamics-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "baeae64d957184984aa276e6205aea214b36099c6f737ae9630f5eea18adafa4";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_quadrotor_dynamics_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "821f8955a1087becabaa394797ae9a9e28b27f1fa3f9f46a71863e2325fecb42";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-scipy-solver/default.nix
+++ b/distros/noetic/exotica-scipy-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-exotica-scipy-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "12ee73b924ddc37144fa88801d21a33b675cceaf2d208002a1915a6ab6496f35";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_scipy_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "46dae74a65ba823ea0ba88ab9bd99d21cd57b130064c1b30ac0a0b0b02ac0c26";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
+++ b/distros/noetic/exotica-time-indexed-rrt-connect-solver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-core, ompl }:
 buildRosPackage {
   pname = "ros-noetic-exotica-time-indexed-rrt-connect-solver";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "89b36aca5ec996c3a5b4ec9e564c92f9350a2e1f300c3234de75094420b87b85";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica_time_indexed_rrt_connect_solver/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "5cc72e41ed448ea01febaf17af48dcffe19d498e3fda230c16b83263491069f7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/exotica/default.nix
+++ b/distros/noetic/exotica/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, exotica-aico-solver, exotica-collision-scene-fcl-latest, exotica-core, exotica-core-task-maps, exotica-ik-solver, exotica-levenberg-marquardt-solver, exotica-ompl-solver, exotica-python, exotica-time-indexed-rrt-connect-solver }:
 buildRosPackage {
   pname = "ros-noetic-exotica";
-  version = "6.1.1-r1";
+  version = "6.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.1.1-1.tar.gz";
-    name = "6.1.1-1.tar.gz";
-    sha256 = "9deeee658d9b2d94c241500dab6d9a216f07f97d3bf3fa3d8a5131a2526b49a7";
+    url = "https://github.com/ipab-slmc/exotica-release/archive/release/noetic/exotica/6.2.0-1.tar.gz";
+    name = "6.2.0-1.tar.gz";
+    sha256 = "c574f23e46c5d676c8ac7b41ea7a37ee616990700048b4047eead4b362aab87f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, tf, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "1af5a61d7eb3481e0c2105355d36bb7431de573466f0aa54f86c3d0d0362bb26";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "edf61fcee7cec88ef37b78fdd1095db3bc83dbf8be226b88b736ec17a7b45e48";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ controller-interface controller-manager franka-description franka-gripper franka-hw franka-msgs geometry-msgs joint-state-publisher libfranka pluginlib realtime-tools robot-state-publisher roscpp sensor-msgs tf tf2-msgs ];
+  propagatedBuildInputs = [ controller-interface controller-manager franka-description franka-gripper franka-hw franka-msgs geometry-msgs joint-state-publisher libfranka pluginlib realtime-tools robot-state-publisher roscpp sensor-msgs std-srvs tf tf2-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "40f47d785043ef8bb088a4cbdcc97de56a24176198460e7e03bfbe278795fae3";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "f9c5839d84b866337cbbc1aa0fd398291ada7d03de327d3cabf3c006cba03633";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "8ed58351a55468de04d19bf16ef19922f56ba1acbc1064e2fc552d0645a2f5bd";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "dbed2239cd51deddb45df921ea510e5e0fb0da78fca098bf1aff2f05000cebe8";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, std-msgs, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-franka-gazebo";
+  version = "0.8.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "4e9ab990dafb016109a030284fc390af025d5ee8482a238bba6a5dcf0522ea20";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ gazebo-dev ];
+  checkInputs = [ gtest rostest ];
+  propagatedBuildInputs = [ angles control-msgs control-toolbox controller-interface controller-manager eigen-conversions franka-example-controllers franka-gripper franka-hw franka-msgs gazebo-ros gazebo-ros-control hardware-interface joint-limits-interface kdl-parser pluginlib roscpp std-msgs transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package offers the FrankaHWSim Class to simulate a Franka Robot in Gazebo'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "f70ddaa277a0b0f50c1dd5cffbad4a7bde476e370ec434dd4abf77a5c43c0dee";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "69c84e340f7924371127061c2e56e2448f37dd8b3105212133754bf73593c69b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, urdf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "97bf36b73fc6d9710fc840af267fc02c491f7ca86fe4b40882f923dfa90c1b31";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "c77a11f6abe0f5e1af075e96cce20b81519fa0f177936cb3ae26e4b62f12bbd2";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ franka-description gtest rostest ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs combined-robot-hw controller-interface franka-msgs hardware-interface joint-limits-interface libfranka pluginlib roscpp urdf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs combined-robot-hw controller-interface franka-msgs hardware-interface joint-limits-interface libfranka pluginlib roscpp std-srvs urdf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "2a0e82b93a2532aa51392bc5133c699079dad1e1f44a600cbc19eb9edc2f41a6";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "24b9a9005c05c7b3cc6de4f71c4d62c01bd57a5099b869591041d6d130af5b57";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "fe487128e603290ee0183cc3c90942d1a4de8436d5707b23ebcd6fcd9fde216d";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "7f60758fe4416f505fce7b87816d4c02a75bffe19998e08c7fdd0527084edb39";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.7.1-r2";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.7.1-2.tar.gz";
-    name = "0.7.1-2.tar.gz";
-    sha256 = "83046ca3016d1387cb2fd65a258135a18aee736e68648752b46c5e38ec03b7af";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "aa5cc382c707b8dec8c9e779efdcb3a0dec0f527ea65d5e523da2ab35277eab5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -576,7 +576,15 @@ self: super: {
 
  dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
 
+ dynamixel-workbench = self.callPackage ./dynamixel-workbench {};
+
+ dynamixel-workbench-controllers = self.callPackage ./dynamixel-workbench-controllers {};
+
  dynamixel-workbench-msgs = self.callPackage ./dynamixel-workbench-msgs {};
+
+ dynamixel-workbench-operators = self.callPackage ./dynamixel-workbench-operators {};
+
+ dynamixel-workbench-toolbox = self.callPackage ./dynamixel-workbench-toolbox {};
 
  easy-markers = self.callPackage ./easy-markers {};
 
@@ -823,6 +831,8 @@ self: super: {
  franka-description = self.callPackage ./franka-description {};
 
  franka-example-controllers = self.callPackage ./franka-example-controllers {};
+
+ franka-gazebo = self.callPackage ./franka-gazebo {};
 
  franka-gripper = self.callPackage ./franka-gripper {};
 
@@ -1471,6 +1481,8 @@ self: super: {
  move-base-msgs = self.callPackage ./move-base-msgs {};
 
  move-base-sequence = self.callPackage ./move-base-sequence {};
+
+ move-basic = self.callPackage ./move-basic {};
 
  move-slow-and-clear = self.callPackage ./move-slow-and-clear {};
 
@@ -2398,6 +2410,8 @@ self: super: {
 
  rtabmap-ros = self.callPackage ./rtabmap-ros {};
 
+ rtcm-msgs = self.callPackage ./rtcm-msgs {};
+
  rviz = self.callPackage ./rviz {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
@@ -2533,6 +2547,8 @@ self: super: {
  speed-scaling-interface = self.callPackage ./speed-scaling-interface {};
 
  speed-scaling-state-controller = self.callPackage ./speed-scaling-state-controller {};
+
+ sr-hand-detector = self.callPackage ./sr-hand-detector {};
 
  srdfdom = self.callPackage ./srdfdom {};
 
@@ -2881,6 +2897,8 @@ self: super: {
  warehouse-ros = self.callPackage ./warehouse-ros {};
 
  wave-front-planner = self.callPackage ./wave-front-planner {};
+
+ web-video-server = self.callPackage ./web-video-server {};
 
  webots-ros = self.callPackage ./webots-ros {};
 

--- a/distros/noetic/mk/default.nix
+++ b/distros/noetic/mk/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosbuild, rospack }:
 buildRosPackage {
   pname = "ros-noetic-mk";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "061d5bb2377d741b1b574f845b3f538ec202ec58fb484ac923da673e88b6062d";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/mk/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "6e570970ed335eace1b1b4ed1f2cdf9b079c31a1a61bd6e73fe794f53ca17bdc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/move-basic/default.nix
+++ b/distros/noetic/move-basic/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, move-base-msgs, nav-core, proj, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-move-basic";
+  version = "0.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/move_basic-release/archive/release/noetic/move_basic/0.4.2-1.tar.gz";
+    name = "0.4.2-1.tar.gz";
+    sha256 = "b333b99887c409c0efcf50bc80a353b7de1df597005a83b27b6a6dc5b38f0859";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ actionlib actionlib-msgs dynamic-reconfigure geometry-msgs message-generation message-runtime move-base-msgs nav-core proj roscpp rostest sensor-msgs std-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Simple navigation package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/pinocchio/default.nix
+++ b/distros/noetic/pinocchio/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, eigenpy, git, python3, python3Packages, urdfdom }:
 buildRosPackage {
   pname = "ros-noetic-pinocchio";
-  version = "2.6.1-r1";
+  version = "2.6.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.1-1.tar.gz";
-    name = "2.6.1-1.tar.gz";
-    sha256 = "e3cbc64999563f286763e321db3b76957ad10d34b30a6c63aed1e1544140fced";
+    url = "https://github.com/ipab-slmc/pinocchio_catkin-release/archive/release/noetic/pinocchio/2.6.3-1.tar.gz";
+    name = "2.6.3-1.tar.gz";
+    sha256 = "6af15f1ded6714909c0a7999b73016b1646f32dfa7ff93ab11e98384d0147121";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rc-genicam-api/default.nix
+++ b/distros/noetic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-api";
-  version = "2.5.0-r1";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.5.0-1.tar.gz";
-    name = "2.5.0-1.tar.gz";
-    sha256 = "51cd256ebff104f226ffa2e131c977c774f1789e0099e3e572a4162401f83371";
+    url = "https://github.com/roboception-gbp/rc_genicam_api-release/archive/release/noetic/rc_genicam_api/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "cd16648e83edf078aa516398e05f192161ce08329f0eb7cfa77b0182c3ac7ef8";
   };
 
   buildType = "cmake";

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.5.2-r1";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.5.2-1.tar.gz";
-    name = "0.5.2-1.tar.gz";
-    sha256 = "dae3b74a8b547d79490ac46446ca11c188d60b6c2bd27e84100eda2e797e5b47";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.6.1-1.tar.gz";
+    name = "0.6.1-1.tar.gz";
+    sha256 = "e0dc37a674633294d6df15e21bd4b152830b25e9b1ac15e39d40f2c2ea6da670";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-hand-eye-calibration-client/default.nix
+++ b/distros/noetic/rc-hand-eye-calibration-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rcdiscover, roscpp, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-rc-hand-eye-calibration-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "a394c030a235cb8b911287081f83264c458c3791b29a054e56293ee991481ea7";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_hand_eye_calibration_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "bffdfa0ff2f0e8ae876f04d5236989317dd66ad2e8efc48d392fb6248696ccf0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-pick-client/default.nix
+++ b/distros/noetic/rc-pick-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, shape-msgs, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-pick-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "a295d36bef0f6fe2b5687a52b9742d3ad13e47af47baa486140feea08151611d";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_pick_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "fa4ca16e95a32dacd9a3b47507750ee4081c16a2993edaf6dbc74ef38f057d94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-roi-manager-gui/default.nix
+++ b/distros/noetic/rc-roi-manager-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, interactive-markers, message-runtime, rc-common-msgs, rc-pick-client, roscpp, shape-msgs, tf, visualization-msgs, wxGTK }:
 buildRosPackage {
   pname = "ros-noetic-rc-roi-manager-gui";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "f8965c08f16dc14848512026f1096a1d58a8c1cbd660152e66eb1494f29412f6";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_roi_manager_gui/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "68646c068bb0f66d27c976a6bf96de1bbb98392fb176f200349c15d5bbce287a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-silhouettematch-client/default.nix
+++ b/distros/noetic/rc-silhouettematch-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-silhouettematch-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "b0be90ca7f912d6057ec37f5afe43c408ff72049a6fe1bba15c5d77c96b410d3";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_silhouettematch_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "d96bfe3bbb355c443895feaf5bacc9ba4111627742a558ba43355f18ee206fd4";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-tagdetect-client/default.nix
+++ b/distros/noetic/rc-tagdetect-client/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, dynamic-reconfigure, geometry-msgs, message-generation, message-runtime, rc-common-msgs, rcdiscover, roscpp, std-srvs, tf, tf2-geometry-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-tagdetect-client";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "50be08bbb7bc704c53eb678e533d5b9140c9826e1bc6c3636d7c9168544155f2";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_tagdetect_client/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "a2a684032221405a92ba245d2af1a3602d74bd294faf9ba290375249f1fbf67f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-description/default.nix
+++ b/distros/noetic/rc-visard-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-description";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "9de1f4de29c30df9ca0ee2e1f3acc485322741d2162b2f42a8e34c010f8a060c";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_description/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "6468fc3852b1f01483e5751ed8f436775f232c07137f8f948981505d6e77137c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard-driver/default.nix
+++ b/distros/noetic/rc-visard-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nav-msgs, nodelet, protobuf, rc-common-msgs, rc-dynamics-api, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard-driver";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "5d55fa6111d000eae9805a069ad34f284b762fc4c503afaab3b9b49e52b6d8ed";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard_driver/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "048a1dfb6875158327ddc6fadacc225c9edddb1c7f83e2a57ecb40343c59360d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-visard/default.nix
+++ b/distros/noetic/rc-visard/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rc-hand-eye-calibration-client, rc-pick-client, rc-roi-manager-gui, rc-silhouettematch-client, rc-tagdetect-client, rc-visard-description, rc-visard-driver }:
 buildRosPackage {
   pname = "ros-noetic-rc-visard";
-  version = "3.2.1-r1";
+  version = "3.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "daea05992b9169246d5907adfe3de2c531128189543b2376e86b301b5f2a316e";
+    url = "https://github.com/roboception-gbp/rc_visard-release/archive/release/noetic/rc_visard/3.2.3-1.tar.gz";
+    name = "3.2.3-1.tar.gz";
+    sha256 = "b0d41d24073a2ea14befc789bd7f23840e844278b03a22f305107b7905e71d06";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-body-filter/default.nix
+++ b/distros/noetic/robot-body-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-robot-body-filter";
-  version = "1.1.9-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/robot_body_filter-release/archive/release/noetic/robot_body_filter/1.1.9-1.tar.gz";
-    name = "1.1.9-1.tar.gz";
-    sha256 = "420340eb7e8b30ccec09e505208cb31e3e305ddb8bc06b18b43412f0289dc9f5";
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/noetic/robot_body_filter/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "b485d2a710308fb3b5284f6b0afc908159ac3175f33907879ad5a3774fa62ee9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/robot-localization/default.nix
+++ b/distros/noetic/robot-localization/default.nix
@@ -5,18 +5,18 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, diagnostic-msgs, diagnostic-updater, eigen, eigen-conversions, geographic-msgs, geographiclib, geometry-msgs, libyamlcpp, message-filters, message-generation, message-runtime, nav-msgs, nodelet, python3Packages, rosbag, roscpp, roslint, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-robot-localization";
-  version = "2.7.2-r1";
+  version = "2.7.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.2-1.tar.gz";
-    name = "2.7.2-1.tar.gz";
-    sha256 = "9ee850a4e0d2db4656976d527e25e35bf5af9fbb742b5b034061d08aa0dc89d5";
+    url = "https://github.com/cra-ros-pkg/robot_localization-release/archive/release/noetic/robot_localization/2.7.3-1.tar.gz";
+    name = "2.7.3-1.tar.gz";
+    sha256 = "8698f935ea320a63e0e4c8ec45938e6d7ee2067b163dcda0fd0c67bb9d2e4b60";
   };
 
   buildType = "catkin";
-  buildInputs = [ geographiclib message-generation python3Packages.catkin-pkg roslint ];
+  buildInputs = [ message-generation python3Packages.catkin-pkg roslint ];
   checkInputs = [ rosbag rostest rosunit ];
-  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-msgs diagnostic-updater eigen eigen-conversions geographic-msgs geographiclib geometry-msgs libyamlcpp message-filters message-runtime nav-msgs nodelet roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ros-controllers-cartesian/default.nix
+++ b/distros/noetic/ros-controllers-cartesian/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
 buildRosPackage {
   pname = "ros-noetic-ros-controllers-cartesian";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "eb3a8412f517dd6aa3a06ab62c52e36fbc0cda9b23e7a504daf25989c4e23e8b";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/ros_controllers_cartesian/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "cc34329ae2086aa68679cf294f7d278139e7eee0043c1ce9af75172fba6f4372";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros/default.nix
+++ b/distros/noetic/ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, mk, rosbash, rosboost-cfg, rosbuild, rosclean, roscreate, roslang, roslib, rosmake, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-ros";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "8a5a5c9371b115c2ba61093a714d50d30d6ba306d813046e3ebfea95bcfdb770";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/ros/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "84a51b386e543407cdf8fe3e318adc5dbffeebd7ec9f1eda709b7d64d3ead11f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbash/default.nix
+++ b/distros/noetic/rosbash/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospack }:
 buildRosPackage {
   pname = "ros-noetic-rosbash";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ae342273fce13575f5b3c8b29355fc0cd70a0b36cfb7aef0b83391732acbcb13";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbash/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "9e29d79829b5a974db4142d1d8f1bc5ed0e412d85694cf707316c503bce81af5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosboost-cfg/default.nix
+++ b/distros/noetic/rosboost-cfg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosboost-cfg";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "7785199b2fb11f649e2783d683b05cc1627213e9f14acece52ddb55e0d4dfe8c";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosboost_cfg/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "7560041d65a39dc786a1202318395c866af0b7b17a5eb8839e4c485f7679c7eb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosbuild/default.nix
+++ b/distros/noetic/rosbuild/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pkg-config }:
 buildRosPackage {
   pname = "ros-noetic-rosbuild";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "b823264a4d9061dfad8bd240161be7a8976f6ea8c14dfd8936fa5b5df51cfd3c";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosbuild/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "0c84f212ce86cdfe61726e3bfd304ca257c1ae4d113bd0524c8f9d7dd6529c43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosclean/default.nix
+++ b/distros/noetic/rosclean/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosclean";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "07f10331747829275619412337672b65f1718fdf2c29fdb3239b29afa186ee2d";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosclean/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "6ce03bce22e1009aa43f3f74f99efd6026702e7d775aac15a1800c7305857086";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roscreate/default.nix
+++ b/distros/noetic/roscreate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-roscreate";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ee8eadf161fe8bb931ee07b2611c74613bdd5488a9713c5f42af61ffffd54434";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roscreate/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "0cd12e40b3e5c68ccd1576f6b0f34be6fa0d98744105bb545d26f41b738d5ca6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslang/default.nix
+++ b/distros/noetic/roslang/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg }:
 buildRosPackage {
   pname = "ros-noetic-roslang";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "1dc142fe4396e3edfcd75777bf049cae4daa6d88ae445d8a08211c33ec277468";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslang/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "920854f983ee43f4eda52a44e2e318f1db47ffd36f74af6cd43c9139c0d5f053";
   };
 
   buildType = "catkin";

--- a/distros/noetic/roslib/default.nix
+++ b/distros/noetic/roslib/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, python3Packages, ros-environment, rosmake, rospack }:
 buildRosPackage {
   pname = "ros-noetic-roslib";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "0655caaa3dd5b82f6255c4b61c3c50244785f4ca8ef4ae352485fbdfc2ac208e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/roslib/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "5842542a7518a694e1e339fb3d59d4807bf15382d0393c4dab077d67f1458148";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmake/default.nix
+++ b/distros/noetic/rosmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-rosmake";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "ccf86e352c39bdf203c0465e1a154021e06d8f3b4face37269b1b01e3cba521e";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosmake/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "03ed121f2231478045cdb983ccbca247f214322acf67d9553d78f78a558c3ffb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon-core/default.nix
+++ b/distros/noetic/rosmon-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catch-ros, catkin, cmake-modules, diagnostic-msgs, libyamlcpp, ncurses, python3, python3Packages, rosbash, roscpp, rosfmt, roslib, rosmon-msgs, rospack, rostest, std-msgs, tinyxml }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-core";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_core/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "1a28b4662b9ef7ec6f67801801c03892c68888cc8f1e0bf92c7d87da04ec454e";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_core/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "de8c15525cefb38d9727a49a66f71f2da3b4bf31de94bd7057d6a80ab5ec8806";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon-msgs/default.nix
+++ b/distros/noetic/rosmon-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rosmon-msgs";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_msgs/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "8b9a71c387ab6dd04e35bf38d424eaaee017ba59c646674c5e8c5b0be242e0eb";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon_msgs/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "32ee0a1cbb51b6143ae74d61e0d2947dd3d37ab47170862619960c83e5328dd1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosmon/default.nix
+++ b/distros/noetic/rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosmon-core, rqt-rosmon }:
 buildRosPackage {
   pname = "ros-noetic-rosmon";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "f6a257b51d9f6fc0e1e4db30e590d4cbb32ddaf23a1ca5667a49d214e9d9bc69";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rosmon/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "22055a518407348cc4061d41a8fd9eaf35b15c279706187f4e6b7a3ebaabdc9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rosunit/default.nix
+++ b/distros/noetic/rosunit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib }:
 buildRosPackage {
   pname = "ros-noetic-rosunit";
-  version = "1.15.7-r1";
+  version = "1.15.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.7-1.tar.gz";
-    name = "1.15.7-1.tar.gz";
-    sha256 = "37e53948063c7b37e461483fe40ae12168dc83f0a4211a40adc9aa8a809ed45f";
+    url = "https://github.com/ros-gbp/ros-release/archive/release/noetic/rosunit/1.15.8-1.tar.gz";
+    name = "1.15.8-1.tar.gz";
+    sha256 = "8a8a32d9a5b42badd7cae613892b2db4a72035923a4e2a369e34e1877b2fa433";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-rosmon/default.nix
+++ b/distros/noetic/rqt-rosmon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, qt5, roscpp, rosmon-msgs, rqt-gui, rqt-gui-cpp }:
 buildRosPackage {
   pname = "ros-noetic-rqt-rosmon";
-  version = "2.3.2-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rqt_rosmon/2.3.2-1.tar.gz";
-    name = "2.3.2-1.tar.gz";
-    sha256 = "828d7c361bb2134b8c188756cb51af94cee9129d741da2233726d877fd05542a";
+    url = "https://github.com/xqms/rosmon-release/archive/release/noetic/rqt_rosmon/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "a396f55c22efecbad5499a7feae65489435d1f093c364a6c577fde1fb34d768f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtcm-msgs/default.nix
+++ b/distros/noetic/rtcm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rtcm-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/nobleo/rtcm_msgs-release/archive/release/noetic/rtcm_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4dfe9abf7aae2ae5ea92717aeaeeacb3dac07d2d67518b0d63eb2eb2e8f5878a";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rtcm_msgs package contains messages related to data in the RTCM format.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-sr-hand-detector";
+  version = "0.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "27031b0e72e17e8522e28555db512b2d837f74e23ac9bbb32fb752866aba2256";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ libyamlcpp roscpp roslib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The sr_hand_detector package'';
+    license = with lib.licenses; [ gpl1 ];
+  };
+}

--- a/distros/noetic/twist-controller/default.nix
+++ b/distros/noetic/twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-twist-controller";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "253ef7df1ede94caf0c028ca4ab17196216aceb3bea364285a6ea837424c95d4";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/noetic/twist_controller/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "9227c502123d4538f51ec94536fe189daf1de5ab3cbf8ccde044c242238f181a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/urg-stamped/default.nix
+++ b/distros/noetic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-urg-stamped";
-  version = "0.0.12-r1";
+  version = "0.0.13-r1";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.12-1.tar.gz";
-    name = "0.0.12-1.tar.gz";
-    sha256 = "3dfd5522e271282f93d381ba0c6ca25f104ff51a79253fd1e908685eba57f75d";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/noetic/urg_stamped/0.0.13-1.tar.gz";
+    name = "0.0.13-1.tar.gz";
+    sha256 = "92a8eab582f48cb48f158799d03177970021ba56b038a51b9cd955ad389efc71";
   };
 
   buildType = "catkin";

--- a/distros/noetic/view-controller-msgs/default.nix
+++ b/distros/noetic/view-controller-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, genmsg, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-view-controller-msgs";
-  version = "0.1.3-r1";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/noetic/view_controller_msgs/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "2790e733c8c9880af8643f5b59523aa1a7a82d562901fc14b307ccfa3b4411bd";
+    url = "https://github.com/ros-gbp/view_controller_msgs-release/archive/release/noetic/view_controller_msgs/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "2157172387b8868d01b73a0cf00fb1425748b9707b54b40f97eb1ef40505aadf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/web-video-server/default.nix
+++ b/distros/noetic/web-video-server/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, async-web-server-cpp, catkin, cv-bridge, ffmpeg, image-transport, roscpp, roslib, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-web-video-server";
+  version = "0.2.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/RobotWebTools-release/web_video_server-release/archive/release/noetic/web_video_server/0.2.2-1.tar.gz";
+    name = "0.2.2-1.tar.gz";
+    sha256 = "7ae5dbf920030dd13a5d7d6010ba398db9efad78a6b382630f7095db0467e467";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ async-web-server-cpp cv-bridge ffmpeg image-transport roscpp roslib sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''HTTP Streaming of ROS Image Topics in Multiple Formats'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 591fd6fea1df4a28e70ddd8f3e9c317a3c661c68.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *diagnostic-aggregator 2.0.7-r1 --> 2.0.8-r2*
* *diagnostic-updater 2.0.7-r1 --> 2.0.8-r2*
* *rc-genicam-api 2.5.0-r1 --> 2.5.6-r1*
* *rc-genicam-driver 0.1.2-r1 --> 0.2.0-r1*
* *robot-state-publisher 2.4.2-r1 --> 2.4.5-r1*
* *self-test 2.0.7-r1 --> 2.0.8-r2*
* *teleop-twist-joy 2.4.2-r1 --> 2.4.3-r1*

Galactic Changes:
-----------------
* *diagnostic-aggregator 2.1.2-r2 --> 2.1.3-r1*
* *diagnostic-updater 2.1.2-r2 --> 2.1.3-r1*
* *fastrtps 2.3.1-r1 --> 2.3.4-r1*
* *lanelet2 1.1.1-r1*
* *lanelet2-core 1.1.1-r1*
* *lanelet2-examples 1.1.1-r1*
* *lanelet2-maps 1.1.1-r1*
* *lanelet2-projection 1.1.1-r1*
* *lanelet2-python 1.1.1-r1*
* *lanelet2-routing 1.1.1-r1*
* *lanelet2-traffic-rules 1.1.1-r1*
* *lanelet2-validation 1.1.1-r1*
* *libphidget22 2.2.0-r1 --> 2.2.1-r1*
* *mrt-cmake-modules 1.0.8-r3*
* *nao-lola 0.0.3-r1*
* *phidgets-accelerometer 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-analog-inputs 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-api 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-digital-inputs 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-digital-outputs 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-drivers 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-gyroscope 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-high-speed-encoder 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-ik 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-magnetometer 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-motors 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-msgs 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-spatial 2.2.0-r1 --> 2.2.1-r1*
* *phidgets-temperature 2.2.0-r1 --> 2.2.1-r1*
* *plotjuggler-ros 1.5.0-r1 --> 1.5.1-r1*
* *rclc 2.0.2-r1 --> 2.0.3-r3*
* *rclc-examples 2.0.2-r1 --> 2.0.3-r3*
* *rclc-lifecycle 2.0.2-r1 --> 2.0.3-r3*
* *rclc-parameter 2.0.2-r1 --> 2.0.3-r3*
* *realsense2-camera 3.2.2-r1 --> 3.2.2-r2*
* *realsense2-camera-msgs 3.2.2-r1 --> 3.2.2-r2*
* *realsense2-description 3.2.2-r1 --> 3.2.2-r2*
* *robot-state-publisher 2.4.3-r2 --> 2.5.1-r1*
* *self-test 2.1.2-r2 --> 2.1.3-r1*
* *soccer-marker-generation 0.0.1-r1*
* *teleop-twist-joy 2.4.2-r2 --> 2.4.3-r1*
* *turtlebot3-fake-node 2.2.4-r1 --> 2.2.4-r2*
* *turtlebot3-gazebo 2.2.4-r1 --> 2.2.4-r2*
* *turtlebot3-simulations 2.2.4-r1 --> 2.2.4-r2*
* *ublox-dgnss 0.2.2-r1 --> 0.2.3-r4*
* *ublox-dgnss-node 0.2.2-r1 --> 0.2.3-r4*
* *ublox-ubx-interfaces 0.2.2-r1 --> 0.2.3-r4*
* *ublox-ubx-msgs 0.2.2-r1 --> 0.2.3-r4*

Melodic Changes:
----------------
* *aques-talk 2.1.23-r1 --> 2.1.24-r1*
* *aruco-pose 0.21.3-r1 --> 0.21.2-r1*
* *assimp-devel 2.1.23-r1 --> 2.1.24-r1*
* *bayesian-belief-networks 2.1.23-r1 --> 2.1.24-r1*
* *chaplus-ros 2.1.23-r1 --> 2.1.24-r1*
* *clover 0.21.3-r1 --> 0.21.2-r1*
* *clover-blocks 0.21.3-r1 --> 0.21.2-r1*
* *clover-description 0.21.3-r1 --> 0.21.2-r1*
* *clover-simulation 0.21.3-r1 --> 0.21.2-r1*
* *downward 2.1.23-r1 --> 2.1.24-r1*
* *exotica 6.1.1-r1 --> 6.2.0-r1*
* *exotica-aico-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-cartpole-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-collision-scene-fcl-latest 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core-task-maps 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ddp-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-double-integrator-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-dynamics-solvers 6.1.1-r1 --> 6.2.0-r1*
* *exotica-examples 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ik-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqg-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqr-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-levenberg-marquardt-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-control-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pendulum-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pinocchio-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-quadrotor-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-scipy-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.1.1-r1 --> 6.2.0-r1*
* *ff 2.1.23-r1 --> 2.1.24-r1*
* *ffha 2.1.23-r1 --> 2.1.24-r1*
* *franka-control 0.7.1-r1 --> 0.8.0-r1*
* *franka-description 0.7.1-r1 --> 0.8.0-r1*
* *franka-example-controllers 0.7.1-r1 --> 0.8.0-r1*
* *franka-gazebo 0.8.0-r1*
* *franka-gripper 0.7.1-r1 --> 0.8.0-r1*
* *franka-hw 0.7.1-r1 --> 0.8.0-r1*
* *franka-msgs 0.7.1-r1 --> 0.8.0-r1*
* *franka-ros 0.7.1-r1 --> 0.8.0-r1*
* *franka-visualization 0.7.1-r1 --> 0.8.0-r1*
* *jsk-3rdparty 2.1.23-r1 --> 2.1.24-r1*
* *julius 2.1.23-r1 --> 2.1.24-r1*
* *laser-filters-jsk-patch 2.1.23-r1 --> 2.1.24-r1*
* *libcmt 2.1.23-r1 --> 2.1.24-r1*
* *libsiftfast 2.1.23-r1 --> 2.1.24-r1*
* *lpg-planner 2.1.23-r1 --> 2.1.24-r1*
* *mini-maxwell 2.1.23-r1 --> 2.1.24-r1*
* *nlopt 2.1.23-r1 --> 2.1.24-r1*
* *opt-camera 2.1.23-r1 --> 2.1.24-r1*
* *pinocchio 2.6.1-r1 --> 2.6.3-r1*
* *rc-genicam-api 2.5.0-r1 --> 2.5.6-r1*
* *rc-genicam-driver 0.5.2-r1 --> 0.6.1-r1*
* *rc-hand-eye-calibration-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-pick-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-roi-manager-gui 3.2.1-r1 --> 3.2.3-r1*
* *rc-silhouettematch-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-tagdetect-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard-description 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard-driver 3.2.1-r1 --> 3.2.3-r1*
* *robot-body-filter 1.1.9-r1 --> 1.2.0-r2*
* *robot-localization 2.6.10-r1 --> 2.6.11-r1*
* *rospatlite 2.1.23-r1 --> 2.1.24-r1*
* *rosping 2.1.23-r1 --> 2.1.24-r1*
* *roswww-static 0.21.3-r1 --> 0.21.2-r1*
* *rtcm-msgs 1.0.0-r1*
* *sesame-ros 2.1.23-r1 --> 2.1.24-r1*
* *slic 2.1.23-r1 --> 2.1.24-r1*
* *switchbot-ros 2.1.23-r1 --> 2.1.24-r1*
* *voice-text 2.1.23-r1 --> 2.1.24-r1*

Noetic Changes:
---------------
* *bosch-locator-bridge 1.0.1-r2 --> 1.0.2-r1*
* *cartesian-interface 0.1.3-r1 --> 0.1.4-r1*
* *cartesian-trajectory-controller 0.1.3-r1 --> 0.1.4-r1*
* *cartesian-trajectory-interpolation 0.1.3-r1 --> 0.1.4-r1*
* *dynamixel-workbench 2.2.1-r1*
* *dynamixel-workbench-controllers 2.2.1-r1*
* *dynamixel-workbench-operators 2.2.1-r1*
* *dynamixel-workbench-toolbox 2.2.1-r1*
* *exotica 6.1.1-r1 --> 6.2.0-r1*
* *exotica-aico-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-cartpole-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-collision-scene-fcl-latest 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core 6.1.1-r1 --> 6.2.0-r1*
* *exotica-core-task-maps 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ddp-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-double-integrator-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-dynamics-solvers 6.1.1-r1 --> 6.2.0-r1*
* *exotica-examples 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ik-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqg-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ilqr-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-levenberg-marquardt-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-control-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-ompl-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pendulum-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-pinocchio-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-quadrotor-dynamics-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-scipy-solver 6.1.1-r1 --> 6.2.0-r1*
* *exotica-time-indexed-rrt-connect-solver 6.1.1-r1 --> 6.2.0-r1*
* *franka-control 0.7.1-r2 --> 0.8.0-r1*
* *franka-description 0.7.1-r2 --> 0.8.0-r1*
* *franka-example-controllers 0.7.1-r2 --> 0.8.0-r1*
* *franka-gazebo 0.8.0-r1*
* *franka-gripper 0.7.1-r2 --> 0.8.0-r1*
* *franka-hw 0.7.1-r2 --> 0.8.0-r1*
* *franka-msgs 0.7.1-r2 --> 0.8.0-r1*
* *franka-ros 0.7.1-r2 --> 0.8.0-r1*
* *franka-visualization 0.7.1-r2 --> 0.8.0-r1*
* *mk 1.15.7-r1 --> 1.15.8-r1*
* *move-basic 0.4.2-r1*
* *pinocchio 2.6.1-r1 --> 2.6.3-r1*
* *rc-genicam-api 2.5.0-r1 --> 2.5.6-r1*
* *rc-genicam-driver 0.5.2-r1 --> 0.6.1-r1*
* *rc-hand-eye-calibration-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-pick-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-roi-manager-gui 3.2.1-r1 --> 3.2.3-r1*
* *rc-silhouettematch-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-tagdetect-client 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard-description 3.2.1-r1 --> 3.2.3-r1*
* *rc-visard-driver 3.2.1-r1 --> 3.2.3-r1*
* *robot-body-filter 1.1.9-r1 --> 1.2.1-r1*
* *robot-localization 2.7.2-r1 --> 2.7.3-r1*
* *ros 1.15.7-r1 --> 1.15.8-r1*
* *ros-controllers-cartesian 0.1.3-r1 --> 0.1.4-r1*
* *rosbash 1.15.7-r1 --> 1.15.8-r1*
* *rosboost-cfg 1.15.7-r1 --> 1.15.8-r1*
* *rosbuild 1.15.7-r1 --> 1.15.8-r1*
* *rosclean 1.15.7-r1 --> 1.15.8-r1*
* *roscreate 1.15.7-r1 --> 1.15.8-r1*
* *roslang 1.15.7-r1 --> 1.15.8-r1*
* *roslib 1.15.7-r1 --> 1.15.8-r1*
* *rosmake 1.15.7-r1 --> 1.15.8-r1*
* *rosmon 2.3.2-r1 --> 2.4.0-r1*
* *rosmon-core 2.3.2-r1 --> 2.4.0-r1*
* *rosmon-msgs 2.3.2-r1 --> 2.4.0-r1*
* *rosunit 1.15.7-r1 --> 1.15.8-r1*
* *rqt-rosmon 2.3.2-r1 --> 2.4.0-r1*
* *rtcm-msgs 1.0.0-r1*
* *sr-hand-detector 0.0.5-r1*
* *twist-controller 0.1.3-r1 --> 0.1.4-r1*
* *urg-stamped 0.0.12-r1 --> 0.0.13-r1*
* *view-controller-msgs 0.1.3-r1 --> 0.2.0-r1*
* *web-video-server 0.2.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

