### PR TITLE
rosdistro sync, Fri Aug 20 13:05:11 2021

### DIFF
--- a/distros/foxy/apriltag/default.nix
+++ b/distros/foxy/apriltag/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-apriltag";
-  version = "3.1.2-r2";
+  version = "3.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/foxy/apriltag/3.1.2-2.tar.gz";
-    name = "3.1.2-2.tar.gz";
-    sha256 = "f79e5ecb5aa78a3e008bc90b292998de17c294565e5b3008d546610bfd939ef1";
+    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/foxy/apriltag/3.1.5-1.tar.gz";
+    name = "3.1.5-1.tar.gz";
+    sha256 = "c7bb3aed55dda58ce94a3749aeaa59938ba15150bd9e9438f1004a0305185d40";
   };
 
   buildType = "cmake";
+  buildInputs = [ python3Packages.numpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/foxy/espeak-interfaces/default.nix
+++ b/distros/foxy/espeak-interfaces/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-espeak-interfaces";
+  version = "0.1.0-r6";
+
+  src = fetchurl {
+    url = "https://gitlab.com/espeak-ros2/espeak-ros2-release/-/archive/release/foxy/espeak_interfaces/0.1.0-6/espeak-ros2-release-release-foxy-espeak_interfaces-0.1.0-6.tar.gz";
+    name = "espeak-ros2-release-release-foxy-espeak_interfaces-0.1.0-6.tar.gz";
+    sha256 = "aa16feb6e81655747a0d031860ace96e3622d84daac6685e98015e23b21860d6";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for the `espeak-ros` package.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/espeak-ros/default.nix
+++ b/distros/foxy/espeak-ros/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-mypy, ament-pep257, espeak, espeak-interfaces, pythonPackages }:
+buildRosPackage {
+  pname = "ros-foxy-espeak-ros";
+  version = "0.1.0-r6";
+
+  src = fetchurl {
+    url = "https://gitlab.com/espeak-ros2/espeak-ros2-release/-/archive/release/foxy/espeak_ros/0.1.0-6/espeak-ros2-release-release-foxy-espeak_ros-0.1.0-6.tar.gz";
+    name = "espeak-ros2-release-release-foxy-espeak_ros-0.1.0-6.tar.gz";
+    sha256 = "9be64de8d00cc217a13aaa3eceab87f09ef4bbfe23b2356540720f5d0df84ced";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-mypy ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ espeak espeak-interfaces ];
+
+  meta = {
+    description = ''ROS interface to the `espeak` command line tool.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -372,6 +372,10 @@ self: super: {
 
  embree-vendor = self.callPackage ./embree-vendor {};
 
+ espeak-interfaces = self.callPackage ./espeak-interfaces {};
+
+ espeak-ros = self.callPackage ./espeak-ros {};
+
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-minimal-action-client = self.callPackage ./examples-rclcpp-minimal-action-client {};
@@ -455,6 +459,8 @@ self: super: {
  geometry2 = self.callPackage ./geometry2 {};
 
  geometry-msgs = self.callPackage ./geometry-msgs {};
+
+ geometry-tutorials = self.callPackage ./geometry-tutorials {};
 
  gmock-vendor = self.callPackage ./gmock-vendor {};
 
@@ -844,6 +850,8 @@ self: super: {
 
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
 
+ picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
+
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
  plansys2-bt-actions = self.callPackage ./plansys2-bt-actions {};
@@ -1124,6 +1132,8 @@ self: super: {
 
  ros-workspace = self.callPackage ./ros-workspace {};
 
+ rosapi = self.callPackage ./rosapi {};
+
  rosauth = self.callPackage ./rosauth {};
 
  rosbag2 = self.callPackage ./rosbag2 {};
@@ -1145,6 +1155,14 @@ self: super: {
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
 
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
+
+ rosbridge-library = self.callPackage ./rosbridge-library {};
+
+ rosbridge-msgs = self.callPackage ./rosbridge-msgs {};
+
+ rosbridge-server = self.callPackage ./rosbridge-server {};
+
+ rosbridge-suite = self.callPackage ./rosbridge-suite {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
@@ -1264,6 +1282,8 @@ self: super: {
 
  rttest = self.callPackage ./rttest {};
 
+ ruckig = self.callPackage ./ruckig {};
+
  run-move-group = self.callPackage ./run-move-group {};
 
  run-moveit-cpp = self.callPackage ./run-moveit-cpp {};
@@ -1321,6 +1341,8 @@ self: super: {
  smac-planner = self.callPackage ./smac-planner {};
 
  smclib = self.callPackage ./smclib {};
+
+ soccer-vision-msgs = self.callPackage ./soccer-vision-msgs {};
 
  sophus = self.callPackage ./sophus {};
 
@@ -1448,6 +1470,10 @@ self: super: {
 
  transmission-interface = self.callPackage ./transmission-interface {};
 
+ turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
+
+ turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
+
  turtlebot3 = self.callPackage ./turtlebot3 {};
 
  turtlebot3-bringup = self.callPackage ./turtlebot3-bringup {};
@@ -1561,6 +1587,8 @@ self: super: {
  webots-ros2-msgs = self.callPackage ./webots-ros2-msgs {};
 
  webots-ros2-tesla = self.callPackage ./webots-ros2-tesla {};
+
+ webots-ros2-tests = self.callPackage ./webots-ros2-tests {};
 
  webots-ros2-tiago = self.callPackage ./webots-ros2-tiago {};
 

--- a/distros/foxy/geometry-tutorials/default.nix
+++ b/distros/foxy/geometry-tutorials/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-foxy-geometry-tutorials";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "c294ac107c09cf598710b598a131a49047d2326a1b2a110ba4c190e1ddc98bba";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of geometry tutorials ROS.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/launch-pal/default.nix
+++ b/distros/foxy/launch-pal/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, python3Packages, pythonPackages }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-pal";
-  version = "0.0.4-r1";
+  version = "0.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.4-1.tar.gz";
-    name = "0.0.4-1.tar.gz";
-    sha256 = "0e27a958c5f16e0f0ad950baeeee1d39750522c20bbe43d20524589c756c9e22";
+    url = "https://github.com/pal-gbp/launch_pal-release/archive/release/foxy/launch_pal/0.0.5-1.tar.gz";
+    name = "0.0.5-1.tar.gz";
+    sha256 = "425e307d49e8f8b032337755dcf081970bc2172884dd811adea7f76f0d0cd594";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ ament-index-python launch python3Packages.pyyaml ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros python3Packages.pyyaml ];
 
   meta = {
     description = ''Utilities for launch files'';

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.7.7-r1";
+  version = "2021.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.7.7-1.tar.gz";
-    name = "2021.7.7-1.tar.gz";
-    sha256 = "95dfd40d7b046fdd345d9f135e2d26d0a5fb26c66f3f273bd018090ea443c1ff";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.8.8-1.tar.gz";
+    name = "2021.8.8-1.tar.gz";
+    sha256 = "dccec0777f7e21cb5cac76ad3d06d7cc9de25100b2a5e4556a4d2783710aac05";
   };
 
   buildType = "cmake";

--- a/distros/foxy/picknik-ament-copyright/default.nix
+++ b/distros/foxy/picknik-ament-copyright/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-foxy-picknik-ament-copyright";
+  version = "0.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/picknik_ament_copyright-release/archive/release/foxy/picknik_ament_copyright/0.0.1-2.tar.gz";
+    name = "0.0.1-2.tar.gz";
+    sha256 = "c5d8bd85234f3480de334143c6f4248d5ed2fa1959561e3103b39f1bdc9914a5";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-copyright ];
+
+  meta = {
+    description = ''Check PickNik-specific copyright headers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/pmb2-2dnav-gazebo/default.nix
+++ b/distros/foxy/pmb2-2dnav-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-2dnav, pmb2-gazebo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pmb2-2dnav, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-2dnav-gazebo";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_2dnav_gazebo/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "56118dc7d7b3b94c719e39cadd23a7d26eac0a31b4e2c285505dcb939b5d9c36";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_2dnav_gazebo/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "588064ee3de24260efde52b106b49951a1e1c07aa28d396a7712bfd57c3ba579";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ pmb2-2dnav pmb2-gazebo ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
     description = ''PMB2-specific launch files needed to run

--- a/distros/foxy/pmb2-gazebo/default.nix
+++ b/distros/foxy/pmb2-gazebo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, launch-pal, pal-gazebo-worlds, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, launch-pal, pal-gazebo-worlds, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-gazebo";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_gazebo/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "7a3aaa8eff3f11c4dda34dc3719adbbaca5d685e0055f6abfeee6b0fd1893ea0";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_gazebo/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "735644418c80be5265f5f6b67159752ab940292fcd4a0ae1ce59617a5daeea8d";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ gazebo-plugins gazebo-ros launch-pal pal-gazebo-worlds pmb2-bringup pmb2-controller-configuration pmb2-description ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {
     description = ''Simulation files for the PMB2 robot.'';

--- a/distros/foxy/pmb2-simulation/default.nix
+++ b/distros/foxy/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-2dnav-gazebo, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-simulation";
-  version = "3.0.0-r1";
+  version = "3.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_simulation/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "faec313fca6e74a7636b1ca4137e45ff779038041e30e9ce097b70269aa08ed7";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_simulation/3.0.1-1.tar.gz";
+    name = "3.0.1-1.tar.gz";
+    sha256 = "7aefc5cc3823c9708f06e7d7de0eefd54879665620bdb55f5c7f5e7f75a8eec4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosapi/default.nix
+++ b/distros/foxy/rosapi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-nose, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rclpy, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosbridge-library, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rosapi";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosapi/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "11fd323e6db0f18eb886469c75f6c10ed07ccb716b44871a17c5316f9785137b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-nose ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosbridge-library rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides service calls for getting ros meta-information, like list of
+    topics, services, params, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rosbridge-library/default.nix
+++ b/distros/foxy/rosbridge-library/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-rosbridge-library";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_library/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "2e2b6dcb3595131a43ff996926f401d1f08b09ddee45b834da47ed316c6ec653";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The core rosbridge package, responsible for interpreting JSON andperforming
+    the appropriate ROS action, like subscribe, publish, call service, and
+    interact with params.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rosbridge-msgs/default.nix
+++ b/distros/foxy/rosbridge-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rosbridge-msgs";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_msgs/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "1f491fdf2569e1d155c7bd12b5a18d520493212d23015e5a1679ee2a1f3324ef";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ builtin-interfaces ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing message files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rosbridge-server/default.nix
+++ b/distros/foxy/rosbridge-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-rosbridge-server";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_server/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "4a176ab54e8383ee032045889d44144437abd3042eb6ba6696251accf182df20";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn ];
+  propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A WebSocket interface to rosbridge.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rosbridge-suite/default.nix
+++ b/distros/foxy/rosbridge-suite/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
+buildRosPackage {
+  pname = "ros-foxy-rosbridge-suite";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/foxy/rosbridge_suite/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "4b5a7d549b0e5147fa261a8eea36da6d3bd70a678be2e2088118f90657af29db";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.
+    There are a variety of front ends that interface with rosbridge, including
+    a WebSocket server for web browsers to interact with.
+
+    Rosbridge_suite is a meta-package containing rosbridge, various front end
+    packages for rosbridge like a WebSocket package, and helper packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/ruckig/default.nix
+++ b/distros/foxy/ruckig/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-foxy-ruckig";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pantor/ruckig-release/archive/release/foxy/ruckig/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "4a5a860fca44dcda382e07f9e935f9b1e0682637c11478731c89f6a677cb1cd9";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Online Trajectory Generation. Real-time. Time-optimal. Jerk-constrained.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/slider-publisher/default.nix
+++ b/distros/foxy/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-slider-publisher";
-  version = "1.0.2-r2";
+  version = "2.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/foxy/slider_publisher/1.0.2-2.tar.gz";
-    name = "1.0.2-2.tar.gz";
-    sha256 = "32cd644d8107e3573bc68eaa103ce05de211dab7532f9350b77fbfe9e0465bd8";
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/foxy/slider_publisher/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "01b7914b50f8a8efbe30490bf31a87432db54760d97976b56f860061dfd34c8d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/soccer-vision-msgs/default.nix
+++ b/distros/foxy/soccer-vision-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-soccer-vision-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/foxy/soccer_vision_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "515d4b307a9882bf727f18db82a91c046fded75eeacf0076a2c582ebbf0cbfa4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Package providing interfaces to be used in a soccer domain.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/turtle-tf2-cpp/default.nix
+++ b/distros/foxy/turtle-tf2-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+buildRosPackage {
+  pname = "ros-foxy-turtle-tf2-cpp";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "34c2f80aa0a0713a485f087a0688e511afbe6a2d743f66b7ee649180786563e1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''turtle_tf2_cpp demonstrates how to write a ROS2 C++ tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/turtle-tf2-py/default.nix
+++ b/distros/foxy/turtle-tf2-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
+buildRosPackage {
+  pname = "ros-foxy-turtle-tf2-py";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "6bc49ae3be60cb9291761824d5e6c90f74faeab866401285d2805351fd5caa52";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclpy tf-transformations tf2-ros turtlesim ];
+
+  meta = {
+    description = ''turtle_tf2_py demonstrates how to write a ROS2 Python tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/usb-cam/default.nix
+++ b/distros/foxy/usb-cam/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, builtin-interfaces, camera-info-manager, ffmpeg, image-transport, image-transport-plugins, rclcpp, rclcpp-components, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, v4l-utils }:
 buildRosPackage {
   pname = "ros-foxy-usb-cam";
-  version = "0.4.0-r1";
+  version = "0.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/foxy/usb_cam/0.4.0-1.tar.gz";
-    name = "0.4.0-1.tar.gz";
-    sha256 = "80afcf551cfac0d60fde305ac68ad73ce18ae1036e44311c56f567b42ac9a840";
+    url = "https://github.com/ros-gbp/usb_cam-release/archive/release/foxy/usb_cam/0.4.1-1.tar.gz";
+    name = "0.4.1-1.tar.gz";
+    sha256 = "b890f9babfa81aa5c85b116196e9b99b69a6ec90595ad98e3dfab1d616d4c96f";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
+  propagatedBuildInputs = [ builtin-interfaces camera-info-manager ffmpeg image-transport image-transport-plugins rclcpp rclcpp-components rosidl-default-runtime sensor-msgs std-msgs std-srvs v4l-utils ];
   nativeBuildInputs = [ ament-cmake-auto rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/webots-ros2-abb/default.nix
+++ b/distros/foxy/webots-ros2-abb/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-abb";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "f9df46ac4aff1710bb6b7d3db376253463b79f0806b0039f08d9bba3855453b0";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_abb/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "38b4719ce9a164bd1840d4b7c8326969115a6c3d78e14c7b38599d0b2756ecf4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-control/default.nix
+++ b/distros/foxy/webots-ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, pluginlib, rclcpp, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-control";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "fd7ba06d9e6f734e9e26f9d214c5eab3e730ab85b28ea53348d123c8a967d664";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_control/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b910c6e0abd5cbb0ba515bdc8a8f3ef5256536d187cf1dd158f55cbfeb346462";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-core/default.nix
+++ b/distros/foxy/webots-ros2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, python3Packages, pythonPackages, rclpy, std-msgs, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-core";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c225e143811d0fdd1bbd446dfb5823d9927901ad862a573167f674906c93272e";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_core/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "049d92019d36981a716964c59bb9b34858128e8aa5d2ac8fdd909a3d1a84802c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-demos/default.nix
+++ b/distros/foxy/webots-ros2-demos/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-demos";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ad584e5cfdadbfef7084c20bc14b2e75bbbb6b793e1eb204e68ce89904eb8396";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_demos/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "0ccefa388ee67c0d05326a2fef15c348256d5f92aa785210a2785f7347fec8fb";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-driver/default.nix
+++ b/distros/foxy/webots-ros2-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-python, ament-lint-auto, ament-lint-common, pluginlib, python-cmake-module, rclcpp, rclcpp-lifecycle, rclpy, sensor-msgs, std-msgs, tf2-ros, tinyxml2-vendor, vision-msgs, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-driver";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "90447cc5fc8f193da2b04132fa1c9990ec91f2f9701338b31aad85a1255f8f03";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_driver/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4c4fb4a35a13314a6c34e4a3feac1abce02e525a7111ec3e8e19a37d404f6fc3";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ pluginlib rclcpp rclcpp-lifecycle rclpy sensor-msgs std-msgs tf2-ros tinyxml2-vendor vision-msgs webots-ros2-msgs ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python python-cmake-module ];
 
   meta = {
     description = ''Implementation of the Webots - ROS 2 interface'';

--- a/distros/foxy/webots-ros2-epuck/default.nix
+++ b/distros/foxy/webots-ros2-epuck/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, nav-msgs, pythonPackages, rclpy, rviz2, sensor-msgs, std-msgs, tf2-ros, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-epuck";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "aa1948024f639ae31b3d1e88331695b89653b3d510149121e31b59cde1bf4641";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_epuck/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "436a1a3283486eb1f0cdc8fb637656691f44d153f72048e85f8ebe84317f851c";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-examples/default.nix
+++ b/distros/foxy/webots-ros2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, sensor-msgs, std-msgs, webots-ros2-core, webots-ros2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-examples";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "c7d8c918efe307d95f38674b140271d432982068279c02903dec3bc999fa692d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_examples/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "45bb57fdc52885b67d5a24a10ca863d405ac37944b65f5c4139f219374063ed8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-mavic/default.nix
+++ b/distros/foxy/webots-ros2-mavic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-mavic";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "6e15bd7a48cc96f6e55e16df9072678c722aff1a3c6be6e4254b77c87c8d9fe9";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_mavic/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "aa08cb5767aff6e02aee8c6de078ea70944865c676ed0badfe1ab0e90d30646a";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-msgs/default.nix
+++ b/distros/foxy/webots-ros2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs, vision-msgs }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-msgs";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "2dcfc0c0f332a1156d1a463914c296a5761441470619f82427efd151d10290be";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_msgs/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d0e4b0a2c0d604bd42d89596be60eeda8a94e3fd18aea8cfe529902fec136090";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/webots-ros2-tesla/default.nix
+++ b/distros/foxy/webots-ros2-tesla/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ackermann-msgs, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tesla";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "ea2c7a201cb2ac8fd573635af2cc6be7cf3abd45e11c5960bb50ac174e16d38f";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tesla/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6873421bd0e2e3a36e8e94e45e55d6a374523476ff25ae61e6a440ffc7816ccc";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-tests/default.nix
+++ b/distros/foxy/webots-ros2-tests/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-testing, launch-testing-ament-cmake, launch-testing-ros, pythonPackages, rclpy, sensor-msgs, std-msgs, std-srvs, webots-ros2-driver }:
+buildRosPackage {
+  pname = "ros-foxy-webots-ros2-tests";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tests/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "4b4eae86b1636137ca02e21bf09fc8140130643fe2c939ddd9ed703b18b1f570";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 geometry-msgs launch launch-testing launch-testing-ament-cmake launch-testing-ros pythonPackages.pytest sensor-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ rclpy webots-ros2-driver ];
+
+  meta = {
+    description = ''System tests for `webots_ros2` packages.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/webots-ros2-tiago/default.nix
+++ b/distros/foxy/webots-ros2-tiago/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, rviz2, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tiago";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "9bb1fc1c4b60d23b2498f5569bc7ce951648128d751e9d4dc66b3f757c974351";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tiago/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "43623baaf5ad8c1ace288f99066a4afb972aa57cb5189e59ad393a97dc99c823";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-turtlebot/default.nix
+++ b/distros/foxy/webots-ros2-turtlebot/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, webots-ros2-control, webots-ros2-core, webots-ros2-driver }:
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, diff-drive-controller, joint-state-broadcaster, pythonPackages, rclpy, webots-ros2-control, webots-ros2-driver }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-turtlebot";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "d3d54543e2109afae75dcceb695d0f77ff39062c418f6f72e8be607e9159e6bb";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_turtlebot/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "cdbd0cad4d4da8947e4cb3a7c880d9613b4da7fef97da583149bc7ce1624a542";
   };
 
   buildType = "ament_python";
   checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
-  propagatedBuildInputs = [ builtin-interfaces diff-drive-controller joint-state-broadcaster rclpy webots-ros2-control webots-ros2-core webots-ros2-driver ];
+  propagatedBuildInputs = [ builtin-interfaces diff-drive-controller joint-state-broadcaster rclpy webots-ros2-control webots-ros2-driver ];
 
   meta = {
     description = ''TurtleBot3 Burger robot ROS2 interface for Webots.'';

--- a/distros/foxy/webots-ros2-tutorials/default.nix
+++ b/distros/foxy/webots-ros2-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, geometry-msgs, pythonPackages, rclpy, std-msgs, webots-ros2-core }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-tutorials";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "e8366d01eac65cf95e113001924dd41cf78ec037c5dcd519c8fc8ae32a04c420";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_tutorials/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c6d87d5013d303b4452d11153ee1b1d24e80a58bbef05e71ffa700d19e96c062";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-universal-robot/default.nix
+++ b/distros/foxy/webots-ros2-universal-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, control-msgs, pythonPackages, rclpy, rosgraph-msgs, rviz2, sensor-msgs, std-msgs, trajectory-msgs, webots-ros2-core, webots-ros2-ur-e-description }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-universal-robot";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "33a9555b2abcd5b0571931cf52f86b8b7556a347a73035cbe727d01d9fa7b9c9";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_universal_robot/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "b5f5af7d30df0be732cf87e77af14355e2080b33fbd3d37252f2b02ac4f0f6eb";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2-ur-e-description/default.nix
+++ b/distros/foxy/webots-ros2-ur-e-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages, urdf }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2-ur-e-description";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "d06876fabec2f6d602fd85aa994209aed7e2dca43240dca983b3dcc3d73c6999";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2_ur_e_description/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "d0c01b5049ea6c46f3615f6f70a7f4aa0a28db678879d4f913286be886b622b5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/webots-ros2/default.nix
+++ b/distros/foxy/webots-ros2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, builtin-interfaces, pythonPackages, rclpy, std-msgs, webots-ros2-abb, webots-ros2-core, webots-ros2-demos, webots-ros2-epuck, webots-ros2-examples, webots-ros2-importer, webots-ros2-mavic, webots-ros2-msgs, webots-ros2-tesla, webots-ros2-tiago, webots-ros2-turtlebot, webots-ros2-tutorials, webots-ros2-universal-robot }:
 buildRosPackage {
   pname = "ros-foxy-webots-ros2";
-  version = "1.1.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.0-1.tar.gz";
-    name = "1.1.0-1.tar.gz";
-    sha256 = "5673c38f65b4b1444b6a06f78e3c7b04ae337b5a80aba3c2c0def2cd8df05f4d";
+    url = "https://github.com/cyberbotics/webots_ros2-release/archive/release/foxy/webots_ros2/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "3b2659f997ee611eb110251eff473ed8d6a372fa1a52730cb7af5df86aeb908d";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/apriltag/default.nix
+++ b/distros/galactic/apriltag/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-apriltag";
-  version = "3.1.2-r4";
+  version = "3.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/galactic/apriltag/3.1.2-4.tar.gz";
-    name = "3.1.2-4.tar.gz";
-    sha256 = "a4ddb3b345bbfec5112ada3e7e4bdabeccc435d3af54b03e61f1694427a129f6";
+    url = "https://github.com/ros2-gbp/apriltag-release/archive/release/galactic/apriltag/3.1.5-1.tar.gz";
+    name = "3.1.5-1.tar.gz";
+    sha256 = "e40e41d3184b4948b52917e24c2f20dd0ea5ed255f32828fe6ab77284b0c1f1d";
   };
 
   buildType = "cmake";
+  buildInputs = [ python3Packages.numpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -248,8 +248,6 @@ self: super: {
 
  eigen-stl-containers = self.callPackage ./eigen-stl-containers {};
 
- embree-vendor = self.callPackage ./embree-vendor {};
-
  example-interfaces = self.callPackage ./example-interfaces {};
 
  examples-rclcpp-cbg-executor = self.callPackage ./examples-rclcpp-cbg-executor {};
@@ -331,6 +329,8 @@ self: super: {
  geometry2 = self.callPackage ./geometry2 {};
 
  geometry-msgs = self.callPackage ./geometry-msgs {};
+
+ geometry-tutorials = self.callPackage ./geometry-tutorials {};
 
  gmock-vendor = self.callPackage ./gmock-vendor {};
 
@@ -608,6 +608,8 @@ self: super: {
 
  nodl-python = self.callPackage ./nodl-python {};
 
+ nodl-to-policy = self.callPackage ./nodl-to-policy {};
+
  ntpd-driver = self.callPackage ./ntpd-driver {};
 
  object-recognition-msgs = self.callPackage ./object-recognition-msgs {};
@@ -673,6 +675,8 @@ self: super: {
  phidgets-spatial = self.callPackage ./phidgets-spatial {};
 
  phidgets-temperature = self.callPackage ./phidgets-temperature {};
+
+ picknik-ament-copyright = self.callPackage ./picknik-ament-copyright {};
 
  plansys2-bringup = self.callPackage ./plansys2-bringup {};
 
@@ -892,6 +896,10 @@ self: super: {
 
  ros2launch = self.callPackage ./ros2launch {};
 
+ ros2launch-security = self.callPackage ./ros2launch-security {};
+
+ ros2launch-security-examples = self.callPackage ./ros2launch-security-examples {};
+
  ros2lifecycle = self.callPackage ./ros2lifecycle {};
 
  ros2lifecycle-test-fixtures = self.callPackage ./ros2lifecycle-test-fixtures {};
@@ -932,6 +940,8 @@ self: super: {
 
  ros-workspace = self.callPackage ./ros-workspace {};
 
+ rosapi = self.callPackage ./rosapi {};
+
  rosbag2 = self.callPackage ./rosbag2 {};
 
  rosbag2-bag-v2-plugins = self.callPackage ./rosbag2-bag-v2-plugins {};
@@ -957,6 +967,14 @@ self: super: {
  rosbag2-tests = self.callPackage ./rosbag2-tests {};
 
  rosbag2-transport = self.callPackage ./rosbag2-transport {};
+
+ rosbridge-library = self.callPackage ./rosbridge-library {};
+
+ rosbridge-msgs = self.callPackage ./rosbridge-msgs {};
+
+ rosbridge-server = self.callPackage ./rosbridge-server {};
+
+ rosbridge-suite = self.callPackage ./rosbridge-suite {};
 
  rosgraph-msgs = self.callPackage ./rosgraph-msgs {};
 
@@ -1059,6 +1077,8 @@ self: super: {
  rti-connext-dds-cmake-module = self.callPackage ./rti-connext-dds-cmake-module {};
 
  rttest = self.callPackage ./rttest {};
+
+ ruckig = self.callPackage ./ruckig {};
 
  run-move-group = self.callPackage ./run-move-group {};
 
@@ -1205,6 +1225,10 @@ self: super: {
  tracetools-test = self.callPackage ./tracetools-test {};
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
+
+ turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
+
+ turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
 
  turtlebot3-fake-node = self.callPackage ./turtlebot3-fake-node {};
 

--- a/distros/galactic/geometry-tutorials/default.nix
+++ b/distros/galactic/geometry-tutorials/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake }:
+buildRosPackage {
+  pname = "ros-galactic-geometry-tutorials";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "007f0ead432be1cb14ddd0ea64ecfc72629878f12ecdbda14566749d5b6366e5";
+  };
+
+  buildType = "ament_cmake";
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage of geometry tutorials ROS.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/lanelet2-core/default.nix
+++ b/distros/galactic/lanelet2-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, eigen, gtest, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-core";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_core/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "b0a84915cf69ef9b1886a93a83134713406811826944225f9350154fbb812ac2";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_core/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "3b30a139e00cbc0aa372af61f2d7221d1e57b8337a142afa8d22c94893e4ce9d";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-examples/default.nix
+++ b/distros/galactic/lanelet2-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules, ros2cli }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-examples";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_examples/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "c5255625ce3f14ecc64570a7591f0e1f90b332e0c4afe2f02e987b0ba824b0df";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_examples/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "2a6851c62686aa525033545813a40ebda834d748af22a7b266f947db44e9f647";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-maps/default.nix
+++ b/distros/galactic/lanelet2-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-maps";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_maps/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "beb9f2699c15c12a195402848416527a1fe399aa2f8948401ef4e51f43de513d";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_maps/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "36f1c983c105112c3d70fa8cb91191cfcb415a36f3ec94ccf90050b27845a982";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-projection/default.nix
+++ b/distros/galactic/lanelet2-projection/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, geographiclib, gtest, lanelet2-io, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-projection";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_projection/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "cd528b555940160b5aac2bfeaff8038e54c04c28df03de6d8d46c74189a6f4e2";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_projection/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "293354a8b0c072c64b55cc333417e3f49b111262cfa69c055eede98038bc537e";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-python/default.nix
+++ b/distros/galactic/lanelet2-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-io, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-python";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_python/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "12adb6188fed913af61e6f1fc95ab2b58db3c467f3388eac7584c356a4b68cdc";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_python/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "75e6c390b165fd5389383c59ed5e91ea62fd8a06d71627a49bd980a721311e11";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-routing/default.nix
+++ b/distros/galactic/lanelet2-routing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-routing";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_routing/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "1d2a5eee38ad730e4013a15851eece4b235850df3ffc97f869b0f61cf659ffd2";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_routing/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "cd07c8fee21f21b9550d3dbf340986fb7bec11f7417ef75660f7d9ba44aa6a2d";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-traffic-rules/default.nix
+++ b/distros/galactic/lanelet2-traffic-rules/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-traffic-rules";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_traffic_rules/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "58952f01ce2ee3d971e77f278eff800fb1c79e89e81a3942f1c6e3f3779e8cfc";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_traffic_rules/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "8ad0c5f333f79f1b842a5e4f5c9c4cca5e08b8c7480505f7988f435c28ea4e7f";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2-validation/default.nix
+++ b/distros/galactic/lanelet2-validation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, gtest, lanelet2-core, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-routing, lanelet2-traffic-rules, mrt-cmake-modules }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2-validation";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_validation/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "2e583f252ed48deadb29ae7844d25408f60604abe1aab510e6d99eb50769d173";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_validation/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "af1131fe9253eea5b6b8f41aeefc1d4ba7aa3ac5930f46f106659d8ae5584bdf";
   };
 
   buildType = "catkin";

--- a/distros/galactic/lanelet2/default.nix
+++ b/distros/galactic/lanelet2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, lanelet2-core, lanelet2-examples, lanelet2-io, lanelet2-maps, lanelet2-projection, lanelet2-python, lanelet2-routing, lanelet2-traffic-rules, lanelet2-validation, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-lanelet2";
-  version = "1.1.1-r1";
+  version = "1.1.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "813163ba02b4f4b155e0bf27d4fb524b3d6dc9ed2e31d6b66c91056de5d957a2";
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "7d216e9ff019500f0fe0ad50569491467b40b85fb63f0e36f41d28b1418a30a6";
   };
 
   buildType = "catkin";

--- a/distros/galactic/libstatistics-collector/default.nix
+++ b/distros/galactic/libstatistics-collector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, performance-test-fixture, rcl, rcpputils, rosidl-default-generators, rosidl-default-runtime, statistics-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-libstatistics-collector";
-  version = "1.1.0-r3";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/galactic/libstatistics_collector/1.1.0-3.tar.gz";
-    name = "1.1.0-3.tar.gz";
-    sha256 = "dcc144c88c9e8749840a888cc14333b517f7cfc34ee2c5a1f10f58d01ab942be";
+    url = "https://github.com/ros2-gbp/libstatistics_collector-release/archive/release/galactic/libstatistics_collector/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "6284d61d302e63e118c53ca206be56a742b4488ae6e0a8d3c868013d94ae9412";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2021.7.7-r1";
+  version = "2021.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.7.7-1.tar.gz";
-    name = "2021.7.7-1.tar.gz";
-    sha256 = "7dcbfb613334b77ce30cacd37fac4cac9e34cf9a7101f959d1a73371f5e3f10f";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.8.8-1.tar.gz";
+    name = "2021.8.8-1.tar.gz";
+    sha256 = "28898d30631d7d463a58f939f33fb6fed19908fec27971a3b6a0fd8e97cb95f0";
   };
 
   buildType = "cmake";

--- a/distros/galactic/nodl-to-policy/default.nix
+++ b/distros/galactic/nodl-to-policy/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-lint-auto, ament-mypy, ament-pep257, ament-pycodestyle, nodl-python, python3Packages, pythonPackages, ros-testing, ros2cli, ros2nodl, ros2run, sros2, test-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-nodl-to-policy";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/nodl_to_policy-release/archive/release/galactic/nodl_to_policy/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ced453e33740f2f527b8653a10a6f67decf87f7efb35fe2fc8e8c3a9f6e36c61";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-lint-auto ament-mypy ament-pep257 ament-pycodestyle python3Packages.pytest-mock pythonPackages.pytest ros-testing test-msgs ];
+  propagatedBuildInputs = [ nodl-python python3Packages.argcomplete python3Packages.lxml ros2cli ros2nodl ros2run sros2 ];
+
+  meta = {
+    description = ''Package to generate a ROS 2 Access Control Policy from the NoDL description of a ROS system'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/picknik-ament-copyright/default.nix
+++ b/distros/galactic/picknik-ament-copyright/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, pythonPackages }:
+buildRosPackage {
+  pname = "ros-galactic-picknik-ament-copyright";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/PickNikRobotics/picknik_ament_copyright-release/archive/release/galactic/picknik_ament_copyright/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "09836477d7137c01aec13a2e7059ebe28711242ddda42c71b0df988e44c9de7b";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-copyright ];
+
+  meta = {
+    description = ''Check PickNik-specific copyright headers.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rc-genicam-api/default.nix
+++ b/distros/galactic/rc-genicam-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, libpng, libusb1 }:
 buildRosPackage {
   pname = "ros-galactic-rc-genicam-api";
-  version = "2.5.0-r2";
+  version = "2.5.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/galactic/rc_genicam_api/2.5.0-2.tar.gz";
-    name = "2.5.0-2.tar.gz";
-    sha256 = "ae48fa7ca9df46f6cb89c342978c5b0462cc11cd66058195ecbcd010b9cbeb1f";
+    url = "https://github.com/ros2-gbp/rc_genicam_api-release/archive/release/galactic/rc_genicam_api/2.5.6-1.tar.gz";
+    name = "2.5.6-1.tar.gz";
+    sha256 = "51fc487557e1cd25ca9e2248e3c99e3a280335289857db11192d28f586519aa1";
   };
 
   buildType = "cmake";

--- a/distros/galactic/rc-genicam-driver/default.nix
+++ b/distros/galactic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-xmllint, ament-lint-auto, diagnostic-updater, image-transport, rc-common-msgs, rc-genicam-api, rclcpp, rclcpp-components, sensor-msgs, stereo-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rc-genicam-driver";
-  version = "0.1.3-r2";
+  version = "0.2.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rc_genicam_driver_ros2-release/archive/release/galactic/rc_genicam_driver/0.1.3-2.tar.gz";
-    name = "0.1.3-2.tar.gz";
-    sha256 = "388deef84ea4ea1674eaa8343ce5eec1d06ff8eb9ca3c2a30afbc6f49e90ab06";
+    url = "https://github.com/ros2-gbp/rc_genicam_driver_ros2-release/archive/release/galactic/rc_genicam_driver/0.2.0-1.tar.gz";
+    name = "0.2.0-1.tar.gz";
+    sha256 = "983e29322738289a3220b25ae7f69b8b9cb47d2bbe57ba6ef12539687c68f9d9";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-examples/default.nix
+++ b/distros/galactic/rclc-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, example-interfaces, lifecycle-msgs, rcl, rclc, rclc-lifecycle, rclc-parameter, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-examples";
-  version = "2.0.3-r3";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "d82f4d21f48d2d31a954b2ca54ea2b91569579affb1675e197dc94cad15be8c9";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_examples/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "9712c52f1ccdc95e4b6d75c011e91fc741fb06e76e33d7772d0f1d0c689f1db3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc-lifecycle/default.nix
+++ b/distros/galactic/rclc-lifecycle/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, osrf-testing-tools-cpp, rcl-lifecycle, rclc, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-lifecycle";
-  version = "2.0.3-r3";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "7d96192d941fa8f07210cc102081bd47e49f34c8ef014449cb415785e798eefa";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_lifecycle/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "d9697115c729326e0793304e22b4fa23fe52ee2ca641498823aa7b87c27ec968";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common osrf-testing-tools-cpp ];
-  propagatedBuildInputs = [ lifecycle-msgs rcl-lifecycle rclc ];
+  propagatedBuildInputs = [ lifecycle-msgs rcl-lifecycle rclc std-msgs ];
   nativeBuildInputs = [ ament-cmake-ros ];
 
   meta = {

--- a/distros/galactic/rclc-parameter/default.nix
+++ b/distros/galactic/rclc-parameter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, example-interfaces, osrf-testing-tools-cpp, rcl, rcl-interfaces, rclc, rclcpp, rcutils, rosidl-runtime-c, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc-parameter";
-  version = "2.0.3-r3";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "f317ae6ac85fba3b4959cb6b39a7d6b0880ed2c23692ddb2bb1677d3318405a3";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc_parameter/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "062035033625259378e8bff1d26182ce486a9ad6989cd57baf5d9aa4f29391f8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rclc/default.nix
+++ b/distros/galactic/rclc/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-ros, ament-lint-auto, ament-lint-common, example-interfaces, launch-testing, osrf-testing-tools-cpp, rcl, rcutils, rosidl-generator-c, rosidl-typesupport-c, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rclc";
-  version = "2.0.3-r3";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.3-3.tar.gz";
-    name = "2.0.3-3.tar.gz";
-    sha256 = "e366a239f16ed2c18057bebeb7a230befff7d8390931c87d34f91f84599be9a7";
+    url = "https://github.com/ros2-gbp/rclc-release/archive/release/galactic/rclc/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "6fcedc0137c9ad1324bbdceacbd73c04222d03428793968c8b98a37aae20d82d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-cpp";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_cpp/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "22a637508c3d7a6b7af6ad46fdd15d589f9e29006b6a4c084fb6c851cc99d682";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_cpp/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "422dfa6e90794bd8952ca91b28c2e57759d5e29628dea140da49dd9ad1a701fd";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-dynamic-cpp";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_dynamic_cpp/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "1e91b209a884df54082f09c4190cfea8f5f2a695f5601b1d2ff25eb66ab48ed9";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_dynamic_cpp/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "2888703340830792e8b97ae224677621da6f0fe0809cff4cd66d44ccedb7b9c1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/galactic/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-galactic-rmw-fastrtps-shared-cpp";
-  version = "5.0.0-r2";
+  version = "5.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_shared_cpp/5.0.0-2.tar.gz";
-    name = "5.0.0-2.tar.gz";
-    sha256 = "e66928039edab5f28ea324ff47362b4639ea26ae5e6f2cedd529e7eca1ca2ef7";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/galactic/rmw_fastrtps_shared_cpp/5.0.1-1.tar.gz";
+    name = "5.0.1-1.tar.gz";
+    sha256 = "02b406c5db05b6817f29e540a159dc6284b8bdbe1a507b2cd418e624038a67d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2launch-security-examples/default.nix
+++ b/distros/galactic/ros2launch-security-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, ament-nodl, example-interfaces, launch-testing, launch-testing-ament-cmake, launch-testing-ros, nodl-python, nodl-to-policy, rclcpp, rclcpp-components, rclpy, ros2launch-security, sensor-msgs, sros2 }:
+buildRosPackage {
+  pname = "ros-galactic-ros2launch-security-examples";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2launch_security-release/archive/release/galactic/ros2launch_security_examples/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "eb5459eed8fa92d97df8f419fb03f49b95478bef1433674a4ae7ab0f389d1916";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common launch-testing launch-testing-ament-cmake launch-testing-ros nodl-python nodl-to-policy sros2 ];
+  propagatedBuildInputs = [ ament-nodl example-interfaces rclcpp rclcpp-components rclpy ros2launch-security sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Examples of how to use the ros2launch_security extension.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2launch-security/default.nix
+++ b/distros/galactic/ros2launch-security/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, demo-nodes-py, launch-ros, nodl-python, pythonPackages, ros2launch, sros2 }:
+buildRosPackage {
+  pname = "ros-galactic-ros2launch-security";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2launch_security-release/archive/release/galactic/ros2launch_security/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "067974698798a01296e64d48b3069f39438a197d873524c9919f1329274d71aa";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 demo-nodes-py launch-ros pythonPackages.pytest ros2launch sros2 ];
+  propagatedBuildInputs = [ ament-index-python nodl-python ros2launch sros2 ];
+
+  meta = {
+    description = ''Security extensions for ros2 launch'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rosapi/default.nix
+++ b/distros/galactic/rosapi/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-nose, ament-cmake-ros, builtin-interfaces, rcl-interfaces, rclpy, ros2node, ros2param, ros2pkg, ros2service, ros2topic, rosbridge-library, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rosapi";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosapi/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "cdb0b9c9f89153a3d2112e34073e3c97e5288b5e981aee7a0e5bc95d975b1ad4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-nose ];
+  propagatedBuildInputs = [ builtin-interfaces rcl-interfaces rclpy ros2node ros2param ros2pkg ros2service ros2topic rosbridge-library rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Provides service calls for getting ros meta-information, like list of
+    topics, services, params, etc.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosbridge-library/default.nix
+++ b/distros/galactic/rosbridge-library/default.nix
@@ -1,0 +1,27 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, builtin-interfaces, geometry-msgs, python3Packages, rclpy, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rosbridge-library";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_library/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "b2cb789e1ecf387653305c8be19710f6e244a2b5195b3a5ce7b6b4af573fdd2b";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs python3Packages.bson python3Packages.pillow rclpy rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The core rosbridge package, responsible for interpreting JSON andperforming
+    the appropriate ROS action, like subscribe, publish, call service, and
+    interact with params.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosbridge-msgs/default.nix
+++ b/distros/galactic/rosbridge-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-ros, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-rosbridge-msgs";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_msgs/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "d3cb1eea4b713080dfbea2fed49301f2c1f27ee21290c7633151280cc4f66f1d";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ builtin-interfaces ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake-ros rosidl-default-generators ];
+
+  meta = {
+    description = ''Package containing message files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosbridge-server/default.nix
+++ b/distros/galactic/rosbridge-server/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, launch, launch-ros, launch-testing, launch-testing-ament-cmake, launch-testing-ros, python3Packages, rclpy, rosapi, rosbridge-library, rosbridge-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rosbridge-server";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_server/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "a91031cb897968629ff86918ce2220354b47ba78f1447877bd98130f1916034b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ launch launch-ros launch-testing launch-testing-ament-cmake launch-testing-ros python3Packages.autobahn ];
+  propagatedBuildInputs = [ python3Packages.tornado python3Packages.twisted rclpy rosapi rosbridge-library rosbridge-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A WebSocket interface to rosbridge.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosbridge-suite/default.nix
+++ b/distros/galactic/rosbridge-suite/default.nix
@@ -1,0 +1,29 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, rosapi, rosbridge-library, rosbridge-server }:
+buildRosPackage {
+  pname = "ros-galactic-rosbridge-suite";
+  version = "1.0.7-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rosbridge_suite-release/archive/release/galactic/rosbridge_suite/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "495a51c091799e929395369df0711d51f7eb0f3f278beeeebd7457a0153f3d6c";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosapi rosbridge-library rosbridge-server ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = ''Rosbridge provides a JSON API to ROS functionality for non-ROS programs.
+    There are a variety of front ends that interface with rosbridge, including
+    a WebSocket server for web browsers to interact with.
+
+    Rosbridge_suite is a meta-package containing rosbridge, various front end
+    packages for rosbridge like a WebSocket package, and helper packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/ruckig/default.nix
+++ b/distros/galactic/ruckig/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-galactic-ruckig";
+  version = "0.3.3-r3";
+
+  src = fetchurl {
+    url = "https://github.com/pantor/ruckig-release/archive/release/galactic/ruckig/0.3.3-3.tar.gz";
+    name = "0.3.3-3.tar.gz";
+    sha256 = "875050f81bdef946ec8e2698bba4f5c9e4558b0f058ce9c4eb51d47647ddd5f1";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Online Trajectory Generation. Real-time. Time-optimal. Jerk-constrained.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/soccer-vision-msgs/default.nix
+++ b/distros/galactic/soccer-vision-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-soccer-vision-msgs";
-  version = "0.0.2-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/galactic/soccer_vision_msgs/0.0.2-1.tar.gz";
-    name = "0.0.2-1.tar.gz";
-    sha256 = "aded059455744e4dec01b420d64aca707f1db55901a85b190c2cb0d318be217b";
+    url = "https://github.com/ijnek/soccer_interfaces-release/archive/release/galactic/soccer_vision_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "840bb322e3c32193056738fe67a70de7c891dcd960eb941772299d028b8e5056";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtle-tf2-cpp/default.nix
+++ b/distros/galactic/turtle-tf2-cpp/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+buildRosPackage {
+  pname = "ros-galactic-turtle-tf2-cpp";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "070e480375537b74c673358ab7b24c110b2f83572e2bb570211caa5383462830";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''turtle_tf2_cpp demonstrates how to write a ROS2 C++ tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtle-tf2-py/default.nix
+++ b/distros/galactic/turtle-tf2-py/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
+buildRosPackage {
+  pname = "ros-galactic-turtle-tf2-py";
+  version = "0.3.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.2-1.tar.gz";
+    name = "0.3.2-1.tar.gz";
+    sha256 = "424233ae4a1b8caaf1fcf6bd83d41636d3f0badc0d984dea77538dda110bc1e2";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclpy tf-transformations tf2-ros turtlesim ];
+
+  meta = {
+    description = ''turtle_tf2_py demonstrates how to write a ROS2 Python tf2 broadcaster and listener with the turtlesim. The turtle_tf2_listener commands turtle2 to follow turtle1 around as you drive turtle1 using the keyboard.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/apriltag/default.nix
+++ b/distros/melodic/apriltag/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-melodic-apriltag";
-  version = "3.1.2-r1";
+  version = "3.1.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/melodic/apriltag/3.1.2-1.tar.gz";
-    name = "3.1.2-1.tar.gz";
-    sha256 = "edeca6ffd2d5da48a525fd278afb41a43d2cf3e0290dadf71bce62620f4ebf9d";
+    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/melodic/apriltag/3.1.6-1.tar.gz";
+    name = "3.1.6-1.tar.gz";
+    sha256 = "05db2d6bcfd95576934394d1a48ec40d28db5dff78e44ecdf11da740c48ddd44";
   };
 
   buildType = "cmake";

--- a/distros/melodic/cartesian-interface/default.nix
+++ b/distros/melodic/cartesian-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, hardware-interface, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-interface";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "d3b6f0185a16c13a29e0992f324542ff0bc53d8e5b4cd5f79f8589137eeb72be";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_interface/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "89669ea66a46f73997d10314571970dda7be6ef6b8844593c3668cfdb02491a6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-trajectory-controller/default.nix
+++ b/distros/melodic/cartesian-trajectory-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, cartesian-interface, cartesian-trajectory-interpolation, catkin, control-msgs, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, joint-state-controller, joint-trajectory-controller, kdl-parser, pluginlib, robot-state-publisher, ros-control-boilerplate, roscpp, rospy, rostest, speed-scaling-interface, trajectory-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-trajectory-controller";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "c46a01abaeb00170a359eb7a8a7068edb8983f88385c35d0437ba7cc64059bdc";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_controller/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "f7341c2494a83b7152a8aa0d9d95134091012c2b80b0598ed39b0f767070d685";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cartesian-trajectory-interpolation/default.nix
+++ b/distros/melodic/cartesian-trajectory-interpolation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-control-msgs, catkin, joint-trajectory-controller, roscpp, rospy, rosunit, tf2-eigen }:
 buildRosPackage {
   pname = "ros-melodic-cartesian-trajectory-interpolation";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "106dcf4af4f487b26db8189c1e2b8b9bb8cbb00d33ac9cb505095945c901a9f6";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/cartesian_trajectory_interpolation/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "f8b6831909f4f9bde2ddf08f3d42ae030fd18cc4c0a27b279dfe22a60a6daffc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3694,6 +3694,8 @@ self: super: {
 
  rtmros-nextage = self.callPackage ./rtmros-nextage {};
 
+ ruckig = self.callPackage ./ruckig {};
+
  rviz = self.callPackage ./rviz {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};

--- a/distros/melodic/ira-laser-tools/default.nix
+++ b/distros/melodic/ira-laser-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
 buildRosPackage {
   pname = "ros-melodic-ira-laser-tools";
-  version = "1.0.4-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/melodic/ira_laser_tools/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "6973e29fd04073a94af1a7d7d1eb03395ef024786672f7c97317f55cacdaad34";
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/melodic/ira_laser_tools/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "3f6b86175e481a8d8c96f645f828fb3c7f9627a6d3ae87f1c212bf8a022689c7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/knowledge-representation/default.nix
+++ b/distros/melodic/knowledge-representation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libpqxx, postgresql, python, pythonPackages, roslint, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-knowledge-representation";
-  version = "0.9.3-r1";
+  version = "0.9.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/melodic/knowledge_representation/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "37052ecadaa9888e16018694a23ba7e0dc36a96d6273097d3b6005fb27df2a90";
+    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/melodic/knowledge_representation/0.9.4-1.tar.gz";
+    name = "0.9.4-1.tar.gz";
+    sha256 = "9d78c86fd031e08f16d5c2592b9f6d24a4d91f97a8c894752727c37ea292820d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.7.7-r1";
+  version = "2021.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.7.7-1.tar.gz";
-    name = "2021.7.7-1.tar.gz";
-    sha256 = "ae5288afecde7eee8d675b9897c61d1c73c21c636ed87b9c9e08b6b7a022d018";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.8.8-1.tar.gz";
+    name = "2021.8.8-1.tar.gz";
+    sha256 = "da94c1697bf62679e6c664daab54d24f92e811b02b0bf31abcda2ccbbacc77ec";
   };
 
   buildType = "cmake";

--- a/distros/melodic/quanergy-client-ros/default.nix
+++ b/distros/melodic/quanergy-client-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, quanergy-client, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-quanergy-client-ros";
-  version = "4.0.0-r1";
+  version = "4.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/melodic/quanergy_client_ros/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "95707f54940cf7aad18f6fe8d4d49c869486715393d6608b0b44beaa3ba60bcb";
+    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/melodic/quanergy_client_ros/4.0.0-2.tar.gz";
+    name = "4.0.0-2.tar.gz";
+    sha256 = "5553613a8d80533a3f3ee1fa87c85b428ce55e6b683dd58154792cc0d15b188a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/robot-body-filter/default.nix
+++ b/distros/melodic/robot-body-filter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, fcl, filters, geometric-shapes, geometry-msgs, laser-geometry, message-generation, message-runtime, moveit-core, moveit-ros-perception, pcl, pcl-conversions, pkg-config, roscpp, rostest, sensor-msgs, std-msgs, tf2, tf2-eigen, tf2-ros, tf2-sensor-msgs, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-robot-body-filter";
-  version = "1.2.0-r2";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/peci1/robot_body_filter-release/archive/release/melodic/robot_body_filter/1.2.0-2.tar.gz";
-    name = "1.2.0-2.tar.gz";
-    sha256 = "d51b48b1688bcf9d53181d592d1f346f3adb017bc1995143bb144d98a87b992f";
+    url = "https://github.com/peci1/robot_body_filter-release/archive/release/melodic/robot_body_filter/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "dd2aa42f62dde98a757abc10e7e7f60192342028cdf7a15de4d674670bd2a6ee";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ros-controllers-cartesian/default.nix
+++ b/distros/melodic/ros-controllers-cartesian/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, cartesian-trajectory-controller, cartesian-trajectory-interpolation, catkin, twist-controller }:
 buildRosPackage {
   pname = "ros-melodic-ros-controllers-cartesian";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "ab8bfadf8aa20429f57c061e79db446aebeea4bcfe285f785220d2b64d2bd212";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/ros_controllers_cartesian/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "5ded3fcc388472e298f2112c0e38d7ae587bd631f78e2c8c3bb2b84eaa32e2d2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ruckig/default.nix
+++ b/distros/melodic/ruckig/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-melodic-ruckig";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pantor/ruckig-release/archive/release/melodic/ruckig/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "feafef442d6c1310e07876e09b570b2f78c096278a1cb6c42e2587e6256abf77";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Online Trajectory Generation. Real-time. Time-optimal. Jerk-constrained.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/twist-controller/default.nix
+++ b/distros/melodic/twist-controller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cartesian-interface, catkin, controller-interface, dynamic-reconfigure, geometry-msgs, hardware-interface, realtime-tools, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-twist-controller";
-  version = "0.1.3-r1";
+  version = "0.1.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.3-1.tar.gz";
-    name = "0.1.3-1.tar.gz";
-    sha256 = "f5d5f9aefac0e3063ac9153eb7090a95038fb43f90ceb80346c08b93d3c96ddd";
+    url = "https://github.com/UniversalRobots/Universal_Robots_ROS_controllers_cartesian-release/archive/release/melodic/twist_controller/0.1.4-1.tar.gz";
+    name = "0.1.4-1.tar.gz";
+    sha256 = "8c275c6ef6b7611f343767f43399b67b5349c1fc4091df5a3773cdec2b0181be";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urg-stamped/default.nix
+++ b/distros/melodic/urg-stamped/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-urg-stamped";
-  version = "0.0.12-r2";
+  version = "0.0.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.12-2.tar.gz";
-    name = "0.0.12-2.tar.gz";
-    sha256 = "6c47c85970feb0713ca00ae6fc35c5c6d2d0f43ada2fce002e70b5ddc632fb8f";
+    url = "https://github.com/seqsense/urg_stamped-release/archive/release/melodic/urg_stamped/0.0.13-2.tar.gz";
+    name = "0.0.13-2.tar.gz";
+    sha256 = "0969129fafb1507491bb61d4c2f7f03fd77d0073288ede3412f6af02157c59cd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/apriltag/default.nix
+++ b/distros/noetic/apriltag/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, cmake }:
+{ lib, buildRosPackage, fetchurl, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-apriltag";
-  version = "3.1.2-r2";
+  version = "3.1.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/noetic/apriltag/3.1.2-2.tar.gz";
-    name = "3.1.2-2.tar.gz";
-    sha256 = "cd865830edbf30f93b897b0b98c3b86d4c5273bceeb5db4e8beba4170d832a4c";
+    url = "https://github.com/AprilRobotics/apriltag-release/archive/release/noetic/apriltag/3.1.5-1.tar.gz";
+    name = "3.1.5-1.tar.gz";
+    sha256 = "85004181ebc6401c30c0c43a0206c5d870c75d9a7b5810b8d1268db60b0f3e01";
   };
 
   buildType = "cmake";
+  buildInputs = [ python3Packages.numpy ];
   nativeBuildInputs = [ cmake ];
 
   meta = {

--- a/distros/noetic/fiducial-msgs/default.nix
+++ b/distros/noetic/fiducial-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-fiducial-msgs";
+  version = "0.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/fiducials-release/archive/release/noetic/fiducial_msgs/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "76793444bb22e7b5ccf9e3bef011af4da9cf7174c3abc800057c556090e578bd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime sensor-msgs std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Package containing message definitions for fiducials'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fiducial-slam/default.nix
+++ b/distros/noetic/fiducial-slam/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, dynamic-reconfigure, fiducial-msgs, image-transport, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-fiducial-slam";
+  version = "0.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/fiducials-release/archive/release/noetic/fiducial_slam/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "347a536eff2ea1deff50491ee500368aebc70783148a2c3204a43da6e1ce0986";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge dynamic-reconfigure fiducial-msgs image-transport roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node to build a 3D map of fiducials and estimate robot pose from fiducial transforms'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/fiducials/default.nix
+++ b/distros/noetic/fiducials/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, aruco-detect, catkin, fiducial-msgs, fiducial-slam }:
+buildRosPackage {
+  pname = "ros-noetic-fiducials";
+  version = "0.12.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/fiducials-release/archive/release/noetic/fiducials/0.12.0-1.tar.gz";
+    name = "0.12.0-1.tar.gz";
+    sha256 = "d9836b134f19867e917a042e35177206a6e63cb4563605ef11dcaa3410714cc9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ aruco-detect fiducial-msgs fiducial-slam ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Localization using fiducial markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -774,6 +774,12 @@ self: super: {
 
  ffha = self.callPackage ./ffha {};
 
+ fiducial-msgs = self.callPackage ./fiducial-msgs {};
+
+ fiducial-slam = self.callPackage ./fiducial-slam {};
+
+ fiducials = self.callPackage ./fiducials {};
+
  filters = self.callPackage ./filters {};
 
  find-object-2d = self.callPackage ./find-object-2d {};
@@ -1125,6 +1131,8 @@ self: super: {
  interval-intersection = self.callPackage ./interval-intersection {};
 
  ipa-3d-fov-visualization = self.callPackage ./ipa-3d-fov-visualization {};
+
+ ira-laser-tools = self.callPackage ./ira-laser-tools {};
 
  iris-lama = self.callPackage ./iris-lama {};
 
@@ -1683,6 +1691,8 @@ self: super: {
  octovis = self.callPackage ./octovis {};
 
  odva-ethernetip = self.callPackage ./odva-ethernetip {};
+
+ oled-display-node = self.callPackage ./oled-display-node {};
 
  ompl = self.callPackage ./ompl {};
 
@@ -2412,6 +2422,8 @@ self: super: {
 
  rtcm-msgs = self.callPackage ./rtcm-msgs {};
 
+ ruckig = self.callPackage ./ruckig {};
+
  rviz = self.callPackage ./rviz {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
@@ -2761,6 +2773,8 @@ self: super: {
  twist-mux-msgs = self.callPackage ./twist-mux-msgs {};
 
  twist-recovery = self.callPackage ./twist-recovery {};
+
+ ubiquity-motor = self.callPackage ./ubiquity-motor {};
 
  ublox = self.callPackage ./ublox {};
 

--- a/distros/noetic/ira-laser-tools/default.nix
+++ b/distros/noetic/ira-laser-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, laser-geometry, pcl, pcl-ros, roscpp, sensor-msgs, std-msgs, tf, vtkWithQt5 }:
+buildRosPackage {
+  pname = "ros-noetic-ira-laser-tools";
+  version = "1.0.6-r2";
+
+  src = fetchurl {
+    url = "https://github.com/iralabdisco/ira_laser_tools-release/archive/release/noetic/ira_laser_tools/1.0.6-2.tar.gz";
+    name = "1.0.6-2.tar.gz";
+    sha256 = "547a2b868bc6d8bd607d9c882674e7ebabf411e3afa1cee18244b61d6c4ab822";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ laser-geometry pcl pcl-ros roscpp sensor-msgs std-msgs tf vtkWithQt5 ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ira_laser_tools package. These nodes are meant to provide some utils for lasers, like listen to different laser scan sources and merge them in a single scan or generate virtual laser scans from a pointcloud.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/knowledge-representation/default.nix
+++ b/distros/noetic/knowledge-representation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, libpqxx, postgresql, python3, python3Packages, roslint, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-knowledge-representation";
-  version = "0.9.3-r1";
+  version = "0.9.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/noetic/knowledge_representation/0.9.3-1.tar.gz";
-    name = "0.9.3-1.tar.gz";
-    sha256 = "8aec57c3d83d986d5b4f140431480cd9e0451c77f87ca18493d6a308e67a5376";
+    url = "https://github.com/utexas-bwi-gbp/knowledge_representation-release/archive/release/noetic/knowledge_representation/0.9.5-1.tar.gz";
+    name = "0.9.5-1.tar.gz";
+    sha256 = "3cdbf4f6a2964d8e9dd9e281936f812e4eee24c1936b3d62aa817f1389ef0e07";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.7.7-r1";
+  version = "2021.8.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.7.7-1.tar.gz";
-    name = "2021.7.7-1.tar.gz";
-    sha256 = "df50afc1cc68b86bff65cffb3da256e38574487ad86b4cdb7efa6a0e5c93a43d";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.8.8-1.tar.gz";
+    name = "2021.8.8-1.tar.gz";
+    sha256 = "e3b39acbb0f72dadf45d20836e740c717e973befebb093251ba65e4fc071dcc3";
   };
 
   buildType = "cmake";

--- a/distros/noetic/oled-display-node/default.nix
+++ b/distros/noetic/oled-display-node/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, roscpp, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-oled-display-node";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/oled_display_node-release/archive/release/noetic/oled_display_node/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "750524faffbef4380b8a808d522c70a6a5b6949bb44af667260c33047aa25d81";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime roscpp rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''OLED I2C display node package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/quanergy-client-ros/default.nix
+++ b/distros/noetic/quanergy-client-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pcl-ros, quanergy-client, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-quanergy-client-ros";
-  version = "4.0.0-r1";
+  version = "4.0.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/noetic/quanergy_client_ros/4.0.0-1.tar.gz";
-    name = "4.0.0-1.tar.gz";
-    sha256 = "bb1bbcd771601402b9bc57f6f0032561ef127d45c4e6424a91b483d54c3c93a7";
+    url = "https://github.com/QuanergySystems/quanergy_client_ros-release/archive/release/noetic/quanergy_client_ros/4.0.0-2.tar.gz";
+    name = "4.0.0-2.tar.gz";
+    sha256 = "737d653907cd30df6587b0d844d82a1af35b6bbb843474b2dee9ce429cd3dd43";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ruckig/default.nix
+++ b/distros/noetic/ruckig/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, cmake }:
+buildRosPackage {
+  pname = "ros-noetic-ruckig";
+  version = "0.3.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pantor/ruckig-release/archive/release/noetic/ruckig/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "cea3b5576bd9c749f3336703ee6990e24e76859b36fbbab05ed3cd73be5ea852";
+  };
+
+  buildType = "cmake";
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Online Trajectory Generation. Real-time. Time-optimal. Jerk-constrained.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/slider-publisher/default.nix
+++ b/distros/noetic/slider-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rospy, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-noetic-slider-publisher";
-  version = "1.0.0-r1";
+  version = "1.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/noetic/slider_publisher/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "82a79a0a9cac662cf81c61dd3efffacee06847054bf5c5f3c0de5e9f59be9dbe";
+    url = "https://github.com/oKermorgant/slider_publisher-release/archive/release/noetic/slider_publisher/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c625745bc79b0ccb639536e058b81b0b04d4df513d1b1f0aea66cd6dc4621935";
   };
 
   buildType = "catkin";

--- a/distros/noetic/sr-hand-detector/default.nix
+++ b/distros/noetic/sr-hand-detector/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libyamlcpp, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-noetic-sr-hand-detector";
-  version = "0.0.5-r1";
+  version = "0.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.5-1.tar.gz";
-    name = "0.0.5-1.tar.gz";
-    sha256 = "27031b0e72e17e8522e28555db512b2d837f74e23ac9bbb32fb752866aba2256";
+    url = "https://github.com/shadow-robot/sr_hand_detector-release/archive/release/noetic/sr_hand_detector/0.0.6-1.tar.gz";
+    name = "0.0.6-1.tar.gz";
+    sha256 = "4bae5c77b710f128080d5cbbb2b5a28de35e94ce1b4bac0a889f71f8aa0e7d14";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ubiquity-motor/default.nix
+++ b/distros/noetic/ubiquity-motor/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diagnostic-updater, diff-drive-controller, dynamic-reconfigure, geometry-msgs, hardware-interface, joint-state-controller, nav-msgs, python3Packages, roscpp, rostest, std-msgs, tf }:
+buildRosPackage {
+  pname = "ros-noetic-ubiquity-motor";
+  version = "0.13.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/UbiquityRobotics-release/ubiquity_motor-release/archive/release/noetic/ubiquity_motor/0.13.2-1.tar.gz";
+    name = "0.13.2-1.tar.gz";
+    sha256 = "3fde6fb69306cea15e1434c20645f5a6d0176e93e1afa13e12a9dea4911a2095";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roscpp ];
+  checkInputs = [ rostest ];
+  propagatedBuildInputs = [ controller-manager diagnostic-updater diff-drive-controller dynamic-reconfigure geometry-msgs hardware-interface joint-state-controller nav-msgs python3Packages.requests std-msgs tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Provides a ROS interface to Ubiquity Robotics Magni motor controllers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 1d6e2b18acd941b077e6986a03cd7cbd55a5f5b1.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *apriltag 3.1.2-r2 --> 3.1.5-r1*
* *espeak-interfaces 0.1.0-r6*
* *espeak-ros 0.1.0-r6*
* *geometry-tutorials 0.3.2-r1*
* *launch-pal 0.0.4-r1 --> 0.0.5-r1*
* *mavlink 2021.7.7-r1 --> 2021.8.8-r1*
* *picknik-ament-copyright 0.0.1-r2*
* *pmb2-2dnav-gazebo 3.0.0-r1 --> 3.0.1-r1*
* *pmb2-gazebo 3.0.0-r1 --> 3.0.1-r1*
* *pmb2-simulation 3.0.0-r1 --> 3.0.1-r1*
* *rosapi 1.0.7-r1*
* *rosbridge-library 1.0.7-r1*
* *rosbridge-msgs 1.0.7-r1*
* *rosbridge-server 1.0.7-r1*
* *rosbridge-suite 1.0.7-r1*
* *ruckig 0.3.3-r1*
* *slider-publisher 1.0.2-r2 --> 2.0.1-r1*
* *soccer-vision-msgs 1.0.0-r1*
* *turtle-tf2-cpp 0.3.2-r1*
* *turtle-tf2-py 0.3.2-r1*
* *usb-cam 0.4.0-r1 --> 0.4.1-r1*
* *webots-ros2 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-abb 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-control 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-core 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-demos 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-driver 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-epuck 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-examples 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-mavic 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-msgs 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-tesla 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-tests 1.1.1-r1*
* *webots-ros2-tiago 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-turtlebot 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-tutorials 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-universal-robot 1.1.0-r1 --> 1.1.1-r1*
* *webots-ros2-ur-e-description 1.1.0-r1 --> 1.1.1-r1*

Galactic Changes:
-----------------
* *apriltag 3.1.2-r4 --> 3.1.5-r1*
* *geometry-tutorials 0.3.2-r1*
* *lanelet2 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-core 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-examples 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-maps 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-projection 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-python 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-routing 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-traffic-rules 1.1.1-r1 --> 1.1.1-r2*
* *lanelet2-validation 1.1.1-r1 --> 1.1.1-r2*
* *libstatistics-collector 1.1.0-r3 --> 1.1.1-r1*
* *mavlink 2021.7.7-r1 --> 2021.8.8-r1*
* *nodl-to-policy 1.0.0-r1*
* *picknik-ament-copyright 0.0.1-r1*
* *rc-genicam-api 2.5.0-r2 --> 2.5.6-r1*
* *rc-genicam-driver 0.1.3-r2 --> 0.2.0-r1*
* *rclc 2.0.3-r3 --> 2.0.4-r1*
* *rclc-examples 2.0.3-r3 --> 2.0.4-r1*
* *rclc-lifecycle 2.0.3-r3 --> 2.0.4-r1*
* *rclc-parameter 2.0.3-r3 --> 2.0.4-r1*
* *rmw-fastrtps-cpp 5.0.0-r2 --> 5.0.1-r1*
* *rmw-fastrtps-dynamic-cpp 5.0.0-r2 --> 5.0.1-r1*
* *rmw-fastrtps-shared-cpp 5.0.0-r2 --> 5.0.1-r1*
* *ros2launch-security 1.0.0-r1*
* *ros2launch-security-examples 1.0.0-r1*
* *rosapi 1.0.7-r1*
* *rosbridge-library 1.0.7-r1*
* *rosbridge-msgs 1.0.7-r1*
* *rosbridge-server 1.0.7-r1*
* *rosbridge-suite 1.0.7-r1*
* *ruckig 0.3.3-r3*
* *soccer-vision-msgs 0.0.2-r1 --> 1.0.0-r1*
* *turtle-tf2-cpp 0.3.2-r1*
* *turtle-tf2-py 0.3.2-r1*

Melodic Changes:
----------------
* *apriltag 3.1.2-r1 --> 3.1.6-r1*
* *cartesian-interface 0.1.3-r1 --> 0.1.4-r1*
* *cartesian-trajectory-controller 0.1.3-r1 --> 0.1.4-r1*
* *cartesian-trajectory-interpolation 0.1.3-r1 --> 0.1.4-r1*
* *ira-laser-tools 1.0.4-r1 --> 1.0.6-r1*
* *knowledge-representation 0.9.3-r1 --> 0.9.4-r1*
* *mavlink 2021.7.7-r1 --> 2021.8.8-r1*
* *quanergy-client-ros 4.0.0-r1 --> 4.0.0-r2*
* *robot-body-filter 1.2.0-r2 --> 1.2.1-r1*
* *ros-controllers-cartesian 0.1.3-r1 --> 0.1.4-r1*
* *ruckig 0.3.3-r1*
* *twist-controller 0.1.3-r1 --> 0.1.4-r1*
* *urg-stamped 0.0.12-r2 --> 0.0.13-r2*

Noetic Changes:
---------------
* *apriltag 3.1.2-r2 --> 3.1.5-r1*
* *fiducial-msgs 0.12.0-r1*
* *fiducial-slam 0.12.0-r1*
* *fiducials 0.12.0-r1*
* *ira-laser-tools 1.0.6-r2*
* *knowledge-representation 0.9.3-r1 --> 0.9.5-r1*
* *mavlink 2021.7.7-r1 --> 2021.8.8-r1*
* *oled-display-node 1.0.0-r1*
* *quanergy-client-ros 4.0.0-r1 --> 4.0.0-r2*
* *ruckig 0.3.3-r1*
* *slider-publisher 1.0.0-r1 --> 1.1.1-r1*
* *sr-hand-detector 0.0.5-r1 --> 0.0.6-r1*
* *ubiquity-motor 0.13.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxmlrpc-c++
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pugixml-dev
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-cairosvg
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-joblib
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pip
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rviz
 * [ ] spirv-headers
 * [ ] spirv-tools
 * [ ] wiimote

