### PR TITLE
rosdistro sync, Wed Sep  8 21:51:54 2021

### DIFF
--- a/distros/foxy/ament-cmake-auto/default.nix
+++ b/distros/foxy/ament-cmake-auto/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-auto";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "c80abcdf2c1008f235d659e323a1d6efa2814b4bbcd4f824e21b552d808620a3";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_auto/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "37945c309dad2ba313941722bbe01f2bed2516a796157dc4207f576ec5df2109";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-catch2/default.nix
+++ b/distros/foxy/ament-cmake-catch2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test }:
+buildRosPackage {
+  pname = "ros-foxy-ament-cmake-catch2";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ament_cmake_catch2-release/archive/release/foxy/ament_cmake_catch2/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "4c435817be2c972b6f062c6dc0cb0bbaeca09abb8c6cd37b185d9153df544e74";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ ament-cmake-test ];
+  nativeBuildInputs = [ ament-cmake-core ];
+
+  meta = {
+    description = ''Allows integrating catch2 tests in the ament buildsystem with CMake'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/ament-cmake-core/default.nix
+++ b/distros/foxy/ament-cmake-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-package, cmake, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-core";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "d7096a75cf43295cef83fe20b85b3b084e9a13c426caefb7b02595873b497800";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_core/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "6ed5349e45a60badb1fbd224db3014b4e2783a7f524d7c78a0c331b16a36d2e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-definitions/default.nix
+++ b/distros/foxy/ament-cmake-export-definitions/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-definitions";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "bb187cd252ccd224fe105f2254dce0724655fe5f23de8097abc5f08e6c0fd36a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_definitions/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "570791560b1ae35567b741689140e71e7a995d093421d2351c7e052c7033c55a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-export-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-dependencies";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "861a62efb7cdbd6b304f6a66117a3f799bfff18d8bcac261f490606db8bf1951";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_dependencies/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "4b360d1e67fe4bf1a9bae38a43e71e85649c2ab15e579aa1ca87a474bcac5c20";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-export-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-include-directories";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "7d8ba8ec48a9301828ebce40aa07306c3471dcd6b64d966800e3ed1b40d2b3a2";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_include_directories/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "c6f619c543c0521520f869a70f519a1ae6ff1fb5a1745347dc8e7e8432161a28";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-interfaces/default.nix
+++ b/distros/foxy/ament-cmake-export-interfaces/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-interfaces";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "360eb3289f82510fd285187967c9d68583a7e16ba6ece114dd4b8bc81fd0a04f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_interfaces/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "fb16cd40c247c9fa6cb60ab0dfd81fcdc6f5b3b6af81cb68ef31b123cb829d1b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-libraries/default.nix
+++ b/distros/foxy/ament-cmake-export-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-libraries";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "89c6514397ae60b68dce59f9f7efda8d1816a840b5fbfd695e887dfef5bd4b57";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_libraries/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "0432bd3d6098f77c2e16e894700b00851e19948202808b4ccfad794cf67b4080";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-link-flags/default.nix
+++ b/distros/foxy/ament-cmake-export-link-flags/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-link-flags";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "75a43cf246bf3febc8809e8f33c9378c341a958fef879b6c0bb7f7ac62d957db";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_link_flags/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "45aebc1193ea14668a8f6c03c1b7a8d44684b4a86d936f29499224b088a5ed6f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-export-targets/default.nix
+++ b/distros/foxy/ament-cmake-export-targets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-export-targets";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "6773550aea6dd88a0d2bdae42d74a7e6408b643a243fe387a020af312e0bed22";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_export_targets/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "3795562d0eeb91c0eb3f59b43271eda4638611f34996573d96c9ac4852969ed7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gmock/default.nix
+++ b/distros/foxy/ament-cmake-gmock/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-gtest, ament-cmake-test, gmock-vendor, gtest }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gmock";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "b8f52df6a0135834cd190a3166fe58eb6bc8c3a3bbee1fd3984dfab3249de342";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gmock/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "3fafecf9716d5609a5b8bb95b28aa04e9f4cd160992604e6795536e55db37f34";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-google-benchmark/default.nix
+++ b/distros/foxy/ament-cmake-google-benchmark/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python, ament-cmake-test, google-benchmark-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-google-benchmark";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "9345411ccdea1c800d4ca3473c0d1f2738afc1a91fd5de22916a52e008bc98f9";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_google_benchmark/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "0a9fade740234a93a9549fccfe61613b287399673bba12671e9dcaf763d97524";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-gtest/default.nix
+++ b/distros/foxy/ament-cmake-gtest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, gtest, gtest-vendor }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-gtest";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "4a81e199a35de59c52738fd2b0472669af803c63bd7897deca281c8dc104658a";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_gtest/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "0c39644d0755a4cb52787e8ba587aacae6d26d3e16af2ea2defdd055418751e5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-include-directories/default.nix
+++ b/distros/foxy/ament-cmake-include-directories/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-include-directories";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "5343bbc3fe436138cf0fb065aaea6b9cbd0d9e569b37e00c198964acc8113af8";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_include_directories/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "cf95b1ccc8341e476dc266c0854ba3411dde433c0a50d00a7277e044d837a765";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-libraries/default.nix
+++ b/distros/foxy/ament-cmake-libraries/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-libraries";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "1777ca70314316d932f1a85d01af09762a2e35c432c7a056535da670162d1650";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_libraries/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "e235cada5f26f96f140e080e9fd7d2c7dd056dbcc6f6c1cf9d1ae7e7d60d8001";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-nose/default.nix
+++ b/distros/foxy/ament-cmake-nose/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-nose";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "97f16779ca7174811c4d626253ed507816433b1f19d87269b1f4b70b18d1f447";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_nose/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "cbd00e249326951b0279fdec0ea15fc88cd5d08d404cae1c08983ac104900f7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-pytest/default.nix
+++ b/distros/foxy/ament-cmake-pytest/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-test, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-pytest";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "737b95c63bc5cfeab42325b9a6f2ee4d72d312f65a870c0ed7bf87409c7abcde";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_pytest/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "6c2f1bc5048c4e08f7e46f08ac29ae86fd509a72030bf19b806185e84671f1e9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-python/default.nix
+++ b/distros/foxy/ament-cmake-python/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-python";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "1617abe83713aca08836201157b926ba3955c5ccf67d48eb653d546ca2a8c2a6";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_python/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "5e32c4aaf7caf333b86e0d0cfe0fc137ce8e3a30c9a20828b1af9777c4c664f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-target-dependencies/default.nix
+++ b/distros/foxy/ament-cmake-target-dependencies/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-include-directories, ament-cmake-libraries }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-target-dependencies";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "1cadd49647506063a15d0c3756df04ae459273f2faa8437471870a004308144f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_target_dependencies/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "9e4c049584955fa7e53f78e733e72b174d2919cc04a70e404d5a5999b293e23c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-test/default.nix
+++ b/distros/foxy/ament-cmake-test/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-python }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-test";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "7a9e55a6ed1c701bcce871d6b43c0fdd002e82d9890902beba790364c31c7ec7";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_test/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "fe907d5b83d1d5214c498ea4f1c81cc535a793ba626fe4fc960b833f466d9d48";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake-version/default.nix
+++ b/distros/foxy/ament-cmake-version/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake-version";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "e5084c50684b7963eebc065508e7c168c7991c02eda65f7a29c886acd1fd2bc4";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake_version/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "b7b9e73d0ec88a5107d3ae72399bed115ef4af80ea5ef80966c4ebc58cff5e84";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ament-cmake/default.nix
+++ b/distros/foxy/ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-core, ament-cmake-export-definitions, ament-cmake-export-dependencies, ament-cmake-export-include-directories, ament-cmake-export-interfaces, ament-cmake-export-libraries, ament-cmake-export-link-flags, ament-cmake-export-targets, ament-cmake-libraries, ament-cmake-python, ament-cmake-target-dependencies, ament-cmake-test, ament-cmake-version, cmake }:
 buildRosPackage {
   pname = "ros-foxy-ament-cmake";
-  version = "0.9.8-r1";
+  version = "0.9.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.8-1.tar.gz";
-    name = "0.9.8-1.tar.gz";
-    sha256 = "1cb4b958e22d787d31e95e21623037eca1ff11aa3f634fd547ae6a8c0713cf5f";
+    url = "https://github.com/ros2-gbp/ament_cmake-release/archive/release/foxy/ament_cmake/0.9.9-1.tar.gz";
+    name = "0.9.9-1.tar.gz";
+    sha256 = "eb11d2cbebecb297f104c616329d1f62cde6d83ebe2ce6ab449829f38d868404";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/asio-cmake-module/default.nix
+++ b/distros/foxy/asio-cmake-module/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-foxy-asio-cmake-module";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/asio_cmake_module/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "22d371d6006055b3c7d56dacc1c33be3760ab1cee55d6c8b932d3a28d7094020";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A CMake module for using the ASIO network library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
+buildRosPackage {
+  pname = "ros-foxy-aws-robomaker-small-warehouse-world";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "26033a906fb2648570cc63ae226c4f1dcc22385737d110204f72cac118ed9bea";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo gazebo-plugins gazebo-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''AWS RoboMaker package for a warehouse world to use in manufacturing and logistics robot applications.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/bosch-locator-bridge/default.nix
+++ b/distros/foxy/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch-xml, nav-msgs, pcl-conversions, poco, rclcpp, rosidl-default-generators, rosidl-default-runtime, std-srvs, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-bosch-locator-bridge";
-  version = "2.0.2-r1";
+  version = "2.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "588323f3c1fda3430d1c31efcda9a121a2f37946e842d38d1232065647fe2436";
+    url = "https://github.com/ros2-gbp/locator_ros_bridge-release/archive/release/foxy/bosch_locator_bridge/2.0.3-2.tar.gz";
+    name = "2.0.3-2.tar.gz";
+    sha256 = "7ec1aa270268eca24535d465eb9192de0b85aa6533b697fc7a3afa84dde5cf64";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-interface/default.nix
+++ b/distros/foxy/controller-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-controller-interface";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "a79375f0b4cb545d3bb5ba5bc56aee4061d3140d5a536d982b3e869886b654a9";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_interface/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "4aed297fd1cab9e95aed271f43e536d15e3ba73233bd9adb72bde9a504358a74";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager-msgs/default.nix
+++ b/distros/foxy/controller-manager-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager-msgs";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "bff11964905d711e3fda7ecd01de6f544f6cf01758b8b88ecd394aef75e05e51";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager_msgs/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "5dd3e58b14aac07124df8bb7870cf4f4c7801a1dca09893fc92db741d3696731";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/controller-manager/default.nix
+++ b/distros/foxy/controller-manager/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2param, ros2run }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
 buildRosPackage {
   pname = "ros-foxy-controller-manager";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "0f5efb5368578364860a86dc645812de9095b6ac1dfb6a06f3553656819f9367";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/controller_manager/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "ffe49b312ab3aaa3f9c9fb3aa95c5fafde3e726b293492371b1ae83dd7b4158b";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2param ros2run ];
+  propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/diff-drive-controller/default.nix
+++ b/distros/foxy/diff-drive-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
 buildRosPackage {
   pname = "ros-foxy-diff-drive-controller";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "02cbb15dd37364a622699b6b9022e08a33829648bbd1c5d1a9276ea23b25c646";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/diff_drive_controller/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "c2cdfcda793c14569cc1719ce0becf03a902a8e47c635c16e114a0ab42a3a559";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ];
+  checkInputs = [ ament-cmake-gmock controller-manager ];
   propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/effort-controllers/default.nix
+++ b/distros/foxy/effort-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-effort-controllers";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "59b8f1ad9edccc447ba4ea89648351ab712d43891b3325b90814678f19d12205";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/effort_controllers/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "0a2a2229c787e95776efcc7100f953292717ac1830b969ed1a664e7190ee7bf6";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/examples-tf2-py/default.nix
+++ b/distros/foxy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-examples-tf2-py";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "908d0f40c9183ab68eba90170e76ec5d57d26df862f41b363cacf33e30c14661";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "2145de3c592a468f7d0b901908a96ae6d0c7ec8a6f5cdf6fe5e777bf2dc1566e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/fastrtps-cmake-module/default.nix
+++ b/distros/foxy/fastrtps-cmake-module/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps-cmake-module";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/fastrtps_cmake_module/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "3e86c20176a31390dfdd24ebf0edaf5fec2cbab6b7ed81bd2e11e14579c3f883";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/fastrtps_cmake_module/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "af9ed13934b1fb4cf80fe45cbce8575e072e6d70001ff980301abe69b6b24e82";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/force-torque-sensor-broadcaster/default.nix
+++ b/distros/foxy/force-torque-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-force-torque-sensor-broadcaster";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "d57aee6b6fb3338e1b28eb4e5d29ce0343fa001b5db1cbc2d13c2b8e53172511";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/force_torque_sensor_broadcaster/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "186838b2d1584f1faf22fc287fac28bd3791d1c7b5690de93d7120a822170933";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/forward-command-controller/default.nix
+++ b/distros/foxy/forward-command-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-forward-command-controller";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "639091192a622a299480d4dfe0ea6fdbc4ab703b97636f36cc90acb79b4a12f4";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/forward_command_controller/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "7aafcf126b6f77b573fca05092e4203c74a1ba0894e9c734f5801f0b6addf43d";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ controller-interface hardware-interface rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -24,6 +24,8 @@ self: super: {
 
  ament-cmake-auto = self.callPackage ./ament-cmake-auto {};
 
+ ament-cmake-catch2 = self.callPackage ./ament-cmake-catch2 {};
+
  ament-cmake-clang-format = self.callPackage ./ament-cmake-clang-format {};
 
  ament-cmake-clang-tidy = self.callPackage ./ament-cmake-clang-tidy {};
@@ -138,6 +140,8 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ asio-cmake-module = self.callPackage ./asio-cmake-module {};
+
  astuff-sensor-msgs = self.callPackage ./astuff-sensor-msgs {};
 
  automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
@@ -145,6 +149,8 @@ self: super: {
  automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
 
  automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
+
+ aws-robomaker-small-warehouse-world = self.callPackage ./aws-robomaker-small-warehouse-world {};
 
  backward-ros = self.callPackage ./backward-ros {};
 
@@ -488,6 +494,8 @@ self: super: {
 
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
 
+ ifm3d-core = self.callPackage ./ifm3d-core {};
+
  image-common = self.callPackage ./image-common {};
 
  image-geometry = self.callPackage ./image-geometry {};
@@ -513,6 +521,8 @@ self: super: {
  interactive-markers = self.callPackage ./interactive-markers {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
+
+ io-context = self.callPackage ./io-context {};
 
  joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
 
@@ -547,6 +557,8 @@ self: super: {
  lanelet2-core = self.callPackage ./lanelet2-core {};
 
  lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-io = self.callPackage ./lanelet2-io {};
 
  lanelet2-maps = self.callPackage ./lanelet2-maps {};
 
@@ -642,7 +654,11 @@ self: super: {
 
  mavros-msgs = self.callPackage ./mavros-msgs {};
 
+ menge-vendor = self.callPackage ./menge-vendor {};
+
  message-filters = self.callPackage ./message-filters {};
+
+ micro-ros-msgs = self.callPackage ./micro-ros-msgs {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
@@ -1028,6 +1044,30 @@ self: super: {
 
  resource-retriever = self.callPackage ./resource-retriever {};
 
+ rmf-building-map-msgs = self.callPackage ./rmf-building-map-msgs {};
+
+ rmf-charger-msgs = self.callPackage ./rmf-charger-msgs {};
+
+ rmf-cmake-uncrustify = self.callPackage ./rmf-cmake-uncrustify {};
+
+ rmf-dispenser-msgs = self.callPackage ./rmf-dispenser-msgs {};
+
+ rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
+
+ rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
+
+ rmf-ingestor-msgs = self.callPackage ./rmf-ingestor-msgs {};
+
+ rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
+
+ rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
+ rmf-visualization-msgs = self.callPackage ./rmf-visualization-msgs {};
+
+ rmf-workcell-msgs = self.callPackage ./rmf-workcell-msgs {};
+
  rmw = self.callPackage ./rmw {};
 
  rmw-connext-cpp = self.callPackage ./rmw-connext-cpp {};
@@ -1366,6 +1406,10 @@ self: super: {
 
  stereo-msgs = self.callPackage ./stereo-msgs {};
 
+ stubborn-buddies = self.callPackage ./stubborn-buddies {};
+
+ stubborn-buddies-msgs = self.callPackage ./stubborn-buddies-msgs {};
+
  swri-console-util = self.callPackage ./swri-console-util {};
 
  swri-dbw-interface = self.callPackage ./swri-dbw-interface {};
@@ -1417,8 +1461,6 @@ self: super: {
  test-launch-system-modes = self.callPackage ./test-launch-system-modes {};
 
  test-msgs = self.callPackage ./test-msgs {};
-
- test-osrf-testing-tools-cpp = self.callPackage ./test-osrf-testing-tools-cpp {};
 
  test-rmw-implementation = self.callPackage ./test-rmw-implementation {};
 

--- a/distros/foxy/geometry-tutorials/default.nix
+++ b/distros/foxy/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-geometry-tutorials";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "c294ac107c09cf598710b598a131a49047d2326a1b2a110ba4c190e1ddc98bba";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "cdc7c3cc9a32f805b6a871f001e9fa925cc01f11186d3a7e6370dcfe16ef71cd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/geometry2/default.nix
+++ b/distros/foxy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-foxy-geometry2";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "e25dab04c5f0b7e0205e66765fae470d5f0c4317e87f2ada01b29ee38617a4d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "26a3fa86990b9855b82cc38b957c62c34a362fa372cd302ee8d9802514b30ff0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/gmock-vendor/default.nix
+++ b/distros/foxy/gmock-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake, gtest-vendor }:
 buildRosPackage {
   pname = "ros-foxy-gmock-vendor";
-  version = "1.8.9000-r1";
+  version = "1.8.9001-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/foxy/gmock_vendor/1.8.9000-1.tar.gz";
-    name = "1.8.9000-1.tar.gz";
-    sha256 = "fdce913e89d9dd510744956016fdc050556a3be85f2c680426afa49ab042fef6";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/foxy/gmock_vendor/1.8.9001-1.tar.gz";
+    name = "1.8.9001-1.tar.gz";
+    sha256 = "581615dd9b22b96edc37031e5198792b5166e9ad36bda361f72d748c20c1ef38";
   };
 
   buildType = "cmake";

--- a/distros/foxy/gripper-controllers/default.nix
+++ b/distros/foxy/gripper-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-gripper-controllers";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "ffec8c9799c072aa0c817f8cbdb1746aaf45694d33ab1ac7972cb0cd77c48f38";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/gripper_controllers/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "41e08495122298123068172f6414908d365ecdca7d6a271ac98e8b6bea42fc2b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs control-toolbox controller-interface hardware-interface rclcpp rclcpp-action realtime-tools ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/gtest-vendor/default.nix
+++ b/distros/foxy/gtest-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-foxy-gtest-vendor";
-  version = "1.8.9000-r1";
+  version = "1.8.9001-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/googletest-release/archive/release/foxy/gtest_vendor/1.8.9000-1.tar.gz";
-    name = "1.8.9000-1.tar.gz";
-    sha256 = "5513885791b5d5a4eecad2860809726323021e5c4776e0c8816e93e20e0ec1a6";
+    url = "https://github.com/ros2-gbp/googletest-release/archive/release/foxy/gtest_vendor/1.8.9001-1.tar.gz";
+    name = "1.8.9001-1.tar.gz";
+    sha256 = "44cb12b30c00c7b3d6001469d62ecaf1d27dfa271f867de849f35e9e6f23ba83";
   };
 
   buildType = "cmake";

--- a/distros/foxy/hardware-interface/default.nix
+++ b/distros/foxy/hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-hardware-interface";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "fc3fc74344107335b7e7f45455e938ba5a8d22e6f2ea4e38ba88b62bb414e474";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/hardware_interface/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "5323961c9d16de5226e8f3a4324f41402b75ee1b5fad27bdde64fc64330cd737";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ifm3d-core/default.nix
+++ b/distros/foxy/ifm3d-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, curl, cv-bridge, glog, pcl, xmlrpc_c }:
+buildRosPackage {
+  pname = "ros-foxy-ifm3d-core";
+  version = "0.18.0-r4";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-release/archive/release/foxy/ifm3d_core/0.18.0-4.tar.gz";
+    name = "0.18.0-4.tar.gz";
+    sha256 = "d66698ff96c051522c171ca7c460e36738d95349a70a8f55929d4d4813b76b84";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ curl cv-bridge glog pcl xmlrpc_c ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Library and Utilities for working with ifm pmd-based 3D ToF Cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/imu-sensor-broadcaster/default.nix
+++ b/distros/foxy/imu-sensor-broadcaster/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-imu-sensor-broadcaster";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "20e14a5f7a76513cd3dac6d214ccd43eae223030d4ec432ada0a863cbd6785da";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/imu_sensor_broadcaster/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "e0944943f7bf8b7a854c0686f2bfa25b618e0cd42eed4daec2f331d3a81c163e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/io-context/default.nix
+++ b/distros/foxy/io-context/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, example-interfaces, rclcpp, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-io-context";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/io_context/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6319763aa21c765ae1f070032c86a7d267dc1cffd66b4d72dcd1bb8a537b42ce";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio example-interfaces rclcpp std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
+
+  meta = {
+    description = ''A library to write Synchronous and Asynchronous networking applications'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/joint-state-broadcaster/default.nix
+++ b/distros/foxy/joint-state-broadcaster/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-broadcaster";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "19f9b34e3bd1dbafca5ed514f68ad64e3336d9b595f432de80bec800f349635b";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_broadcaster/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "347f3ab84b2a1c86e28a937e7bc19608a843f3a8c978ae7c9fd7477cec6d5842";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager rclcpp ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager rclcpp ros2-control-test-assets ];
   propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/joint-state-controller/default.nix
+++ b/distros/foxy/joint-state-controller/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, hardware-interface, joint-state-broadcaster, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-joint-state-controller";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "122ab22f91e433c395efa3722fa4c9215125f17b1804db9e67a413d2995ec732";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_state_controller/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "5b5bb31473bcadd06bf569142bd9c9be2e30f8db8834ce16ff426e1d4a98f1fc";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface rclcpp ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface rclcpp ros2-control-test-assets ];
   propagatedBuildInputs = [ joint-state-broadcaster ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/joint-trajectory-controller/default.nix
+++ b/distros/foxy/joint-trajectory-controller/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-foxy-joint-trajectory-controller";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "c559585a0b70e30c31d4c3520e634c403fa3562268a905342285929e11dc5e8a";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/joint_trajectory_controller/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "eb932423febd3cbeddd39c666b05bfcd253735887d3dcaa0e328783f3758ff53";
   };
 
   buildType = "ament_cmake";
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common controller-manager ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gtest controller-manager ros2-control-test-assets ];
   propagatedBuildInputs = [ angles control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/lanelet2-io/default.nix
+++ b/distros/foxy/lanelet2-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
+buildRosPackage {
+  pname = "ros-foxy-lanelet2-io";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/foxy/lanelet2_io/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "408c1360908af9c0bd336550027a95b811f73fca34bf94f125bba5b89163b7c7";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core mrt-cmake-modules pugixml ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Parser/Writer module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/launch-ros/default.nix
+++ b/distros/foxy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-launch-ros";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "87fbe5e6f24cc2b2793ef71c9d8d80bb79afdbf510cbb3e5b4077fd378bcd9c8";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "cc16f69f9fdbc93b4d2ea1982ea410c58b0b2ee87db6902d584ffcd2dda0cc11";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing-ament-cmake/default.nix
+++ b/distros/foxy/launch-testing-ament-cmake/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-test, launch-testing, python-cmake-module }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ament-cmake";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "fe621632b2cca00ace5d3691c1aa73b86205b5764a69736088df3c341f900ea2";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing_ament_cmake/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "a064c0f530e5b5a3ce5646f56f10e892ff2d4b762524efbba2a3e999f496ef8d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-testing-ros/default.nix
+++ b/distros/foxy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ros";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "ce429e005b42234305be336353f51f307ccc19550a74a706b6694faffcf0fe07";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "fd71d8d3340b0ccb165b6c8f5517da92b85c90cc44eca05213c9926175662d02";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing/default.nix
+++ b/distros/foxy/launch-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "85ee1e719974059ea7bbc9988cf5da810a6909486e75972896e4888658eccdf9";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_testing/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "20df90419e4935a3ec96271ff166caefb57ee152c09d81acab0cc2c642256fa7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-xml/default.nix
+++ b/distros/foxy/launch-xml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-xml";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "4b22ec6c77f13ceb6e81dd7e53b03adbee1c99b1e52b1a9628da1b5992a63c3c";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_xml/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "05e43bc92517b4efb7ece09c6de555d2bb13531eb627c48e301989bfe4924458";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-yaml/default.nix
+++ b/distros/foxy/launch-yaml/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch-yaml";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "c167189cd118da6736fe7aab39ee8c886032e1f834886cdddcc584d70d4c0c42";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch_yaml/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "89f98fdf66fbfc9a6de99a7c322b6be8cf4b00e821e6ddd20ab150c9862c942b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch/default.nix
+++ b/distros/foxy/launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, osrf-pycommon, python3Packages, pythonPackages }:
 buildRosPackage {
   pname = "ros-foxy-launch";
-  version = "0.10.5-r1";
+  version = "0.10.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.5-1.tar.gz";
-    name = "0.10.5-1.tar.gz";
-    sha256 = "f4552e5a161ee5bb6a83c6fb554a012f79ad05ea3f27fe4ef967124bdbdeef95";
+    url = "https://github.com/ros2-gbp/launch-release/archive/release/foxy/launch/0.10.6-1.tar.gz";
+    name = "0.10.6-1.tar.gz";
+    sha256 = "bd9e09df4c229b5d930ce2c9d98fe7dafb66780eaaf157a05734a37f120062d6";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/menge-vendor/default.nix
+++ b/distros/foxy/menge-vendor/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, pkg-config, tinyxml }:
+buildRosPackage {
+  pname = "ros-foxy-menge-vendor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/menge_vendor-release/archive/release/foxy/menge_vendor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "6e3c898f2741cfa032a497738943927dc6f8b144e6dd4427e0085541212dee88";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ pkg-config ];
+  propagatedBuildInputs = [ tinyxml ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Menge is a powerful, cross-platform, modular framework for crowd simulation developed at the University of North Carolina - Chapel Hill. This package includes the core simulation part of origin menge package, with a bit modification for crowd simulation in gazebo and ignition gazebo.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/micro-ros-msgs/default.nix
+++ b/distros/foxy/micro-ros-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-micro-ros-msgs";
+  version = "1.0.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_msgs-release/archive/release/foxy/micro_ros_msgs/1.0.0-2.tar.gz";
+    name = "1.0.0-2.tar.gz";
+    sha256 = "1f00588d7f0b7ef394d3b60d273439bb0603418898d6c380048304973ebce860";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Definitions for the ROS 2 msgs entities information used by micro-ROS to leverage its functionality to the same level as ROS 2, by means of a dedicated graph manager'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/osrf-pycommon/default.nix
+++ b/distros/foxy/osrf-pycommon/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-osrf-pycommon";
-  version = "0.1.10-r1";
+  version = "0.1.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/foxy/osrf_pycommon/0.1.10-1.tar.gz";
-    name = "0.1.10-1.tar.gz";
-    sha256 = "6364a61ed9dda779546c10506c5097203e8ece2413e49b9c6dc4dc259692ea0b";
+    url = "https://github.com/ros2-gbp/osrf_pycommon-release/archive/release/foxy/osrf_pycommon/0.1.11-1.tar.gz";
+    name = "0.1.11-1.tar.gz";
+    sha256 = "62adc3d4029feb8f2baf55d7375d25f444e38e63a9c24795c78643e66d0d2b92";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/osrf-testing-tools-cpp/default.nix
+++ b/distros/foxy/osrf-testing-tools-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, cmake }:
 buildRosPackage {
   pname = "ros-foxy-osrf-testing-tools-cpp";
-  version = "1.3.2-r1";
+  version = "1.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/osrf_testing_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.2-1.tar.gz";
-    name = "1.3.2-1.tar.gz";
-    sha256 = "e45c6bfaaf2feb2cd5fdad1a85efc2219d7621db4adaaf8344ab69e9f292b8b3";
+    url = "https://github.com/ros2-gbp/osrf_testing_tools_cpp-release/archive/release/foxy/osrf_testing_tools_cpp/1.3.4-1.tar.gz";
+    name = "1.3.4-1.tar.gz";
+    sha256 = "98f3344389c89ad4266310729ed091cc523b3bd3827760aa36e55b2eacf071f8";
   };
 
   buildType = "cmake";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "7d88c36d8fae75d1f7d41f1406e77e1f860fde4392fa658af9275aeeb1f6de01";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "d840cdbdae7895b553f81d056c6a54a5cf1253491b83eab4dfef69613640d368";
   };
 
   buildType = "catkin";

--- a/distros/foxy/position-controllers/default.nix
+++ b/distros/foxy/position-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-position-controllers";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "6e214f37ed74a9741b5648fefb2e2d90c6366226d275064a2cb4c93953fd46dd";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/position_controllers/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "dc3794d79ebb75b2edb6fcee1538c1ec89f682d614d1dd75feea34253295c876";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/qt-dotgraph/default.nix
+++ b/distros/foxy/qt-dotgraph/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-qt-dotgraph";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_dotgraph/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "0e8452a237beaa839ffe6cc40eab7b32c38bac548cb0ed72306f0597694ab19d";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_dotgraph/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "f9e446a5abb8ed7cd475e7ebc010f035c0bfb212a61f3da9d55ca55da87cc66e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/qt-gui-app/default.nix
+++ b/distros/foxy/qt-gui-app/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, qt-gui }:
 buildRosPackage {
   pname = "ros-foxy-qt-gui-app";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_app/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "70a909573e52110d6c1cb5b64517add19021a516ffbab22a2c122ba143f3ba7c";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_app/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "d3ac7eb057b999393f423d79ad7b4646df60653c8e8b5791915af37a25a6fffd";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/qt-gui-core/default.nix
+++ b/distros/foxy/qt-gui-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, qt-dotgraph, qt-gui, qt-gui-app, qt-gui-cpp, qt-gui-py-common }:
 buildRosPackage {
   pname = "ros-foxy-qt-gui-core";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_core/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "fa465099dfcbb349383a65fbd9579c8637dc4fa1c3c1448dc54201f6827fc1d1";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_core/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "1b891a4fd2c59681d21cd99ad6fafe9d1cf54d4b20d56e757335fcedb1cdf37c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/qt-gui-cpp/default.nix
+++ b/distros/foxy/qt-gui-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, pkg-config, pluginlib, python-qt-binding, qt-gui, qt5, tinyxml2-vendor }:
 buildRosPackage {
   pname = "ros-foxy-qt-gui-cpp";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_cpp/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "1f26f8c270e3f4b86a4933b35ead223dadff2ea532d8997ae84ed86d7a3dfcc1";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_cpp/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "15b48e76707aa4d4eaf441a63926e5d960808eb52ec358b8fb57b9fb857b3b3e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/qt-gui-py-common/default.nix
+++ b/distros/foxy/qt-gui-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding }:
 buildRosPackage {
   pname = "ros-foxy-qt-gui-py-common";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_py_common/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "8b9e0ee1fef1a69e56d2454ef75c72a774d447f3e20100f9d414d49b4d18d90e";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui_py_common/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "2ad6a653a25b88d458f7a654ef9f0a122f321f656aac220e703fb135ee455a2a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/qt-gui/default.nix
+++ b/distros/foxy/qt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt5, tango-icons-vendor }:
 buildRosPackage {
   pname = "ros-foxy-qt-gui";
-  version = "1.1.2-r2";
+  version = "1.1.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui/1.1.2-2.tar.gz";
-    name = "1.1.2-2.tar.gz";
-    sha256 = "4c8a1a6533a89a256b2b329d73368ab5ed2d28ad4b1f20b5d89478cd6ac9f6c4";
+    url = "https://github.com/ros2-gbp/qt_gui_core-release/archive/release/foxy/qt_gui/1.1.3-1.tar.gz";
+    name = "1.1.3-1.tar.gz";
+    sha256 = "81b90472e1ac0b7800135c977440ad85c3ef7c61ffa0ec8b36de65e0450e947f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-action/default.nix
+++ b/distros/foxy/rclcpp-action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, mimick-vendor, performance-test-fixture, rcl-action, rclcpp, rosidl-runtime-c, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-action";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "fffc7762093deeaa711ce610155b516a6e3f498235d3e0db9e7687707eadadc9";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_action/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "58ba0e379715e44cedc4a3fc53867337feddf4e92446213eb8425778fd5b11bb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-components/default.nix
+++ b/distros/foxy/rclcpp-components/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-google-benchmark, ament-cmake-gtest, ament-cmake-ros, ament-index-cpp, ament-lint-auto, ament-lint-common, class-loader, composition-interfaces, launch-testing, rclcpp, rcpputils, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-components";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "690b1547c67e01ec5381f41d6efc76bc45e6cf5ff00d2f4dfdc4f08ef7aca095";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_components/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "ce75b9592f3fa8b7dc5c86baad2d02df4f73b0b6368e9d3853806054e80b0fa1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp-lifecycle/default.nix
+++ b/distros/foxy/rclcpp-lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, lifecycle-msgs, mimick-vendor, performance-test-fixture, rcl-lifecycle, rclcpp, rcutils, rmw, rosidl-typesupport-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp-lifecycle";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "08f33994e0819f75486eae532048ff4da11b9ded9223780bb847b38c4d7b6c87";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp_lifecycle/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "2c1a195db7839de79edde1917aabb703e5cb97d6f57c4e2e4252ce87023e56a0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclcpp/default.nix
+++ b/distros/foxy/rclcpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, builtin-interfaces, libstatistics-collector, mimick-vendor, performance-test-fixture, rcl, rcl-interfaces, rcl-yaml-param-parser, rcpputils, rcutils, rmw, rmw-implementation-cmake, rosgraph-msgs, rosidl-default-generators, rosidl-runtime-cpp, rosidl-typesupport-c, rosidl-typesupport-cpp, statistics-msgs, test-msgs, tracetools }:
 buildRosPackage {
   pname = "ros-foxy-rclcpp";
-  version = "2.3.1-r1";
+  version = "2.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.3.1-1.tar.gz";
-    name = "2.3.1-1.tar.gz";
-    sha256 = "50e96b8a3d90f8fffabb4337bbca8207fcb30525b25960a7e6169902c748a898";
+    url = "https://github.com/ros2-gbp/rclcpp-release/archive/release/foxy/rclcpp/2.4.0-1.tar.gz";
+    name = "2.4.0-1.tar.gz";
+    sha256 = "6401716a94da798089cc3cd5cd74aa4b29afc2cfe5229405d2dcaeaacc510e69";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rclpy/default.nix
+++ b/distros/foxy/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclpy";
-  version = "1.0.5-r1";
+  version = "1.0.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.5-1.tar.gz";
-    name = "1.0.5-1.tar.gz";
-    sha256 = "9557a0503acf498b60cf4e175121faa5e316c150d85f7137037373b6c7dde827";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.6-1.tar.gz";
+    name = "1.0.6-1.tar.gz";
+    sha256 = "e5e60c94022ba5e1b110b2a40255b64587e317faa2beb13742dceb9d1112e927";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rcpputils/default.nix
+++ b/distros/foxy/rcpputils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-rcpputils";
-  version = "1.3.1-r1";
+  version = "1.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/foxy/rcpputils/1.3.1-1.tar.gz";
-    name = "1.3.1-1.tar.gz";
-    sha256 = "2bdda95ed4fbbdbc39450cfe2753c89c5bb9001e5f5b007ce8e057a60b6591f0";
+    url = "https://github.com/ros2-gbp/rcpputils-release/archive/release/foxy/rcpputils/1.3.2-1.tar.gz";
+    name = "1.3.2-1.tar.gz";
+    sha256 = "9320a98fab63a0e1b7516f5fb16d49f6bfd6f4a50f8e37f02c52296c410d4725";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmf-building-map-msgs/default.nix
+++ b/distros/foxy/rmf-building-map-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-building-map-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_building_map_msgs-release/archive/release/foxy/rmf_building_map_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "2b1a4311a35385da0020e6417583feca52c4a97b00fdd4db1b39a6e3b51abf2e";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to send building maps'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-charger-msgs/default.nix
+++ b/distros/foxy/rmf-charger-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-charger-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_charger_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2c6506fcab77988525c9a2de397fa44d449f697e19c81b496a7eb6fa68a58d76";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''This package contains messages regarding charging and discharging'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-cmake-uncrustify/default.nix
+++ b/distros/foxy/rmf-cmake-uncrustify/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-cmake-uncrustify";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_cmake_uncrustify-release/archive/release/foxy/rmf_cmake_uncrustify/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "9b944ee56be4a6dba660c38212522682ba9ac121e3352db10e9ff08ef5e415f7";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-copyright ament-cmake-lint-cmake ];
+  propagatedBuildInputs = [ ament-cmake-test ament-uncrustify ];
+  nativeBuildInputs = [ ament-cmake-core ament-cmake-test ];
+
+  meta = {
+    description = ''ament_cmake_uncrustify with support for parsing a config file.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-dispenser-msgs/default.nix
+++ b/distros/foxy/rmf-dispenser-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-dispenser-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_dispenser_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "e7441a4fd7590ff76e2514732ce765b06e22e25eebe3bc549ae0f57b21902213";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to dispenser workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-door-msgs/default.nix
+++ b/distros/foxy/rmf-door-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-door-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_door_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2f225bb5fa54a832d4d4f838358c4d69c4a195d78dbf2e308ece6d647de72603";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to doors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-fleet-msgs/default.nix
+++ b/distros/foxy/rmf-fleet-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-fleet-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_fleet_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "baf1a625bd178c22f7b5ef3fcdb6f6a401720aa52fb4f41412f2d857d07df42d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to fleet managers'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-ingestor-msgs/default.nix
+++ b/distros/foxy/rmf-ingestor-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-ingestor-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_ingestor_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "5a6afefac6627f66850b053729fcb13b8b9c1e20aaa07f22f2928309eac135ca";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to interface to ingestor workcells'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-lift-msgs/default.nix
+++ b/distros/foxy/rmf-lift-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-lift-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_lift_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "0f6bb1441f407c44dc5809841bf7af6e833b1c216f88cf894dfe14ced3437c2a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages used to interface to lifts.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-task-msgs/default.nix
+++ b/distros/foxy/rmf-task-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-task-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_task_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "323b4c6b89ee7eb73fa36a6fd98e0ed19f4a973b07d5289c5189bddfb95c7745";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rmf-dispenser-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used to specify tasks'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-traffic-msgs/default.nix
+++ b/distros/foxy/rmf-traffic-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-traffic-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_traffic_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c2ef9e63a73c1b47f02488054a1fe7bc5df0be7589419b08b831f11c312e4b1d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by the RMF traffic management system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-visualization-msgs/default.nix
+++ b/distros/foxy/rmf-visualization-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-visualization-msgs";
+  version = "1.2.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_visualization_msgs-release/archive/release/foxy/rmf_visualization_msgs/1.2.0-1.tar.gz";
+    name = "1.2.0-1.tar.gz";
+    sha256 = "df2912d73cbd6526c1edddf4f126709663e1a95f532e2b6b2502caf67d7dd850";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used for visualizations'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmf-workcell-msgs/default.nix
+++ b/distros/foxy/rmf-workcell-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-foxy-rmf-workcell-msgs";
+  version = "1.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/foxy/rmf_workcell_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "20ef7de00f04af76311a4b12f1f03a3e12ef93533c364f4a26e59cf3a1953e54";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''A package containing messages used by all workcells generically to interfact with rmf_core'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/rmw-cyclonedds-cpp/default.nix
+++ b/distros/foxy/rmw-cyclonedds-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-ros, ament-lint-auto, ament-lint-common, cyclonedds, rcpputils, rcutils, rmw, rmw-dds-common, rosidl-runtime-c, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp }:
 buildRosPackage {
   pname = "ros-foxy-rmw-cyclonedds-cpp";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "4e942e245f6caf40b0d296977dcda91b684fefd186766c89598a303aef00de54";
+    url = "https://github.com/ros2-gbp/rmw_cyclonedds-release/archive/release/foxy/rmw_cyclonedds_cpp/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "f23bf035b9f92094af5c3e1815bc84aef40e6013cb7ad267596449ef45dce17a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-cmake, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-cpp";
-  version = "1.2.5-r1";
+  version = "1.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "e89f29899cb5e39410dcb683b8420494a3e691aaeb87b7d1ffe25ddf15640739";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_cpp/1.2.6-1.tar.gz";
+    name = "1.2.6-1.tar.gz";
+    sha256 = "f110fd4410f783699a0cafefd2bc5c2dfb721dfa96624f32421b1722826c7806";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-dynamic-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common, rmw-fastrtps-shared-cpp, rosidl-runtime-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-introspection-c, rosidl-typesupport-introspection-cpp, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-dynamic-cpp";
-  version = "1.2.5-r1";
+  version = "1.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "3991d382c4195f3761aeee745a15a5d7b74eaac777833e6c4a20c48d4d482d36";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_dynamic_cpp/1.2.6-1.tar.gz";
+    name = "1.2.6-1.tar.gz";
+    sha256 = "e92496c85b4bfc4a74ccf8bac04084cc025573c5933cdbbf9ce1a264540e86ff";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
+++ b/distros/foxy/rmw-fastrtps-shared-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, rcpputils, rcutils, rmw, rmw-dds-common }:
 buildRosPackage {
   pname = "ros-foxy-rmw-fastrtps-shared-cpp";
-  version = "1.2.5-r1";
+  version = "1.2.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.5-1.tar.gz";
-    name = "1.2.5-1.tar.gz";
-    sha256 = "96dea9e2e38c8b78b2a0b872384346e78a4cede5708d49f80f405cf151772d95";
+    url = "https://github.com/ros2-gbp/rmw_fastrtps-release/archive/release/foxy/rmw_fastrtps_shared_cpp/1.2.6-1.tar.gz";
+    name = "1.2.6-1.tar.gz";
+    sha256 = "3b5ab23e777c29e75366706be393001a61dc3469a37366bf170f31337bbbd053";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control-test-assets/default.nix
+++ b/distros/foxy/ros2-control-test-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control-test-assets";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "35e10772f1d182091ada1902e717e7f60111c8d19164b71a5c13942f5f984673";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control_test_assets/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "25d5f1ab4bd9304e06a0867e18a35ef09aee185b96fd342b76e7427ca09e504a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-control/default.nix
+++ b/distros/foxy/ros2-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, hardware-interface, ros2-control-test-assets, ros2controlcli }:
 buildRosPackage {
   pname = "ros-foxy-ros2-control";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "7e80381a0f5e3b1a7572ca40a9b68469be8727dc255037d834ef44bcc36ccf37";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2_control/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "df6a615b1f10ae67d9973655d6691d13f8fd6faf7457ec0c0190139fb0a65397";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2-controllers/default.nix
+++ b/distros/foxy/ros2-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-state-controller, joint-trajectory-controller, position-controllers, velocity-controllers }:
 buildRosPackage {
   pname = "ros-foxy-ros2-controllers";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "57de40e5564783aafa649ec789431c1aa31dedb985d3c04612549c425284b9d9";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/ros2_controllers/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "3df2822aa9ee99cc324f041202562fbf42b194a3846239b2a8f94ef0ecb446c7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2controlcli/default.nix
+++ b/distros/foxy/ros2controlcli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
 buildRosPackage {
   pname = "ros-foxy-ros2controlcli";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "ecd3ca9891f4e69bd7b25a6b9d110226c79e5e9b5284f8976c36d0edef596102";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/ros2controlcli/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "0d728afce4d7a5d38cf37bce6ddfd781b3b1ba537f5213b0ab5278e38a961d0e";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2launch/default.nix
+++ b/distros/foxy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2launch";
-  version = "0.11.2-r1";
+  version = "0.11.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.2-1.tar.gz";
-    name = "0.11.2-1.tar.gz";
-    sha256 = "af1257292a0c82ee726c04df777fa618fef6c9a6ef3641053be8ac06735afb95";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.3-1.tar.gz";
+    name = "0.11.3-1.tar.gz";
+    sha256 = "f8d2a77e9b8deec2bb429022843bbddd54a60b791a073f9e4f8a7bc412ee59e8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rosidl-typesupport-fastrtps-c/default.nix
+++ b/distros/foxy/rosidl-typesupport-fastrtps-c/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, rmw, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-fastrtps-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-fastrtps-c";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_c/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "9e9cecdbb898ea74136ec98146004c0e12c418430b3dfcfbe699fc403513609c";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_c/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "179c65edc79a738849459b8078b91922baa6974996cee99a7a7029efd4fa8bd7";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rosidl-typesupport-fastrtps-cpp/default.nix
+++ b/distros/foxy/rosidl-typesupport-fastrtps-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-ros, ament-lint-auto, ament-lint-common, fastcdr, fastrtps, fastrtps-cmake-module, osrf-testing-tools-cpp, performance-test-fixture, rmw, rosidl-cmake, rosidl-parser, rosidl-runtime-c, rosidl-runtime-cpp, rosidl-typesupport-interface }:
 buildRosPackage {
   pname = "ros-foxy-rosidl-typesupport-fastrtps-cpp";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_cpp/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "1a79f13180b8ca50e74537721f868326c51aa2d4e31117ac85ef61421a7fe671";
+    url = "https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release/archive/release/foxy/rosidl_typesupport_fastrtps_cpp/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "86edb940683229c785785a9c254ef5b6cdcfdd51e10e7b94aa13cc80ac59be36";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-gui-cpp/default.nix
+++ b/distros/foxy/rqt-gui-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, qt-gui, qt-gui-cpp, qt5, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-cpp";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "4a822b3483a082a53a52a7f071f861d370dedf5274b86eede42603c12f4b7600";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_cpp/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "d1fa25e5c28e68a30851a41d238dc949c1607f49986a936f16937505af200d4b";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ qt5.qtbase ];
-  propagatedBuildInputs = [ qt-gui qt-gui-cpp rclcpp ];
+  propagatedBuildInputs = [ pluginlib qt-gui qt-gui-cpp rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/rqt-gui-py/default.nix
+++ b/distros/foxy/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui-py";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "24676fd2cd84cbcf850d3bf5daf9a6ac42e1e388a5abf8d390cab695b9ba4008";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui_py/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f1494bc84267c38a9189da464ec1b893af51efc7b6e3f6c7e87be9130095d2fa";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-gui/default.nix
+++ b/distros/foxy/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-rqt-gui";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "595fa107266592c4b0b4b56ab31920eff4b5fdfb6f31ed5b8ad018692fbb8fea";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_gui/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "fa8ac31e554aec867a54cf524e79a17a90e6a14727b349351d3ce599c4dcd783";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-msg/default.nix
+++ b/distros/foxy/rqt-msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-msg";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "cb2fc6d9c49fc2db31e3c28615d994fcbf3eb896682577abbf7ab7d1f3fa4a54";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/foxy/rqt_msg/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "99a54eeef627f2fcbd7c5a1ae133183c61145d321d21557381c52b7f9abfc1df";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-plot/default.nix
+++ b/distros/foxy/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rqt-plot";
-  version = "1.0.10-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "975d869e369a098157b3a097780d951c1e9e6732beda66c9444acee9a1d20e87";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/foxy/rqt_plot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "4657f76028513187a4cb879d3ad871a54dcf7e5b529355cc16e53535fff1edf7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-py-common/default.nix
+++ b/distros/foxy/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-rqt-py-common";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "d87c479605e5ce7e1e322e21cc8c94333ac81800c9394dc488e77f961a6e2d12";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt_py_common/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3b4935a602734a0a52b7ed39622b43411e9d297541037c81ed5fc2373eabf112";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rqt-py-console/default.nix
+++ b/distros/foxy/rqt-py-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-py-console";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/foxy/rqt_py_console/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "1f8ca426804703dce0530abddfa66a3ec9fff96a7038a953793c8ba6f6df81ef";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/foxy/rqt_py_console/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "232841a16cb289ef21d6f2851c0826a98ba3940e6edc89f9fb6d6db458633c88";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-service-caller/default.nix
+++ b/distros/foxy/rqt-service-caller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-service-caller";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/foxy/rqt_service_caller/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "9dc34d9e41b2ceed4825eefc80c45e3c8e691a35abce7aef02bf85ba9259c38d";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/foxy/rqt_service_caller/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "345c29256ee1c7ccd34aa936bd089ee543db38079bade04366ed876641b98afb";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-shell/default.nix
+++ b/distros/foxy/rqt-shell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-shell";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/foxy/rqt_shell/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "c442c88a2ab6b2599b18253df950b86398a0b790fe2fe52133890b6f38863e2f";
+    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/foxy/rqt_shell/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "ddae8c454b782e3cb1f361cef4adcb906c1c5cd7a2a8ef23d20d66f972e03059";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-srv/default.nix
+++ b/distros/foxy/rqt-srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-foxy-rqt-srv";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/foxy/rqt_srv/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "1c5dcfcc4583b81a4525ee5451701d0cb7c0e271a5b472b4cea8674c78747b9f";
+    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/foxy/rqt_srv/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "7b126f474d382c6d52510f804ebc633a5b8f7b9912cfe3503404c1e4d8943df3";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-top/default.nix
+++ b/distros/foxy/rqt-top/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-foxy-rqt-top";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/foxy/rqt_top/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "cfd078a9e077da41da7f379b523a9a282a36c88304ed1397df746f3a5af4abd4";
+    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/foxy/rqt_top/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "93abf9fbb6cc63c1fcc7cb61b3c58bcfd8b747112a3fea0bde975d0d09d7ce22";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-topic/default.nix
+++ b/distros/foxy/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python-qt-binding, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt-topic";
-  version = "1.2.1-r1";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/foxy/rqt_topic/1.2.1-1.tar.gz";
-    name = "1.2.1-1.tar.gz";
-    sha256 = "2e20db684a5ddf987a9f9184346d80a7a152be07eb32027b2e43be8e7681115e";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/foxy/rqt_topic/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "ac9dcbcab70daf3ee3640fc2bd93b75b84dcfed156a631031189611bb8520d5a";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt/default.nix
+++ b/distros/foxy/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-foxy-rqt";
-  version = "1.1.1-r1";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.1.1-1.tar.gz";
-    name = "1.1.1-1.tar.gz";
-    sha256 = "432bfb597a8a54fc435d51906a4d3e3c9f5153857a5da5be60d98eeffe5d1df2";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/foxy/rqt/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "19eb2e617f89eb90e8f1bb10f322c6312198cd14b848c7a1396e7f7d259a44db";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "63df880de10fcf407c395b0dd2ad0bf38cf160c3e370230aa8e6891b49fc835c";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "2e927d697aff34189a0937ea187862a2e86322a8c834c8e0f79879080153363b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "dbe6bf7dab75fe4f18ef8d6efb6739f58a7ccc1eef2f0ee85f4be09f62e48ebe";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "319c937d5ca59091bd458762fda78b43b5cb8c595dfef72bb2eccadc9074bad0";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "09a02e702ee921f7473fe1bbd97a63373986dbee484bdbdf04f5464d6b74b82a";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "8601c4616676297f2d760ab48ab1498af18ed3e8a53a23214fdb5814397376f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "c353bca18cc752233fdcff751c211f72738775655024eacc6b73b933904acc25";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "ce2a258243f033abe41a2c7b67a822368db3a6dc275947602a8e73bf341f62dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "6b108568e600f98fe816f4edef76cd6ad806c236372739157d2e4d4017f1f432";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "ee6a45796033185b6c4ec9f415f1757432c819cd839ce2a1b1333b1c8e04f870";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "81c29efdc09d20e76f2bd0da3b7ca01a7b60a1bb8f058bc5467a85f68deade18";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "8c262531a7a99775dccaf0da6b1ac066738a39c27b180a221ef0a246d5645cd2";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "b937d5a8561b9eb39fb441fe25fd1f3605caa50d981b19ec6236847eb6c6fb77";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "d6cb35af76e5b9e0231459a6f413f517c4768140a6158628c5f9e806a4d06a1d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.2-r1";
+  version = "8.2.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.2-1.tar.gz";
-    name = "8.2.2-1.tar.gz";
-    sha256 = "fd899ddcd93971eb78612dda61e1d9f0aaa487a2c63db56d1cd7d417f16a351e";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.3-1.tar.gz";
+    name = "8.2.3-1.tar.gz";
+    sha256 = "db4a69532da748da127048a2be0779de474842855299cd6fe3061072eeaf7d08";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/serial-driver/default.nix
+++ b/distros/foxy/serial-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, io-context, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-serial-driver";
-  version = "0.0.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/serial_driver/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "7382b9b80f5e21777704bcf10891f2d356a6d6f63270ca866e02da8ed4d8ec5d";
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/serial_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "156514da3368035e73c93ec4f3437a8adee80b7dc98fdfef6932ba4d2b819d9d";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost rclcpp std-msgs ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  propagatedBuildInputs = [ asio io-context rclcpp rclcpp-components rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
 
   meta = {
     description = ''A template class and associated utilities which encapsulate basic reading from serial ports'';

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.0.3-r2";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.3-2.tar.gz";
-    name = "1.0.3-2.tar.gz";
-    sha256 = "5c005f945b9c18437a4f9ba844e2a0ca4e19c43f7b51df69a18279599b78f0ea";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "db66305a0e7f9bdb0355832a6243abd3686d19228e60b7a745817ab4f8833757";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/stubborn-buddies-msgs/default.nix
+++ b/distros/foxy/stubborn-buddies-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-stubborn-buddies-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/foxy/stubborn_buddies_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "de34d205fa9836959a978197400c8566906156f2fcf6353ee62ba6ba3e918617";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages to support library of stubborn buddies'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/stubborn-buddies/default.nix
+++ b/distros/foxy/stubborn-buddies/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, rclcpp, rclcpp-components, rclcpp-lifecycle, rcutils, std-msgs, stubborn-buddies-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-stubborn-buddies";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/stubborn_buddies-release/archive/release/foxy/stubborn_buddies/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "078d45e7645796f3097900a77778dada7232ec352fce9b00db861fd17e7ab152";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rclcpp rclcpp-components rclcpp-lifecycle rcutils std-msgs stubborn-buddies-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Demo that uses node composition of lifecycle nodes to achieve fail-over robustness on ROS nodes'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/foxy/tf2-bullet/default.nix
+++ b/distros/foxy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-bullet";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "f9476cd779c9400f5c4328700e9056083694e9082f5a628ed8e0b684ee2c0336";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "16281df8cdf2b71fc6231e8bba87b3dc7c44b79a574185cc4cce979c6bf81bcf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen-kdl/default.nix
+++ b/distros/foxy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen-kdl";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "69f77e45befb6174aee8fdac68c918321803dbeaf31784e7d502e10611c19eb4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "9832870e714b6c8074232689d5d37ec82d203fe44b4d331de3f7621c7f734b0f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen/default.nix
+++ b/distros/foxy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "4eaf920a4265a55b7989c7faed6ef4206b18fed70d07823d022262b8b6e85854";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "85237c02f5be3a4e636da800f91e63183f0385cd98a837698896156959caa25a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-geometry-msgs/default.nix
+++ b/distros/foxy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-geometry-msgs";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "35a6e52aa3ffc7c4e01ff9f30d927cdab374a2dc92783b31c2dff33d97fabd59";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "bfe7fce8dfd94ffcf64fd47b1aaa4457fb35c41a9c4fd9862b2c17baf85e90cb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-kdl/default.nix
+++ b/distros/foxy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-kdl";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "5f98099398d98fde8bdc7c8071ab3510701611a81eb9a81c46efd723364d6bb1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "5282a33b83e1bf38ca984c049e918231966b4966e7d9986d572dc8c2f197a2dc";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-msgs/default.nix
+++ b/distros/foxy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-tf2-msgs";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "8c1872ddaf254a36a6ba3fe36a975fc4cc9853c46f4f568a6cb615820edf0404";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "3130068ae9bb5c9161d4c983ba36f7d3af37eff2b9da9bc13c0a11606e8986b4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-py/default.nix
+++ b/distros/foxy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-py";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "2478d0aca7ecbc34ad07c2a06f9efc5606cbe7212fcfc39cbffdeb6d4545bf06";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "045da2ddc9528dc847b6b3b8e1f07a81b4980be34b2a48acd51a965b26e3c8f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-ros/default.nix
+++ b/distros/foxy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, message-filters, python-cmake-module, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-foxy-tf2-ros";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "601e1056ec032863b9d848022531425ebb0ea7c5e67748d19403f34237c6db01";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "d8003376caead32ce62ade592757ba3ed55e36572b5c0f648a2e12ac3beb0d23";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-sensor-msgs/default.nix
+++ b/distros/foxy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-sensor-msgs";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "31537c5a0d00ef9150b409bd85bcb5c11464ed7e353474cd81ba8d3686533113";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "c89036bfcd2ef4f8848a8de58c93f46a357d648a646cb000ba901c9c6103bed4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-tools/default.nix
+++ b/distros/foxy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-tools";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "0b50013b49888fc36b1803ee539411348f99b257cbec5dcc2896607a536a764d";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "6f8009ff79913e49ea232aef290cd445f540b40bc70d1e2c8a580d369a2a9228";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2/default.nix
+++ b/distros/foxy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-tf2";
-  version = "0.13.10-r1";
+  version = "0.13.11-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.10-1.tar.gz";
-    name = "0.13.10-1.tar.gz";
-    sha256 = "f1914c963cd4a14f833824d17bd44f120bbc0d216b69d51a4ce18a1b01b5d945";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.11-1.tar.gz";
+    name = "0.13.11-1.tar.gz";
+    sha256 = "e3a4075c30e851c54d0a4449bc01246a2aaed421f9270d14ade587f262a273d1";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/transmission-interface/default.nix
+++ b/distros/foxy/transmission-interface/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, tinyxml2-vendor }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
 buildRosPackage {
   pname = "ros-foxy-transmission-interface";
-  version = "0.7.1-r1";
+  version = "0.8.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.7.1-1.tar.gz";
-    name = "0.7.1-1.tar.gz";
-    sha256 = "dd0b3bda53487647909b1f20e33485f297012af4f38d010720414c2a4e8856f8";
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/foxy/transmission_interface/0.8.0-1.tar.gz";
+    name = "0.8.0-1.tar.gz";
+    sha256 = "7ecba6d8ac29b6433b5b0d831dd3f146253dd755ed2722ea83a7c531a429cad4";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ hardware-interface tinyxml2-vendor ];
+  propagatedBuildInputs = [ hardware-interface ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/turtle-tf2-cpp/default.nix
+++ b/distros/foxy/turtle-tf2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-cpp";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "34c2f80aa0a0713a485f087a0688e511afbe6a2d743f66b7ee649180786563e1";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "95c28fe2c391de9a609a38c038e37f31c03f703e46dfffc8a8a80e7cb9f2a07c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtle-tf2-py/default.nix
+++ b/distros/foxy/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-py";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "6bc49ae3be60cb9291761824d5e6c90f74faeab866401285d2805351fd5caa52";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "ba9d9454c7cb589b6ebcdc264520597bfbcd511974f3d2582a06f6505cbee3b4";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/udp-driver/default.nix
+++ b/distros/foxy/udp-driver/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, io-context, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-foxy-udp-driver";
-  version = "0.0.6-r1";
+  version = "1.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/udp_driver/0.0.6-1.tar.gz";
-    name = "0.0.6-1.tar.gz";
-    sha256 = "3977d82fe54e1bfe2ec2008f3325b8cbe8f2fc3b579507e6083b3756f55e4a6d";
+    url = "https://github.com/ros-drivers-gbp/transport_drivers-release/archive/release/foxy/udp_driver/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "86f5a94b58a8d74940bb43bcc3cbbddc670b3015150a0b077e977c5bd8169be3";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost rclcpp std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ asio io-context lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
 
   meta = {
-    description = ''A template class and associated utilities which encapsulate basic reading from UDP sockets'';
+    description = ''A library to write Synchronous and Asynchronous networking applications, ROS and ROS2 nodes'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/foxy/udp-msgs/default.nix
+++ b/distros/foxy/udp-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-udp-msgs";
-  version = "0.0.3-r1";
+  version = "0.0.3-r2";
 
   src = fetchurl {
-    url = "https://github.com/flynneva/udp_msgs-release/archive/release/foxy/udp_msgs/0.0.3-1.tar.gz";
-    name = "0.0.3-1.tar.gz";
-    sha256 = "7b8d5517aa76084998a225508489812d0650a003c489af6bb94d5f743a3565a0";
+    url = "https://github.com/flynneva/udp_msgs-release/archive/release/foxy/udp_msgs/0.0.3-2.tar.gz";
+    name = "0.0.3-2.tar.gz";
+    sha256 = "3640e6e621147b16d70326cc86f81e9a5a2c713321662c44fa599fdfd1202e4c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/velocity-controllers/default.nix
+++ b/distros/foxy/velocity-controllers/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
 buildRosPackage {
   pname = "ros-foxy-velocity-controllers";
-  version = "0.4.1-r1";
+  version = "0.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.4.1-1.tar.gz";
-    name = "0.4.1-1.tar.gz";
-    sha256 = "56cc86d1d3d4d353fe3b221ccd5e071c3c608ba54fb598f17e0582c1c7bb1997";
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/foxy/velocity_controllers/0.5.0-1.tar.gz";
+    name = "0.5.0-1.tar.gz";
+    sha256 = "e17a4a4fde06564669ccaa7015fdec292b59b0ae03ca8a2472442894478c2a51";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pluginlib ];
-  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
   propagatedBuildInputs = [ forward-command-controller rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 

--- a/distros/foxy/xacro/default.nix
+++ b/distros/foxy/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-foxy-xacro";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/foxy/xacro/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "a908a72b0aae1a53618b3ef49de9c87d9459d7beba6452de75d9c7a02e1cae16";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/foxy/xacro/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "a824cb5f545d8c9146ee835d0020db083b1f0edbc3d280bdc8c24198328a34fa";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/asio-cmake-module/default.nix
+++ b/distros/galactic/asio-cmake-module/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common }:
+buildRosPackage {
+  pname = "ros-galactic-asio-cmake-module";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/asio_cmake_module/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d99bfb223aacbe7fa819e07123708eaeddc0a78c0861bf50a93bbab34e4a5616";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A CMake module for using the ASIO network library'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/automotive-autonomy-msgs/default.nix
+++ b/distros/galactic/automotive-autonomy-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, automotive-navigation-msgs, automotive-platform-msgs, ros-environment }:
+buildRosPackage {
+  pname = "ros-galactic-automotive-autonomy-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/galactic/automotive_autonomy_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "3db764baa8bb3f64600c8e538af5c3a4d7a21ed8a14d1b9fd21e3787a19bf7fd";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment ];
+  propagatedBuildInputs = [ automotive-navigation-msgs automotive-platform-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Messages for vehicle automation'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/automotive-navigation-msgs/default.nix
+++ b/distros/galactic/automotive-navigation-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-automotive-navigation-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/galactic/automotive_navigation_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "2c8427a76cdb711fb50f86d221f03437f841e5381fff92a915e2b773a65d274c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces geometry-msgs rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic Messages for Navigation Objectives in Automotive Automation Software'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/automotive-platform-msgs/default.nix
+++ b/distros/galactic/automotive-platform-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, ros-environment, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-automotive-platform-msgs";
+  version = "3.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/astuff/automotive_autonomy_msgs-release/archive/release/galactic/automotive_platform_msgs/3.0.4-1.tar.gz";
+    name = "3.0.4-1.tar.gz";
+    sha256 = "9fc8aa25dbb5300ee388979528c8ee5a37ad43ffa234ab8359909237a010498c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ ros-environment rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic Messages for Communication with an Automotive Autonomous Platform'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -142,6 +142,14 @@ self: super: {
 
  apriltag = self.callPackage ./apriltag {};
 
+ asio-cmake-module = self.callPackage ./asio-cmake-module {};
+
+ automotive-autonomy-msgs = self.callPackage ./automotive-autonomy-msgs {};
+
+ automotive-navigation-msgs = self.callPackage ./automotive-navigation-msgs {};
+
+ automotive-platform-msgs = self.callPackage ./automotive-platform-msgs {};
+
  autoware-auto-msgs = self.callPackage ./autoware-auto-msgs {};
 
  backward-ros = self.callPackage ./backward-ros {};
@@ -356,6 +364,8 @@ self: super: {
 
  iceoryx-utils = self.callPackage ./iceoryx-utils {};
 
+ ifm3d-core = self.callPackage ./ifm3d-core {};
+
  image-common = self.callPackage ./image-common {};
 
  image-geometry = self.callPackage ./image-geometry {};
@@ -380,6 +390,8 @@ self: super: {
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
+ io-context = self.callPackage ./io-context {};
+
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
  joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
@@ -399,6 +411,8 @@ self: super: {
  lanelet2-core = self.callPackage ./lanelet2-core {};
 
  lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-io = self.callPackage ./lanelet2-io {};
 
  lanelet2-maps = self.callPackage ./lanelet2-maps {};
 
@@ -481,6 +495,8 @@ self: super: {
  menge-vendor = self.callPackage ./menge-vendor {};
 
  message-filters = self.callPackage ./message-filters {};
+
+ micro-ros-msgs = self.callPackage ./micro-ros-msgs {};
 
  mimick-vendor = self.callPackage ./mimick-vendor {};
 
@@ -824,13 +840,21 @@ self: super: {
 
  rmf-door-msgs = self.callPackage ./rmf-door-msgs {};
 
+ rmf-fleet-adapter = self.callPackage ./rmf-fleet-adapter {};
+
+ rmf-fleet-adapter-python = self.callPackage ./rmf-fleet-adapter-python {};
+
  rmf-fleet-msgs = self.callPackage ./rmf-fleet-msgs {};
 
  rmf-ingestor-msgs = self.callPackage ./rmf-ingestor-msgs {};
 
  rmf-lift-msgs = self.callPackage ./rmf-lift-msgs {};
 
+ rmf-task = self.callPackage ./rmf-task {};
+
  rmf-task-msgs = self.callPackage ./rmf-task-msgs {};
+
+ rmf-task-ros2 = self.callPackage ./rmf-task-ros2 {};
 
  rmf-traffic = self.callPackage ./rmf-traffic {};
 
@@ -841,6 +865,8 @@ self: super: {
  rmf-traffic-editor-test-maps = self.callPackage ./rmf-traffic-editor-test-maps {};
 
  rmf-traffic-msgs = self.callPackage ./rmf-traffic-msgs {};
+
+ rmf-traffic-ros2 = self.callPackage ./rmf-traffic-ros2 {};
 
  rmf-utils = self.callPackage ./rmf-utils {};
 
@@ -1121,6 +1147,10 @@ self: super: {
  shared-queues-vendor = self.callPackage ./shared-queues-vendor {};
 
  slam-toolbox = self.callPackage ./slam-toolbox {};
+
+ smacc2 = self.callPackage ./smacc2 {};
+
+ smacc2-msgs = self.callPackage ./smacc2-msgs {};
 
  smclib = self.callPackage ./smclib {};
 

--- a/distros/galactic/geometry-tutorials/default.nix
+++ b/distros/galactic/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-geometry-tutorials";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "007f0ead432be1cb14ddd0ea64ecfc72629878f12ecdbda14566749d5b6366e5";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "5cefc15dadbb18e4ec2745610625d85fcbb228ff5b2a16cbc22c3d2259e33fc3";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ifm3d-core/default.nix
+++ b/distros/galactic/ifm3d-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, curl, cv-bridge, glog, pcl, xmlrpc_c }:
+buildRosPackage {
+  pname = "ros-galactic-ifm3d-core";
+  version = "0.18.0-r6";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ifm3d-release/archive/release/galactic/ifm3d_core/0.18.0-6.tar.gz";
+    name = "0.18.0-6.tar.gz";
+    sha256 = "0fe643916a6ee1b259e206420d4967cf821e147d019a4f8f2584eb3a40d2052a";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ curl cv-bridge glog pcl xmlrpc_c ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Library and Utilities for working with ifm pmd-based 3D ToF Cameras'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/io-context/default.nix
+++ b/distros/galactic/io-context/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, example-interfaces, rclcpp, std-msgs, udp-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-io-context";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/io_context/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "fe1781df60e76e5eb0e03bf46f2b36127e500c65431491014d0729fdffef5a14";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ asio example-interfaces rclcpp std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
+
+  meta = {
+    description = ''A library to write Synchronous and Asynchronous networking applications'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/lanelet2-io/default.nix
+++ b/distros/galactic/lanelet2-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-core, boost, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
+buildRosPackage {
+  pname = "ros-galactic-lanelet2-io";
+  version = "1.1.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/galactic/lanelet2_io/1.1.1-2.tar.gz";
+    name = "1.1.1-2.tar.gz";
+    sha256 = "8cfdafb7de8796ca131858f3b201ce6a88f94ed7657231f07bb6913776e94dd6";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core mrt-cmake-modules pugixml ];
+  nativeBuildInputs = [ ament-cmake-core mrt-cmake-modules ];
+
+  meta = {
+    description = ''Parser/Writer module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/micro-ros-msgs/default.nix
+++ b/distros/galactic/micro-ros-msgs/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-micro-ros-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/micro_ros_msgs-release/archive/release/galactic/micro_ros_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "123c04bd352f8babdc83c0c4be4dcac972c4c01046a381624bc9802468a9ad66";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ rosidl-default-generators ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Definitions for the ROS 2 msgs entities information used by micro-ROS to leverage its functionality to the same level as ROS 2, by means of a dedicated graph manager'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/plotjuggler/default.nix
+++ b/distros/galactic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-plotjuggler";
-  version = "3.2.1-r2";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.2.1-2.tar.gz";
-    name = "3.2.1-2.tar.gz";
-    sha256 = "3791ade6fb304f5f1197504231ce09fa42bc5a76e3b165cec1121015c4342ae9";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/galactic/plotjuggler/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "8ff87369227746810a8068000a5379d6369035e98df6007fedfc4929c2f3f1e2";
   };
 
   buildType = "catkin";

--- a/distros/galactic/rmf-battery/default.nix
+++ b/distros/galactic/rmf-battery/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, eigen, rmf-cmake-uncrustify, rmf-traffic, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, rmf-cmake-uncrustify, rmf-traffic, rmf-utils }:
 buildRosPackage {
   pname = "ros-galactic-rmf-battery";
-  version = "0.1.0-r1";
+  version = "0.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_battery-release/archive/release/galactic/rmf_battery/0.1.0-1.tar.gz";
-    name = "0.1.0-1.tar.gz";
-    sha256 = "f35acb0a973133f680546c728f0c2ae25092d9780ad10a5b14216d85a7b3773e";
+    url = "https://github.com/ros2-gbp/rmf_battery-release/archive/release/galactic/rmf_battery/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "0ff6497fc75b9ca946780f0396c6b36be04c4568bc3052d67db2a6717ba439de";
   };
 
-  buildType = "ament_cmake";
+  buildType = "cmake";
   checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
   propagatedBuildInputs = [ eigen rmf-traffic rmf-utils ];
-  nativeBuildInputs = [ ament-cmake ];
 
   meta = {
     description = ''Package for modelling battery life of robots'';

--- a/distros/galactic/rmf-building-map-msgs/default.nix
+++ b/distros/galactic/rmf-building-map-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-building-map-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_building_map_msgs-release/archive/release/galactic/rmf_building_map_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "32105bd1e925e358048cc1d33d517e8effb1149fce1b07f3a22db3b8de725130";
+    url = "https://github.com/ros2-gbp/rmf_building_map_msgs-release/archive/release/galactic/rmf_building_map_msgs/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "b6cde1e5c3ae0a65beb771fa13508e517bee36f7cac94475f6d1941c4e055a9c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-building-map-tools/default.nix
+++ b/distros/galactic/rmf-building-map-tools/default.nix
@@ -5,17 +5,17 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python3Packages, pythonPackages, rclpy, rmf-building-map-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rmf-building-map-tools";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_building_map_tools/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "fc079670b32cedbd394597fbd7506af719c0e9403c8bcaec2c37c760a6fa80d4";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_building_map_tools/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "848b729c5d689e47cf029858eacb29df8bf8d50774e5cdf6b339368b8f74cc28";
   };
 
   buildType = "ament_python";
   checkInputs = [ pythonPackages.pytest ];
-  propagatedBuildInputs = [ ament-index-python python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs std-msgs ];
+  propagatedBuildInputs = [ ament-index-python python3Packages.pyproj python3Packages.pyyaml python3Packages.requests python3Packages.shapely rclpy rmf-building-map-msgs std-msgs ];
 
   meta = {
     description = ''RMF Building map tools'';

--- a/distros/galactic/rmf-charger-msgs/default.nix
+++ b/distros/galactic/rmf-charger-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-charger-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_charger_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "91e5bd6743437d99cf2463a789522fc84018df0b5ad628b2d3f9aab62d8f6a94";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_charger_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "0b30a0f35ab95c793465602cf1ce290e4ed9ff75911f46807b8d7347a5bb86a7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-cmake-uncrustify/default.nix
+++ b/distros/galactic/rmf-cmake-uncrustify/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-copyright, ament-cmake-core, ament-cmake-lint-cmake, ament-cmake-test, ament-uncrustify }:
 buildRosPackage {
   pname = "ros-galactic-rmf-cmake-uncrustify";
-  version = "1.2.0-r1";
+  version = "1.2.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_cmake_uncrustify-release/archive/release/galactic/rmf_cmake_uncrustify/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "b16e279e4476f18946013027a112ab29462794d48d17fc269492dd86cdf587af";
+    url = "https://github.com/ros2-gbp/rmf_cmake_uncrustify-release/archive/release/galactic/rmf_cmake_uncrustify/1.2.0-2.tar.gz";
+    name = "1.2.0-2.tar.gz";
+    sha256 = "0e7edde221bfa87d6f749780198532abaddddb2a02416d8787ce8e418ac31418";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-dispenser-msgs/default.nix
+++ b/distros/galactic/rmf-dispenser-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-dispenser-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_dispenser_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "925f68b62baf8a5fbcce1c68d53b050fce94bc768c8e5436df0d28754d280fc2";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_dispenser_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c53fac3a314da8c6feb6b9d313618219361bc193ebcad941b782e907449de060";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-door-msgs/default.nix
+++ b/distros/galactic/rmf-door-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-door-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_door_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "1911e95e3c21c0a3a226c1a52511667fac173bc7db6e5aec189e07fa8e20f972";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_door_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "a7c19a70c43957b2125466d048821a7f202f59f811c3754e76c13b49e7a4463b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-fleet-adapter-python/default.nix
+++ b/distros/galactic/rmf-fleet-adapter-python/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-pytest, pybind11-vendor, rclpy, rmf-fleet-adapter }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-fleet-adapter-python";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/galactic/rmf_fleet_adapter_python/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "56b8998ee2c6eabd535f0d6328b1066f5a1357ede9d38d7eb53269ce58c65093";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-pytest ];
+  propagatedBuildInputs = [ pybind11-vendor rclpy rmf-fleet-adapter ];
+
+  meta = {
+    description = ''Python bindings for the rmf_fleet_adapter'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-fleet-adapter/default.nix
+++ b/distros/galactic/rmf-fleet-adapter/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, eigen, libyamlcpp, rclcpp, rclcpp-components, rmf-battery, rmf-cmake-uncrustify, rmf-dispenser-msgs, rmf-door-msgs, rmf-fleet-msgs, rmf-ingestor-msgs, rmf-lift-msgs, rmf-task, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-fleet-adapter";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/galactic/rmf_fleet_adapter/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "265246acbfe894059ddab2e624fa8d91981b6e0c72c7fc98486ceb3aa353d914";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen libyamlcpp ];
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ rclcpp rclcpp-components rmf-battery rmf-dispenser-msgs rmf-door-msgs rmf-fleet-msgs rmf-ingestor-msgs rmf-lift-msgs rmf-task rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Fleet Adapter package for RMF fleets.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-fleet-msgs/default.nix
+++ b/distros/galactic/rmf-fleet-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-fleet-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_fleet_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "794357732594b85329c1373d8d3fe4955ea6dbcd32c90af2b5cf60e5719564af";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_fleet_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "c3855695045a0376ae4085db79e056a720761c6165be4722ef5aa6c228c7d13c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-ingestor-msgs/default.nix
+++ b/distros/galactic/rmf-ingestor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-ingestor-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_ingestor_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "9c45ed33db91ba0f78874a2d3c8fb76807654c0e080f6fb06200b51431e59bbf";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_ingestor_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "a93bed9b83509830ef45f06392999e1ea16731fd3e9163ca3ad0b48fd82bb631";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-lift-msgs/default.nix
+++ b/distros/galactic/rmf-lift-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-lift-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_lift_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "9b4c6b2f74b3eea329b51a2aaf223a5a9215a1913feef87b05de55d7e1cdcc0c";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_lift_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "9da4d014f008f1856623efeeacebde64cb3cfb4e24e39d11e9248d736fd81802";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-task-msgs/default.nix
+++ b/distros/galactic/rmf-task-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rmf-dispenser-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-task-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_task_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "484cbaf76a57288cf1427f22eccf44ff20b0a8b6302f66439ebc304c8016f951";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_task_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "038bccd4807f783c1977419b6f0d69bcf3feb3df995eabfcbb01ff59425156b1";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-task-ros2/default.nix
+++ b/distros/galactic/rmf-task-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, eigen, rclcpp, rmf-cmake-uncrustify, rmf-task-msgs, rmf-traffic, rmf-traffic-ros2, rmf-utils }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-task-ros2";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/galactic/rmf_task_ros2/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "0d01035426478aa1f75baece3255327d00270e869fe94befc49c220937bd9108";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen ];
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ rclcpp rmf-task-msgs rmf-traffic rmf-traffic-ros2 rmf-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A package managing the dispatching of tasks in RMF system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-task/default.nix
+++ b/distros/galactic/rmf-task/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, rmf-battery, rmf-cmake-uncrustify, rmf-utils }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-task";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_task-release/archive/release/galactic/rmf_task/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c395182e16a2b6944aa77ee9c57678d02a8c0c53f9db9d52ab6030a95db43d35";
+  };
+
+  buildType = "cmake";
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ eigen rmf-battery rmf-utils ];
+
+  meta = {
+    description = ''Package for managing tasks in the Robotics Middleware Framework'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic-editor-assets/default.nix
+++ b/distros/galactic/rmf-traffic-editor-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl,  }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic-editor-assets";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_assets/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "1060a5ea3cc4e0a2ff51bf8cada19c1badbe7dc6a679715b32e9139123595d39";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_assets/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "3d1e84f86ebb88391ac8e9ded87eedb2511370fc6146b938344efafcfb43606f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rmf-traffic-editor-test-maps/default.nix
+++ b/distros/galactic/rmf-traffic-editor-test-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, rmf-building-map-tools, ros2run }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic-editor-test-maps";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_test_maps/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "fd5f1248fa859db07e7eddc744a72258337a7e79027abe21841d39880bb07d4a";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor_test_maps/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "f8f73cd898cdbdf159d4f8492a020c7e1b6c7c50b254d0ef498777cdece0f5f5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-traffic-editor/default.nix
+++ b/distros/galactic/rmf-traffic-editor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ceres-solver, eigen, glog, libyamlcpp, qt5 }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic-editor";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "07a2a5cb5e86765880732a46a69a715c0fa1792ff62b21d172ee14956d82c840";
+    url = "https://github.com/ros2-gbp/rmf_traffic_editor-release/archive/release/galactic/rmf_traffic_editor/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "7ec2d4374b8f9db87284509e7a0f6e0c1da92a4a3c72feebce91911bf6022310";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-traffic-msgs/default.nix
+++ b/distros/galactic/rmf-traffic-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_traffic_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "78255a10d00ef93f716bae24b65d918e4ac5e56a468760c308770daeadf1fde9";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_traffic_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "d7b5c9472d2ee121421c0c794cbd24655212a236044857f0579d649ac806bfd8";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rmf-traffic-ros2/default.nix
+++ b/distros/galactic/rmf-traffic-ros2/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-catch2, eigen, libyamlcpp, rclcpp, rmf-cmake-uncrustify, rmf-fleet-msgs, rmf-traffic, rmf-traffic-msgs, rmf-utils }:
+buildRosPackage {
+  pname = "ros-galactic-rmf-traffic-ros2";
+  version = "1.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rmf_ros2-release/archive/release/galactic/rmf_traffic_ros2/1.3.0-1.tar.gz";
+    name = "1.3.0-1.tar.gz";
+    sha256 = "45e812e3166caace2b41583a3b675884eb1690785db316f1429c33eadc7ce0c0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ eigen ];
+  checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
+  propagatedBuildInputs = [ libyamlcpp rclcpp rmf-fleet-msgs rmf-traffic rmf-traffic-msgs rmf-utils ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''A package containing messages used by the RMF traffic management system.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rmf-traffic/default.nix
+++ b/distros/galactic/rmf-traffic/default.nix
@@ -2,21 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, fcl, libccd, rmf-cmake-uncrustify, rmf-utils }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-catch2, eigen, libccd, rmf-cmake-uncrustify, rmf-utils }:
 buildRosPackage {
   pname = "ros-galactic-rmf-traffic";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_traffic-release/archive/release/galactic/rmf_traffic/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "b4b6789cf2a06f24e396962cf4a92bd3f4a5c1b4e527051a655a78aaf52d46c4";
+    url = "https://github.com/ros2-gbp/rmf_traffic-release/archive/release/galactic/rmf_traffic/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "2dc63ae78516675b4baa8f03421f6c16c26fe3a4574b294f667950974b1bcfe6";
   };
 
   buildType = "cmake";
-  buildInputs = [ fcl libccd ];
   checkInputs = [ ament-cmake-catch2 rmf-cmake-uncrustify ];
-  propagatedBuildInputs = [ eigen rmf-utils ];
+  propagatedBuildInputs = [ eigen libccd rmf-utils ];
 
   meta = {
     description = ''Package for managing traffic in the Robotics Middleware Framework'';

--- a/distros/galactic/rmf-workcell-msgs/default.nix
+++ b/distros/galactic/rmf-workcell-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rmf-workcell-msgs";
-  version = "1.3.0-r1";
+  version = "1.4.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_workcell_msgs/1.3.0-1.tar.gz";
-    name = "1.3.0-1.tar.gz";
-    sha256 = "c2850542c925c969fe88986d6d28d4e29be06cad8f37f9099e52e46208fb4847";
+    url = "https://github.com/ros2-gbp/rmf_internal_msgs-release/archive/release/galactic/rmf_workcell_msgs/1.4.0-1.tar.gz";
+    name = "1.4.0-1.tar.gz";
+    sha256 = "7ce462419bde3e139bab05b675091251f09a204a4c1cb44907d5fc024c62d47c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-gui-cpp/default.nix
+++ b/distros/galactic/rqt-gui-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, qt-gui, qt-gui-cpp, qt5, rclcpp }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, pluginlib, qt-gui, qt-gui-cpp, qt5, rclcpp }:
 buildRosPackage {
   pname = "ros-galactic-rqt-gui-cpp";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui_cpp/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "663361025b3b2a1947e43617ce699c310c994107ff7c39be88bfccbf292e19aa";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui_cpp/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "c62a569cecab3de27606bc9b11aa357507cfb36958dc2294a7d9ced158713a60";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ qt5.qtbase ];
-  propagatedBuildInputs = [ qt-gui qt-gui-cpp rclcpp ];
+  propagatedBuildInputs = [ pluginlib qt-gui qt-gui-cpp rclcpp ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rqt-gui-py/default.nix
+++ b/distros/galactic/rqt-gui-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-lint-auto, ament-lint-common, qt-gui, rqt-gui }:
 buildRosPackage {
   pname = "ros-galactic-rqt-gui-py";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui_py/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "5c36d33ff55be3b912a52bf9b05d44ad3bedfdd17a6f5edc0b024ef6c03fe4d4";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui_py/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "7ef3fcbcb013a9f65ec8c4f81872a39fa8a2a68bba5a14085d2ab0fc20306fab";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-gui/default.nix
+++ b/distros/galactic/rqt-gui/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, ament-lint-auto, ament-lint-common, python-qt-binding, python3Packages, qt-gui, rclpy }:
 buildRosPackage {
   pname = "ros-galactic-rqt-gui";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "6a5828b56c4e67f5e895b736ff002ad243bf596ff5e37801ecc070692c2d28a3";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_gui/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f3f7b95caebe053eb422347d737406b600c05228470c8d5f5f57e2fa8748a140";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-msg/default.nix
+++ b/distros/galactic/rqt-msg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-console, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-msg";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/galactic/rqt_msg/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "5bdcc03005f50232d03cfb18458aa6814d55779ab5a76a1638c84c360f4fd653";
+    url = "https://github.com/ros2-gbp/rqt_msg-release/archive/release/galactic/rqt_msg/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "eee318f85b396ff53e49a341dc3672d4e41e252d1c18653bff3a7dd4e102e0b8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-plot/default.nix
+++ b/distros/galactic/rqt-plot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py, rqt-py-common, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rqt-plot";
-  version = "1.0.10-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/galactic/rqt_plot/1.0.10-1.tar.gz";
-    name = "1.0.10-1.tar.gz";
-    sha256 = "f20751607252a8ac3d3bbaa5d727c9783d6327d6e99c518bd9dfdafdd08722fe";
+    url = "https://github.com/ros2-gbp/rqt_plot-release/archive/release/galactic/rqt_plot/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "62e816285327a8eb886b9d5cc7c4159aa584185c1a54b78bf5a2c31a9ccdd467";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-py-common/default.nix
+++ b/distros/galactic/rqt-py-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, python-cmake-module, python-qt-binding, qt-gui, qt5, rclpy, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-galactic-rqt-py-common";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_py_common/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "7804438021c06b25ccd10d188c583a145f49228c3bd99d7261d7f0a2157ddc42";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt_py_common/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "3848496d45a7ab40aa0d62556b3db7c9f3c482cb2b11897acc716c80010659d7";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rqt-py-console/default.nix
+++ b/distros/galactic/rqt-py-console/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-index-python, python-qt-binding, qt-gui, qt-gui-py-common, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-py-console";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/galactic/rqt_py_console/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "30ff0a1ae2ad66f7b47ea1e5c2c54525a76e2b88abf83f087e98274750640a1d";
+    url = "https://github.com/ros2-gbp/rqt_py_console-release/archive/release/galactic/rqt_py_console/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6e22796eee3f5319604be1b1231f89a3c43a503414141cb25b04d76a5c673f2f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-service-caller/default.nix
+++ b/distros/galactic/rqt-service-caller/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-service-caller";
-  version = "1.0.4-r1";
+  version = "1.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/galactic/rqt_service_caller/1.0.4-1.tar.gz";
-    name = "1.0.4-1.tar.gz";
-    sha256 = "bf7af8383ab77847fe97d435cdc97b15a79e459eddc052d25e335c6a18d2500f";
+    url = "https://github.com/ros2-gbp/rqt_service_caller-release/archive/release/galactic/rqt_service_caller/1.0.5-1.tar.gz";
+    name = "1.0.5-1.tar.gz";
+    sha256 = "ab9e3ab9d473cb06470691f415fe7c1e13ceb2048e5a7dce211b8a7f74fb4e32";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-shell/default.nix
+++ b/distros/galactic/rqt-shell/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, qt-gui, qt-gui-py-common, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-shell";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/galactic/rqt_shell/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "fb7af10b4e5ddad1faa220f0b0716b17effc713eea3a2571f4e5fa4b5ee7ef43";
+    url = "https://github.com/ros2-gbp/rqt_shell-release/archive/release/galactic/rqt_shell/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "6d47ce4c547faeea2f2ac4881564564c60d6e55ad18ebc1b1f1ba649b8d968d6";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-srv/default.nix
+++ b/distros/galactic/rqt-srv/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rclpy, rqt-gui, rqt-gui-py, rqt-msg }:
 buildRosPackage {
   pname = "ros-galactic-rqt-srv";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/galactic/rqt_srv/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "e58cb772bb39fba67a7247e1f45e866155c69ee1f533aaf5a674c1e261ebe98a";
+    url = "https://github.com/ros2-gbp/rqt_srv-release/archive/release/galactic/rqt_srv/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "792cad20d9d26660de5c5314e4da193069104005a0cc91aa551590b67da2cedc";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-top/default.nix
+++ b/distros/galactic/rqt-top/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, python-qt-binding, python3Packages, rclpy, rqt-gui, rqt-gui-py }:
 buildRosPackage {
   pname = "ros-galactic-rqt-top";
-  version = "1.0.1-r1";
+  version = "1.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/galactic/rqt_top/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "f65eacf6c645bb749a4df01f7062cd7988fe1769a01a3b52ec675003829c25a9";
+    url = "https://github.com/ros2-gbp/rqt_top-release/archive/release/galactic/rqt_top/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "93fb0e859fa1bf14fdd96fbe50c76071d70d59ab5f487292dfeaa59aaf7d782f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt-topic/default.nix
+++ b/distros/galactic/rqt-topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-flake8, ament-xmllint, python-qt-binding, rqt-gui, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt-topic";
-  version = "1.2.1-r2";
+  version = "1.2.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/galactic/rqt_topic/1.2.1-2.tar.gz";
-    name = "1.2.1-2.tar.gz";
-    sha256 = "40051938771562d1422027b8a9a1649893fac2b4b15f6776edb04a4ada4e639a";
+    url = "https://github.com/ros2-gbp/rqt_topic-release/archive/release/galactic/rqt_topic/1.2.2-1.tar.gz";
+    name = "1.2.2-1.tar.gz";
+    sha256 = "cc03d4e2f124da412802e906d403f58548349e125161a71fe68d168820219844";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/rqt/default.nix
+++ b/distros/galactic/rqt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, rqt-gui, rqt-gui-cpp, rqt-gui-py, rqt-py-common }:
 buildRosPackage {
   pname = "ros-galactic-rqt";
-  version = "1.1.1-r2";
+  version = "1.1.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt/1.1.1-2.tar.gz";
-    name = "1.1.1-2.tar.gz";
-    sha256 = "d2f180740ddcd727002dfdc946a2604a42c14cf65172d63e699a9fc06b611068";
+    url = "https://github.com/ros2-gbp/rqt-release/archive/release/galactic/rqt/1.1.2-1.tar.gz";
+    name = "1.1.2-1.tar.gz";
+    sha256 = "f2f32f5d52ea4e771d75a92ea7a5c2c87755cb4ad9683b43217ab15d43a3fdd8";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/serial-driver/default.nix
+++ b/distros/galactic/serial-driver/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, io-context, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs }:
 buildRosPackage {
   pname = "ros-galactic-serial-driver";
-  version = "0.0.6-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/serial_driver/0.0.6-2.tar.gz";
-    name = "0.0.6-2.tar.gz";
-    sha256 = "9e7409dff4b5044dfc09a83b958af9c2b3fc551c59a1ae38f9aebdaa458c9181";
+    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/serial_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "29d76b7fcd85d37ee47af9c38ce7211db07780d9cae023816c898c2cf465bc1b";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost rclcpp std-msgs ];
-  nativeBuildInputs = [ ament-cmake-auto ];
+  propagatedBuildInputs = [ asio io-context rclcpp rclcpp-components rclcpp-lifecycle std-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
 
   meta = {
     description = ''A template class and associated utilities which encapsulate basic reading from serial ports'';

--- a/distros/galactic/smacc2-msgs/default.nix
+++ b/distros/galactic/smacc2-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-smacc2-msgs";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2_msgs/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "e8e86cb1727ae7c1e66e3d7d663b0d5a111d13308437c824b9b8513ca29787ef";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ action-msgs builtin-interfaces rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages and services used in smacc2.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/smacc2/default.nix
+++ b/distros/galactic/smacc2/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, lttng-ust, rcl, rclcpp, rclcpp-action, smacc2-msgs, tracetools, tracetools-launch, tracetools-trace }:
+buildRosPackage {
+  pname = "ros-galactic-smacc2";
+  version = "0.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/robosoft-ai/SMACC2-release/archive/release/galactic/smacc2/0.1.0-1.tar.gz";
+    name = "0.1.0-1.tar.gz";
+    sha256 = "08e3221e2ab93c13ea21d927d859a98bfb6d56d633cf5fa6234797a53bc6814e";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost lttng-ust rcl rclcpp rclcpp-action smacc2-msgs tracetools tracetools-launch tracetools-trace ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''An Event-Driven, Asynchronous, Behavioral State Machine Library for ROS2 (Robotic Operating System) applications written in C++.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/turtle-tf2-cpp/default.nix
+++ b/distros/galactic/turtle-tf2-cpp/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-cpp";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "070e480375537b74c673358ab7b24c110b2f83572e2bb570211caa5383462830";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6888a79a8f9b4ca2442f9fd1942b04ab912dbd582e0bf4acd9a7921ccd81971d";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/turtle-tf2-py/default.nix
+++ b/distros/galactic/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-py";
-  version = "0.3.2-r1";
+  version = "0.3.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.2-1.tar.gz";
-    name = "0.3.2-1.tar.gz";
-    sha256 = "424233ae4a1b8caaf1fcf6bd83d41636d3f0badc0d984dea77538dda110bc1e2";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.3-1.tar.gz";
+    name = "0.3.3-1.tar.gz";
+    sha256 = "6c3e3d5ccfc070eae63e8529368c0071d747c74511917b6d410ebaf54c2b9189";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/udp-driver/default.nix
+++ b/distros/galactic/udp-driver/default.nix
@@ -2,24 +2,24 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, rclcpp, std-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, ament-lint-auto, ament-lint-common, asio, asio-cmake-module, io-context, lifecycle-msgs, rclcpp, rclcpp-components, rclcpp-lifecycle, std-msgs, udp-msgs }:
 buildRosPackage {
   pname = "ros-galactic-udp-driver";
-  version = "0.0.6-r2";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/udp_driver/0.0.6-2.tar.gz";
-    name = "0.0.6-2.tar.gz";
-    sha256 = "61f3c125877c2372c552f40ba7567526eb4fb464e191c33b4fedc254a3c3c860";
+    url = "https://github.com/ros2-gbp/transport_drivers-release/archive/release/galactic/udp_driver/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "c0832f450e2aebabfce86df050e1b5453f3008a511d7d6ad6411f4c47e811fca";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ boost rclcpp std-msgs ];
-  nativeBuildInputs = [ ament-cmake ];
+  propagatedBuildInputs = [ asio io-context lifecycle-msgs rclcpp rclcpp-components rclcpp-lifecycle std-msgs udp-msgs ];
+  nativeBuildInputs = [ ament-cmake-auto asio-cmake-module ];
 
   meta = {
-    description = ''A template class and associated utilities which encapsulate basic reading from UDP sockets'';
+    description = ''A library to write Synchronous and Asynchronous networking applications, ROS and ROS2 nodes'';
     license = with lib.licenses; [ asl20 ];
   };
 }

--- a/distros/galactic/xacro/default.nix
+++ b/distros/galactic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, python3Packages }:
 buildRosPackage {
   pname = "ros-galactic-xacro";
-  version = "2.0.6-r1";
+  version = "2.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.6-1.tar.gz";
-    name = "2.0.6-1.tar.gz";
-    sha256 = "7b4cea7136e4c340cacf3e08d63adfe6e34923baec25425adf0969e6765dbcd6";
+    url = "https://github.com/ros2-gbp/xacro-release/archive/release/galactic/xacro/2.0.7-1.tar.gz";
+    name = "2.0.7-1.tar.gz";
+    sha256 = "c6aeb71b83e4aa7c0f2a074ecef114137db3474c3b4728308a100e1baa20c847";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/audio-capture/default.nix
+++ b/distros/melodic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-capture";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "a992f06b5d928fa16258c4b3ec8c1474771d13380313485ce63ef4fb9dd3cc51";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_capture/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "e449a9cd40c6016617ea822e0a776867a9a7bd712b74237b0be752976f964681";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common-msgs/default.nix
+++ b/distros/melodic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-melodic-audio-common-msgs";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "570e136669c60d593c226c7e110bee681c1fa3aabd96cd55e4e9424862f75cc6";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common_msgs/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "2fa2c49d7c20011de78ea20187f3608ae6338f8d55c4ac96b9f8b47d06d992c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-common/default.nix
+++ b/distros/melodic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-melodic-audio-common";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "a329333e28bba5335211f486356f08910e917b4695f3f53e97ba73c20c9341a8";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_common/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "a459a57a6f6e797b4d980fc71482a072a0df75a68349f2417a50f342b49717b5";
   };
 
   buildType = "catkin";

--- a/distros/melodic/audio-play/default.nix
+++ b/distros/melodic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-audio-play";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "c8a1efb4ed711abfab5ae03d48ee105caf4a47d0f04e74bb0751ca167ae19a99";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/melodic/audio_play/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "ee5613f0a767a2a6dda6b40df2c3a332537ecf5b734452b261da0a426347ae8a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/costmap-cspace/default.nix
+++ b/distros/melodic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-costmap-cspace";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "06392b3a48b6732ab992cb671c725fa159fdf9e83073ca292aad3a741022dc86";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/costmap_cspace/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "76f9fac33ea80df5d18c3a53409d7a1b7428277ab065f202208aca263d8cbb8e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/eigenpy/default.nix
+++ b/distros/melodic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-eigenpy";
-  version = "2.6.7-r2";
+  version = "2.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.7-2.tar.gz";
-    name = "2.6.7-2.tar.gz";
-    sha256 = "fe22787a846c08efaa4ff95b7987ed86715486577dad4fe88ee25521f8e9d5f9";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/melodic/eigenpy/2.6.8-1.tar.gz";
+    name = "2.6.8-1.tar.gz";
+    sha256 = "76e3b67f639023210e9e434eaca30dda22927dfd3d1ee1f5f7da66ee8ba8c2d6";
   };
 
   buildType = "cmake";

--- a/distros/melodic/franka-control/default.nix
+++ b/distros/melodic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-control";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "50a9759027ad8342c024da2c531baad88c49daa30b9c1fa76ba757e745cc4150";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_control/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "b74d6ef97b4ae7541aec33fb678128468091d6f2c33f9b37bce4fba12bbe37c2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-description/default.nix
+++ b/distros/melodic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-description";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "2be5aadd4d6ad6b77207e4d024570f7d70c588eeb6d565106008339b8a03732b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_description/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "9372a9dacec54997429650d9c1a1b93469e3728e938cdea9401539770031cace";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-example-controllers/default.nix
+++ b/distros/melodic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-melodic-franka-example-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "0ad67a6533256a467a61b6bed080a1d982a5246ae198f5050d65ec8934c53444";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_example_controllers/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "bdc565b94ad6b72a600ffd05f54f32d6972a735b222d32ba6619ccb285fa54c6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-gazebo/default.nix
+++ b/distros/melodic/franka-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-franka-gazebo";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gazebo/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "596ca26ce1a567d664f987fc7caf9dfc085fd5ba4134551f05a3506a17d81f33";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gazebo/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "744e40d8cba133c9225208368b0a3d5d257a6fbe3a657b0d37d8085ccdc0ca35";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-gripper/default.nix
+++ b/distros/melodic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-franka-gripper";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "a9e109dc85ed5886534c0696892a29572b8c6eae07225297ce97105b7f5708ac";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_gripper/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "368b6f97226d6f15066994f113fceade5de3f685bef63d7853394ac9fb4a5ae8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-hw/default.nix
+++ b/distros/melodic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-melodic-franka-hw";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7b0688fc23757b0169ad5e90ff363cb67462b6ebc70d394a0ae8b42a5aabc52a";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_hw/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "922e1bd73bcdebd7eff90484d228210b4c18b8a7921feaf0d392b94e09928c15";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-msgs/default.nix
+++ b/distros/melodic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-franka-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "a9ad6ea5c30756f51c72134b4530c4352c1cdd8cdd4f3493bdc4d0c4ff67bd0c";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_msgs/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "e8f19ad1198bff3b4c7c5df55b833cf14eab70c09c7ad2b9c8f7d60381a3f403";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-ros/default.nix
+++ b/distros/melodic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-melodic-franka-ros";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "e48f2cd6f6aea7e68e81d3a11325cbf04a1030f1dc7db0e4be5f1812d398778e";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_ros/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "cb96b6417dd37b5794d5d8da7bcbeb7707b07e0b8cd9b8b8f7cd34a94f2e2172";
   };
 
   buildType = "catkin";

--- a/distros/melodic/franka-visualization/default.nix
+++ b/distros/melodic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-franka-visualization";
-  version = "0.8.0-r1";
+  version = "0.8.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "3505398ec199018247dcce2fd60284336ddf1a6856a939d08e4b70ae9cac4188";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/melodic/franka_visualization/0.8.1-2.tar.gz";
+    name = "0.8.1-2.tar.gz";
+    sha256 = "633ee8c9b3b7cd44c69fdd3b79d665fb4516e3bc68ea2be18f2ab5ddd6ffaa2f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1464,6 +1464,8 @@ self: super: {
 
  ifm3d = self.callPackage ./ifm3d {};
 
+ ifm3d-core = self.callPackage ./ifm3d-core {};
+
  igvc-self-drive-description = self.callPackage ./igvc-self-drive-description {};
 
  igvc-self-drive-gazebo = self.callPackage ./igvc-self-drive-gazebo {};
@@ -1781,6 +1783,8 @@ self: super: {
  lanelet2-core = self.callPackage ./lanelet2-core {};
 
  lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-io = self.callPackage ./lanelet2-io {};
 
  lanelet2-maps = self.callPackage ./lanelet2-maps {};
 
@@ -2976,7 +2980,11 @@ self: super: {
 
  qb-chain-control = self.callPackage ./qb-chain-control {};
 
+ qb-chain-controllers = self.callPackage ./qb-chain-controllers {};
+
  qb-chain-description = self.callPackage ./qb-chain-description {};
+
+ qb-chain-msgs = self.callPackage ./qb-chain-msgs {};
 
  qb-device = self.callPackage ./qb-device {};
 
@@ -2987,6 +2995,8 @@ self: super: {
  qb-device-description = self.callPackage ./qb-device-description {};
 
  qb-device-driver = self.callPackage ./qb-device-driver {};
+
+ qb-device-gazebo = self.callPackage ./qb-device-gazebo {};
 
  qb-device-hardware-interface = self.callPackage ./qb-device-hardware-interface {};
 
@@ -3002,6 +3012,8 @@ self: super: {
 
  qb-hand-description = self.callPackage ./qb-hand-description {};
 
+ qb-hand-gazebo = self.callPackage ./qb-hand-gazebo {};
+
  qb-hand-hardware-interface = self.callPackage ./qb-hand-hardware-interface {};
 
  qb-move = self.callPackage ./qb-move {};
@@ -3009,6 +3021,8 @@ self: super: {
  qb-move-control = self.callPackage ./qb-move-control {};
 
  qb-move-description = self.callPackage ./qb-move-description {};
+
+ qb-move-gazebo = self.callPackage ./qb-move-gazebo {};
 
  qb-move-hardware-interface = self.callPackage ./qb-move-hardware-interface {};
 
@@ -3699,6 +3713,8 @@ self: super: {
  ruckig = self.callPackage ./ruckig {};
 
  rviz = self.callPackage ./rviz {};
+
+ rviz-animated-view-controller = self.callPackage ./rviz-animated-view-controller {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
 

--- a/distros/melodic/ifm3d-core/default.nix
+++ b/distros/melodic/ifm3d-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, curl, cv-bridge, glog, pcl, xmlrpc_c }:
+buildRosPackage {
+  pname = "ros-melodic-ifm3d-core";
+  version = "0.18.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-release/archive/release/melodic/ifm3d_core/0.18.0-1.tar.gz";
+    name = "0.18.0-1.tar.gz";
+    sha256 = "c34250d57fa25729bccdf466a3b94c02a22e900d7b17a9b88fc5ec34b60b98b4";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ curl cv-bridge glog pcl xmlrpc_c ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Library and Utilities for working with ifm pmd-based 3D ToF Cameras'';
+    license = with lib.licenses; [ "Apache-1.0" ];
+  };
+}

--- a/distros/melodic/joystick-interrupt/default.nix
+++ b/distros/melodic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-melodic-joystick-interrupt";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "c0a76bbb0c21c48e857a843778217320de64c507e7440fb0c94bb9ee5069c6ef";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/joystick_interrupt/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "d2112673e46f6303562e28623d59b37ca6f427b42a0fc44d839f398ad0c519e7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/lanelet2-io/default.nix
+++ b/distros/melodic/lanelet2-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
+buildRosPackage {
+  pname = "ros-melodic-lanelet2-io";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/melodic/lanelet2_io/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "1b2f1ca013896894b8119cd6926789840420a14a736807691265f0520b22fa91";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core mrt-cmake-modules pugixml ];
+  nativeBuildInputs = [ catkin mrt-cmake-modules ];
+
+  meta = {
+    description = ''Parser/Writer module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/map-organizer/default.nix
+++ b/distros/melodic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-melodic-map-organizer";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "44de099e841a55c1c8a68178858cdd2d5d4d341d1aa2dabd371e085050317e69";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/map_organizer/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "65f1c9776979280b74dc2b58b55cc898ef2373062a54503be8d08db5054cad41";
   };
 
   buildType = "catkin";

--- a/distros/melodic/multi-object-tracking-lidar/default.nix
+++ b/distros/melodic/multi-object-tracking-lidar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, pcl, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-multi-object-tracking-lidar";
-  version = "1.0.2-r1";
+  version = "1.0.4-r2";
 
   src = fetchurl {
-    url = "https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release/archive/release/melodic/multi_object_tracking_lidar/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "736bfb056dc664589213481247b3c7c824f011e8ed6edcf937eb5dcc5e7b7790";
+    url = "https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release/archive/release/melodic/multi_object_tracking_lidar/1.0.4-2.tar.gz";
+    name = "1.0.4-2.tar.gz";
+    sha256 = "63755a5dbaa0f51fce61f80fb41810d2dbeee04ea715a685ea4e130ccb6691fe";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-common/default.nix
+++ b/distros/melodic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-common";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "3fb1cb2114916f4b6d9658b6e4dc70a3b131bfcaf38681946f71ae7099277262";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_common/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "c8905e70f394a421dd865180afb90d018ede6d32c0ae36da496c700432059b7e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation-launch/default.nix
+++ b/distros/melodic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation-launch";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "db346e0b32e1baa9176c30283a147085aaa0357b6fd707be53ebe8d3276fbfea";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation_launch/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "191c1b78cb6c2cdb49be36f66c96013aa724497c4327679cf5230b124a2b925a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/neonavigation/default.nix
+++ b/distros/melodic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-melodic-neonavigation";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "b0e230c3ed5f1935966c0070e90c72209900f3daf25a041353d387ffa3cd380b";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/neonavigation/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "5cb37e4bd963188db5e70bb676c6ce79bf55420691e636f0c5630e9de69bc93f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/obj-to-pointcloud/default.nix
+++ b/distros/melodic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-obj-to-pointcloud";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "731521d8cadd3547278ba1eb85de6b5622b2fc6202def52334afdacb76c0f553";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/obj_to_pointcloud/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "6bd84db929849ccc66aec928e915394c89f60b78120a142e82fb0f38705cc5b9";
   };
 
   buildType = "catkin";

--- a/distros/melodic/planner-cspace/default.nix
+++ b/distros/melodic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-planner-cspace";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "febc9c253d95c53d6a5d38b159df8031485c13edf8432e4cfb2d5b2f8a204c40";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/planner_cspace/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "9258257983d972f10c08221790b6e3678d5bedd8f2f9f5861693a2c4a2288790";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "080f24423050014f15feadaaa64038e3cf5a3a27cee98a193820cad43b1d8329";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "a331afac0527850d2c44cf58ce7e650d3be1209588414ce2dcaa8ed3019b3d7b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-control/default.nix
+++ b/distros/melodic/qb-chain-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain-control";
-  version = "2.0.0";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_control/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "b24868d85ac57809f85562dd92fae1ca2c99950d820b4f3a78e3df006e3d66b4";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_control/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "5ad6482196e5e7afbdf5856339d01f6c1757872eefd2a486977ca3d34b516413";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-controllers/default.nix
+++ b/distros/melodic/qb-chain-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, geometry-msgs, interactive-markers, qb-chain-msgs, roscpp, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros, trac-ik-lib }:
+buildRosPackage {
+  pname = "ros-melodic-qb-chain-controllers";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_controllers/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "f112ea1bd34c7d9e2a2bd6fece233824295eecbf5240a40f4f3ba8ae378fe089";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-msgs controller-interface geometry-msgs interactive-markers qb-chain-msgs roscpp sensor-msgs tf2 tf2-geometry-msgs tf2-ros trac-ik-lib ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the specific controllers for qbrobotics® kinematic structures, e.g. the qbdelta controller.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-chain-description/default.nix
+++ b/distros/melodic/qb-chain-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain-description";
-  version = "2.0.0";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_description/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "fe4822d09d3d0b0ec0a6b337799c04774d1a775d700962cb6e5fd043c836d7c2";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "5f97e0abb6fbfc1927ae6c257c025e32ed4c7e03ddc96fcb1071109c6753ce00";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-chain-msgs/default.nix
+++ b/distros/melodic/qb-chain-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-qb-chain-msgs";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain_msgs/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "029044f1222a3bdb843d9ff947a760e81858208fcc2f50cceb54789313ac5a90";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''message to control end-effector pose, robot sitiffness and velocity'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-chain/default.nix
+++ b/distros/melodic/qb-chain/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-chain-control, qb-chain-description }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-chain-control, qb-chain-controllers, qb-chain-description, qb-chain-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-chain";
-  version = "2.0.0";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain/2.0.0-0.tar.gz";
-    name = "2.0.0-0.tar.gz";
-    sha256 = "e21beffe73643665345d9027e82e376dd9b4cad3b1e429653276333060221e60";
+    url = "https://bitbucket.org/qbrobotics/qbchain-ros-release/get/release/melodic/qb_chain/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "fd69a4195e5785f5d4c1572323024ade0f7dd2e9eb78e438aa1715b76793dedd";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-chain-control qb-chain-description ];
+  propagatedBuildInputs = [ qb-chain-control qb-chain-controllers qb-chain-description qb-chain-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/qb-device-bringup/default.nix
+++ b/distros/melodic/qb-device-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-bringup";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "443a0556f062e710b5f7d7dc73d706cf568d89df0fd7ad5166709f879da7949b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_bringup/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "eea51c7b4bb001ea010e18e926e3c057d700ea673940f8af72331a8b56d77471";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-control/default.nix
+++ b/distros/melodic/qb-device-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, combined-robot-hw, control-msgs, controller-manager, qb-device-hardware-interface, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-control";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "aa15f86f450ad62174010eae97ce5ba325a52e62a638a01ae3b7a100ec406a6b";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_control/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "86fdaa78a65c1b831fc657528214af30b26c25bc72d7c528af3122045044d96f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-description/default.nix
+++ b/distros/melodic/qb-device-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-description";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "68b1656670c1a86828fc13dd7ad3943209f3b95df25079c632717d2a3a326aea";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_description/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "1b05000e7e154768a7c80971e176aec3b18f7581db7cee088d52df85cd867b7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-driver/default.nix
+++ b/distros/melodic/qb-device-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, qb-device-srvs, qb-device-utils, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-driver";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "5b3ec2c7b2ecf6aa8e1b99156423cb9f88208eb8d02024c2b30b8c6b1570e5d4";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_driver/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "ec6b1724aa5c7160cadbfef373f11a0ec19c0f7aaf0feb0eb716815614f349d1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-gazebo/default.nix
+++ b/distros/melodic/qb-device-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qb-device-gazebo";
+  version = "2.2.1-r3";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_gazebo/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "cd16a082716023e9b759005851fa2e9d23171b082a6875d3258e7876f4a76f66";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control custom dependencies for qbrobotics® devices.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-device-hardware-interface/default.nix
+++ b/distros/melodic/qb-device-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, hardware-interface, joint-limits-interface, qb-device-msgs, qb-device-srvs, roscpp, rostest, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-hardware-interface";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "16e0d28b4e8b145ae272049cdf232830fd7e6ffc50145bcb04a1570fa1e0f791";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_hardware_interface/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "09aeea2c08ce2007eea90577857ddaa0a4173981fb5d84de4203a8feebccd470";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-msgs/default.nix
+++ b/distros/melodic/qb-device-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-msgs";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "0a101007de0e30caec152ebe1d7f6bd676382b6b9df4e8353acb6a061bb57ab6";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_msgs/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "ae9f371c8f4f75cc3e1a31e9e74b20df32d4c63c87b818afa302c56a815bb758";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-srvs/default.nix
+++ b/distros/melodic/qb-device-srvs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, qb-device-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-srvs";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "3368262c75e15bb0fe756a1a54ae5dbef310d58c351c97e62766135641c68cab";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_srvs/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "6f173cc6e299a30ea0be552c1f122b010231e2c62e5be0c1e573ade2beda55b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device-utils/default.nix
+++ b/distros/melodic/qb-device-utils/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-qb-device-utils";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "b7ece361d35ee477a65ab530192408ac5a4fb3f8813c52a48a911989568fd0cf";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device_utils/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "222e3e8e62d4a993ecb02be66294eff8c1983adf28a3e0ac5a336038c780be36";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-device/default.nix
+++ b/distros/melodic/qb-device/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-device-bringup, qb-device-control, qb-device-description, qb-device-driver, qb-device-gazebo, qb-device-hardware-interface, qb-device-msgs, qb-device-srvs, qb-device-utils }:
 buildRosPackage {
   pname = "ros-melodic-qb-device";
-  version = "2.0.1";
+  version = "2.2.1-r3";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/2.0.1-0.tar.gz";
-    name = "2.0.1-0.tar.gz";
-    sha256 = "732baae03ff35decece845d122f21d7b7b86d2c31f726cfce269be208c306724";
+    url = "https://bitbucket.org/qbrobotics/qbdevice-ros-release/get/release/melodic/qb_device/2.2.1-3.tar.gz";
+    name = "2.2.1-3.tar.gz";
+    sha256 = "193f0f318f460c9c037446675ffca75ce460d8975f4703660af96841309c30c0";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-hardware-interface qb-device-msgs qb-device-srvs ];
+  propagatedBuildInputs = [ qb-device-bringup qb-device-control qb-device-description qb-device-driver qb-device-gazebo qb-device-hardware-interface qb-device-msgs qb-device-srvs qb-device-utils ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/qb-hand-control/default.nix
+++ b/distros/melodic/qb-hand-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-hand-control";
-  version = "2.0.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_control/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "b8ceb134cabb1903f8f236fa03e0b74c0f7555506bb3842ba586590f9e844790";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_control/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "d8a82f474238258428c1ff4d62abe31283fbd75b49c0114674cb43ec8ac709d6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-hand-description/default.nix
+++ b/distros/melodic/qb-hand-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-hand-description";
-  version = "2.0.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "95d0fbcd6f6d04fdae88fb2e6087f57ba833fb10d788a396c21dbe04c731120a";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_description/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "558c93f49f903529c71f8d49b03c2a86406123ff1d36d2c898ab4b579514a4b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-hand-gazebo/default.nix
+++ b/distros/melodic/qb-hand-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qb-hand-gazebo";
+  version = "2.2.2-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_gazebo/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c94b754ea29339587636c92db35822fc7fa6aae82b6a71ab2ff958b98c4bf797";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control qb-device-gazebo qb-device-hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control plugins for qbrobotics® SoftHand device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-hand-hardware-interface/default.nix
+++ b/distros/melodic/qb-hand-hardware-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, qb-device-hardware-interface, roscpp, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-qb-hand-hardware-interface";
-  version = "2.0.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_hardware_interface/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "88138eb2c19395bcb633d026f37a60414f12797a08392c17d9cb967f13bef9c5";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand_hardware_interface/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "26981de4c7d213739f2fd601fc8579afa0540b213dcb9bb8a9968232e151f839";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-hand/default.nix
+++ b/distros/melodic/qb-hand/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-hand-control, qb-hand-description, qb-hand-hardware-interface }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-hand-control, qb-hand-description, qb-hand-gazebo, qb-hand-hardware-interface }:
 buildRosPackage {
   pname = "ros-melodic-qb-hand";
-  version = "2.0.0-r1";
+  version = "2.2.2-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "aabf19f098662ae7195c61133104fbb799d47e58f9fcc52a069fcd08978b3cc9";
+    url = "https://bitbucket.org/qbrobotics/qbhand-ros-release/get/release/melodic/qb_hand/2.2.2-1.tar.gz";
+    name = "2.2.2-1.tar.gz";
+    sha256 = "c5f392b47b9ba4596bfdd4de7d478838156926462422b5cbc0261a60b4c0d4b2";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-hand-control qb-hand-description qb-hand-hardware-interface ];
+  propagatedBuildInputs = [ qb-hand-control qb-hand-description qb-hand-gazebo qb-hand-hardware-interface ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/qb-move-control/default.nix
+++ b/distros/melodic/qb-move-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-move-control";
-  version = "2.0.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_control/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "d7df8abcb9d4579698e9452e057d58e12d8da5ad622c6bdaf5066cd9525f5499";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_control/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "b87a0c73db421036e7ccddebfd4dbd769ee82822bb773ac0d36284fecd529491";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-move-description/default.nix
+++ b/distros/melodic/qb-move-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-qb-move-description";
-  version = "2.0.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_description/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "2d1f33dc9544f001b41cd0c45f89465a068bda8b7a5948953d21581639069f5c";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_description/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "a00e40888c01b1759b70f6aae1dfc8bac4d0f3f00055362f0346bbf0e6941c2a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/qb-move-gazebo/default.nix
+++ b/distros/melodic/qb-move-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-ros-control, qb-device-gazebo, qb-device-hardware-interface, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qb-move-gazebo";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_gazebo/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "2f1b840ab2d243ab3fff963acebd366df17ce2aa5cc80a9c9beecfc412381dbb";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-manager gazebo-ros-control qb-device-gazebo qb-device-hardware-interface roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the Gazebo ROS control plugins for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/qb-move-hardware-interface/default.nix
+++ b/distros/melodic/qb-move-hardware-interface/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, qb-device-hardware-interface, roscpp, transmission-interface }:
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, hardware-interface, interactive-markers, qb-device-hardware-interface, roscpp, tf2, tf2-geometry-msgs, transmission-interface }:
 buildRosPackage {
   pname = "ros-melodic-qb-move-hardware-interface";
-  version = "2.0.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_hardware_interface/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "f286bcac0739c1e7f8572d5e8abd413d25b541e3d54efa3b9805482543cd9c97";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move_hardware_interface/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "aa01391e426a4afa023e3255ecceadd74fdbd0809d4f90d511a4b28d5b2686cf";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ control-toolbox hardware-interface qb-device-hardware-interface roscpp transmission-interface ];
+  propagatedBuildInputs = [ control-toolbox hardware-interface interactive-markers qb-device-hardware-interface roscpp tf2 tf2-geometry-msgs transmission-interface ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/qb-move/default.nix
+++ b/distros/melodic/qb-move/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, qb-move-control, qb-move-description, qb-move-hardware-interface }:
+{ lib, buildRosPackage, fetchurl, catkin, qb-move-control, qb-move-description, qb-move-gazebo, qb-move-hardware-interface }:
 buildRosPackage {
   pname = "ros-melodic-qb-move";
-  version = "2.0.0-r1";
+  version = "2.2.1-r1";
 
   src = fetchurl {
-    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move/2.0.0-1.tar.gz";
-    name = "2.0.0-1.tar.gz";
-    sha256 = "1a320423c63420ddd649d7df7f9e5a973078788f6ca6f4ef5d0675eb69c4b62c";
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/melodic/qb_move/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "1f56d36fb9131f6a552f6e755183bd5c6b8b2302da8937cf7156ef49a18d9471";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ qb-move-control qb-move-description qb-move-hardware-interface ];
+  propagatedBuildInputs = [ qb-move-control qb-move-description qb-move-gazebo qb-move-hardware-interface ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rospy-message-converter/default.nix
+++ b/distros/melodic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, pythonPackages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-rospy-message-converter";
-  version = "0.5.6-r1";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.6-1.tar.gz";
-    name = "0.5.6-1.tar.gz";
-    sha256 = "f4ba994c272d9ed2e6bfb6ba9e76aeec2a0aa0a56f399efef5395d80cb009893";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/melodic/rospy_message_converter/0.5.7-1.tar.gz";
+    name = "0.5.7-1.tar.gz";
+    sha256 = "7958ef16277c2a1a2364af1075b8b8f3fe88baefeaf25f10a048f776d7eac005";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rviz-animated-view-controller/default.nix
+++ b/distros/melodic/rviz-animated-view-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-transport, libGL, libGLU, pluginlib, qt5, rviz, std-msgs, view-controller-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-rviz-animated-view-controller";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rviz_animated_view_controller-release/archive/release/melodic/rviz_animated_view_controller/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "2528e6708151c41f229ca409f625c143ad8ee2db43fc65ba12e4216df54e0a59";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules cv-bridge eigen geometry-msgs image-transport libGL libGLU pluginlib qt5.qtbase rviz std-msgs view-controller-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A rviz view controller featuring smooth transitions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/safety-limiter/default.nix
+++ b/distros/melodic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-melodic-safety-limiter";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "27575ceb198545d2e463ae739ab581a56ba4e59d7e6cfbe7fcf0e138f1aaf0e5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/safety_limiter/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "9e2d3893c7b15481b54c99e0d43085d19f2df0137c9c7e6eead1dab271a6d75e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sbg-driver/default.nix
+++ b/distros/melodic/sbg-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-sbg-driver";
-  version = "2.0.2-r1";
+  version = "3.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "e4993f0efb6ad38028d9c4d521e40a631f6c66b844a91188790803620f59ac3c";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/3.0.0-1.tar.gz";
+    name = "3.0.0-1.tar.gz";
+    sha256 = "d9eacffb9bd5b9b0807ad482598c36932f04ca9b8313bc1714c140a6c5a02d7b";
   };
 
   buildType = "catkin";
@@ -19,7 +19,7 @@ buildRosPackage {
   nativeBuildInputs = [ catkin ];
 
   meta = {
-    description = ''The SBG ROS Driver package'';
+    description = ''ROS driver package for communication with the SBG navigation systems.'';
     license = with lib.licenses; [ mit ];
   };
 }

--- a/distros/melodic/track-odometry/default.nix
+++ b/distros/melodic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-melodic-track-odometry";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "d19de80f539e0390ed2d3f3d42cbc782dcb49f0c74d5186b6a268d0808a7d8bc";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/track_odometry/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "cc3155c946216c271777e683cf2aa57cbf48869991695d096f45e3bcfa0ad9f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/trajectory-tracker/default.nix
+++ b/distros/melodic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-melodic-trajectory-tracker";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "22652522e436d7c52e1637b5e2c96d6a815baa208bd2ce89b0738f50a2db0c9e";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/melodic/trajectory_tracker/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "56cd70d3089f81f540477790a110981f8905055406bbd6e05392e0a8b30a422e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.12-r1";
+  version = "1.13.13-r2";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.12-1.tar.gz";
-    name = "1.13.12-1.tar.gz";
-    sha256 = "8b727673a70f77dbdc4ac44544c2e39724cd37b49246998a7e954fa790817ab5";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.13-2.tar.gz";
+    name = "1.13.13-2.tar.gz";
+    sha256 = "824f3f329cead6514efd154ac92883725ffbf9da5b8c998fffbbbd267c8e3445";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-capture/default.nix
+++ b/distros/noetic/audio-capture/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-capture";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "d6910eec960e3c2b43e2ffa790148b50be4aea412edd51b832e99bcfc1919e60";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_capture/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "71568fe0b7464aedb6680df26c8f4994dda8f09cc084f2436d19271f695ae39d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common-msgs/default.nix
+++ b/distros/noetic/audio-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime }:
 buildRosPackage {
   pname = "ros-noetic-audio-common-msgs";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "9ce2196c6af0918ba14c24ffef9087468c888d3b878cee851d8868bda9b751f0";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common_msgs/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "bb111d35a2c4435c9c0ef69b59684ac7881b99138f52bfc4169879dc0daae053";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-common/default.nix
+++ b/distros/noetic/audio-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-capture, audio-common-msgs, audio-play, catkin, sound-play }:
 buildRosPackage {
   pname = "ros-noetic-audio-common";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "a13659c5a4fb5f2fc347f01181e9b3f7b0f67fb27df0c1f4cd7bdad579fa72b1";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_common/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "65726768cee810e697a9a497c07119212732341bee0accf88dfe971f0ede4a1f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/audio-play/default.nix
+++ b/distros/noetic/audio-play/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, audio-common-msgs, catkin, gst_all_1, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-audio-play";
-  version = "0.3.11-r1";
+  version = "0.3.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.11-1.tar.gz";
-    name = "0.3.11-1.tar.gz";
-    sha256 = "763d5d491156d3902552b81e0e093a269749603f90f369112af9fd0db8f681cd";
+    url = "https://github.com/ros-gbp/audio_common-release/archive/release/noetic/audio_play/0.3.12-1.tar.gz";
+    name = "0.3.12-1.tar.gz";
+    sha256 = "64f78c942eda1646e3d50397503e66d2e18600ef78607b22da77335f1b583223";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bosch-locator-bridge/default.nix
+++ b/distros/noetic/bosch-locator-bridge/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, pcl-conversions, poco, roscpp, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-bosch-locator-bridge";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "8d122dad07b506b904befd65db6d44d6f90b9c0c2306ac75fdd77dc58b70546f";
+    url = "https://github.com/ros-gbp/locator_ros_bridge-release/archive/release/noetic/bosch_locator_bridge/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "c0d3fbb53b24308e56923195b0445842ed107f5718f1911bb32d568fb1df93ac";
   };
 
   buildType = "catkin";

--- a/distros/noetic/costmap-cspace/default.nix
+++ b/distros/noetic/costmap-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace-msgs, geometry-msgs, laser-geometry, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-costmap-cspace";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "c12309230ec4b6764a680ebf1d1198d24468529a0f10e913b17f12f0d99eda76";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/costmap_cspace/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "4f8b3c15cb4b03656cce48bfc762c79baccd6b5f5517a1c7180abf31b9487265";
   };
 
   buildType = "catkin";

--- a/distros/noetic/eigenpy/default.nix
+++ b/distros/noetic/eigenpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, cmake, doxygen, eigen, git, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-eigenpy";
-  version = "2.6.7-r1";
+  version = "2.6.8-r1";
 
   src = fetchurl {
-    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.7-1.tar.gz";
-    name = "2.6.7-1.tar.gz";
-    sha256 = "6ad50a889cd4115dde546a74c1cdc4c328175eea1e7ea4e3b3b2b54b49bda1f7";
+    url = "https://github.com/ipab-slmc/eigenpy_catkin-release/archive/release/noetic/eigenpy/2.6.8-1.tar.gz";
+    name = "2.6.8-1.tar.gz";
+    sha256 = "8031a9803a39d9550122cc3de58730198b88a3c1d17f8fa30f0e806c50b523a0";
   };
 
   buildType = "cmake";

--- a/distros/noetic/franka-control/default.nix
+++ b/distros/noetic/franka-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, franka-description, franka-gripper, franka-hw, franka-msgs, geometry-msgs, joint-state-publisher, libfranka, pluginlib, realtime-tools, robot-state-publisher, roscpp, sensor-msgs, std-srvs, tf, tf2-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-control";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "edf61fcee7cec88ef37b78fdd1095db3bc83dbf8be226b88b736ec17a7b45e48";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_control/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "76538347272c693f28ffea0b2f7b110e2dadc2be1eec0b35f51867ad257acdda";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-description/default.nix
+++ b/distros/noetic/franka-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-description";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "f9c5839d84b866337cbbc1aa0fd398291ada7d03de327d3cabf3c006cba03633";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_description/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "6dd7bd6df274a27db4173a62c551b32e9028350a8039d24ba72509f9448aaf6f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-example-controllers/default.nix
+++ b/distros/noetic/franka-example-controllers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-interface, dynamic-reconfigure, eigen, eigen-conversions, franka-control, franka-description, franka-gripper, franka-hw, geometry-msgs, hardware-interface, libfranka, message-generation, message-runtime, panda-moveit-config, pluginlib, realtime-tools, roscpp, rospy, tf, tf-conversions }:
 buildRosPackage {
   pname = "ros-noetic-franka-example-controllers";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "dbed2239cd51deddb45df921ea510e5e0fb0da78fca098bf1aff2f05000cebe8";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_example_controllers/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "9ec88a732af531e411bd7f67096ed5d75f473332e128f3d9d47cfc72450b5cad";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gazebo/default.nix
+++ b/distros/noetic/franka-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, angles, catkin, control-msgs, control-toolbox, controller-interface, controller-manager, eigen-conversions, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, gazebo-dev, gazebo-ros, gazebo-ros-control, gtest, hardware-interface, joint-limits-interface, kdl-parser, pluginlib, roscpp, rostest, std-msgs, transmission-interface, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-gazebo";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "4e9ab990dafb016109a030284fc390af025d5ee8482a238bba6a5dcf0522ea20";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gazebo/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "46271d33a777e64854b1c843a6466d801222cc7e308d39bff560d700dc4da962";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-gripper/default.nix
+++ b/distros/noetic/franka-gripper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, control-msgs, libfranka, message-generation, message-runtime, roscpp, sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-franka-gripper";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "69c84e340f7924371127061c2e56e2448f37dd8b3105212133754bf73593c69b";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_gripper/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "33bbb9b4379cbca9c6c089cc8cc6c96c5849fd92f12f9e7be4c0d4b0f4781603";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-hw/default.nix
+++ b/distros/noetic/franka-hw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, combined-robot-hw, controller-interface, franka-description, franka-msgs, gtest, hardware-interface, joint-limits-interface, libfranka, message-generation, pluginlib, roscpp, rostest, std-srvs, urdf }:
 buildRosPackage {
   pname = "ros-noetic-franka-hw";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "c77a11f6abe0f5e1af075e96cce20b81519fa0f177936cb3ae26e4b62f12bbd2";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_hw/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "b61760dab1903ffa564950c14ad13ae03aa92d9462a3aa98f09aaaeaf085813e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-msgs/default.nix
+++ b/distros/noetic/franka-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-franka-msgs";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "24b9a9005c05c7b3cc6de4f71c4d62c01bd57a5099b869591041d6d130af5b57";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_msgs/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "c6c5aaa276b25c1d8031011cee8c4a21f3f30bba9ea9e9dc43048bade69cb11b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-ros/default.nix
+++ b/distros/noetic/franka-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-control, franka-description, franka-example-controllers, franka-gripper, franka-hw, franka-msgs, franka-visualization, panda-moveit-config }:
 buildRosPackage {
   pname = "ros-noetic-franka-ros";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "7f60758fe4416f505fce7b87816d4c02a75bffe19998e08c7fdd0527084edb39";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_ros/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "d4abf2ee039643120a37bc48f2886d1178fc93242d6ec262e2946912d65b3985";
   };
 
   buildType = "catkin";

--- a/distros/noetic/franka-visualization/default.nix
+++ b/distros/noetic/franka-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, franka-description, libfranka, roscpp, sensor-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-franka-visualization";
-  version = "0.8.0-r1";
+  version = "0.8.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.0-1.tar.gz";
-    name = "0.8.0-1.tar.gz";
-    sha256 = "aa5cc382c707b8dec8c9e779efdcb3a0dec0f527ea65d5e523da2ab35277eab5";
+    url = "https://github.com/frankaemika/franka_ros-release/archive/release/noetic/franka_visualization/0.8.1-1.tar.gz";
+    name = "0.8.1-1.tar.gz";
+    sha256 = "ef7aa4c6028b2639daf2bd940009740cf23ddc196ec4bd7e5b2dce257bfb1770";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1062,6 +1062,8 @@ self: super: {
 
  ifm3d = self.callPackage ./ifm3d {};
 
+ ifm3d-core = self.callPackage ./ifm3d-core {};
+
  image-cb-detector = self.callPackage ./image-cb-detector {};
 
  image-common = self.callPackage ./image-common {};
@@ -1259,6 +1261,8 @@ self: super: {
  lanelet2-core = self.callPackage ./lanelet2-core {};
 
  lanelet2-examples = self.callPackage ./lanelet2-examples {};
+
+ lanelet2-io = self.callPackage ./lanelet2-io {};
 
  lanelet2-maps = self.callPackage ./lanelet2-maps {};
 
@@ -1458,6 +1462,12 @@ self: super: {
 
  microstrain-3dmgx2-imu = self.callPackage ./microstrain-3dmgx2-imu {};
 
+ microstrain-inertial-driver = self.callPackage ./microstrain-inertial-driver {};
+
+ microstrain-inertial-examples = self.callPackage ./microstrain-inertial-examples {};
+
+ microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
+
  mini-maxwell = self.callPackage ./mini-maxwell {};
 
  mir-actions = self.callPackage ./mir-actions {};
@@ -1581,6 +1591,8 @@ self: super: {
  mpc-local-planner-examples = self.callPackage ./mpc-local-planner-examples {};
 
  mpc-local-planner-msgs = self.callPackage ./mpc-local-planner-msgs {};
+
+ mqtt-bridge = self.callPackage ./mqtt-bridge {};
 
  mrpt-msgs = self.callPackage ./mrpt-msgs {};
 
@@ -2004,6 +2016,12 @@ self: super: {
 
  python-qt-binding = self.callPackage ./python-qt-binding {};
 
+ qb-move = self.callPackage ./qb-move {};
+
+ qb-move-control = self.callPackage ./qb-move-control {};
+
+ qb-move-description = self.callPackage ./qb-move-description {};
+
  qpoases-vendor = self.callPackage ./qpoases-vendor {};
 
  qt-dotgraph = self.callPackage ./qt-dotgraph {};
@@ -2078,7 +2096,27 @@ self: super: {
 
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
+ rm-base = self.callPackage ./rm-base {};
+
+ rm-calibration-controllers = self.callPackage ./rm-calibration-controllers {};
+
+ rm-chassis-controllers = self.callPackage ./rm-chassis-controllers {};
+
+ rm-common = self.callPackage ./rm-common {};
+
+ rm-control = self.callPackage ./rm-control {};
+
  rm-controllers = self.callPackage ./rm-controllers {};
+
+ rm-description = self.callPackage ./rm-description {};
+
+ rm-gazebo = self.callPackage ./rm-gazebo {};
+
+ rm-gimbal-controllers = self.callPackage ./rm-gimbal-controllers {};
+
+ rm-msgs = self.callPackage ./rm-msgs {};
+
+ rm-shooter-controllers = self.callPackage ./rm-shooter-controllers {};
 
  robot = self.callPackage ./robot {};
 
@@ -2107,6 +2145,8 @@ self: super: {
  robot-navigation = self.callPackage ./robot-navigation {};
 
  robot-self-filter = self.callPackage ./robot-self-filter {};
+
+ robot-state-controller = self.callPackage ./robot-state-controller {};
 
  robot-state-publisher = self.callPackage ./robot-state-publisher {};
 
@@ -2431,6 +2471,8 @@ self: super: {
  ruckig = self.callPackage ./ruckig {};
 
  rviz = self.callPackage ./rviz {};
+
+ rviz-animated-view-controller = self.callPackage ./rviz-animated-view-controller {};
 
  rviz-imu-plugin = self.callPackage ./rviz-imu-plugin {};
 

--- a/distros/noetic/ifm3d-core/default.nix
+++ b/distros/noetic/ifm3d-core/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, cmake, curl, cv-bridge, glog, pcl, xmlrpc_c }:
+buildRosPackage {
+  pname = "ros-noetic-ifm3d-core";
+  version = "0.18.0-r5";
+
+  src = fetchurl {
+    url = "https://github.com/ifm/ifm3d-release/archive/release/noetic/ifm3d_core/0.18.0-5.tar.gz";
+    name = "0.18.0-5.tar.gz";
+    sha256 = "f47b95f7f05e7bf5ffb163f50200112b0cf3f13a2c270bf3895e034252c1a4cc";
+  };
+
+  buildType = "cmake";
+  buildInputs = [ boost ];
+  propagatedBuildInputs = [ curl cv-bridge glog pcl xmlrpc_c ];
+  nativeBuildInputs = [ cmake ];
+
+  meta = {
+    description = ''Library and Utilities for working with ifm pmd-based 3D ToF Cameras'';
+    license = with lib.licenses; [ "Apache-1.0" ];
+  };
+}

--- a/distros/noetic/joystick-interrupt/default.nix
+++ b/distros/noetic/joystick-interrupt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-joystick-interrupt";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "1ac9ed1b3dbb86118de53541e1a098209fb495be21b81dcabfbdc188f809de41";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/joystick_interrupt/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "eecb2701675608b9c0463b9ca7576864b3263251ae4fbe5d61a23e096ca3312c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/lanelet2-io/default.nix
+++ b/distros/noetic/lanelet2-io/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, boost, catkin, gtest, lanelet2-core, mrt-cmake-modules, pugixml }:
+buildRosPackage {
+  pname = "ros-noetic-lanelet2-io";
+  version = "1.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fzi-forschungszentrum-informatik/lanelet2-release/archive/release/noetic/lanelet2_io/1.1.1-1.tar.gz";
+    name = "1.1.1-1.tar.gz";
+    sha256 = "c17faa85a5a1fad9b956597b60963cb78e7f497e2b45356c67b24aea8c1efc4b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ boost lanelet2-core mrt-cmake-modules pugixml ];
+  nativeBuildInputs = [ catkin mrt-cmake-modules ];
+
+  meta = {
+    description = ''Parser/Writer module for lanelet2'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/map-organizer/default.nix
+++ b/distros/noetic/map-organizer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, map-organizer-msgs, map-server, nav-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-map-organizer";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "aa4a9e49cdc5d85853d1b614d7c3ca9761f4e54232fc8f5b2f8e4585840a1b41";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/map_organizer/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "209fa656f4905118e2c768b1d553a7b1e66ce7c9eeef0f7a5c1328df91154aa1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-microstrain-inertial-driver";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d1abe09d564cc64690f72c25ad97220567aeb15b5397572b902485bdac050e4b";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ curl jq message-generation roslint ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs message-runtime microstrain-inertial-msgs nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros_mscl package provides a driver for the LORD/Microstrain inertial products.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-microstrain-inertial-examples";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "71512057db17370a287afd6bb643545091638c887b13ddcabc95fbe340eef5d2";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ cmake-modules microstrain-inertial-msgs roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Example listener for Parker LORD Sensing inertial device driver ros_mscl (C++).'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-microstrain-inertial-msgs";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "9a26dc269ad55bab05c95f08d37179b7f0b1752bf182222b59827d6d731a2524";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A package that contains ROS message corresponding to microstrain message types.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/mqtt-bridge/default.nix
+++ b/distros/noetic/mqtt-bridge/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosbridge-library, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-mqtt-bridge";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/groove-x/mqtt_bridge-release/archive/release/noetic/mqtt_bridge/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "f35df5101540e03754e6d9a80d5e64babf9e7b4a16aeaa595c6235d82c91b8d0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ python3Packages.pip ];
+  propagatedBuildInputs = [ python3Packages.msgpack python3Packages.pymongo rosbridge-library rospy std-msgs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''The mqtt_bridge package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/multi-object-tracking-lidar/default.nix
+++ b/distros/noetic/multi-object-tracking-lidar/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, pcl, pcl-ros, roscpp, sensor-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-multi-object-tracking-lidar";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release/archive/release/noetic/multi_object_tracking_lidar/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "c9453caabc6fbc604c796da7cc2fded0ab86d8c410c3232b67d54e7d0d25e6c0";
+    url = "https://github.com/praveen-palanisamy/multi_object_tracking_lidar-release/archive/release/noetic/multi_object_tracking_lidar/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "934d72355b1e02337c0b9cb6ed42e43ed9bd6f4930277c8182f69251c8a14c59";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-common/default.nix
+++ b/distros/noetic/neonavigation-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roslint, rostest, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-common";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "0b3e8fa8c9047e9fcbb8ae8e536e48bbfea7dc2d16f31c0c426ba20cfdabba7d";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_common/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "46e4902fe6f31055311cb20114e74e1ed8c1a2968d6885ef87d2e07937c01843";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation-launch/default.nix
+++ b/distros/noetic/neonavigation-launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, map-server, planner-cspace, safety-limiter, tf2-ros, trajectory-tracker, trajectory-tracker-rviz-plugins }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation-launch";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "3c764ef682de3917c676ab3a434aca99c1e45c538042681dfb411b79b8fd1196";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation_launch/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "0bf34fe27e93592ef055b1054d3ce77d3f9b513b055be16d2831a7b3d5f1d980";
   };
 
   buildType = "catkin";

--- a/distros/noetic/neonavigation/default.nix
+++ b/distros/noetic/neonavigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, costmap-cspace, joystick-interrupt, map-organizer, neonavigation-common, neonavigation-launch, obj-to-pointcloud, planner-cspace, safety-limiter, track-odometry, trajectory-tracker }:
 buildRosPackage {
   pname = "ros-noetic-neonavigation";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "87b080dba20d0ce30fcd5a4310ceafdcd4149eb3cf5f6d916b027d782e30d7be";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/neonavigation/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "71ea814e2bfe5014ec442a9ba7dda9cddb05890ef386ce5150c00b626df9fa3b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/obj-to-pointcloud/default.nix
+++ b/distros/noetic/obj-to-pointcloud/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, neonavigation-common, pcl, pcl-conversions, roscpp, roslint, rostest, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-obj-to-pointcloud";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "6d36ca975656411c5871ccadb514b6f92a21a705a4ddf8a95f5892da184a4a18";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/obj_to_pointcloud/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "60b9a85b4fae06fc03631f760d63fb981e2b195aa3839f3e1600b26e10dbeeeb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/planner-cspace/default.nix
+++ b/distros/noetic/planner-cspace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, actionlib, catkin, costmap-cspace, costmap-cspace-msgs, diagnostic-updater, geometry-msgs, map-server, move-base-msgs, nav-msgs, neonavigation-common, planner-cspace-msgs, roscpp, roslint, rostest, sensor-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs, trajectory-tracker, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-planner-cspace";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "38ab016aec2340731c583cdf946cef406c911f1fe9f27993e7a75b6b29d16c72";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/planner_cspace/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "66fee8d7dfca075b71630878739c7a60ab0d2e62fb5f808221666a8d540ed4dc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.2.1-r1";
+  version = "3.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.2.1-1.tar.gz";
-    name = "3.2.1-1.tar.gz";
-    sha256 = "d5739d38d9878dfd43f504f049d110d5e4e5666fa3d6a8b8f88b6303eeed3ab2";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.0-1.tar.gz";
+    name = "3.3.0-1.tar.gz";
+    sha256 = "36339200b6c76256e09ee0cbd414464bb0db63c946f15d0b6a4666af4a52811b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/qb-move-control/default.nix
+++ b/distros/noetic/qb-move-control/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-move-control";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_control/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "cf9d4c5c2639475912f62d71be16b22e3dcfa411228c79c9824ce04c95466bf7";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS control node for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qb-move-description/default.nix
+++ b/distros/noetic/qb-move-description/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin }:
+buildRosPackage {
+  pname = "ros-noetic-qb-move-description";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move_description/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "39d1d6f4a9ea5f313e7d9eea7f7f49d41390078313012112326cc98490b52465";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS description for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/qb-move/default.nix
+++ b/distros/noetic/qb-move/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qb-move-control, qb-move-description, qb-move-gazebo, qb-move-hardware-interface }:
+buildRosPackage {
+  pname = "ros-noetic-qb-move";
+  version = "2.2.1-r1";
+
+  src = fetchurl {
+    url = "https://bitbucket.org/qbrobotics/qbmove-ros-release/get/release/noetic/qb_move/2.2.1-1.tar.gz";
+    name = "2.2.1-1.tar.gz";
+    sha256 = "9bd51c37e7e888f9babf7aebaee59eccbb2d87a48a9b486819960401e7302ee1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qb-move-control qb-move-description qb-move-gazebo qb-move-hardware-interface ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''This package contains the ROS interface for qbrobotics® qbmove device.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-base/default.nix
+++ b/distros/noetic/rm-base/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-rm-base";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_base/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "c184b98b34c7e3d521ec64f85fb0983fb33ccaaca0b1a2a1a65cd1cee165cbea";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface controller-manager hardware-interface joint-limits-interface realtime-tools rm-common rm-msgs roscpp roslint transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS control warped interface for RoboMaster motor and some robot hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-calibration-controllers/default.nix
+++ b/distros/noetic/rm-calibration-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-interface, effort-controllers, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rm-calibration-controllers";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_calibration_controllers/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "fc9807f8ad601650cf3e885e6606114b9638c74a7cf351e89feb306daa5461f9";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-msgs controller-interface effort-controllers hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster standard robot Gimbal controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-chassis-controllers/default.nix
+++ b/distros/noetic/rm-chassis-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, effort-controllers, forward-command-controller, hardware-interface, imu-sensor-controller, pluginlib, realtime-tools, rm-common, rm-msgs, robot-localization, roscpp, roslint, tf2, tf2-geometry-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rm-chassis-controllers";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_chassis_controllers/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "50d4c3c45a996841a88993c09b2930abb9ecb4835e5700c6de3a15285bbfda16";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ angles control-toolbox controller-interface effort-controllers forward-command-controller hardware-interface imu-sensor-controller pluginlib realtime-tools rm-common rm-msgs robot-localization roscpp roslint tf2 tf2-geometry-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster standard robot Chassis controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
+buildRosPackage {
+  pname = "ros-noetic-rm-common";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "3b416613a6cd85b83de05616a3e7d1e12c1ae98afd778b68e7b5d364415dab6c";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-msgs controller-manager-msgs dynamic-reconfigure eigen geometry-msgs realtime-tools rm-msgs roscpp roslint tf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rm_common package'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rm-common, rm-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rm-control";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "badd44a2c96c661235de0304340dabb8f3e552489c7ae695d94edab2090baaf8";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rm-common rm-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Meta package that contains package of rm_control.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-rm-description";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "9efff0393a8fd9a0ad6fe81a918f2ab1abaa31a2684bddf8bae58be2ffe9bd72";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster robot description files'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rm-gazebo";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "8b4d10fcf5aec733eb27ca415dffbe4705e754707e621f9e9c5a8c4ceccfce3b";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ gazebo gazebo-ros gazebo-ros-control rm-common rm-description roboticsgroup-upatras-gazebo-plugins roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A template for ROS packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-gimbal-controllers/default.nix
+++ b/distros/noetic/rm-gimbal-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, angles, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint, tf2, tf2-geometry-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rm-gimbal-controllers";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_gimbal_controllers/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "1521aeb8e4342a29d996ee3c274be2c6c90fa0df7694cd4631f377d0f81b6862";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ angles control-toolbox controller-interface dynamic-reconfigure effort-controllers forward-command-controller hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint tf2 tf2-geometry-msgs visualization-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster standard robot Gimbal controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rm-msgs";
+  version = "0.1.1-r5";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.1-5.tar.gz";
+    name = "0.1.1-5.tar.gz";
+    sha256 = "818f207b30dc64bd121e80eab1e6339d09049e993160ffe5ff26fb8f8b64cdab";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rm_msgs package provides all the messages for all kind of robot'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-shooter-controllers/default.nix
+++ b/distros/noetic/rm-shooter-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, control-toolbox, controller-interface, dynamic-reconfigure, effort-controllers, forward-command-controller, hardware-interface, pluginlib, realtime-tools, rm-common, rm-msgs, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rm-shooter-controllers";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/rm_shooter_controllers/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "5a4ebee8b376ae673159daa3915d8dc17736589773119caf52b21f4ee4c63526";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ control-toolbox controller-interface dynamic-reconfigure effort-controllers forward-command-controller hardware-interface pluginlib realtime-tools rm-common rm-msgs roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''RoboMaster standard robot Shooter controller'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/robot-state-controller/default.nix
+++ b/distros/noetic/robot-state-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, hardware-interface, kdl-parser, pluginlib, realtime-tools, rm-common, roscpp, roslint, tf2-kdl, tf2-ros, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-robot-state-controller";
+  version = "0.1.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_controllers-release/archive/release/noetic/robot_state_controller/0.1.1-1.tar.gz";
+    name = "0.1.1-1.tar.gz";
+    sha256 = "75be7d9635cbd80a57c25984d65d2604dd0e6696aef7707e761bf07336b352b1";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface hardware-interface kdl-parser pluginlib realtime-tools rm-common roscpp roslint tf2-kdl tf2-ros urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A template for ROS packages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rospy-message-converter/default.nix
+++ b/distros/noetic/rospy-message-converter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, python3Packages, roslib, rospy, rosunit, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-rospy-message-converter";
-  version = "0.5.6-r1";
+  version = "0.5.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.6-1.tar.gz";
-    name = "0.5.6-1.tar.gz";
-    sha256 = "701b88b355e63656be43cd0a1819d5bc9d1d598b3f238d67e85ed769b13e65de";
+    url = "https://github.com/uos-gbp/rospy_message_converter-release/archive/release/noetic/rospy_message_converter/0.5.7-1.tar.gz";
+    name = "0.5.7-1.tar.gz";
+    sha256 = "96c5848b0adf9e1b9ef5a0039e6ef3bfbcfd4d446ce1c0da05cad09ceef75945";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rviz-animated-view-controller/default.nix
+++ b/distros/noetic/rviz-animated-view-controller/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, cv-bridge, eigen, geometry-msgs, image-transport, libGL, libGLU, pluginlib, qt5, rviz, std-msgs, view-controller-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-rviz-animated-view-controller";
+  version = "0.2.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros-gbp/rviz_animated_view_controller-release/archive/release/noetic/rviz_animated_view_controller/0.2.0-2.tar.gz";
+    name = "0.2.0-2.tar.gz";
+    sha256 = "0e034b66239818b2e641e61653fa7b17ce61e191868b0c2e7fe4b84b917ebf9a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cmake-modules cv-bridge eigen geometry-msgs image-transport libGL libGLU pluginlib qt5.qtbase rviz std-msgs view-controller-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A rviz view controller featuring smooth transitions.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/safety-limiter/default.nix
+++ b/distros/noetic/safety-limiter/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, dynamic-reconfigure, eigen, geometry-msgs, nav-msgs, neonavigation-common, pcl, pcl-conversions, pcl-ros, roscpp, roslint, rostest, safety-limiter-msgs, sensor-msgs, std-msgs, tf2-geometry-msgs, tf2-ros, tf2-sensor-msgs, xmlrpcpp }:
 buildRosPackage {
   pname = "ros-noetic-safety-limiter";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "9b1ab4db7f58b5b33c5c011fcfd3fbbcd69889d95182f270b00e097c2dce7bcb";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/safety_limiter/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "69e9cae3f3533f07476b48d74b400e70d4ab5b1d3b371f84c1871ae6cb04afd1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/track-odometry/default.nix
+++ b/distros/noetic/track-odometry/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, message-filters, nav-msgs, neonavigation-common, roscpp, roslint, rostest, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-noetic-track-odometry";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "a57bdbf32c0ef5af08b43ae3e03c134ab75c14c8372b744930693bfc1514ad9a";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/track_odometry/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "12e69a79581bc96e41701b1cef6eb7b84726fffa7ab215adf8046132f64c5b2d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/trajectory-tracker/default.nix
+++ b/distros/noetic/trajectory-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dynamic-reconfigure, eigen, geometry-msgs, interactive-markers, nav-msgs, neonavigation-common, roscpp, roslint, rostest, std-srvs, tf2, tf2-geometry-msgs, tf2-ros, trajectory-tracker-msgs }:
 buildRosPackage {
   pname = "ros-noetic-trajectory-tracker";
-  version = "0.10.11-r1";
+  version = "0.11.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.10.11-1.tar.gz";
-    name = "0.10.11-1.tar.gz";
-    sha256 = "41609700f7cda6a10dabb04a85cf7db215b83f55dc757c611f84da651c4c4eb5";
+    url = "https://github.com/at-wat/neonavigation-release/archive/release/noetic/trajectory_tracker/0.11.0-1.tar.gz";
+    name = "0.11.0-1.tar.gz";
+    sha256 = "e71d0b09f84c560ba0b67c39e82e916af1c0e14354f54c09f6e0e3d9f81a084c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.8-r1";
+  version = "1.14.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.8-1.tar.gz";
-    name = "1.14.8-1.tar.gz";
-    sha256 = "eaf183c11a4feb2dcb79f6320fc443ad08cb395045c2a8ae53dd4c86f3370e8a";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.9-1.tar.gz";
+    name = "1.14.9-1.tar.gz";
+    sha256 = "d25f54c72871d94ad902660bc0c2eeec5fa879f043af7cddd14589b5d7bb1da7";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 6ed3fe9f34a9b44dc306bcc668ea70d0685d86be.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *ament-cmake 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-auto 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-catch2 1.2.0-r1*
* *ament-cmake-core 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-definitions 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-dependencies 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-include-directories 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-interfaces 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-libraries 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-link-flags 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-export-targets 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-gmock 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-google-benchmark 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-gtest 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-include-directories 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-libraries 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-nose 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-pytest 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-python 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-target-dependencies 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-test 0.9.8-r1 --> 0.9.9-r1*
* *ament-cmake-version 0.9.8-r1 --> 0.9.9-r1*
* *asio-cmake-module 1.0.0-r1*
* *aws-robomaker-small-warehouse-world 1.0.1-r1*
* *bosch-locator-bridge 2.0.2-r1 --> 2.0.3-r2*
* *controller-interface 0.7.1-r1 --> 0.8.0-r1*
* *controller-manager 0.7.1-r1 --> 0.8.0-r1*
* *controller-manager-msgs 0.7.1-r1 --> 0.8.0-r1*
* *diff-drive-controller 0.4.1-r1 --> 0.5.0-r1*
* *effort-controllers 0.4.1-r1 --> 0.5.0-r1*
* *examples-tf2-py 0.13.10-r1 --> 0.13.11-r1*
* *fastrtps-cmake-module 1.0.3-r1 --> 1.0.4-r1*
* *force-torque-sensor-broadcaster 0.4.1-r1 --> 0.5.0-r1*
* *forward-command-controller 0.4.1-r1 --> 0.5.0-r1*
* *geometry-tutorials 0.3.2-r1 --> 0.3.3-r1*
* *geometry2 0.13.10-r1 --> 0.13.11-r1*
* *gmock-vendor 1.8.9000-r1 --> 1.8.9001-r1*
* *gripper-controllers 0.4.1-r1 --> 0.5.0-r1*
* *gtest-vendor 1.8.9000-r1 --> 1.8.9001-r1*
* *hardware-interface 0.7.1-r1 --> 0.8.0-r1*
* *ifm3d-core 0.18.0-r4*
* *imu-sensor-broadcaster 0.4.1-r1 --> 0.5.0-r1*
* *io-context 1.0.0-r1*
* *joint-state-broadcaster 0.4.1-r1 --> 0.5.0-r1*
* *joint-state-controller 0.4.1-r1 --> 0.5.0-r1*
* *joint-trajectory-controller 0.4.1-r1 --> 0.5.0-r1*
* *lanelet2-io 1.1.1-r1*
* *launch 0.10.5-r1 --> 0.10.6-r1*
* *launch-ros 0.11.2-r1 --> 0.11.3-r1*
* *launch-testing 0.10.5-r1 --> 0.10.6-r1*
* *launch-testing-ament-cmake 0.10.5-r1 --> 0.10.6-r1*
* *launch-testing-ros 0.11.2-r1 --> 0.11.3-r1*
* *launch-xml 0.10.5-r1 --> 0.10.6-r1*
* *launch-yaml 0.10.5-r1 --> 0.10.6-r1*
* *menge-vendor 1.0.0-r1*
* *micro-ros-msgs 1.0.0-r2*
* *osrf-pycommon 0.1.10-r1 --> 0.1.11-r1*
* *osrf-testing-tools-cpp 1.3.2-r1 --> 1.3.4-r1*
* *plotjuggler 3.2.1-r1 --> 3.3.0-r1*
* *position-controllers 0.4.1-r1 --> 0.5.0-r1*
* *qt-dotgraph 1.1.2-r2 --> 1.1.3-r1*
* *qt-gui 1.1.2-r2 --> 1.1.3-r1*
* *qt-gui-app 1.1.2-r2 --> 1.1.3-r1*
* *qt-gui-core 1.1.2-r2 --> 1.1.3-r1*
* *qt-gui-cpp 1.1.2-r2 --> 1.1.3-r1*
* *qt-gui-py-common 1.1.2-r2 --> 1.1.3-r1*
* *rclcpp 2.3.1-r1 --> 2.4.0-r1*
* *rclcpp-action 2.3.1-r1 --> 2.4.0-r1*
* *rclcpp-components 2.3.1-r1 --> 2.4.0-r1*
* *rclcpp-lifecycle 2.3.1-r1 --> 2.4.0-r1*
* *rclpy 1.0.5-r1 --> 1.0.6-r1*
* *rcpputils 1.3.1-r1 --> 1.3.2-r1*
* *rmf-building-map-msgs 1.2.0-r1*
* *rmf-charger-msgs 1.4.0-r1*
* *rmf-cmake-uncrustify 1.2.0-r1*
* *rmf-dispenser-msgs 1.4.0-r1*
* *rmf-door-msgs 1.4.0-r1*
* *rmf-fleet-msgs 1.4.0-r1*
* *rmf-ingestor-msgs 1.4.0-r1*
* *rmf-lift-msgs 1.4.0-r1*
* *rmf-task-msgs 1.4.0-r1*
* *rmf-traffic-msgs 1.4.0-r1*
* *rmf-visualization-msgs 1.2.0-r1*
* *rmf-workcell-msgs 1.4.0-r1*
* *rmw-cyclonedds-cpp 0.7.6-r1 --> 0.7.7-r1*
* *rmw-fastrtps-cpp 1.2.5-r1 --> 1.2.6-r1*
* *rmw-fastrtps-dynamic-cpp 1.2.5-r1 --> 1.2.6-r1*
* *rmw-fastrtps-shared-cpp 1.2.5-r1 --> 1.2.6-r1*
* *ros2-control 0.7.1-r1 --> 0.8.0-r1*
* *ros2-control-test-assets 0.7.1-r1 --> 0.8.0-r1*
* *ros2-controllers 0.4.1-r1 --> 0.5.0-r1*
* *ros2controlcli 0.7.1-r1 --> 0.8.0-r1*
* *ros2launch 0.11.2-r1 --> 0.11.3-r1*
* *rosidl-typesupport-fastrtps-c 1.0.3-r1 --> 1.0.4-r1*
* *rosidl-typesupport-fastrtps-cpp 1.0.3-r1 --> 1.0.4-r1*
* *rqt 1.1.1-r1 --> 1.1.2-r1*
* *rqt-gui 1.1.1-r1 --> 1.1.2-r1*
* *rqt-gui-cpp 1.1.1-r1 --> 1.1.2-r1*
* *rqt-gui-py 1.1.1-r1 --> 1.1.2-r1*
* *rqt-msg 1.0.4-r1 --> 1.0.5-r1*
* *rqt-plot 1.0.10-r1 --> 1.1.0-r1*
* *rqt-py-common 1.1.1-r1 --> 1.1.2-r1*
* *rqt-py-console 1.0.1-r1 --> 1.0.2-r1*
* *rqt-service-caller 1.0.4-r1 --> 1.0.5-r1*
* *rqt-shell 1.0.1-r1 --> 1.0.2-r1*
* *rqt-srv 1.0.2-r1 --> 1.0.3-r1*
* *rqt-top 1.0.1-r1 --> 1.0.2-r1*
* *rqt-topic 1.2.1-r1 --> 1.2.2-r1*
* *rviz-assimp-vendor 8.2.2-r1 --> 8.2.3-r1*
* *rviz-common 8.2.2-r1 --> 8.2.3-r1*
* *rviz-default-plugins 8.2.2-r1 --> 8.2.3-r1*
* *rviz-ogre-vendor 8.2.2-r1 --> 8.2.3-r1*
* *rviz-rendering 8.2.2-r1 --> 8.2.3-r1*
* *rviz-rendering-tests 8.2.2-r1 --> 8.2.3-r1*
* *rviz-visual-testing-framework 8.2.2-r1 --> 8.2.3-r1*
* *rviz2 8.2.2-r1 --> 8.2.3-r1*
* *serial-driver 0.0.6-r1 --> 1.0.0-r1*
* *simple-launch 1.0.3-r2 --> 1.0.4-r1*
* *stubborn-buddies 1.0.0-r1*
* *stubborn-buddies-msgs 1.0.0-r1*
* *tf2 0.13.10-r1 --> 0.13.11-r1*
* *tf2-bullet 0.13.10-r1 --> 0.13.11-r1*
* *tf2-eigen 0.13.10-r1 --> 0.13.11-r1*
* *tf2-eigen-kdl 0.13.10-r1 --> 0.13.11-r1*
* *tf2-geometry-msgs 0.13.10-r1 --> 0.13.11-r1*
* *tf2-kdl 0.13.10-r1 --> 0.13.11-r1*
* *tf2-msgs 0.13.10-r1 --> 0.13.11-r1*
* *tf2-py 0.13.10-r1 --> 0.13.11-r1*
* *tf2-ros 0.13.10-r1 --> 0.13.11-r1*
* *tf2-sensor-msgs 0.13.10-r1 --> 0.13.11-r1*
* *tf2-tools 0.13.10-r1 --> 0.13.11-r1*
* *transmission-interface 0.7.1-r1 --> 0.8.0-r1*
* *turtle-tf2-cpp 0.3.2-r1 --> 0.3.3-r1*
* *turtle-tf2-py 0.3.2-r1 --> 0.3.3-r1*
* *udp-driver 0.0.6-r1 --> 1.0.0-r1*
* *udp-msgs 0.0.3-r1 --> 0.0.3-r2*
* *velocity-controllers 0.4.1-r1 --> 0.5.0-r1*
* *xacro 2.0.6-r1 --> 2.0.7-r1*

Galactic Changes:
-----------------
* *asio-cmake-module 1.0.1-r1*
* *automotive-autonomy-msgs 3.0.4-r1*
* *automotive-navigation-msgs 3.0.4-r1*
* *automotive-platform-msgs 3.0.4-r1*
* *geometry-tutorials 0.3.2-r1 --> 0.3.3-r1*
* *ifm3d-core 0.18.0-r6*
* *io-context 1.0.1-r1*
* *lanelet2-io 1.1.1-r2*
* *micro-ros-msgs 1.0.0-r1*
* *plotjuggler 3.2.1-r2 --> 3.3.0-r1*
* *rmf-battery 0.1.0-r1 --> 0.1.1-r1*
* *rmf-building-map-msgs 1.2.0-r1 --> 1.2.0-r2*
* *rmf-building-map-tools 1.3.0-r1 --> 1.4.0-r1*
* *rmf-charger-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-cmake-uncrustify 1.2.0-r1 --> 1.2.0-r2*
* *rmf-dispenser-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-door-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-fleet-adapter 1.3.0-r1*
* *rmf-fleet-adapter-python 1.3.0-r1*
* *rmf-fleet-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-ingestor-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-lift-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-task 1.0.0-r1*
* *rmf-task-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-task-ros2 1.3.0-r1*
* *rmf-traffic 1.3.0-r1 --> 1.4.0-r1*
* *rmf-traffic-editor 1.3.0-r1 --> 1.4.0-r1*
* *rmf-traffic-editor-assets 1.3.0-r1 --> 1.4.0-r1*
* *rmf-traffic-editor-test-maps 1.3.0-r1 --> 1.4.0-r1*
* *rmf-traffic-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rmf-traffic-ros2 1.3.0-r1*
* *rmf-workcell-msgs 1.3.0-r1 --> 1.4.0-r1*
* *rqt 1.1.1-r2 --> 1.1.2-r1*
* *rqt-gui 1.1.1-r2 --> 1.1.2-r1*
* *rqt-gui-cpp 1.1.1-r2 --> 1.1.2-r1*
* *rqt-gui-py 1.1.1-r2 --> 1.1.2-r1*
* *rqt-msg 1.0.4-r1 --> 1.0.5-r1*
* *rqt-plot 1.0.10-r1 --> 1.1.0-r1*
* *rqt-py-common 1.1.1-r2 --> 1.1.2-r1*
* *rqt-py-console 1.0.1-r1 --> 1.0.2-r1*
* *rqt-service-caller 1.0.4-r1 --> 1.0.5-r1*
* *rqt-shell 1.0.1-r1 --> 1.0.2-r1*
* *rqt-srv 1.0.2-r1 --> 1.0.3-r1*
* *rqt-top 1.0.1-r1 --> 1.0.2-r1*
* *rqt-topic 1.2.1-r2 --> 1.2.2-r1*
* *serial-driver 0.0.6-r2 --> 1.0.1-r1*
* *smacc2 0.1.0-r1*
* *smacc2-msgs 0.1.0-r1*
* *turtle-tf2-cpp 0.3.2-r1 --> 0.3.3-r1*
* *turtle-tf2-py 0.3.2-r1 --> 0.3.3-r1*
* *udp-driver 0.0.6-r2 --> 1.0.1-r1*
* *xacro 2.0.6-r1 --> 2.0.7-r1*

Melodic Changes:
----------------
* *audio-capture 0.3.11-r1 --> 0.3.12-r1*
* *audio-common 0.3.11-r1 --> 0.3.12-r1*
* *audio-common-msgs 0.3.11-r1 --> 0.3.12-r1*
* *audio-play 0.3.11-r1 --> 0.3.12-r1*
* *costmap-cspace 0.10.11-r1 --> 0.11.0-r1*
* *eigenpy 2.6.7-r2 --> 2.6.8-r1*
* *franka-control 0.8.0-r1 --> 0.8.1-r2*
* *franka-description 0.8.0-r1 --> 0.8.1-r2*
* *franka-example-controllers 0.8.0-r1 --> 0.8.1-r2*
* *franka-gazebo 0.8.0-r1 --> 0.8.1-r2*
* *franka-gripper 0.8.0-r1 --> 0.8.1-r2*
* *franka-hw 0.8.0-r1 --> 0.8.1-r2*
* *franka-msgs 0.8.0-r1 --> 0.8.1-r2*
* *franka-ros 0.8.0-r1 --> 0.8.1-r2*
* *franka-visualization 0.8.0-r1 --> 0.8.1-r2*
* *ifm3d-core 0.18.0-r1*
* *joystick-interrupt 0.10.11-r1 --> 0.11.0-r1*
* *lanelet2-io 1.0.1-r1*
* *map-organizer 0.10.11-r1 --> 0.11.0-r1*
* *multi-object-tracking-lidar 1.0.2-r1 --> 1.0.4-r2*
* *neonavigation 0.10.11-r1 --> 0.11.0-r1*
* *neonavigation-common 0.10.11-r1 --> 0.11.0-r1*
* *neonavigation-launch 0.10.11-r1 --> 0.11.0-r1*
* *obj-to-pointcloud 0.10.11-r1 --> 0.11.0-r1*
* *planner-cspace 0.10.11-r1 --> 0.11.0-r1*
* *plotjuggler 3.2.1-r1 --> 3.3.0-r1*
* *qb-chain 2.0.0 --> 2.2.2-r1*
* *qb-chain-control 2.0.0 --> 2.2.2-r1*
* *qb-chain-controllers 2.2.2-r1*
* *qb-chain-description 2.0.0 --> 2.2.2-r1*
* *qb-chain-msgs 2.2.2-r1*
* *qb-device 2.0.1 --> 2.2.1-r3*
* *qb-device-bringup 2.0.1 --> 2.2.1-r3*
* *qb-device-control 2.0.1 --> 2.2.1-r3*
* *qb-device-description 2.0.1 --> 2.2.1-r3*
* *qb-device-driver 2.0.1 --> 2.2.1-r3*
* *qb-device-gazebo 2.2.1-r3*
* *qb-device-hardware-interface 2.0.1 --> 2.2.1-r3*
* *qb-device-msgs 2.0.1 --> 2.2.1-r3*
* *qb-device-srvs 2.0.1 --> 2.2.1-r3*
* *qb-device-utils 2.0.1 --> 2.2.1-r3*
* *qb-hand 2.0.0-r1 --> 2.2.2-r1*
* *qb-hand-control 2.0.0-r1 --> 2.2.2-r1*
* *qb-hand-description 2.0.0-r1 --> 2.2.2-r1*
* *qb-hand-gazebo 2.2.2-r1*
* *qb-hand-hardware-interface 2.0.0-r1 --> 2.2.2-r1*
* *qb-move 2.0.0-r1 --> 2.2.1-r1*
* *qb-move-control 2.0.0-r1 --> 2.2.1-r1*
* *qb-move-description 2.0.0-r1 --> 2.2.1-r1*
* *qb-move-gazebo 2.2.1-r1*
* *qb-move-hardware-interface 2.0.0-r1 --> 2.2.1-r1*
* *rospy-message-converter 0.5.6-r1 --> 0.5.7-r1*
* *rviz-animated-view-controller 0.2.0-r2*
* *safety-limiter 0.10.11-r1 --> 0.11.0-r1*
* *sbg-driver 2.0.2-r1 --> 3.0.0-r1*
* *track-odometry 0.10.11-r1 --> 0.11.0-r1*
* *trajectory-tracker 0.10.11-r1 --> 0.11.0-r1*
* *xacro 1.13.12-r1 --> 1.13.13-r2*

Noetic Changes:
---------------
* *audio-capture 0.3.11-r1 --> 0.3.12-r1*
* *audio-common 0.3.11-r1 --> 0.3.12-r1*
* *audio-common-msgs 0.3.11-r1 --> 0.3.12-r1*
* *audio-play 0.3.11-r1 --> 0.3.12-r1*
* *bosch-locator-bridge 1.0.2-r1 --> 1.0.3-r1*
* *costmap-cspace 0.10.11-r1 --> 0.11.0-r1*
* *eigenpy 2.6.7-r1 --> 2.6.8-r1*
* *franka-control 0.8.0-r1 --> 0.8.1-r1*
* *franka-description 0.8.0-r1 --> 0.8.1-r1*
* *franka-example-controllers 0.8.0-r1 --> 0.8.1-r1*
* *franka-gazebo 0.8.0-r1 --> 0.8.1-r1*
* *franka-gripper 0.8.0-r1 --> 0.8.1-r1*
* *franka-hw 0.8.0-r1 --> 0.8.1-r1*
* *franka-msgs 0.8.0-r1 --> 0.8.1-r1*
* *franka-ros 0.8.0-r1 --> 0.8.1-r1*
* *franka-visualization 0.8.0-r1 --> 0.8.1-r1*
* *ifm3d-core 0.18.0-r5*
* *joystick-interrupt 0.10.11-r1 --> 0.11.0-r1*
* *lanelet2-io 1.1.1-r1*
* *map-organizer 0.10.11-r1 --> 0.11.0-r1*
* *microstrain-inertial-driver 2.0.3-r1*
* *microstrain-inertial-examples 2.0.3-r1*
* *microstrain-inertial-msgs 2.0.3-r1*
* *mqtt-bridge 0.2.1-r1*
* *multi-object-tracking-lidar 1.0.3-r1 --> 1.0.4-r1*
* *neonavigation 0.10.11-r1 --> 0.11.0-r1*
* *neonavigation-common 0.10.11-r1 --> 0.11.0-r1*
* *neonavigation-launch 0.10.11-r1 --> 0.11.0-r1*
* *obj-to-pointcloud 0.10.11-r1 --> 0.11.0-r1*
* *planner-cspace 0.10.11-r1 --> 0.11.0-r1*
* *plotjuggler 3.2.1-r1 --> 3.3.0-r1*
* *qb-move 2.2.1-r1*
* *qb-move-control 2.2.1-r1*
* *qb-move-description 2.2.1-r1*
* *rm-base 0.1.1-r5*
* *rm-calibration-controllers 0.1.1-r1*
* *rm-chassis-controllers 0.1.1-r1*
* *rm-common 0.1.1-r5*
* *rm-control 0.1.1-r5*
* *rm-description 0.1.1-r5*
* *rm-gazebo 0.1.1-r5*
* *rm-gimbal-controllers 0.1.1-r1*
* *rm-msgs 0.1.1-r5*
* *rm-shooter-controllers 0.1.1-r1*
* *robot-state-controller 0.1.1-r1*
* *rospy-message-converter 0.5.6-r1 --> 0.5.7-r1*
* *rviz-animated-view-controller 0.2.0-r2*
* *safety-limiter 0.10.11-r1 --> 0.11.0-r1*
* *track-odometry 0.10.11-r1 --> 0.11.0-r1*
* *trajectory-tracker 0.10.11-r1 --> 0.11.0-r1*
* *xacro 1.14.8-r1 --> 1.14.9-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] avr-libc
 * [ ] benchmark
 * [ ] bullet-extras
 * [ ] catkin
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] curlpp-dev
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libspnav-dev
 * [ ] libuvc-dev
 * [ ] libvulkan-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-cairosvg
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-cherrypy3
 * [ ] python3-collada
 * [ ] python3-github
 * [ ] python3-ifcfg
 * [ ] python3-joblib
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-pyqt5.qtwebengine
 * [ ] python3-qt5-bindings-webkit
 * [ ] python3-requests-oauthlib
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] qttools5-dev-tools
 * [ ] roseus
 * [ ] rospy
 * [ ] rviz
 * [ ] wiimote

