### PR TITLE
Add output, notification, parallel plugins for colcon.

### DIFF
--- a/pkgs/colcon/notification.nix
+++ b/pkgs/colcon/notification.nix
@@ -1,0 +1,22 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, colcon-core, notify2 }:
+
+buildPythonPackage rec {
+  pname = "colcon-notification";
+  version = "0.2.13";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-aq4f/nOulWvLNuMwgizSMKKojJGBsxcKr9GkRmOOabM=";
+  };
+
+  propagatedBuildInputs = [ colcon-core notify2 ];
+
+  doCheck = false;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to provide status notifications.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/colcon/output.nix
+++ b/pkgs/colcon/output.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-output";
+  version = "0.2.12";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-ohHp8fcO2xVnwHR1Mq0iLkd5nO8ly4Y+SkOvRmB5izA=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  doCheck = false;
+
+  disabled = isPy27;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to customize the output in various ways.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/colcon/parallel-executor.nix
+++ b/pkgs/colcon/parallel-executor.nix
@@ -1,0 +1,24 @@
+{ lib, buildPythonPackage, fetchPypi, isPy27, colcon-core }:
+
+buildPythonPackage rec {
+  pname = "colcon-parallel-executor";
+  version = "0.2.4";
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-bATsJAzgpra65psT2IWeoerANGlCT6IgvkOpnn0dMSM=";
+  };
+
+  propagatedBuildInputs = [ colcon-core ];
+
+  doCheck = false;
+
+  disabled = isPy27;
+
+  meta = with lib; {
+    description = "An extension for colcon-core to process packages in parallel.";
+    homepage = "https://colcon.readthedocs.io";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ lopsided98 ];
+  };
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -19,7 +19,13 @@ self: super: with self.lib; let
 
       colcon-metadata = pySelf.callPackage ./colcon/metadata.nix { };
 
+      colcon-notification = pySelf.callPackage ./colcon/notification.nix { };
+
+      colcon-output = pySelf.callPackage ./colcon/output.nix { };
+
       colcon-package-selection = pySelf.callPackage ./colcon/package-selection.nix { };
+
+      colcon-parallel-executor = pySelf.callPackage ./colcon/parallel-executor.nix { };
 
       colcon-pkg-config = pySelf.callPackage ./colcon/pkg-config.nix { };
 


### PR DESCRIPTION
These are needed for QoL when building multi-package workspaces with colcon in a developer context. I've handled the two use-cases separately— defining `colcon` for interactive use, with these plugins included, and then a separate, much more stripped down `colconMinimal` to be used with derivations.

Not sure if you have much in the way of tooling to monitor these kinds of packages for new versions or whatever else, but I've been pleased with what https://github.com/nix-community/pip2nix has been able to generate based just on `requirements.txt` files. The resulting derivations are not publication-quality (missing all metadata, for example), but possibly that's worth it in some of these cases.