### PR TITLE
rosdistro sync, Fri Oct  1 13:26:14 2021

### DIFF
--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -1372,6 +1372,8 @@ self: super: {
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
+ rqt-runtime-monitor = self.callPackage ./rqt-runtime-monitor {};
+
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
 
  rqt-shell = self.callPackage ./rqt-shell {};

--- a/distros/foxy/rqt-runtime-monitor/default.nix
+++ b/distros/foxy/rqt-runtime-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, diagnostic-msgs, python-qt-binding, python3Packages, pythonPackages, qt-gui, rclpy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-foxy-rqt-runtime-monitor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_runtime_monitor-release/archive/release/foxy/rqt_runtime_monitor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dcc8128caebc7c57f725c94691de328ebcb37085a739cb610e2d8135c43ef4c1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py ];
+
+  meta = {
+    description = ''rqt_runtime_monitor provides a GUI plugin viewing DiagnosticsArray messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, launch, launch-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "b757efbbf85defdce94211a9c275a6db614ab2f605556559b911f81d52381982";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7ea89fc795caffc229159afefb4ec51e08a0cb3f09dd83c91a7c2cdfa441dab7";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ launch launch-ros xacro ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros xacro ];
 
   meta = {
     description = ''Python helper class for the ROS 2 launch system'';

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-controller-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3a421d48b8f4b22a954974fde7bd26412f1cbc2a87ad1375448b47521e656bf4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-controller-manager-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b236a584cd2585b3113f86ce657983b9e20bb89522b7e0dcd7c51de008ff09f9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages and services for the controller manager.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
+buildRosPackage {
+  pname = "ros-galactic-controller-manager";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3eaf8a278b08cc982ea42b14a66adcacd02c4735497d3bf0245012a55d6d9dae";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_manager'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -204,6 +204,12 @@ self: super: {
 
  control-toolbox = self.callPackage ./control-toolbox {};
 
+ controller-interface = self.callPackage ./controller-interface {};
+
+ controller-manager = self.callPackage ./controller-manager {};
+
+ controller-manager-msgs = self.callPackage ./controller-manager-msgs {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cv-bridge = self.callPackage ./cv-bridge {};
@@ -361,6 +367,8 @@ self: super: {
  grbl-ros = self.callPackage ./grbl-ros {};
 
  gtest-vendor = self.callPackage ./gtest-vendor {};
+
+ hardware-interface = self.callPackage ./hardware-interface {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
@@ -946,6 +954,10 @@ self: super: {
 
  ros1-rosbag-storage-vendor = self.callPackage ./ros1-rosbag-storage-vendor {};
 
+ ros2-control = self.callPackage ./ros2-control {};
+
+ ros2-control-test-assets = self.callPackage ./ros2-control-test-assets {};
+
  ros2-ouster = self.callPackage ./ros2-ouster {};
 
  ros2-socketcan = self.callPackage ./ros2-socketcan {};
@@ -961,6 +973,8 @@ self: super: {
  ros2cli-test-interfaces = self.callPackage ./ros2cli-test-interfaces {};
 
  ros2component = self.callPackage ./ros2component {};
+
+ ros2controlcli = self.callPackage ./ros2controlcli {};
 
  ros2interface = self.callPackage ./ros2interface {};
 
@@ -1133,6 +1147,8 @@ self: super: {
  rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
+
+ rqt-runtime-monitor = self.callPackage ./rqt-runtime-monitor {};
 
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
 
@@ -1327,6 +1343,8 @@ self: super: {
  tracetools-test = self.callPackage ./tracetools-test {};
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
+
+ transmission-interface = self.callPackage ./transmission-interface {};
 
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometric-shapes";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "b9e0b3411f625d8136db04625f7fae1a45311f1f8e6c3072653dc1d0428889f9";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e7e2b87af7bd3a814701e20285053b142a8cfa91ac1c5393d5b0978c6b46346f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+buildRosPackage {
+  pname = "ros-galactic-hardware-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "79d2ca211a8e342d249811b661fb05bf3c134cd522f4d6027261ffdcfca56b0b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 ros_control hardware interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-msgs/default.nix
+++ b/distros/galactic/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "37ce402737f464583838204fbde1831bdee9fcaa0f8aa337ba02e800cff3e847";
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "cc8f2c74459e4702fa373e12a463b98b58260170cd1fae1c868299c9d1abbe7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
+buildRosPackage {
+  pname = "ros-galactic-ros2-control-test-assets";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "67ba677e3968233f97eb5052343ab1be1cbeed746e8f84e853193458e63b6ac0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The package provides shared test resources for ros2_control stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
+buildRosPackage {
+  pname = "ros-galactic-ros2-control";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3d3c38c005eadf8974b215713e48662a94fee45dc5c6f082a5907b2bea880253";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface ros2-control-test-assets ros2controlcli transmission-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for ROS2 control related packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-galactic-ros2controlcli";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "89ca90181d5776b2e6d9403db3ef6b97b2c2189ea3314cfbbb57840d6c7d3f1f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs rclpy ros2cli ros2node ros2param rosidl-runtime-py ];
+
+  meta = {
+    description = ''The ROS 2 command line tools for ROS2 Control.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-runtime-monitor/default.nix
+++ b/distros/galactic/rqt-runtime-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, diagnostic-msgs, python-qt-binding, python3Packages, pythonPackages, qt-gui, rclpy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-runtime-monitor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_runtime_monitor-release/archive/release/galactic/rqt_runtime_monitor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ca117541656a782e067af881de1cf72d9fd26f5786edfafc775aa849a8827c23";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py ];
+
+  meta = {
+    description = ''rqt_runtime_monitor provides a GUI plugin viewing DiagnosticsArray messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/srdfdom/default.nix
+++ b/distros/galactic/srdfdom/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-galactic-srdfdom";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "85093ec96f860df084a864588c8be49480f8f05ac6ed74e93725b92ad366f518";
+    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d26208cbfe91d59104d357d18e53a55275f31d8208684688b22a271066334dcb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ boost urdfdom-headers ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ console-bridge console-bridge-vendor tinyxml2-vendor urdf urdfdom-py ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''Parser for Semantic Robot Description Format (SRDF).'';

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
+buildRosPackage {
+  pname = "ros-galactic-transmission-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "62e47e87cc2572c014b9efe62252c31434a21a6b6c46472a0f30a5574e0e02a0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''transmission_interface contains data structures for representing mechanical transmissions, methods for propagating values between actuator and joint spaces and tooling to support this.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/warehouse-ros/default.nix
+++ b/distros/galactic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-warehouse-ros";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "5de10f5f42f9a055c0775b226714bd629f9b0b7fcf682a1cb89ce12735217331";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "c559cc10d1bdb1fbce7222f80c65e042fdc094661fa9a876c2e0669fde8140b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/dbw-fca-can/default.nix
+++ b/distros/melodic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-can";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ed6706a6ee497bece0f61267f7ef7b21e216ad3c79cf6fcf037c9783f0884307";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3a8843dad523a2d1a5a66847cceb20ef391488ea8ad11a38eacad7bb6da60c74";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-description/default.nix
+++ b/distros/melodic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-description";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "26d7b4037bfa82e49fdff61e2c4efc6f5bfda7c99c40a6081ec15476e5c9e9fa";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3dd6e9e7b55f80be647d0ceed0f1029325fa4d6c2635dd3ef97f37c2a1cdea17";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-joystick-demo/default.nix
+++ b/distros/melodic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-joystick-demo";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "accb8db15f7f579109ea55c57ab25d7a61c40f975980397a8fa72d032047ebd4";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "63a655231fbec314ce818e51cfff0dce44cba0b411a83229b5934ad2a7aaf01f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-msgs/default.nix
+++ b/distros/melodic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "57979b8ef2a270bbd58de137e157bc951249abba8f6b6d56bb5fa1fb603b2518";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "da0eac4d4147c2e8668ee0c6943d4f70b027f9df5cc740337a90d07de0ea93cb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca/default.nix
+++ b/distros/melodic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "449771786211501c849d229b2ea64bebb3219f2ff1a9a4924b6dda1d8b00dab2";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "d0904de7804faee0500c0a375cd2e2822f5ed33c6ffcbfc6e68fda54dac514b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-can/default.nix
+++ b/distros/melodic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-can";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f9739687c666069c032dea89eab27ce849b88cc315712834dbc445a69f9447a7";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "5da58e3e59545bcda58119cf7a6590a5e9425f970a7e5e2e43a68379f367c205";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-description/default.nix
+++ b/distros/melodic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-description";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2f02629bf7cc37a406d0846918612ba39d5004cae81b91fb84340ad8bcd8803b";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "4c7175c49a87299aa59caa561d605d5fa56b09560b4a70924ffb064ec42edc9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/melodic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-joystick-demo";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ceeabf98e13b09d6de9538306fd2dfe2e8e2151f9c93683e689b670fb3d00225";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "4bc1ebf988877821847913b3fc162a7755ba1618b4d2646d9431898b4068df50";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-msgs/default.nix
+++ b/distros/melodic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ffb51c05bdc7b0586d648180a02e581ee49d2739eb484845237771543323352f";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "232b96cb74523937f73a80822367a773673a1bef0d568c17fe94c3e0e805ba06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz/default.nix
+++ b/distros/melodic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "5dd8e343968cc64156151c36c2f52a2055217296347bac4a24eefaf2b5d3fd53";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "99fc02c3b49c9072a2f0517e813d40bce4c484d2d60ae096980ccf8b20ea0aa8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-can/default.nix
+++ b/distros/melodic/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-can";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4d4009f6fe4aea380079f99ba438064f808d3b8232244df76139517e90c898c";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7c97c5a3b70b9a45017215ed05823972a4e6100279043b1a125b729c156acb46";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-description/default.nix
+++ b/distros/melodic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-description";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "af3c10674ef2b53c465d213369595fc02994e948f3a63458c569de51a3452367";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "67effacbd8a9fe192fcd35079704442844f221526df1aacabd9997897f098ff8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/melodic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-joystick-demo";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2eb169222ae90f560f008eaedf494180fd381d5ba679de180266e43b9b159f49";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d6d450ef6ae5f4f419ed6dd618b3c5d0def611d081a0b49188b1e5dc7f11a794";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-msgs/default.nix
+++ b/distros/melodic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "396cc140856577e2e6fed099a808d059205350d441339f44bafa18d4a3844586";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2f0503e4de1855927ac0ad0c414346fa729eb68dbfaf41d25b264a01ce2ff457";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris/default.nix
+++ b/distros/melodic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4c19322c344787cab8c3893fa7e526e01eb455ad3c8f59422078d8abf78c34e";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bb7a84d6e0e1a97c2dc3cbcb0f2e2ed11d2293c897452763938ae7a1d4818d4c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -1548,6 +1548,8 @@ self: super: {
 
  industrial-utils = self.callPackage ./industrial-utils {};
 
+ inorbit-republisher = self.callPackage ./inorbit-republisher {};
+
  interactive-marker-proxy = self.callPackage ./interactive-marker-proxy {};
 
  interactive-marker-tutorials = self.callPackage ./interactive-marker-tutorials {};

--- a/distros/melodic/inorbit-republisher/default.nix
+++ b/distros/melodic/inorbit-republisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-inorbit-republisher";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3cb5d5fc327542c8fece9309e5c6a91d0656bcfc5a917d1cb23c884d363b6d11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.pyyaml roslib rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS to InOrbit topic republisher'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/leo-bringup/default.nix
+++ b/distros/melodic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-melodic-leo-bringup";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "514b122fc75f96603bc2815f4119ccd879bb1e88c6872390232792f09a29f505";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "9f4c8a488f3d7ad25d0e3591c082f868c96b80c0b8d0f6ee7b97c537138bbcbb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-fw/default.nix
+++ b/distros/melodic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-leo-fw";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "42c12033819e86cda2a5050f76d739ec7fdcc17e9d6de5e545c275bffc7ede41";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "e4c46151e1c7234f2888dc20a2bb0b9014931264e0bb1fcea3a89e8505bc1049";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-robot/default.nix
+++ b/distros/melodic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-melodic-leo-robot";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2938d90306d1433d772c494bb527f88b02d654f41e482d0d3743471fdea326e5";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ff74d389667659898cd61e0a039ca5d3c510ba3c43bb3ce28d443dfd908f2795";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-can-msgs/default.nix
+++ b/distros/melodic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-can-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "1be95a543e72a45295379a47b783c65880bcbe9246b03d1213c1344904492186";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f68e8194a14c01ac2fedd55efb803f78a27c1c7d7fc966910c94dc6bac13d95e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-common-msgs/default.nix
+++ b/distros/melodic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-common-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "0f4ea5d731118ba3a4e6cfbd2ffcc767d3b5859f5c04f5e6223dbc439a2f5540";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f02b5cc31a17570231e8e10b2d55c5791ed8cbed8510cd40347d6ecc06f25316";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-dbw-msgs/default.nix
+++ b/distros/melodic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-dbw-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "20487e82ca16abb4fe5d854860aff1f68533ace6bf57664e84f0252b02e6d6d6";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "c220e3f20ba487235ee2bd09d847bc936592ed2bcc596ffbe146d16943122035";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-nav-msgs/default.nix
+++ b/distros/melodic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-nav-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "463a70a959ac961c1a95e1c89288a8c8cc68413a42e740fa122cc2f79e2c2793";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "e02bad17b082c27c390410be00958fbe30e9d861af6678b0c0eec56ff317522b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-perception-msgs/default.nix
+++ b/distros/melodic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-perception-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "a1ce04d43b2f67e595ee8af7d02ed4ac4c56c4f491e186ff95669a39f19634ef";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "a460597ba5de6f799b64e95f158a367a4e16bc032150cb7b0627caa6ef50000a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-sensor-msgs/default.nix
+++ b/distros/melodic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-sensor-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "3017eb3324444f38714aae48f986ab73734b5ea75e50cd50d90ecd7d70857e2e";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f67e116de61763b26fba3c3971f443cf89efa11812303b06d6c303ef688ed9e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-status-msgs/default.nix
+++ b/distros/melodic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-status-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "689c8cf6cd5a54fd8ecf3f2780b1ef1ed99ce9fe240ca79ea5d97ab2c74d8583";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "56c8dd1217e86e01705211990c154d90d3a94095ff0b42439d7934673567fcd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-visualization-msgs/default.nix
+++ b/distros/melodic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-visualization-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "160b50a1c64d4b72e9afc643a6458e7f10123ec3a70e4e950f0e90c394c03ebb";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "10db790551687d6618942216d11f049cf36281c3951153b98b5c4ba1ecdd87cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.20.9-r2";
+  version = "0.20.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.9-2.tar.gz";
-    name = "0.20.9-2.tar.gz";
-    sha256 = "07b6323ad08f6144ec2fda544479893306e574662581ccf64a51814d9d2ca9db";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.14-1.tar.gz";
+    name = "0.20.14-1.tar.gz";
+    sha256 = "d9d882c91b301c548931162eac1fc0c10ad01ccbd3296fca5fa9b09a2e8f2220";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ apriltag-ros class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros theora-image-transport visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.19-r1";
+  version = "1.13.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.19-1.tar.gz";
-    name = "1.13.19-1.tar.gz";
-    sha256 = "a65767d5f5329ad27ce497b0a018378f5fedf2382b846a5faf9c773a6efcede6";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.20-1.tar.gz";
+    name = "1.13.20-1.tar.gz";
+    sha256 = "5ae39f7f2e81ba2d5b23f00c8b26a599d4a8b294e9cbee7dfbd7ac9a11e29e0d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-can";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "255a3a8e3b4badee3e3c6fd811271da49f6d5c80038dbc2cb8ec24dbcfbabb77";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "35e3b5abf42cd4147ae857854629d5b7be74100cdc96bde40b018e9c6d6c582e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-description";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "50e0e1324da794fea40df40c29bc5906cce9b810d192b28aa36f0a8228d35097";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "e95759232986a3323cca750a6819e49b8dc223e4ca260b4327fea65cb27aeeb0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-joystick-demo";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "19709b0b133dfa8ad5b129f3df179db18270df2ca595f0402981fc106ee71b08";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "b50971422ca4df0976ce3292eea9d7edd8d7db4b4b0edd22907093c175a7673e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "bef0f78b9e56648eccb2902a0e8e32c6188250cea725629bedbeda8edc231754";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3a4fc663d87c3246a14727f243ee6666580a33b387de2d07fd3e0f46d7ddd901";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d58a31fdc7345fe6dfc5906b2143444a9214b8532fa86a8d7a57d1e310459fa4";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "1b080248abc6b54857d218774790c0617217cf3654499842616060435677d21c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-can";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "c5ce21b3888b71a5f90e714a3c2a4d1b506d37b3efce41581f6ebacd441c66a7";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "9cf430f81fe3c49cd1027c7638f94b52c3f68d2d96434b94b23ed5c30fd69786";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-description";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "7ab02ae3997621fd53c3693f9851bd6fbcdf047b98d5c20eaba770394f5d1612";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "d991ee4c29949a3aa20cdb07ca19a3dab32721a6296d4791a422e7f9f4bddafa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-joystick-demo";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "37d09beac34caa8b645f7571f0a02a4073fe02b9b6eb96c7f162c0891df045dd";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "291e594ab93cfcc6336001c6d104e586b7bfbf3aa797e0608170ca3fd0dd683c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "72a164dbaec7c221713652023322491fdd8d464c73304a3b3d50537002b17cbf";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "0e4ec5522ffec1e64ae047f07440475904d410aeac5a08b9f14b7cda68cdbda2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ed47697b9e2e238a916afc22a724c6ad7038dd324e0e5b0b8708602b16b72a35";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "fc65c579bfe0aedec995127a4098202a9f28da6bcc4aed3d00892a9edcb1e698";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-can/default.nix
+++ b/distros/noetic/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-can";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2515778c68b8f9cb2153e1f886b0d6d5c7b97355ac0acafadab0bcaea7aa53ee";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4622a58474d705636d1bf6bd68eab77d2e65ba78de2d7483fa510f44f3d15e70";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-description/default.nix
+++ b/distros/noetic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-description";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9b770811e84e71eae953cb787c745152ad47dd1331ac9e1f36d0b487cedd1a02";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "69fce680c38a639172e89ef8b2cab5ae8e557a95bb33af68b6a8713398e90b59";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/noetic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-joystick-demo";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "dc192c68eebdf67f243944fe805cd7c25939db8b02037513169455b69f718bcd";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8c9ea3b4d2a371df6ccacf4429555869b02d014e88f85f60fc5ff2dff255ca8d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-msgs/default.nix
+++ b/distros/noetic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f964d212b38b5048afe2e312c421e0ef943c9d41e0397431abeff21a73d3724b";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "11baff27365fc74f0e6405218ab40d6fc79ea30d02db1463688bea2bce19af5b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris/default.nix
+++ b/distros/noetic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0f40796df33956ed30974ccf12340a223fe2b06cfd2c2bca2ab7495e123e163b";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "37c5b018b3ef96923d34d4ed6088a0910792bea90d4e295f4bc9059d9fe6a27a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -1318,11 +1318,17 @@ self: super: {
 
  leo = self.callPackage ./leo {};
 
+ leo-bringup = self.callPackage ./leo-bringup {};
+
  leo-description = self.callPackage ./leo-description {};
 
  leo-desktop = self.callPackage ./leo-desktop {};
 
+ leo-fw = self.callPackage ./leo-fw {};
+
  leo-gazebo = self.callPackage ./leo-gazebo {};
+
+ leo-robot = self.callPackage ./leo-robot {};
 
  leo-simulator = self.callPackage ./leo-simulator {};
 
@@ -1537,6 +1543,8 @@ self: super: {
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-opw-kinematics-plugin = self.callPackage ./moveit-opw-kinematics-plugin {};
 
  moveit-planners = self.callPackage ./moveit-planners {};
 
@@ -1801,6 +1809,8 @@ self: super: {
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
 
  phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
+
+ phidgets-analog-outputs = self.callPackage ./phidgets-analog-outputs {};
 
  phidgets-api = self.callPackage ./phidgets-api {};
 
@@ -2126,8 +2136,6 @@ self: super: {
 
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
- rm-base = self.callPackage ./rm-base {};
-
  rm-calibration-controllers = self.callPackage ./rm-calibration-controllers {};
 
  rm-chassis-controllers = self.callPackage ./rm-chassis-controllers {};
@@ -2138,11 +2146,15 @@ self: super: {
 
  rm-controllers = self.callPackage ./rm-controllers {};
 
+ rm-dbus = self.callPackage ./rm-dbus {};
+
  rm-description = self.callPackage ./rm-description {};
 
  rm-gazebo = self.callPackage ./rm-gazebo {};
 
  rm-gimbal-controllers = self.callPackage ./rm-gimbal-controllers {};
+
+ rm-hw = self.callPackage ./rm-hw {};
 
  rm-msgs = self.callPackage ./rm-msgs {};
 

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-leo-bringup";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "439d51236941302eb886b10982e8155d712caffe832b0fe1efda5eac21fcbb56";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs leo-description robot-state-publisher rosbridge-server rosserial-python sensor-msgs web-video-server xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Scripts and launch files for starting basic Leo Rover functionalities.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-leo-fw";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ea6d85b60e0fc3cba87c02afb908effaac46f6fe1353744a6e670b27e56eaacd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.rospkg python3Packages.whichcraft rosgraph rosmon-msgs rosnode rospy rosservice std-srvs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Firmware binary releases and update script for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
+buildRosPackage {
+  pname = "ros-noetic-leo-robot";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3bb65090341100981479eb4f998afb8980f87f3455ff8e91e255e9d1f3173da4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ leo leo-bringup leo-fw ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage of software to install on Leo Rover.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "13448a827747b404a950c49df14ba9adec5d38b60d62dde4e3add13f337d213a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "22c5f108d6be26bdc8dc34c00b8f459a6e3cf4709276817b57b00e6252bb306c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-opw-kinematics-plugin/default.nix
+++ b/distros/noetic/moveit-opw-kinematics-plugin/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, moveit-resources-fanuc-moveit-config, moveit-ros-planning, opw-kinematics, pluginlib, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-opw-kinematics-plugin";
+  version = "0.3.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release/archive/release/noetic/moveit_opw_kinematics_plugin/0.3.1-2.tar.gz";
+    name = "0.3.1-2.tar.gz";
+    sha256 = "c1222455493b3d0d601d777ea264e4ef6b5f9ee6b3c6ad330eb2fa871ae54fbf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions opw-kinematics ];
+  checkInputs = [ moveit-resources-fanuc-moveit-config moveit-ros-planning rostest ];
+  propagatedBuildInputs = [ moveit-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+      MoveIt kinematics plugin for industrial robots.
+    </p>
+    <p>
+      This plugin uses an analytical inverse kinematic library, opw_kinematics,
+      to calculate the inverse kinematics for industrial robots with 6 degrees of freedom,
+      two parallel joints, and a spherical wrist.
+    </p>'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "9973c4e460483bea8ab2fe76f976fb9faf9708ee05d42ed408877d507c85889b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "0f39ce926508512bcdfbb4bc5c3bb85bdae880926080b5e5e9e7cf7f00ce7233";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7dcd2bc2cd5afced604837687f56a436fc3ddd1195402ee25721773bf42d14dc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "493a5e7f5174e4db0b9065f656cdc41558e5b3b37166791136a2c3bf9ada628a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-analog-outputs";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "11fdb823ce48393ccd28ecf1eb3cc1dd8040bea571f39b0d87b5f269290aad92";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Analog Output devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "82c3c565bca2961eadb2acc1d543bd1a8369579859ee668016f9edda4a3cc5bc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "875c61236a2d3d493d14ff125851c160c24f42deafcb02dc626304c04ae9499e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "92813a56daf204152b99a1d41b67093ccda583ae6f878bbe7d7fa6c5d2ce7114";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d0ba2bceea038f3405dcd7ccd7e6547d7a8ab98900b3e1f4d41b30f52a70a70e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "82b8e84fab49ae6f80529cc0f18fe3124548ba34b8f1fc5e3d359a3694c66f67";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9cc2f5304a8ecb01e65d1c0edf70a559e078fecd34676549645add6ed3e7e349";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "f5cac996d9547056119ed4af8495d511f868d89121f0cb2098f348648ef7a2bb";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "89d9e577bb8b9c166834e7a5ba31eb421cbc1b7c7cb755eb7b1fa021610dcb1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0f2f44967ed4f81e33e6ba841c2293b2196ccd3e5dab4c7eec0f7ddffc5136c2";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "77a1630f1467cee9bf96e8b831c4e12e8d95f710d0edec78c1454ae3dd721c8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "46053584a6ca253e2a530e85166bb92f81a82587fc080b89a4808da202c4d574";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "702c6a7dbd53bdeb546e068275f34368ada8c1f7ff8f27a34bc82b346b3d5554";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "d14222ef6400806227923f5e6414e59100c05c73874c0ac88de53dc26ea0e205";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "4499560825d29cae1009b8ba07db6141ddcfdc399c662301dbbb95f49645cc35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a5758231079a6729f9c64926031db941dd0ff0efd0704baf45d1c31fc755dbfd";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "43a0a178a08520d45e0e228d78ebdb09660887ce8879c7047012f494a40b4e90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "87d56112414a32f4e10c118e46ffbed311366c780604733c960d3d30f46a8cd6";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "45b9abdf7d5dea528528d44d50062a1738da9356a620096c8fd5ce3595630e86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a8c2cd6af1a49a18bd30abbd3778bd91ecdeb04e75a89b4afeb5e425b996db01";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "e8bf989729254c001671bd0a3bfecf8024d5c9184c147847745865a4fdcfe066";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "499c1bf8bf2d771b102881cd05fd1cde6c0224c85bb49d88cd968ea03f2e6af2";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2c9ec42c52b8ef017867fac29d9b11c2888bdcf483176a420e3f60769f3e8a9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7ce183c877cfd658a29b64dd24533651816043ab3c84eba33820d38fb56ea134";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2d79450020d11642e3b0b7a4add3b9b2cb650f381f8501782421f127c3a25bd1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "3b416613a6cd85b83de05616a3e7d1e12c1ae98afd778b68e7b5d364415dab6c";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "8a385e0dccb4cbca7d1f7ffee9ac9a52a98ad261cce2a4f81974ec147079a298";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rm-common, rm-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "badd44a2c96c661235de0304340dabb8f3e552489c7ae695d94edab2090baaf8";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "cced513a80e500ac41365668df44ef4df96f78c2a016b6b6fc4636f00fe1f3f5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rm-common rm-msgs ];
+  propagatedBuildInputs = [ rm-common rm-description rm-gazebo rm-hw rm-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rm-dbus";
+  version = "0.1.7-r3";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "513ff4146b0c5f95cace971c65735d9f38bf7816387044bd3488b4cacf7b4893";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rm-common roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A package that uses dbus to read remote control information'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "9efff0393a8fd9a0ad6fe81a918f2ab1abaa31a2684bddf8bae58be2ffe9bd72";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "ce1edcca5d7d79f4efb39108eb0ff9e1a7348a270c601e0c81abb57298c80bd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "8b4d10fcf5aec733eb27ca415dffbe4705e754707e621f9e9c5a8c4ceccfce3b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "483da5a38f0a7d3a4534c4e6980aac1c6876acff5148e891e8866b98d2afe4be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-rm-hw";
+  version = "0.1.7-r3";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "d75b09754f020e9536cba1101f76ab0524171188abbc8dc7be8783154e9864d6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface controller-manager hardware-interface joint-limits-interface realtime-tools rm-common rm-msgs roscpp roslint transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS control warped interface for RoboMaster motor and some robot hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,17 +5,16 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "818f207b30dc64bd121e80eab1e6339d09049e993160ffe5ff26fb8f8b64cdab";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "5cbfcb09b9b23668ecbe61880c234908ad0c86754819dbfd7cb4a970b8d729b9";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime std-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-generation message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-state-publisher/default.nix
+++ b/distros/noetic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, kdl-parser, orocos-kdl, rosbag, rosconsole, roscpp, rostest, rostime, sensor-msgs, tf, tf2-kdl, tf2-ros, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-publisher";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "1a12e4672ace312f3ba8ca281b50c211d7060cd0cc532dac395ea5061844880b";
+    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "9939e39eb22755515c60d7d1941f9775c44725dbd10e79c18fc558c4a5b6af94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.20.10-r1";
+  version = "0.20.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.10-1.tar.gz";
-    name = "0.20.10-1.tar.gz";
-    sha256 = "4385208a6c891fd32d9017f0ce6ccc556d58a319ea7cdb3fdafdbffa3a291cbe";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.14-1.tar.gz";
+    name = "0.20.14-1.tar.gz";
+    sha256 = "3def585ea3acd32d4767c993376708b51544c4e6f027a69b5481872ea270e39d";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ apriltag-ros class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros theora-image-transport visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.9-r2";
+  version = "1.14.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.9-2.tar.gz";
-    name = "1.14.9-2.tar.gz";
-    sha256 = "612a7d4a5dedc61354a8d0db0b19447e1e64f401feb2a9b3a826fb644826343f";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.10-1.tar.gz";
+    name = "1.14.10-1.tar.gz";
+    sha256 = "e55513ec8a0219e94812f70145357f9d3f0a3d80d71e267de2394bf11d028b83";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules eigen message-generation urdfdom urdfdom-headers ];
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-eigen tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs ];
+  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 0c9bc531da293ff0723733948cadf21d4c44fbc4.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *rqt-runtime-monitor 1.0.0-r1*
* *simple-launch 1.0.6-r1 --> 1.1.0-r1*

Galactic Changes:
-----------------
* *controller-interface 1.0.0-r1*
* *controller-manager 1.0.0-r1*
* *controller-manager-msgs 1.0.0-r1*
* *geometric-shapes 2.1.0-r2 --> 2.1.1-r1*
* *hardware-interface 1.0.0-r1*
* *moveit-msgs 2.1.0-r1 --> 2.1.1-r1*
* *ros2-control 1.0.0-r1*
* *ros2-control-test-assets 1.0.0-r1*
* *ros2controlcli 1.0.0-r1*
* *rqt-runtime-monitor 1.0.0-r1*
* *srdfdom 2.0.2-r1 --> 2.0.3-r1*
* *transmission-interface 1.0.0-r1*
* *warehouse-ros 2.0.3-r1 --> 2.0.4-r1*

Melodic Changes:
----------------
* *dbw-fca 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-can 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-description 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-joystick-demo 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-msgs 1.2.0-r1 --> 1.2.1-r1*
* *dbw-mkz 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-can 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-description 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-joystick-demo 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-msgs 1.4.0-r1 --> 1.4.1-r1*
* *dbw-polaris 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-can 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-description 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-joystick-demo 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-msgs 1.0.0-r1 --> 1.0.1-r1*
* *inorbit-republisher 0.2.1-r1*
* *leo-bringup 1.2.0-r1 --> 1.2.1-r1*
* *leo-fw 1.2.0-r1 --> 1.2.1-r1*
* *leo-robot 1.2.0-r1 --> 1.2.1-r1*
* *marti-can-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-common-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-dbw-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-nav-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-perception-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-sensor-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-status-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-visualization-msgs 0.10.0-r1 --> 0.10.0-r2*
* *rtabmap-ros 0.20.9-r2 --> 0.20.14-r1*
* *rviz 1.13.19-r1 --> 1.13.20-r1*

Noetic Changes:
---------------
* *dbw-fca 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-can 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-description 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-joystick-demo 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-msgs 1.2.0-r1 --> 1.2.1-r1*
* *dbw-mkz 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-can 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-description 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-joystick-demo 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-msgs 1.4.0-r1 --> 1.4.1-r1*
* *dbw-polaris 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-can 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-description 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-joystick-demo 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-msgs 1.0.0-r1 --> 1.0.1-r1*
* *leo-bringup 1.2.1-r1*
* *leo-fw 1.2.1-r1*
* *leo-robot 1.2.1-r1*
* *libphidget22 1.0.2-r1 --> 1.0.3-r1*
* *moveit-opw-kinematics-plugin 0.3.1-r2*
* *phidgets-accelerometer 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-analog-inputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-analog-outputs 1.0.3-r1*
* *phidgets-api 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-digital-inputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-digital-outputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-drivers 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-gyroscope 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-high-speed-encoder 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-ik 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-magnetometer 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-motors 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-msgs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-spatial 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-temperature 1.0.2-r1 --> 1.0.3-r1*
* *rm-common 0.1.1-r5 --> 0.1.7-r3*
* *rm-control 0.1.1-r5 --> 0.1.7-r3*
* *rm-dbus 0.1.7-r3*
* *rm-description 0.1.1-r5 --> 0.1.7-r3*
* *rm-gazebo 0.1.1-r5 --> 0.1.7-r3*
* *rm-hw 0.1.7-r3*
* *rm-msgs 0.1.1-r5 --> 0.1.7-r3*
* *robot-state-publisher 1.15.0-r1 --> 1.15.2-r1*
* *rtabmap-ros 0.20.10-r1 --> 0.20.14-r1*
* *rviz 1.14.9-r2 --> 1.14.10-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] wiimote

