### PR TITLE
rosdistro sync, Fri Oct  8 13:26:21 2021

### DIFF
--- a/distros/foxy/examples-tf2-py/default.nix
+++ b/distros/foxy/examples-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, pythonPackages, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-examples-tf2-py";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "2145de3c592a468f7d0b901908a96ae6d0c7ec8a6f5cdf6fe5e777bf2dc1566e";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/examples_tf2_py/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "78c29edb13d95dc1e0bf363d7c5f4f32ba13dbe86156fe18c7d57f74a2065d28";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -1372,6 +1372,8 @@ self: super: {
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
 
+ rqt-runtime-monitor = self.callPackage ./rqt-runtime-monitor {};
+
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
 
  rqt-shell = self.callPackage ./rqt-shell {};

--- a/distros/foxy/geometry2/default.nix
+++ b/distros/foxy/geometry2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-bullet, tf2-eigen, tf2-geometry-msgs, tf2-kdl, tf2-msgs, tf2-py, tf2-ros, tf2-sensor-msgs, tf2-tools }:
 buildRosPackage {
   pname = "ros-foxy-geometry2";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "26a3fa86990b9855b82cc38b957c62c34a362fa372cd302ee8d9802514b30ff0";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/geometry2/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "a5a386c84429a92b0b825c16a128c8e090ecc086bab5f70858049fc297e04136";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/launch-ros/default.nix
+++ b/distros/foxy/launch-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, composition-interfaces, launch, lifecycle-msgs, osrf-pycommon, python3Packages, pythonPackages, rclpy }:
 buildRosPackage {
   pname = "ros-foxy-launch-ros";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "cc16f69f9fdbc93b4d2ea1982ea410c58b0b2ee87db6902d584ffcd2dda0cc11";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_ros/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "a81941707aa3d0fd3198bb5e141b4b47ddad51e814505495443e63dc3b7bbc15";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/launch-testing-ros/default.nix
+++ b/distros/foxy/launch-testing-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, launch-ros, launch-testing, pythonPackages, rclpy, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-launch-testing-ros";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "fd71d8d3340b0ccb165b6c8f5517da92b85c90cc44eca05213c9926175662d02";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/launch_testing_ros/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "83fa54f06992419d0cabba68f755f302c55218365fd554a32b6eaf81a989f672";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/plotjuggler-msgs/default.nix
+++ b/distros/foxy/plotjuggler-msgs/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, rosidl-cmake, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-msgs";
-  version = "0.1.2-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/foxy/plotjuggler_msgs/0.1.2-1.tar.gz";
-    name = "0.1.2-1.tar.gz";
-    sha256 = "241245a077a07b49f69e9d9e30c6b5beb3215466a9a3252572a8cf19c0e2134d";
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/foxy/plotjuggler_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "8eaaa4edd0769369814358e7d4efd264bfd86a604f731ca288b8510df2278a33";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common rosidl-cmake ];
-  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
   nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
 
   meta = {

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.5.0-r1";
+  version = "1.6.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "add291faf30c6fde2b5ff4776f1ac283c13d01f957c2ad2fe2b65c07c502733e";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.6.1-1.tar.gz";
+    name = "1.6.1-1.tar.gz";
+    sha256 = "0c87da7bacd74e464639baf32ca805b9332b22dc9429461a563142b96ad803ab";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.3.0-r1";
+  version = "3.3.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "d840cdbdae7895b553f81d056c6a54a5cf1253491b83eab4dfef69613640d368";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.3.1-2.tar.gz";
+    name = "3.3.1-2.tar.gz";
+    sha256 = "f5d60df50cef6a96b323b028d6f09a96fac3e94b7807c005c35d123e5f4419f3";
   };
 
   buildType = "catkin";

--- a/distros/foxy/rclpy/default.nix
+++ b/distros/foxy/rclpy/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, builtin-interfaces, python-cmake-module, pythonPackages, rcl, rcl-action, rcl-interfaces, rcl-yaml-param-parser, rcutils, rmw-implementation, rmw-implementation-cmake, rosgraph-msgs, rosidl-generator-py, rpyutils, test-msgs, unique-identifier-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rclpy";
-  version = "1.0.6-r1";
+  version = "1.0.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "e5e60c94022ba5e1b110b2a40255b64587e317faa2beb13742dceb9d1112e927";
+    url = "https://github.com/ros2-gbp/rclpy-release/archive/release/foxy/rclpy/1.0.7-1.tar.gz";
+    name = "1.0.7-1.tar.gz";
+    sha256 = "bf43371d70dc43b050ccf687043879ad4e9f519a0a431038e46a3332dc241e67";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2action/default.nix
+++ b/distros/foxy/ros2action/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2action";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2action/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "5ccd107cb18f428c5cb1c9bb6f8e826ab09565645386d398f47fa99f1a1b912f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2action/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "89162ecf3f188f507d3c088acfac799340562f54b12f9afd3e89365100faf58a";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2cli/default.nix
+++ b/distros/foxy/ros2cli/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2cli";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2cli/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "895824a52636de046cf4c94d46b1e9075daa227446a1c9d3114f2864e249c83c";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2cli/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "1b10ebb587e3dddcf3460e0753e1947deef9cbb995ea62e62a979e2d0e1fadaf";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2component/default.nix
+++ b/distros/foxy/ros2component/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, composition-interfaces, pythonPackages, rcl-interfaces, rclcpp-components, rclpy, ros2cli, ros2node, ros2param, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2component";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2component/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "4d375331d389317f5bb33ecb4ac91cb71a241600ace4879359edcf480175f99b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2component/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "763de7fe7d33065b48a255f5cd82a94e4b0374226a12b06e3e81ba2ab284cbc7";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2interface/default.nix
+++ b/distros/foxy/ros2interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, pythonPackages, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2interface";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2interface/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "2cbf2e1fa35905f17428d433f9013e7c495e29b8acf344c92cc20f79d5a75a1d";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2interface/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "0e15660a513739e68e271bb05c9da4b82b942fb768b86b418b05ae03a61c0cd5";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2launch/default.nix
+++ b/distros/foxy/ros2launch/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, launch, launch-ros, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2launch";
-  version = "0.11.3-r1";
+  version = "0.11.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.3-1.tar.gz";
-    name = "0.11.3-1.tar.gz";
-    sha256 = "f8d2a77e9b8deec2bb429022843bbddd54a60b791a073f9e4f8a7bc412ee59e8";
+    url = "https://github.com/ros2-gbp/launch_ros-release/archive/release/foxy/ros2launch/0.11.4-1.tar.gz";
+    name = "0.11.4-1.tar.gz";
+    sha256 = "1ed537ffec0cae359ffbe196cb97b46eb317c4b97a170a256108794c2ee8d05b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2lifecycle-test-fixtures/default.nix
+++ b/distros/foxy/ros2lifecycle-test-fixtures/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, rclcpp, rclcpp-lifecycle }:
 buildRosPackage {
   pname = "ros-foxy-ros2lifecycle-test-fixtures";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle_test_fixtures/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "25f2202df06b2186e7cd3451f10db974a46df402c544b9ce26621b10c49c4b6b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle_test_fixtures/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "a64bc75b85442292dc0b0365ce1b581e52c166b636e87b9c3f1890d8299cfc48";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/ros2lifecycle/default.nix
+++ b/distros/foxy/ros2lifecycle/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, lifecycle-msgs, pythonPackages, rclpy, ros-testing, ros2cli, ros2lifecycle-test-fixtures, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-foxy-ros2lifecycle";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "462a6c16125064bd0b796b3a62a32c6e25ce8a81c763282b501a526424b98454";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2lifecycle/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "b3e8677a071929376b5de51afe373a3982ea3cb2990bb571f8b8292c1b8355db";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2multicast/default.nix
+++ b/distros/foxy/ros2multicast/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli }:
 buildRosPackage {
   pname = "ros-foxy-ros2multicast";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2multicast/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "bffb6e10dd7375675069608a3ec260e084d66f605764d8d3688aa24a4899cd46";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2multicast/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "25b54268f0a38edb7a29e1afed2abb430ded9ef2a3c4398b7edac836e555f662";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2node/default.nix
+++ b/distros/foxy/ros2node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, rclpy, ros-testing, ros2cli, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2node";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2node/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "c7a155455a28d1b5d26447bcaf1353dcce46ee255077d89966540d58ec4465de";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2node/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "a30b99b25eeeaee6a2208e5616d49c53d9a65e99823ccb50aa683270cea8378b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2param/default.nix
+++ b/distros/foxy/ros2param/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, launch, launch-ros, launch-testing, launch-testing-ros, pythonPackages, rcl-interfaces, rclpy, ros2cli, ros2node, ros2service }:
 buildRosPackage {
   pname = "ros-foxy-ros2param";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2param/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "a16157733f49dca03e68ae925af3a2b4ad5719c768edc25befaaf107ee21157b";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2param/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "8b02db5ccec254ffebeeb4d3835d67fb5c8355c44c6d067906be0aaaee3ac3f1";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2pkg/default.nix
+++ b/distros/foxy/ros2pkg/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, ament-xmllint, python3Packages, pythonPackages, ros-testing, ros2cli }:
 buildRosPackage {
   pname = "ros-foxy-ros2pkg";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2pkg/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "dc95899b2380bec2761b39c21febede5390b974b207e9d7f416d3d3295986d0f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2pkg/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "3630a77a93043a2f63ce0028ed5684324d81ee45f1d7bbd6b780fbf162139e95";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2run/default.nix
+++ b/distros/foxy/ros2run/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, pythonPackages, ros2cli, ros2pkg }:
 buildRosPackage {
   pname = "ros-foxy-ros2run";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2run/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "ae0dbdfb2aae8a380003372981d5f7d21b7f2e3cdb6dd91c3604919f051bb48f";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2run/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "6cd4f34c1daccc4ae65e8f08ee27490ba93663629d6cfd9a30d3f4ec6836628b";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2service/default.nix
+++ b/distros/foxy/ros2service/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2service";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2service/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "cd0fbb6837b06640f7e08a38d52b31fb3bf12f75e6c59ae909bf39cc2074a8d5";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2service/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "0dab218802fb0f80f7bc84d62987e0739a282a4e51e838a72e3cb45ad1dc318d";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/ros2topic/default.nix
+++ b/distros/foxy/ros2topic/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, geometry-msgs, python3Packages, pythonPackages, rclpy, ros-testing, ros2cli, rosidl-runtime-py, std-msgs, test-msgs }:
 buildRosPackage {
   pname = "ros-foxy-ros2topic";
-  version = "0.9.9-r1";
+  version = "0.9.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2topic/0.9.9-1.tar.gz";
-    name = "0.9.9-1.tar.gz";
-    sha256 = "8cb774a4bc1d0829c57641503aac83ccb17cd80d2cabb8bfab96867092b66e34";
+    url = "https://github.com/ros2-gbp/ros2cli-release/archive/release/foxy/ros2topic/0.9.10-1.tar.gz";
+    name = "0.9.10-1.tar.gz";
+    sha256 = "a94162a37bbb3ede9d32210a578c3af03e2c24abc38025582d6bfc3b4ce6b5b8";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/rqt-runtime-monitor/default.nix
+++ b/distros/foxy/rqt-runtime-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, diagnostic-msgs, python-qt-binding, python3Packages, pythonPackages, qt-gui, rclpy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-foxy-rqt-runtime-monitor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_runtime_monitor-release/archive/release/foxy/rqt_runtime_monitor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "dcc8128caebc7c57f725c94691de328ebcb37085a739cb610e2d8135c43ef4c1";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py ];
+
+  meta = {
+    description = ''rqt_runtime_monitor provides a GUI plugin viewing DiagnosticsArray messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "2e927d697aff34189a0937ea187862a2e86322a8c834c8e0f79879080153363b";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "dbc51d2c80485d3a7d6c47f4966f5357ec354020021b7c2bf7e1d629af999802";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "319c937d5ca59091bd458762fda78b43b5cb8c595dfef72bb2eccadc9074bad0";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "973139e7962c803ddfe0ff1153250370fe304dbbef5b1fb3479262b923454827";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "8601c4616676297f2d760ab48ab1498af18ed3e8a53a23214fdb5814397376f5";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "26f437bfa3b8757d567eb7f05eaa31b29b664cf84f751f06f645ce3b09c594ef";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "ce2a258243f033abe41a2c7b67a822368db3a6dc275947602a8e73bf341f62dc";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "dff7ebf930bb222ef291ddfbb6f3a10a6ce5837e0306b11fe3cd1c34ece82e58";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "ee6a45796033185b6c4ec9f415f1757432c819cd839ce2a1b1333b1c8e04f870";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "25de944535e55d84a603296b66d1a5cf1148c26f1cbb10d1323623f35ccac149";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "8c262531a7a99775dccaf0da6b1ac066738a39c27b180a221ef0a246d5645cd2";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "4a34d713c0b5e3aad8034db5b32e93cf58ed21bfee2070449813f3e630ac1a7f";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "d6cb35af76e5b9e0231459a6f413f517c4768140a6158628c5f9e806a4d06a1d";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "ae58b014d67e43f8334cef764d2fbc581eecffbf704960a9f86a3b17b8428557";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.3-r1";
+  version = "8.2.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.3-1.tar.gz";
-    name = "8.2.3-1.tar.gz";
-    sha256 = "db4a69532da748da127048a2be0779de474842855299cd6fe3061072eeaf7d08";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.4-1.tar.gz";
+    name = "8.2.4-1.tar.gz";
+    sha256 = "dafc94e5a219d3c1fc0a238a73076c2a01c31a2fc5df7171a3bdab7077365dbf";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/simple-launch/default.nix
+++ b/distros/foxy/simple-launch/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, launch, launch-ros, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-index-python, launch, launch-ros, xacro }:
 buildRosPackage {
   pname = "ros-foxy-simple-launch";
-  version = "1.0.6-r1";
+  version = "1.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.0.6-1.tar.gz";
-    name = "1.0.6-1.tar.gz";
-    sha256 = "b757efbbf85defdce94211a9c275a6db614ab2f605556559b911f81d52381982";
+    url = "https://github.com/oKermorgant/simple_launch-release/archive/release/foxy/simple_launch/1.1.0-1.tar.gz";
+    name = "1.1.0-1.tar.gz";
+    sha256 = "7ea89fc795caffc229159afefb4ec51e08a0cb3f09dd83c91a7c2cdfa441dab7";
   };
 
   buildType = "ament_python";
-  propagatedBuildInputs = [ launch launch-ros xacro ];
+  propagatedBuildInputs = [ ament-index-python launch launch-ros xacro ];
 
   meta = {
     description = ''Python helper class for the ROS 2 launch system'';

--- a/distros/foxy/tf2-bullet/default.nix
+++ b/distros/foxy/tf2-bullet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, bullet, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-bullet";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "16281df8cdf2b71fc6231e8bba87b3dc7c44b79a574185cc4cce979c6bf81bcf";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_bullet/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "f1e50c565f39f7c9d5ab503cb78dd619170ae82974347c14e664a955be1528b9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen-kdl/default.nix
+++ b/distros/foxy/tf2-eigen-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, orocos-kdl, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen-kdl";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "9832870e714b6c8074232689d5d37ec82d203fe44b4d331de3f7621c7f734b0f";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen_kdl/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "1063f87e9ecba4d758bc581ec751ae974a4d6d8787dd572400a4853fdbc34a48";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-eigen/default.nix
+++ b/distros/foxy/tf2-eigen/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, eigen, eigen3-cmake-module, geometry-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-eigen";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "85237c02f5be3a4e636da800f91e63183f0385cd98a837698896156959caa25a";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_eigen/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "8e60acbeb6909956ee3d7e8ca0cebd75eed93d647a5ef48c1b8b9761f6144eb6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-geometry-msgs/default.nix
+++ b/distros/foxy/tf2-geometry-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-geometry-msgs";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "bfe7fce8dfd94ffcf64fd47b1aaa4457fb35c41a9c4fd9862b2c17baf85e90cb";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_geometry_msgs/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "693cda73de3757407eae280358af50e10bc4b0a082c0a1a88079d6c9e2087972";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-kdl/default.nix
+++ b/distros/foxy/tf2-kdl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, builtin-interfaces, geometry-msgs, orocos-kdl, rclcpp, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-kdl";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "5282a33b83e1bf38ca984c049e918231966b4966e7d9986d572dc8c2f197a2dc";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_kdl/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "cfb45d1af533720346794296503c44ba61149e43923185b439255ddca5e2bf6b";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-msgs/default.nix
+++ b/distros/foxy/tf2-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-common, builtin-interfaces, geometry-msgs, rosidl-default-generators, rosidl-default-runtime }:
 buildRosPackage {
   pname = "ros-foxy-tf2-msgs";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "3130068ae9bb5c9161d4c983ba36f7d3af37eff2b9da9bc13c0a11606e8986b4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_msgs/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "56e8df9f8043867338ae74ce8d70c0ec7a40b11ce6224aae68d6aec3cfaec453";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-py/default.nix
+++ b/distros/foxy/tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-lint-auto, ament-lint-common, builtin-interfaces, geometry-msgs, python-cmake-module, rclpy, rpyutils, tf2 }:
 buildRosPackage {
   pname = "ros-foxy-tf2-py";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "045da2ddc9528dc847b6b3b8e1f07a81b4980be34b2a48acd51a965b26e3c8f5";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_py/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "58da1c1d898472e28b016ab5a2c5c83414e85dbb47affa90ca73190a92facea5";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-ros/default.nix
+++ b/distros/foxy/tf2-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, builtin-interfaces, geometry-msgs, message-filters, python-cmake-module, rcl-interfaces, rclcpp, rclcpp-action, rclcpp-components, rclpy, std-msgs, tf2, tf2-msgs, tf2-py }:
 buildRosPackage {
   pname = "ros-foxy-tf2-ros";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "d8003376caead32ce62ade592757ba3ed55e36572b5c0f648a2e12ac3beb0d23";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_ros/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "21a3ead1f3e799d872883098c3061ed9c96dd9240a5c6bb67e82f409bef472a9";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-sensor-msgs/default.nix
+++ b/distros/foxy/tf2-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, eigen, eigen3-cmake-module, sensor-msgs, tf2, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-sensor-msgs";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "c89036bfcd2ef4f8848a8de58c93f46a357d648a646cb000ba901c9c6103bed4";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_sensor_msgs/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "c2613e0fc644690cd2dce25e7f4ee3dc483989f86261a71031e82839baaee56e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2-tools/default.nix
+++ b/distros/foxy/tf2-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, tf2, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-tf2-tools";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "6f8009ff79913e49ea232aef290cd445f540b40bc70d1e2c8a580d369a2a9228";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2_tools/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "89473b9eec78af311c8a344f5d9c4aeaaa4745b5954d48d6bfbcb5fad5ff4f35";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/tf2/default.nix
+++ b/distros/foxy/tf2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, console-bridge, console-bridge-vendor, geometry-msgs, rcutils }:
 buildRosPackage {
   pname = "ros-foxy-tf2";
-  version = "0.13.11-r1";
+  version = "0.13.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.11-1.tar.gz";
-    name = "0.13.11-1.tar.gz";
-    sha256 = "e3a4075c30e851c54d0a4449bc01246a2aaed421f9270d14ade587f262a273d1";
+    url = "https://github.com/ros2-gbp/geometry2-release/archive/release/foxy/tf2/0.13.12-1.tar.gz";
+    name = "0.13.12-1.tar.gz";
+    sha256 = "511a596613d525ac12605da01086e7399a4642b722ec177482242587a8fb7d7a";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/controller-interface/default.nix
+++ b/distros/galactic/controller-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface, rclcpp-lifecycle, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-controller-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3a421d48b8f4b22a954974fde7bd26412f1cbc2a87ad1375448b47521e656bf4";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface rclcpp-lifecycle sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/controller-manager-msgs/default.nix
+++ b/distros/galactic/controller-manager-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, builtin-interfaces, rosidl-default-generators, rosidl-default-runtime }:
+buildRosPackage {
+  pname = "ros-galactic-controller-manager-msgs";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager_msgs/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b236a584cd2585b3113f86ce657983b9e20bb89522b7e0dcd7c51de008ff09f9";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ builtin-interfaces rosidl-default-runtime ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''Messages and services for the controller manager.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/controller-manager/default.nix
+++ b/distros/galactic/controller-manager/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, controller-interface, controller-manager-msgs, hardware-interface, launch, launch-ros, pluginlib, rclcpp, rcpputils, ros2-control-test-assets, ros2param, ros2run }:
+buildRosPackage {
+  pname = "ros-galactic-controller-manager";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/controller_manager/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3eaf8a278b08cc982ea42b14a66adcacd02c4735497d3bf0245012a55d6d9dae";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ ament-index-cpp controller-interface controller-manager-msgs hardware-interface launch launch-ros pluginlib rclcpp rcpputils ros2-control-test-assets ros2param ros2run ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Description of controller_manager'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/diff-drive-controller/default.nix
+++ b/distros/galactic/diff-drive-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, nav-msgs, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, tf2, tf2-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-diff-drive-controller";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/diff_drive_controller/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c32958e98d058c3355048e2e1f180c4e4079f89a97a936b0d42c3f546111a6b0";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ];
+  propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface nav-msgs rclcpp rclcpp-lifecycle realtime-tools tf2 tf2-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller for a differential drive mobile base.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/effort-controllers/default.nix
+++ b/distros/galactic/effort-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-galactic-effort-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/effort_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "b436d50196946a9a8f57608e78ca91707e5d66859ac67b95ec4fa77cea616876";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic controller for forwarding commands.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/force-torque-sensor-broadcaster/default.nix
+++ b/distros/galactic/force-torque-sensor-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, geometry-msgs, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-galactic-force-torque-sensor-broadcaster";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/force_torque_sensor_broadcaster/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "9497abf9bb9a5458ed0adc6513686a9fb98320e330b8e2935538bf76fc93200b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface geometry-msgs hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller to publish state of force-torque sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/forward-command-controller/default.nix
+++ b/distros/galactic/forward-command-controller/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, std-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-forward-command-controller";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/forward_command_controller/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1a4a32ca280ee44fd6bc14ad4c8a0d8d72349862bfd07d8ed36b706cc7bf2834";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface hardware-interface rclcpp rclcpp-lifecycle realtime-tools std-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic controller for forwarding commands.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -204,6 +204,12 @@ self: super: {
 
  control-toolbox = self.callPackage ./control-toolbox {};
 
+ controller-interface = self.callPackage ./controller-interface {};
+
+ controller-manager = self.callPackage ./controller-manager {};
+
+ controller-manager-msgs = self.callPackage ./controller-manager-msgs {};
+
  costmap-queue = self.callPackage ./costmap-queue {};
 
  cv-bridge = self.callPackage ./cv-bridge {};
@@ -227,6 +233,8 @@ self: super: {
  diagnostic-msgs = self.callPackage ./diagnostic-msgs {};
 
  diagnostic-updater = self.callPackage ./diagnostic-updater {};
+
+ diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
  domain-bridge = self.callPackage ./domain-bridge {};
 
@@ -253,6 +261,8 @@ self: super: {
  dynamixel-sdk-custom-interfaces = self.callPackage ./dynamixel-sdk-custom-interfaces {};
 
  dynamixel-sdk-examples = self.callPackage ./dynamixel-sdk-examples {};
+
+ effort-controllers = self.callPackage ./effort-controllers {};
 
  eigen3-cmake-module = self.callPackage ./eigen3-cmake-module {};
 
@@ -316,6 +326,10 @@ self: super: {
 
  foonathan-memory-vendor = self.callPackage ./foonathan-memory-vendor {};
 
+ force-torque-sensor-broadcaster = self.callPackage ./force-torque-sensor-broadcaster {};
+
+ forward-command-controller = self.callPackage ./forward-command-controller {};
+
  four-wheel-steering-msgs = self.callPackage ./four-wheel-steering-msgs {};
 
  gazebo-dev = self.callPackage ./gazebo-dev {};
@@ -360,7 +374,11 @@ self: super: {
 
  grbl-ros = self.callPackage ./grbl-ros {};
 
+ gripper-controllers = self.callPackage ./gripper-controllers {};
+
  gtest-vendor = self.callPackage ./gtest-vendor {};
+
+ hardware-interface = self.callPackage ./hardware-interface {};
 
  hls-lfcd-lds-driver = self.callPackage ./hls-lfcd-lds-driver {};
 
@@ -392,15 +410,21 @@ self: super: {
 
  image-view = self.callPackage ./image-view {};
 
+ imu-sensor-broadcaster = self.callPackage ./imu-sensor-broadcaster {};
+
  interactive-markers = self.callPackage ./interactive-markers {};
 
  intra-process-demo = self.callPackage ./intra-process-demo {};
 
  io-context = self.callPackage ./io-context {};
 
+ joint-state-broadcaster = self.callPackage ./joint-state-broadcaster {};
+
  joint-state-publisher = self.callPackage ./joint-state-publisher {};
 
  joint-state-publisher-gui = self.callPackage ./joint-state-publisher-gui {};
+
+ joint-trajectory-controller = self.callPackage ./joint-trajectory-controller {};
 
  joy = self.callPackage ./joy {};
 
@@ -740,6 +764,8 @@ self: super: {
 
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
 
+ position-controllers = self.callPackage ./position-controllers {};
+
  pybind11-vendor = self.callPackage ./pybind11-vendor {};
 
  python-cmake-module = self.callPackage ./python-cmake-module {};
@@ -946,6 +972,12 @@ self: super: {
 
  ros1-rosbag-storage-vendor = self.callPackage ./ros1-rosbag-storage-vendor {};
 
+ ros2-control = self.callPackage ./ros2-control {};
+
+ ros2-control-test-assets = self.callPackage ./ros2-control-test-assets {};
+
+ ros2-controllers = self.callPackage ./ros2-controllers {};
+
  ros2-ouster = self.callPackage ./ros2-ouster {};
 
  ros2-socketcan = self.callPackage ./ros2-socketcan {};
@@ -961,6 +993,8 @@ self: super: {
  ros2cli-test-interfaces = self.callPackage ./ros2cli-test-interfaces {};
 
  ros2component = self.callPackage ./ros2component {};
+
+ ros2controlcli = self.callPackage ./ros2controlcli {};
 
  ros2interface = self.callPackage ./ros2interface {};
 
@@ -1133,6 +1167,8 @@ self: super: {
  rqt-robot-monitor = self.callPackage ./rqt-robot-monitor {};
 
  rqt-robot-steering = self.callPackage ./rqt-robot-steering {};
+
+ rqt-runtime-monitor = self.callPackage ./rqt-runtime-monitor {};
 
  rqt-service-caller = self.callPackage ./rqt-service-caller {};
 
@@ -1328,6 +1364,8 @@ self: super: {
 
  trajectory-msgs = self.callPackage ./trajectory-msgs {};
 
+ transmission-interface = self.callPackage ./transmission-interface {};
+
  turtle-tf2-cpp = self.callPackage ./turtle-tf2-cpp {};
 
  turtle-tf2-py = self.callPackage ./turtle-tf2-py {};
@@ -1387,6 +1425,8 @@ self: super: {
  usb-cam = self.callPackage ./usb-cam {};
 
  v4l2-camera = self.callPackage ./v4l2-camera {};
+
+ velocity-controllers = self.callPackage ./velocity-controllers {};
 
  velodyne = self.callPackage ./velodyne {};
 

--- a/distros/galactic/geometric-shapes/default.nix
+++ b/distros/galactic/geometric-shapes/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, assimp, boost, console-bridge-vendor, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, octomap, pkg-config, qhull, random-numbers, rclcpp, resource-retriever, rosidl-default-generators, rosidl-default-runtime, shape-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-geometric-shapes";
-  version = "2.1.0-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.0-2.tar.gz";
-    name = "2.1.0-2.tar.gz";
-    sha256 = "b9e0b3411f625d8136db04625f7fae1a45311f1f8e6c3072653dc1d0428889f9";
+    url = "https://github.com/moveit/geometric_shapes-release/archive/release/galactic/geometric_shapes/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "e7e2b87af7bd3a814701e20285053b142a8cfa91ac1c5393d5b0978c6b46346f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ pkg-config ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ assimp boost console-bridge-vendor eigen eigen-stl-containers eigen3-cmake-module geometry-msgs octomap qhull random-numbers rclcpp resource-retriever rosidl-default-runtime shape-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module rosidl-default-generators ];
 

--- a/distros/galactic/gripper-controllers/default.nix
+++ b/distros/galactic/gripper-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, control-toolbox, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-action, realtime-tools, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-galactic-gripper-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/gripper_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "04ca14d3eced1f989d983f5755e9b507d0cb765164d38563074426c50e73da97";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs control-toolbox controller-interface hardware-interface rclcpp rclcpp-action realtime-tools ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The gripper_controllers package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/hardware-interface/default.nix
+++ b/distros/galactic/hardware-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, control-msgs, pluginlib, rclcpp-lifecycle, rcpputils, rcutils, ros2-control-test-assets, tinyxml2-vendor }:
+buildRosPackage {
+  pname = "ros-galactic-hardware-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/hardware_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "79d2ca211a8e342d249811b661fb05bf3c134cd522f4d6027261ffdcfca56b0b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs pluginlib rclcpp-lifecycle rcpputils rcutils tinyxml2-vendor ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ROS2 ros_control hardware interface'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/imu-sensor-broadcaster/default.nix
+++ b/distros/galactic/imu-sensor-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-imu-sensor-broadcaster";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/imu_sensor_broadcaster/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "1c51e623c342d4411a44470c13233895a7caa3bf37237f1704a9b1e5356dcadb";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller to publish readings of IMU sensors.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/joint-state-broadcaster/default.nix
+++ b/distros/galactic/joint-state-broadcaster/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, rcutils, ros2-control-test-assets, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-joint-state-broadcaster";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_state_broadcaster/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "807bb0e118ab24356fe408081083f9d5f4d65975596efaa4a73a07fddde40bcd";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock controller-manager rclcpp ros2-control-test-assets ];
+  propagatedBuildInputs = [ control-msgs controller-interface hardware-interface pluginlib rclcpp-lifecycle rcutils sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Broadcaster to publish joint state'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/joint-trajectory-controller/default.nix
+++ b/distros/galactic/joint-trajectory-controller/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, angles, control-msgs, controller-interface, controller-manager, hardware-interface, pluginlib, rclcpp, rclcpp-lifecycle, realtime-tools, ros2-control-test-assets, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-joint-trajectory-controller";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/joint_trajectory_controller/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "4300cae1ce37ae51e76374ea458baa9c1c148b9d1670b92b7bca9e2b4874c95d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ angles control-msgs controller-interface hardware-interface pluginlib rclcpp rclcpp-lifecycle realtime-tools trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Controller for executing joint-space trajectories on a group of joints'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/moveit-msgs/default.nix
+++ b/distros/galactic/moveit-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, action-msgs, ament-cmake, ament-lint-auto, ament-lint-cmake, geometry-msgs, object-recognition-msgs, octomap-msgs, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, shape-msgs, std-msgs, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-msgs";
-  version = "2.1.0-r1";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.0-1.tar.gz";
-    name = "2.1.0-1.tar.gz";
-    sha256 = "37ce402737f464583838204fbde1831bdee9fcaa0f8aa337ba02e800cff3e847";
+    url = "https://github.com/moveit/moveit_msgs-release/archive/release/galactic/moveit_msgs/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "cc8f2c74459e4702fa373e12a463b98b58260170cd1fae1c868299c9d1abbe7c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/position-controllers/default.nix
+++ b/distros/galactic/position-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, pluginlib, rclcpp, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-galactic-position-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/position_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ad08df41c4281f314632f7c3a618d2d8b8b011a2088df9956fbf0908ebf20d38";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager ros2-control-test-assets ];
+  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic controller for forwarding commands.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-control-test-assets/default.nix
+++ b/distros/galactic/ros2-control-test-assets/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto }:
+buildRosPackage {
+  pname = "ros-galactic-ros2-control-test-assets";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control_test_assets/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "67ba677e3968233f97eb5052343ab1be1cbeed746e8f84e853193458e63b6ac0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''The package provides shared test resources for ros2_control stack'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-control/default.nix
+++ b/distros/galactic/ros2-control/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, controller-interface, controller-manager, controller-manager-msgs, hardware-interface, ros2-control-test-assets, ros2controlcli, transmission-interface }:
+buildRosPackage {
+  pname = "ros-galactic-ros2-control";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2_control/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "3d3c38c005eadf8974b215713e48662a94fee45dc5c6f082a5907b2bea880253";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ controller-interface controller-manager controller-manager-msgs hardware-interface ros2-control-test-assets ros2controlcli transmission-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for ROS2 control related packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2-controllers/default.nix
+++ b/distros/galactic/ros2-controllers/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, diff-drive-controller, effort-controllers, force-torque-sensor-broadcaster, forward-command-controller, imu-sensor-broadcaster, joint-state-broadcaster, joint-trajectory-controller, position-controllers, velocity-controllers }:
+buildRosPackage {
+  pname = "ros-galactic-ros2-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/ros2_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "c4221f939305d15311c694aa2f6638bdfb82ed5e4dce724d76da4203280c840b";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ diff-drive-controller effort-controllers force-torque-sensor-broadcaster forward-command-controller imu-sensor-broadcaster joint-state-broadcaster joint-trajectory-controller position-controllers velocity-controllers ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage for ROS2 controllers related packages'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/ros2controlcli/default.nix
+++ b/distros/galactic/ros2controlcli/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, ament-xmllint, controller-manager, controller-manager-msgs, rclpy, ros2cli, ros2node, ros2param, rosidl-runtime-py }:
+buildRosPackage {
+  pname = "ros-galactic-ros2controlcli";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/ros2controlcli/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "89ca90181d5776b2e6d9403db3ef6b97b2c2189ea3314cfbbb57840d6c7d3f1f";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 ament-xmllint ];
+  propagatedBuildInputs = [ controller-manager controller-manager-msgs rclpy ros2cli ros2node ros2param rosidl-runtime-py ];
+
+  meta = {
+    description = ''The ROS 2 command line tools for ROS2 Control.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/rqt-runtime-monitor/default.nix
+++ b/distros/galactic/rqt-runtime-monitor/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-index-python, ament-pep257, diagnostic-msgs, python-qt-binding, python3Packages, pythonPackages, qt-gui, rclpy, rqt-gui, rqt-gui-py }:
+buildRosPackage {
+  pname = "ros-galactic-rqt-runtime-monitor";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/rqt_runtime_monitor-release/archive/release/galactic/rqt_runtime_monitor/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "ca117541656a782e067af881de1cf72d9fd26f5786edfafc775aa849a8827c23";
+  };
+
+  buildType = "ament_python";
+  checkInputs = [ ament-copyright ament-flake8 ament-pep257 pythonPackages.pytest ];
+  propagatedBuildInputs = [ ament-index-python diagnostic-msgs python-qt-binding python3Packages.rospkg qt-gui rclpy rqt-gui rqt-gui-py ];
+
+  meta = {
+    description = ''rqt_runtime_monitor provides a GUI plugin viewing DiagnosticsArray messages.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/srdfdom/default.nix
+++ b/distros/galactic/srdfdom/default.nix
@@ -2,22 +2,22 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-cmake-pytest, ament-cmake-python, ament-lint-auto, ament-lint-cmake, boost, console-bridge, console-bridge-vendor, tinyxml2-vendor, urdf, urdfdom-headers, urdfdom-py }:
 buildRosPackage {
   pname = "ros-galactic-srdfdom";
-  version = "2.0.2-r1";
+  version = "2.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.2-1.tar.gz";
-    name = "2.0.2-1.tar.gz";
-    sha256 = "85093ec96f860df084a864588c8be49480f8f05ac6ed74e93725b92ad366f518";
+    url = "https://github.com/moveit/srdfdom-release/archive/release/galactic/srdfdom/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "d26208cbfe91d59104d357d18e53a55275f31d8208684688b22a271066334dcb";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ boost urdfdom-headers ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-cmake ];
+  checkInputs = [ ament-cmake-gtest ament-cmake-pytest ament-lint-auto ament-lint-cmake ];
   propagatedBuildInputs = [ console-bridge console-bridge-vendor tinyxml2-vendor urdf urdfdom-py ];
-  nativeBuildInputs = [ ament-cmake ];
+  nativeBuildInputs = [ ament-cmake ament-cmake-python ];
 
   meta = {
     description = ''Parser for Semantic Robot Description Format (SRDF).'';

--- a/distros/galactic/transmission-interface/default.nix
+++ b/distros/galactic/transmission-interface/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, hardware-interface }:
+buildRosPackage {
+  pname = "ros-galactic-transmission-interface";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_control-release/archive/release/galactic/transmission_interface/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "62e47e87cc2572c014b9efe62252c31434a21a6b6c46472a0f30a5574e0e02a0";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ hardware-interface ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''transmission_interface contains data structures for representing mechanical transmissions, methods for propagating values between actuator and joint spaces and tooling to support this.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/velocity-controllers/default.nix
+++ b/distros/galactic/velocity-controllers/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, controller-manager, forward-command-controller, hardware-interface, pluginlib, rclcpp, ros2-control-test-assets }:
+buildRosPackage {
+  pname = "ros-galactic-velocity-controllers";
+  version = "1.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/ros2_controllers-release/archive/release/galactic/velocity_controllers/1.0.0-1.tar.gz";
+    name = "1.0.0-1.tar.gz";
+    sha256 = "017736d8cc6bcf59a3d42780ebb30bea6912f2ca992ca31d32e73c08fbf6d633";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ pluginlib ];
+  checkInputs = [ ament-cmake-gmock controller-manager hardware-interface ros2-control-test-assets ];
+  propagatedBuildInputs = [ forward-command-controller rclcpp ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Generic controller for forwarding commands.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/warehouse-ros/default.nix
+++ b/distros/galactic/warehouse-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-lint-auto, boost, geometry-msgs, openssl, pluginlib, rclcpp, std-msgs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-warehouse-ros";
-  version = "2.0.3-r1";
+  version = "2.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.3-1.tar.gz";
-    name = "2.0.3-1.tar.gz";
-    sha256 = "5de10f5f42f9a055c0775b226714bd629f9b0b7fcf682a1cb89ce12735217331";
+    url = "https://github.com/moveit/warehouse_ros-release/archive/release/galactic/warehouse_ros/2.0.4-1.tar.gz";
+    name = "2.0.4-1.tar.gz";
+    sha256 = "c559cc10d1bdb1fbce7222f80c65e042fdc094661fa9a876c2e0669fde8140b3";
   };
 
   buildType = "ament_cmake";

--- a/distros/melodic/bota-driver-testing/default.nix
+++ b/distros/melodic/bota-driver-testing/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, geometry-msgs, gtest, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial, rosgraph-msgs, rostest, rosunit }:
+buildRosPackage {
+  pname = "ros-melodic-bota-driver-testing";
+  version = "0.6.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver_testing/0.6.1-1/bota_driver-release-release-melodic-bota_driver_testing-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_driver_testing-0.6.1-1.tar.gz";
+    sha256 = "66542da7abaf7112dedfb4b4e2710ec8b6e0ed9896174de95ddf66c9ea08be12";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-node geometry-msgs rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-msgs rokubimini-serial rosgraph-msgs rostest ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/bota-driver/default.nix
+++ b/distros/melodic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-melodic-bota-driver";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.6.0-5/bota_driver-release-release-melodic-bota_driver-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_driver-0.6.0-5.tar.gz";
-    sha256 = "f127c97547367d82f48c7642730df96011b2bbafbb0460524bac02a1cad6c9f1";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_driver/0.6.1-1/bota_driver-release-release-melodic-bota_driver-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_driver-0.6.1-1.tar.gz";
+    sha256 = "10cfcffc756323213907bc58cecf3d803efc65e7b8f18e6186d76ac5b9ee5d7d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-node/default.nix
+++ b/distros/melodic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-node";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.6.0-5/bota_driver-release-release-melodic-bota_node-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_node-0.6.0-5.tar.gz";
-    sha256 = "1a4b717128ff061556708ac2099c79e194fcc3f1b518914d9b5082a51de7e607";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_node/0.6.1-1/bota_driver-release-release-melodic-bota_node-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_node-0.6.1-1.tar.gz";
+    sha256 = "723de28331c1bd06644ed12ed30f6b76726976646dedd0886668d53d4ad3e251";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-signal-handler/default.nix
+++ b/distros/melodic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-signal-handler";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.6.0-5/bota_driver-release-release-melodic-bota_signal_handler-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_signal_handler-0.6.0-5.tar.gz";
-    sha256 = "54609572eb3d346054a85e8ad3b39a6f31d5dbb2312a7e3d0f7ee92d4de385ef";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_signal_handler/0.6.1-1/bota_driver-release-release-melodic-bota_signal_handler-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_signal_handler-0.6.1-1.tar.gz";
+    sha256 = "bd544d86c3b6fb896fccd1dd079ec588a3d50afd6577c1299c7eabe9bec020ca";
   };
 
   buildType = "catkin";

--- a/distros/melodic/bota-worker/default.nix
+++ b/distros/melodic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-melodic-bota-worker";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.6.0-5/bota_driver-release-release-melodic-bota_worker-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-bota_worker-0.6.0-5.tar.gz";
-    sha256 = "2717a05a4d971346ab8326f9f10710f05c661951dcecb9e669402624edd5e13a";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/bota_worker/0.6.1-1/bota_driver-release-release-melodic-bota_worker-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-bota_worker-0.6.1-1.tar.gz";
+    sha256 = "a96fd54d4e69bafbb3151b8126d2abf51a7d515663019713cdacacf5ce14f0b6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/cpu-temperature-diagnostics/default.nix
+++ b/distros/melodic/cpu-temperature-diagnostics/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, lm_sensors, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-cpu-temperature-diagnostics";
+  version = "0.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/yotabits/cpu_temperature_diagnostics-release/archive/release/melodic/cpu_temperature_diagnostics/0.0.1-1.tar.gz";
+    name = "0.0.1-1.tar.gz";
+    sha256 = "8d3218594e5c1ffcff59e590550b892ad1192987698156b748d5b344876daebc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ diagnostic-updater lm_sensors roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Collect and diagnose cpu temperature informations'';
+    license = with lib.licenses; [ "(c) Ascent Robotics Inc. All rights reserved." ];
+  };
+}

--- a/distros/melodic/dbw-fca-can/default.nix
+++ b/distros/melodic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-can";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "ed6706a6ee497bece0f61267f7ef7b21e216ad3c79cf6fcf037c9783f0884307";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_can/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3a8843dad523a2d1a5a66847cceb20ef391488ea8ad11a38eacad7bb6da60c74";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-description/default.nix
+++ b/distros/melodic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-description";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "26d7b4037bfa82e49fdff61e2c4efc6f5bfda7c99c40a6081ec15476e5c9e9fa";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_description/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3dd6e9e7b55f80be647d0ceed0f1029325fa4d6c2635dd3ef97f37c2a1cdea17";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-joystick-demo/default.nix
+++ b/distros/melodic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-joystick-demo";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "accb8db15f7f579109ea55c57ab25d7a61c40f975980397a8fa72d032047ebd4";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_joystick_demo/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "63a655231fbec314ce818e51cfff0dce44cba0b411a83229b5934ad2a7aaf01f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca-msgs/default.nix
+++ b/distros/melodic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "57979b8ef2a270bbd58de137e157bc951249abba8f6b6d56bb5fa1fb603b2518";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "da0eac4d4147c2e8668ee0c6943d4f70b027f9df5cc740337a90d07de0ea93cb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-fca/default.nix
+++ b/distros/melodic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-fca";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "449771786211501c849d229b2ea64bebb3219f2ff1a9a4924b6dda1d8b00dab2";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/melodic/dbw_fca/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "d0904de7804faee0500c0a375cd2e2822f5ed33c6ffcbfc6e68fda54dac514b8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-can/default.nix
+++ b/distros/melodic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-can";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "f9739687c666069c032dea89eab27ce849b88cc315712834dbc445a69f9447a7";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_can/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "5da58e3e59545bcda58119cf7a6590a5e9425f970a7e5e2e43a68379f367c205";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-description/default.nix
+++ b/distros/melodic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-description";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "2f02629bf7cc37a406d0846918612ba39d5004cae81b91fb84340ad8bcd8803b";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_description/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "4c7175c49a87299aa59caa561d605d5fa56b09560b4a70924ffb064ec42edc9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/melodic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-joystick-demo";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ceeabf98e13b09d6de9538306fd2dfe2e8e2151f9c93683e689b670fb3d00225";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_joystick_demo/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "4bc1ebf988877821847913b3fc162a7755ba1618b4d2646d9431898b4068df50";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz-msgs/default.nix
+++ b/distros/melodic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ffb51c05bdc7b0586d648180a02e581ee49d2739eb484845237771543323352f";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "232b96cb74523937f73a80822367a773673a1bef0d568c17fe94c3e0e805ba06";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-mkz/default.nix
+++ b/distros/melodic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-mkz";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "5dd8e343968cc64156151c36c2f52a2055217296347bac4a24eefaf2b5d3fd53";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/melodic/dbw_mkz/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "99fc02c3b49c9072a2f0517e813d40bce4c484d2d60ae096980ccf8b20ea0aa8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-can/default.nix
+++ b/distros/melodic/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-can";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4d4009f6fe4aea380079f99ba438064f808d3b8232244df76139517e90c898c";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_can/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "7c97c5a3b70b9a45017215ed05823972a4e6100279043b1a125b729c156acb46";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-description/default.nix
+++ b/distros/melodic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-description";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "af3c10674ef2b53c465d213369595fc02994e948f3a63458c569de51a3452367";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "67effacbd8a9fe192fcd35079704442844f221526df1aacabd9997897f098ff8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/melodic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-joystick-demo";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2eb169222ae90f560f008eaedf494180fd381d5ba679de180266e43b9b159f49";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_joystick_demo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "d6d450ef6ae5f4f419ed6dd618b3c5d0def611d081a0b49188b1e5dc7f11a794";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris-msgs/default.nix
+++ b/distros/melodic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "396cc140856577e2e6fed099a808d059205350d441339f44bafa18d4a3844586";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2f0503e4de1855927ac0ad0c414346fa729eb68dbfaf41d25b264a01ce2ff457";
   };
 
   buildType = "catkin";

--- a/distros/melodic/dbw-polaris/default.nix
+++ b/distros/melodic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-melodic-dbw-polaris";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "e4c19322c344787cab8c3893fa7e526e01eb455ad3c8f59422078d8abf78c34e";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/melodic/dbw_polaris/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "bb7a84d6e0e1a97c2dc3cbcb0f2e2ed11d2293c897452763938ae7a1d4818d4c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/end-effector/default.nix
+++ b/distros/melodic/end-effector/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, gtest, joint-state-publisher-gui, kdl-parser, libyamlcpp, message-runtime, moveit-ros-planning-interface, muparser, roscpp, rosee-msg, rospy, srdfdom }:
+buildRosPackage {
+  pname = "ros-melodic-end-effector";
+  version = "1.0.4-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ADVRHumanoids/ROSEndEffector-release/archive/release/melodic/end_effector/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "7bfaf2e109b2c7cb6a21eb989e3092513a2a4b94b3a8e9f1f5b945536f28721b";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest ];
+  propagatedBuildInputs = [ joint-state-publisher-gui kdl-parser libyamlcpp message-runtime moveit-ros-planning-interface muparser roscpp rosee-msg rospy srdfdom ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''End-Effector package: provides a ROS-based set of standard interfaces to command robotics end-effectors in an agnostic fashion'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -216,6 +216,8 @@ self: super: {
 
  bota-driver = self.callPackage ./bota-driver {};
 
+ bota-driver-testing = self.callPackage ./bota-driver-testing {};
+
  bota-node = self.callPackage ./bota-node {};
 
  bota-signal-handler = self.callPackage ./bota-signal-handler {};
@@ -604,6 +606,8 @@ self: super: {
 
  cpr-multimaster-tools = self.callPackage ./cpr-multimaster-tools {};
 
+ cpu-temperature-diagnostics = self.callPackage ./cpu-temperature-diagnostics {};
+
  criutils = self.callPackage ./criutils {};
 
  csm = self.callPackage ./csm {};
@@ -929,6 +933,8 @@ self: super: {
  eiquadprog = self.callPackage ./eiquadprog {};
 
  eml = self.callPackage ./eml {};
+
+ end-effector = self.callPackage ./end-effector {};
 
  er-public-msgs = self.callPackage ./er-public-msgs {};
 
@@ -1547,6 +1553,8 @@ self: super: {
  industrial-trajectory-filters = self.callPackage ./industrial-trajectory-filters {};
 
  industrial-utils = self.callPackage ./industrial-utils {};
+
+ inorbit-republisher = self.callPackage ./inorbit-republisher {};
 
  interactive-marker-proxy = self.callPackage ./interactive-marker-proxy {};
 
@@ -3407,6 +3415,8 @@ self: super: {
  roscreate = self.callPackage ./roscreate {};
 
  rosdiagnostic = self.callPackage ./rosdiagnostic {};
+
+ rosee-msg = self.callPackage ./rosee-msg {};
 
  rosemacs = self.callPackage ./rosemacs {};
 

--- a/distros/melodic/inorbit-republisher/default.nix
+++ b/distros/melodic/inorbit-republisher/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, roslib, rospy, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-inorbit-republisher";
+  version = "0.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/inorbit-ai/ros_inorbit_samples-release/archive/release/melodic/inorbit_republisher/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "3cb5d5fc327542c8fece9309e5c6a91d0656bcfc5a917d1cb23c884d363b6d11";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.pyyaml roslib rospy std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS to InOrbit topic republisher'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/jackal-control/default.nix
+++ b/distros/melodic/jackal-control/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
 buildRosPackage {
   pname = "ros-melodic-jackal-control";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "9e30cadcad73a39729b96fc7bc702fee43d71cc20317b0e4d92cbf5d58a119ec";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_control/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "fd09c26650d3f79df023c270c34b393b5ee16a8da622efe3f2926d6016c0137d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-description/default.nix
+++ b/distros/melodic/jackal-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-description";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "2fcd30f53b30cef383f0758b1d8c96db2b8e26bdba15788708e81b5c449b26ac";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_description/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "0c3b2b89bac7988a33517390b85aebe7c17108c68428ba42fdf5386e8b7e65af";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-msgs/default.nix
+++ b/distros/melodic/jackal-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-jackal-msgs";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "3cf501c738d0f9b33bd7c744277110bcf206eeaf5116f57794ecfa339e3b9e2b";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_msgs/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "c951675a95eb8d978a900fca445e435062dbe20e75479f7274b26b7bb90abc12";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-navigation/default.nix
+++ b/distros/melodic/jackal-navigation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-jackal-navigation";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "09a22aad9574fe03bd81b4352a87aff8a0629043367dd957ce6c9d1a0d804a7b";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_navigation/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "e866dcee4e81fed58cdf6124fe3605b09c5178a8818cd325400ff7cc6f13b6dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/jackal-tutorials/default.nix
+++ b/distros/melodic/jackal-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
 buildRosPackage {
   pname = "ros-melodic-jackal-tutorials";
-  version = "0.7.6-r1";
+  version = "0.7.7-r1";
 
   src = fetchurl {
-    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.6-1.tar.gz";
-    name = "0.7.6-1.tar.gz";
-    sha256 = "f3b43616ea52bf0b0e8bd0c1ac11269b06f6e7779f356143bfaf5acdad5514ad";
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/melodic/jackal_tutorials/0.7.7-1.tar.gz";
+    name = "0.7.7-1.tar.gz";
+    sha256 = "c486e6a59c096ea2947610a84f1c5670cabbdfee198fc6b9dbad90a296c7f9b2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-bringup/default.nix
+++ b/distros/melodic/leo-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
 buildRosPackage {
   pname = "ros-melodic-leo-bringup";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "514b122fc75f96603bc2815f4119ccd879bb1e88c6872390232792f09a29f505";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_bringup/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "9f4c8a488f3d7ad25d0e3591c082f868c96b80c0b8d0f6ee7b97c537138bbcbb";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-fw/default.nix
+++ b/distros/melodic/leo-fw/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-leo-fw";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "42c12033819e86cda2a5050f76d739ec7fdcc17e9d6de5e545c275bffc7ede41";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_fw/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "e4c46151e1c7234f2888dc20a2bb0b9014931264e0bb1fcea3a89e8505bc1049";
   };
 
   buildType = "catkin";

--- a/distros/melodic/leo-robot/default.nix
+++ b/distros/melodic/leo-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
 buildRosPackage {
   pname = "ros-melodic-leo-robot";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "2938d90306d1433d772c494bb527f88b02d654f41e482d0d3743471fdea326e5";
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/melodic/leo_robot/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ff74d389667659898cd61e0a039ca5d3c510ba3c43bb3ce28d443dfd908f2795";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-can-msgs/default.nix
+++ b/distros/melodic/marti-can-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-can-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "1be95a543e72a45295379a47b783c65880bcbe9246b03d1213c1344904492186";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_can_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f68e8194a14c01ac2fedd55efb803f78a27c1c7d7fc966910c94dc6bac13d95e";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-common-msgs/default.nix
+++ b/distros/melodic/marti-common-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-common-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "0f4ea5d731118ba3a4e6cfbd2ffcc767d3b5859f5c04f5e6223dbc439a2f5540";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_common_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f02b5cc31a17570231e8e10b2d55c5791ed8cbed8510cd40347d6ecc06f25316";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-dbw-msgs/default.nix
+++ b/distros/melodic/marti-dbw-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-dbw-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "20487e82ca16abb4fe5d854860aff1f68533ace6bf57664e84f0252b02e6d6d6";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_dbw_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "c220e3f20ba487235ee2bd09d847bc936592ed2bcc596ffbe146d16943122035";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-nav-msgs/default.nix
+++ b/distros/melodic/marti-nav-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geographic-msgs, geometry-msgs, marti-common-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-nav-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "463a70a959ac961c1a95e1c89288a8c8cc68413a42e740fa122cc2f79e2c2793";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_nav_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "e02bad17b082c27c390410be00958fbe30e9d861af6678b0c0eec56ff317522b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-perception-msgs/default.nix
+++ b/distros/melodic/marti-perception-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-perception-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "a1ce04d43b2f67e595ee8af7d02ed4ac4c56c4f491e186ff95669a39f19634ef";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_perception_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "a460597ba5de6f799b64e95f158a367a4e16bc032150cb7b0627caa6ef50000a";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-sensor-msgs/default.nix
+++ b/distros/melodic/marti-sensor-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-sensor-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "3017eb3324444f38714aae48f986ab73734b5ea75e50cd50d90ecd7d70857e2e";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_sensor_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "f67e116de61763b26fba3c3971f443cf89efa11812303b06d6c303ef688ed9e2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-status-msgs/default.nix
+++ b/distros/melodic/marti-status-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-status-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "689c8cf6cd5a54fd8ecf3f2780b1ef1ed99ce9fe240ca79ea5d97ab2c74d8583";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_status_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "56c8dd1217e86e01705211990c154d90d3a94095ff0b42439d7934673567fcd8";
   };
 
   buildType = "catkin";

--- a/distros/melodic/marti-visualization-msgs/default.nix
+++ b/distros/melodic/marti-visualization-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-marti-visualization-msgs";
-  version = "0.10.0-r1";
+  version = "0.10.0-r2";
 
   src = fetchurl {
-    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-1.tar.gz";
-    name = "0.10.0-1.tar.gz";
-    sha256 = "160b50a1c64d4b72e9afc643a6458e7f10123ec3a70e4e950f0e90c394c03ebb";
+    url = "https://github.com/swri-robotics-gbp/marti_messages-release/archive/release/melodic/marti_visualization_msgs/0.10.0-2.tar.gz";
+    name = "0.10.0-2.tar.gz";
+    sha256 = "10db790551687d6618942216d11f049cf36281c3951153b98b5c4ba1ecdd87cf";
   };
 
   buildType = "catkin";

--- a/distros/melodic/plotjuggler-msgs/default.nix
+++ b/distros/melodic/plotjuggler-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler-msgs";
-  version = "0.1.1-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/melodic/plotjuggler_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "5c49fdb2fd2b1a0d2134406bfb65964d83cad90ba1441eb4cbaf6c1d7cf5769d";
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/melodic/plotjuggler_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2754a3a1a90ad84be9e6e470d5201f7e1e7da603a325b8b082925f84829b33d6";
   };
 
-  buildType = "catkin";
+  buildType = "ament_cmake";
   propagatedBuildInputs = [ message-generation message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/melodic/plotjuggler/default.nix
+++ b/distros/melodic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-melodic-plotjuggler";
-  version = "3.3.0-r1";
+  version = "3.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "a331afac0527850d2c44cf58ce7e650d3be1209588414ce2dcaa8ed3019b3d7b";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/melodic/plotjuggler/3.3.1-1.tar.gz";
+    name = "3.3.1-1.tar.gz";
+    sha256 = "c88ba00d0b923695d47f6bfe8c90e6f00036a4b38238a27a9795f9a1a4ee035f";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-bus-manager/default.nix
+++ b/distros/melodic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-bus-manager";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.6.0-5/bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.0-5.tar.gz";
-    sha256 = "1104f46480de718e9b27e97b33edd3f8c6295eb246bc70c1ed0483db97f83dde";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_bus_manager/0.6.1-1/bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_bus_manager-0.6.1-1.tar.gz";
+    sha256 = "c1183bd1a9fa9877b99d9c193cd8274f039d16c9bcf268d33b77d8fcbd0c00d4";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-description/default.nix
+++ b/distros/melodic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-description";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.6.0-5/bota_driver-release-release-melodic-rokubimini_description-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_description-0.6.0-5.tar.gz";
-    sha256 = "b5e1767ef15b4d7b0948be9abd38396428e3985792c55a668632badb44026d93";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_description/0.6.1-1/bota_driver-release-release-melodic-rokubimini_description-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_description-0.6.1-1.tar.gz";
+    sha256 = "59668d594bd3c32d2b2a0510e3afa31e42f248658f296600d2d7528b9950f6cd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-ethercat/default.nix
+++ b/distros/melodic/rokubimini-ethercat/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-ethercat";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.6.0-5/bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.6.0-5.tar.gz";
-    sha256 = "154038dee6f96382a3cb09cc83f62d21da440cd71387c6560cff00418da6d345";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_ethercat/0.6.1-1/bota_driver-release-release-melodic-rokubimini_ethercat-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_ethercat-0.6.1-1.tar.gz";
+    sha256 = "0d8913768f976284fb54f975cca09d060a05fd26c0c405508343491c055e4c8a";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  propagatedBuildInputs = [ ethercat-grant rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/rokubimini-msgs/default.nix
+++ b/distros/melodic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-msgs";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.6.0-5/bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.6.0-5.tar.gz";
-    sha256 = "37925d489e5eafc39d69005070d29aa82bad73ef6a9917e6c3525f09ab639d76";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_msgs/0.6.1-1/bota_driver-release-release-melodic-rokubimini_msgs-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_msgs-0.6.1-1.tar.gz";
+    sha256 = "2a50234d0be498b0a6cb8f7775907ace7436c99b271e3276b959ba8b6341b893";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini-serial/default.nix
+++ b/distros/melodic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini-serial";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.6.0-5/bota_driver-release-release-melodic-rokubimini_serial-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini_serial-0.6.0-5.tar.gz";
-    sha256 = "61f460714694cafafac8cf3f213d1f5fc4a371a4f73bb00d78c39b24d6503625";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini_serial/0.6.1-1/bota_driver-release-release-melodic-rokubimini_serial-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini_serial-0.6.1-1.tar.gz";
+    sha256 = "03189c95343c384a677014c7dcc1ec55a3657a813a5b72b9cc13a88b7ff49d22";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rokubimini/default.nix
+++ b/distros/melodic/rokubimini/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rokubimini";
-  version = "0.6.0-r5";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.6.0-5/bota_driver-release-release-melodic-rokubimini-0.6.0-5.tar.gz";
-    name = "bota_driver-release-release-melodic-rokubimini-0.6.0-5.tar.gz";
-    sha256 = "4dd066b3dda6c1ea4b79a477bead2b39797e9918fed355b18ef2fbab27491a7c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/melodic/rokubimini/0.6.1-1/bota_driver-release-release-melodic-rokubimini-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-melodic-rokubimini-0.6.1-1.tar.gz";
+    sha256 = "4408f8c802a771910831719bcf8f084af00db22d9272b2dfa248f20953abfbb6";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rosee-msg/default.nix
+++ b/distros/melodic/rosee-msg/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, roscpp, rospy, std-msgs, std-srvs }:
+buildRosPackage {
+  pname = "ros-melodic-rosee-msg";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ADVRHumanoids/rosee_msg-release/archive/release/melodic/rosee_msg/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "5a08f47967aa20234b992f8c945d4e05f1a6bc45f70ea76b923fabcb93c35818";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ geometry-msgs std-msgs std-srvs ];
+  propagatedBuildInputs = [ actionlib-msgs message-generation message-runtime roscpp rospy ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The rosee_msg package'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/melodic/rosfmt/default.nix
+++ b/distros/melodic/rosfmt/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rosconsole, roscpp }:
 buildRosPackage {
   pname = "ros-melodic-rosfmt";
-  version = "6.2.0-r1";
+  version = "7.0.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/xqms/rosfmt-release/archive/release/melodic/rosfmt/6.2.0-1.tar.gz";
-    name = "6.2.0-1.tar.gz";
-    sha256 = "2d4429dfb2fe8c718c060da04c0ac1cfbbf3befcdcca82b079bcdc9f8f1bfe53";
+    url = "https://github.com/xqms/rosfmt-release/archive/release/melodic/rosfmt/7.0.0-1.tar.gz";
+    name = "7.0.0-1.tar.gz";
+    sha256 = "9b377b866f2d9d6fc807b982f0893cf58a95fbce0af4a7cc92b88507db5c037b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rtabmap-ros/default.nix
+++ b/distros/melodic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rtabmap-ros";
-  version = "0.20.9-r2";
+  version = "0.20.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.9-2.tar.gz";
-    name = "0.20.9-2.tar.gz";
-    sha256 = "07b6323ad08f6144ec2fda544479893306e574662581ccf64a51814d9d2ca9db";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/melodic/rtabmap_ros/0.20.14-1.tar.gz";
+    name = "0.20.14-1.tar.gz";
+    sha256 = "d9d882c91b301c548931162eac1fc0c10ad01ccbd3296fca5fa9b09a2e8f2220";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ apriltag-ros class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros theora-image-transport visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/melodic/rviz/default.nix
+++ b/distros/melodic/rviz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rviz";
-  version = "1.13.19-r1";
+  version = "1.13.20-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.19-1.tar.gz";
-    name = "1.13.19-1.tar.gz";
-    sha256 = "a65767d5f5329ad27ce497b0a018378f5fedf2382b846a5faf9c773a6efcede6";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/melodic/rviz/1.13.20-1.tar.gz";
+    name = "1.13.20-1.tar.gz";
+    sha256 = "5ae39f7f2e81ba2d5b23f00c8b26a599d4a8b294e9cbee7dfbd7ac9a11e29e0d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/sbg-driver/default.nix
+++ b/distros/melodic/sbg-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-melodic-sbg-driver";
-  version = "3.0.0-r1";
+  version = "3.1.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/3.0.0-1.tar.gz";
-    name = "3.0.0-1.tar.gz";
-    sha256 = "d9eacffb9bd5b9b0807ad482598c36932f04ca9b8313bc1714c140a6c5a02d7b";
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/melodic/sbg_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "76e75583d09bd612ed0d336e641cc886601ff2990e07c9baeeba1d3ab8097997";
   };
 
   buildType = "catkin";

--- a/distros/melodic/urdfdom-py/default.nix
+++ b/distros/melodic/urdfdom-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pythonPackages, rospy }:
 buildRosPackage {
   pname = "ros-melodic-urdfdom-py";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "71ec45fcaee84a9e37e1706732507bc5b1b5ec2599d6222cd76648ed244295f0";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/melodic/urdfdom_py/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "4422ae385618443c9dd7c0e834cf457d73ddeffedc14c44f682fbd769ab913f7";
   };
 
   buildType = "catkin";

--- a/distros/melodic/xacro/default.nix
+++ b/distros/melodic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-melodic-xacro";
-  version = "1.13.13-r2";
+  version = "1.13.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.13-2.tar.gz";
-    name = "1.13.13-2.tar.gz";
-    sha256 = "824f3f329cead6514efd154ac92883725ffbf9da5b8c998fffbbbd267c8e3445";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/melodic/xacro/1.13.14-1.tar.gz";
+    name = "1.13.14-1.tar.gz";
+    sha256 = "73b5aa3e0251b99b527e9bc8e2f8e298a29f50fe738b106ab0be40641c37700b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver-testing/default.nix
+++ b/distros/noetic/bota-driver-testing/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, bota-node, catkin, geometry-msgs, gtest, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial, rosgraph-msgs, rostest, rosunit }:
+buildRosPackage {
+  pname = "ros-noetic-bota-driver-testing";
+  version = "0.6.1-r1";
+
+  src = fetchurl {
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver_testing/0.6.1-1/bota_driver-release-release-noetic-bota_driver_testing-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver_testing-0.6.1-1.tar.gz";
+    sha256 = "ac50c8e4df53bcde4aa759a249b37ffde265f8382aa38eddf13b4ef00bd164eb";
+  };
+
+  buildType = "catkin";
+  checkInputs = [ gtest rosunit ];
+  propagatedBuildInputs = [ bota-node geometry-msgs rokubimini rokubimini-bus-manager rokubimini-ethercat rokubimini-msgs rokubimini-serial rosgraph-msgs rostest ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS node for communicating with rokubimini sensors'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.0-3/bota_driver-release-release-noetic-bota_driver-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_driver-0.6.0-3.tar.gz";
-    sha256 = "99624576836ba668531f370c6384d815884e79650549decf44c2b249152dc3a1";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.1-1/bota_driver-release-release-noetic-bota_driver-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver-0.6.1-1.tar.gz";
+    sha256 = "1054bd95ac5a372efbce8182f1deb70b620dd3a2eac2e78a8988f5c1c935516c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-node";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.0-3/bota_driver-release-release-noetic-bota_node-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_node-0.6.0-3.tar.gz";
-    sha256 = "2dceca17011829a9bbbb383efc59b006b66f9e5e1fcd4042e47d5ecd00f80752";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.1-1/bota_driver-release-release-noetic-bota_node-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_node-0.6.1-1.tar.gz";
+    sha256 = "57da1a9bddd29243710018d23153ef1e4632267ce6a01878dfb77e64fee8256a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-signal-handler";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.0-3/bota_driver-release-release-noetic-bota_signal_handler-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.0-3.tar.gz";
-    sha256 = "c0ead51c2f2b6c54146f3cdd533d7fe79edff814f43c5e2e9544f3433649aad6";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.1-1/bota_driver-release-release-noetic-bota_signal_handler-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.1-1.tar.gz";
+    sha256 = "7dc49e99b76064c8e35f714e631b047dd48556b7456691bead648c8a14e86926";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-worker";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.0-3/bota_driver-release-release-noetic-bota_worker-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_worker-0.6.0-3.tar.gz";
-    sha256 = "df042edcda3b0ebaab5aa4f5d89ce2b98e633e655108b04ca9bc30971657622d";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.1-1/bota_driver-release-release-noetic-bota_worker-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_worker-0.6.1-1.tar.gz";
+    sha256 = "c58f317cfb01f213c11fa9e8e0f8c0b9a032e1283dd035fd86226c066ed5127e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/cmvision/default.nix
+++ b/distros/noetic/cmvision/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, fltk, message-generation, message-runtime, roscpp, sensor-msgs, std-msgs, wxGTK }:
+buildRosPackage {
+  pname = "ros-noetic-cmvision";
+  version = "0.5.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/teshanshanuka/cmvision-release/archive/release/noetic/cmvision/0.5.0-2.tar.gz";
+    name = "0.5.0-2.tar.gz";
+    sha256 = "edbbbcac9c23621ab1408052274744ddbd47e972d2d6c3db1657baa893fec78c";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ cv-bridge fltk message-runtime roscpp sensor-msgs std-msgs wxGTK ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Node for the Color Machine Vision Project, used for fast color blob detection'';
+    license = with lib.licenses; [ lgpl2 ];
+  };
+}

--- a/distros/noetic/dbw-fca-can/default.nix
+++ b/distros/noetic/dbw-fca-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-fca-description, dbw-fca-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-can";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "255a3a8e3b4badee3e3c6fd811271da49f6d5c80038dbc2cb8ec24dbcfbabb77";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_can/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "35e3b5abf42cd4147ae857854629d5b7be74100cdc96bde40b018e9c6d6c582e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-description/default.nix
+++ b/distros/noetic/dbw-fca-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-description";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "50e0e1324da794fea40df40c29bc5906cce9b810d192b28aa36f0a8228d35097";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_description/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "e95759232986a3323cca750a6819e49b8dc223e4ca260b4327fea65cb27aeeb0";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-joystick-demo/default.nix
+++ b/distros/noetic/dbw-fca-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-joystick-demo";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "19709b0b133dfa8ad5b129f3df179db18270df2ca595f0402981fc106ee71b08";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_joystick_demo/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "b50971422ca4df0976ce3292eea9d7edd8d7db4b4b0edd22907093c175a7673e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca-msgs/default.nix
+++ b/distros/noetic/dbw-fca-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca-msgs";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "bef0f78b9e56648eccb2902a0e8e32c6188250cea725629bedbeda8edc231754";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca_msgs/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3a4fc663d87c3246a14727f243ee6666580a33b387de2d07fd3e0f46d7ddd901";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-fca/default.nix
+++ b/distros/noetic/dbw-fca/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-fca-can, dbw-fca-description, dbw-fca-joystick-demo, dbw-fca-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-fca";
-  version = "1.2.0-r1";
+  version = "1.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.0-1.tar.gz";
-    name = "1.2.0-1.tar.gz";
-    sha256 = "d58a31fdc7345fe6dfc5906b2143444a9214b8532fa86a8d7a57d1e310459fa4";
+    url = "https://github.com/DataspeedInc-release/dbw_fca_ros-release/archive/release/noetic/dbw_fca/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "1b080248abc6b54857d218774790c0617217cf3654499842616060435677d21c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-can/default.nix
+++ b/distros/noetic/dbw-mkz-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-mkz-description, dbw-mkz-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-can";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "c5ce21b3888b71a5f90e714a3c2a4d1b506d37b3efce41581f6ebacd441c66a7";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_can/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "9cf430f81fe3c49cd1027c7638f94b52c3f68d2d96434b94b23ed5c30fd69786";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-description/default.nix
+++ b/distros/noetic/dbw-mkz-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-description";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "7ab02ae3997621fd53c3693f9851bd6fbcdf047b98d5c20eaba770394f5d1612";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_description/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "d991ee4c29949a3aa20cdb07ca19a3dab32721a6296d4791a422e7f9f4bddafa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-joystick-demo/default.nix
+++ b/distros/noetic/dbw-mkz-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-joystick-demo";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "37d09beac34caa8b645f7571f0a02a4073fe02b9b6eb96c7f162c0891df045dd";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_joystick_demo/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "291e594ab93cfcc6336001c6d104e586b7bfbf3aa797e0608170ca3fd0dd683c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz-msgs/default.nix
+++ b/distros/noetic/dbw-mkz-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "72a164dbaec7c221713652023322491fdd8d464c73304a3b3d50537002b17cbf";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz_msgs/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "0e4ec5522ffec1e64ae047f07440475904d410aeac5a08b9f14b7cda68cdbda2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-mkz/default.nix
+++ b/distros/noetic/dbw-mkz/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-mkz-can, dbw-mkz-description, dbw-mkz-joystick-demo, dbw-mkz-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-mkz";
-  version = "1.4.0-r1";
+  version = "1.4.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "ed47697b9e2e238a916afc22a724c6ad7038dd324e0e5b0b8708602b16b72a35";
+    url = "https://github.com/DataspeedInc-release/dbw_mkz_ros-release/archive/release/noetic/dbw_mkz/1.4.1-1.tar.gz";
+    name = "1.4.1-1.tar.gz";
+    sha256 = "fc65c579bfe0aedec995127a4098202a9f28da6bcc4aed3d00892a9edcb1e698";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-can/default.nix
+++ b/distros/noetic/dbw-polaris-can/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, can-msgs, catkin, dataspeed-can-msg-filters, dataspeed-can-usb, dataspeed-ulc-can, dbw-polaris-description, dbw-polaris-msgs, geometry-msgs, nodelet, roscpp, roslaunch, rospy, sensor-msgs, socketcan-bridge, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-can";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "2515778c68b8f9cb2153e1f886b0d6d5c7b97355ac0acafadab0bcaea7aa53ee";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_can/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "4622a58474d705636d1bf6bd68eab77d2e65ba78de2d7483fa510f44f3d15e70";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-description/default.nix
+++ b/distros/noetic/dbw-polaris-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, robot-state-publisher, roslaunch, roslib, rviz, urdf, xacro }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-description";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9b770811e84e71eae953cb787c745152ad47dd1331ac9e1f36d0b487cedd1a02";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_description/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "69fce680c38a639172e89ef8b2cab5ae8e557a95bb33af68b6a8713398e90b59";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-joystick-demo/default.nix
+++ b/distros/noetic/dbw-polaris-joystick-demo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-msgs, joy, roscpp, roslaunch, roslib, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-joystick-demo";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "dc192c68eebdf67f243944fe805cd7c25939db8b02037513169455b69f718bcd";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_joystick_demo/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "8c9ea3b4d2a371df6ccacf4429555869b02d014e88f85f60fc5ff2dff255ca8d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris-msgs/default.nix
+++ b/distros/noetic/dbw-polaris-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, rosbag-migration-rule, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris-msgs";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "f964d212b38b5048afe2e312c421e0ef943c9d41e0397431abeff21a73d3724b";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris_msgs/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "11baff27365fc74f0e6405218ab40d6fc79ea30d02db1463688bea2bce19af5b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/dbw-polaris/default.nix
+++ b/distros/noetic/dbw-polaris/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, dbw-polaris-can, dbw-polaris-description, dbw-polaris-joystick-demo, dbw-polaris-msgs }:
 buildRosPackage {
   pname = "ros-noetic-dbw-polaris";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0f40796df33956ed30974ccf12340a223fe2b06cfd2c2bca2ab7495e123e163b";
+    url = "https://github.com/DataspeedInc-release/dbw_polaris_ros-release/archive/release/noetic/dbw_polaris/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "37c5b018b3ef96923d34d4ed6088a0910792bea90d4e295f4bc9059d9fe6a27a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/drone-assets/default.nix
+++ b/distros/noetic/drone-assets/default.nix
@@ -2,18 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin }:
+{ lib, buildRosPackage, fetchurl, catkin, gazebo-ros }:
 buildRosPackage {
   pname = "ros-noetic-drone-assets";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_assets/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "fe6c1d0b77977a27226148598d70eb902bb833ed24fd59cb6f32c80322489399";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_assets/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "b649dc4b8693580aecb298c383b786f15be7c225b7971356c7251536b63c1dd9";
   };
 
   buildType = "catkin";
+  propagatedBuildInputs = [ gazebo-ros ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/drone-circuit-assets/default.nix
+++ b/distros/noetic/drone-circuit-assets/default.nix
@@ -1,0 +1,23 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages }:
+buildRosPackage {
+  pname = "ros-noetic-drone-circuit-assets";
+  version = "1.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_circuit_assets/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "1265679acee200442cbded215e33fc9b9e72734af75cd3b6b605becbf5eb8dc6";
+  };
+
+  buildType = "catkin";
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''The JdeRobot Behavior Metrics drone assets package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/drone-wrapper/default.nix
+++ b/distros/noetic/drone-wrapper/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-drone-wrapper";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_wrapper/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "a08c33118fc65b516e994a1c0d433256fd4e3a9b2a2f686726dcb6915e234b8e";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/drone_wrapper/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a3b6b97dd4608ffae016999446165c3b7cdc2a25845cc7344482d58ded3e52c3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -126,6 +126,8 @@ self: super: {
 
  bota-driver = self.callPackage ./bota-driver {};
 
+ bota-driver-testing = self.callPackage ./bota-driver-testing {};
+
  bota-node = self.callPackage ./bota-node {};
 
  bota-signal-handler = self.callPackage ./bota-signal-handler {};
@@ -193,6 +195,8 @@ self: super: {
  clober-msgs = self.callPackage ./clober-msgs {};
 
  cmake-modules = self.callPackage ./cmake-modules {};
+
+ cmvision = self.callPackage ./cmvision {};
 
  cnpy = self.callPackage ./cnpy {};
 
@@ -547,6 +551,8 @@ self: super: {
  driver-common = self.callPackage ./driver-common {};
 
  drone-assets = self.callPackage ./drone-assets {};
+
+ drone-circuit-assets = self.callPackage ./drone-circuit-assets {};
 
  drone-wrapper = self.callPackage ./drone-wrapper {};
 
@@ -1070,6 +1076,22 @@ self: super: {
 
  hokuyo3d = self.callPackage ./hokuyo3d {};
 
+ husky-control = self.callPackage ./husky-control {};
+
+ husky-description = self.callPackage ./husky-description {};
+
+ husky-desktop = self.callPackage ./husky-desktop {};
+
+ husky-gazebo = self.callPackage ./husky-gazebo {};
+
+ husky-msgs = self.callPackage ./husky-msgs {};
+
+ husky-navigation = self.callPackage ./husky-navigation {};
+
+ husky-simulator = self.callPackage ./husky-simulator {};
+
+ husky-viz = self.callPackage ./husky-viz {};
+
  ibeo-msgs = self.callPackage ./ibeo-msgs {};
 
  ifm3d = self.callPackage ./ifm3d {};
@@ -1165,6 +1187,16 @@ self: super: {
  ixblue-ins-msgs = self.callPackage ./ixblue-ins-msgs {};
 
  ixblue-stdbin-decoder = self.callPackage ./ixblue-stdbin-decoder {};
+
+ jackal-control = self.callPackage ./jackal-control {};
+
+ jackal-description = self.callPackage ./jackal-description {};
+
+ jackal-msgs = self.callPackage ./jackal-msgs {};
+
+ jackal-navigation = self.callPackage ./jackal-navigation {};
+
+ jackal-tutorials = self.callPackage ./jackal-tutorials {};
 
  jderobot-assets = self.callPackage ./jderobot-assets {};
 
@@ -1318,11 +1350,17 @@ self: super: {
 
  leo = self.callPackage ./leo {};
 
+ leo-bringup = self.callPackage ./leo-bringup {};
+
  leo-description = self.callPackage ./leo-description {};
 
  leo-desktop = self.callPackage ./leo-desktop {};
 
+ leo-fw = self.callPackage ./leo-fw {};
+
  leo-gazebo = self.callPackage ./leo-gazebo {};
+
+ leo-robot = self.callPackage ./leo-robot {};
 
  leo-simulator = self.callPackage ./leo-simulator {};
 
@@ -1537,6 +1575,8 @@ self: super: {
  moveit-kinematics = self.callPackage ./moveit-kinematics {};
 
  moveit-msgs = self.callPackage ./moveit-msgs {};
+
+ moveit-opw-kinematics-plugin = self.callPackage ./moveit-opw-kinematics-plugin {};
 
  moveit-planners = self.callPackage ./moveit-planners {};
 
@@ -1801,6 +1841,8 @@ self: super: {
  phidgets-accelerometer = self.callPackage ./phidgets-accelerometer {};
 
  phidgets-analog-inputs = self.callPackage ./phidgets-analog-inputs {};
+
+ phidgets-analog-outputs = self.callPackage ./phidgets-analog-outputs {};
 
  phidgets-api = self.callPackage ./phidgets-api {};
 
@@ -2126,8 +2168,6 @@ self: super: {
 
  rgbd-launch = self.callPackage ./rgbd-launch {};
 
- rm-base = self.callPackage ./rm-base {};
-
  rm-calibration-controllers = self.callPackage ./rm-calibration-controllers {};
 
  rm-chassis-controllers = self.callPackage ./rm-chassis-controllers {};
@@ -2138,11 +2178,15 @@ self: super: {
 
  rm-controllers = self.callPackage ./rm-controllers {};
 
+ rm-dbus = self.callPackage ./rm-dbus {};
+
  rm-description = self.callPackage ./rm-description {};
 
  rm-gazebo = self.callPackage ./rm-gazebo {};
 
  rm-gimbal-controllers = self.callPackage ./rm-gimbal-controllers {};
+
+ rm-hw = self.callPackage ./rm-hw {};
 
  rm-msgs = self.callPackage ./rm-msgs {};
 
@@ -2721,6 +2765,8 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
+
+ tello-driver = self.callPackage ./tello-driver {};
 
  tesseract-common = self.callPackage ./tesseract-common {};
 

--- a/distros/noetic/husky-control/default.nix
+++ b/distros/noetic/husky-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, husky-description, interactive-marker-twist-server, joint-state-controller, joint-trajectory-controller, joy, robot-localization, robot-state-publisher, roslaunch, rostopic, teleop-twist-joy, twist-mux }:
+buildRosPackage {
+  pname = "ros-noetic-husky-control";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_control/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "1db8871eb73e5beef231014b634d915feb75af33194a629db9be05b1028d3dcb";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller husky-description interactive-marker-twist-server joint-state-controller joint-trajectory-controller joy robot-localization robot-state-publisher rostopic teleop-twist-joy twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clearpath Husky controller configurations'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-description/default.nix
+++ b/distros/noetic/husky-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, realsense2-description, roslaunch, urdf, velodyne-description, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-husky-description";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_description/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "c5b3c1ad386301b2cafacb5d7c50274ba81432fc9acfb60118a2863b7053f852";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ lms1xx realsense2-description urdf velodyne-description xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clearpath Husky URDF description'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-desktop/default.nix
+++ b/distros/noetic/husky-desktop/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, husky-msgs, husky-viz }:
+buildRosPackage {
+  pname = "ros-noetic-husky-desktop";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_desktop/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "1730333b7c26682e88ff291ed90754c0d655da2322556d649aed59b6f1dbde71";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ husky-msgs husky-viz ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for Clearpath Husky visualization software'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-gazebo/default.nix
+++ b/distros/noetic/husky-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, gazebo-plugins, gazebo-ros, gazebo-ros-control, hector-gazebo-plugins, husky-control, husky-description, pointcloud-to-laserscan, roslaunch, rostopic, velodyne-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-noetic-husky-gazebo";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_gazebo/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "95de732bbb7dd74184e2be2d0e8274189843e37665781f719daba43c1dcd4c86";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-manager gazebo-plugins gazebo-ros gazebo-ros-control hector-gazebo-plugins husky-control husky-description pointcloud-to-laserscan rostopic velodyne-gazebo-plugins ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Clearpath Husky Simulator bringup'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-msgs/default.nix
+++ b/distros/noetic/husky-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-husky-msgs";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_msgs/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "987db29f075edf2453fb6e1de2b294127c3aa63956b06c9c8c80dd7216d61df4";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages for Clearpath Husky'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-navigation/default.nix
+++ b/distros/noetic/husky-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, base-local-planner, catkin, dwa-local-planner, gmapping, map-server, move-base, navfn, roslaunch }:
+buildRosPackage {
+  pname = "ros-noetic-husky-navigation";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_navigation/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "6c26bf002a85d313377225ca2d0428748ad56e9e9a0211ab9e40d401bc919d9d";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ amcl base-local-planner dwa-local-planner gmapping map-server move-base navfn ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Autonomous mapping and navigation demos for the Clearpath Husky'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-simulator/default.nix
+++ b/distros/noetic/husky-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, husky-gazebo }:
+buildRosPackage {
+  pname = "ros-noetic-husky-simulator";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_simulator/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "3620bb1fda92bf34cfa1409ff9b3bcfc4bec074970cf77287cfdb8ba39b7a5dc";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ husky-gazebo ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage for Clearpath Husky simulation software'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/husky-viz/default.nix
+++ b/distros/noetic/husky-viz/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, husky-description, joint-state-publisher, joint-state-publisher-gui, robot-state-publisher, roslaunch, rviz, rviz-imu-plugin }:
+buildRosPackage {
+  pname = "ros-noetic-husky-viz";
+  version = "0.6.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/husky-release/archive/release/noetic/husky_viz/0.6.0-2.tar.gz";
+    name = "0.6.0-2.tar.gz";
+    sha256 = "c1ab7320429e8296f11e4208d6dd909bb2490f54d9d4458d09840827bb667e73";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ husky-description joint-state-publisher joint-state-publisher-gui robot-state-publisher rviz rviz-imu-plugin ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Visualization configuration for Clearpath Husky'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jackal-control/default.nix
+++ b/distros/noetic/jackal-control/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-manager, diff-drive-controller, interactive-marker-twist-server, joint-state-controller, joy, robot-localization, roslaunch, teleop-twist-joy, topic-tools, twist-mux }:
+buildRosPackage {
+  pname = "ros-noetic-jackal-control";
+  version = "0.8.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_control/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "b8459680ad2b7d142bbe682fa5c0af7a677c6be7e2b6c635cf319d3a0e416520";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ controller-manager diff-drive-controller interactive-marker-twist-server joint-state-controller joy robot-localization teleop-twist-joy topic-tools twist-mux ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Controllers for Jackal'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jackal-description/default.nix
+++ b/distros/noetic/jackal-description/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, lms1xx, pointgrey-camera-description, robot-state-publisher, roslaunch, urdf, velodyne-description, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-jackal-description";
+  version = "0.8.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_description/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "5e2e251134e7a043ea490901d66c4ada68c3c7673fb87e06b92eaa374768d092";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ lms1xx pointgrey-camera-description robot-state-publisher urdf velodyne-description xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''URDF robot description for Jackal'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jackal-msgs/default.nix
+++ b/distros/noetic/jackal-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-jackal-msgs";
+  version = "0.8.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_msgs/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "6c429bb1db69083f8cb31cb17d9c334a89fe7e76ddaadd7f4555606626d454a0";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Messages exclusive to Jackal, especially for representing low-level motor commands and sensors.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jackal-navigation/default.nix
+++ b/distros/noetic/jackal-navigation/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, amcl, catkin, gmapping, map-server, move-base, roslaunch, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-jackal-navigation";
+  version = "0.8.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_navigation/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "763f658d66cee27fb29268e67f179b2dbec849461f62df9382e439ade12c65ec";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslaunch ];
+  propagatedBuildInputs = [ amcl gmapping map-server move-base urdf xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Launch files and code for autonomous navigation of the Jackal'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jackal-tutorials/default.nix
+++ b/distros/noetic/jackal-tutorials/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rosdoc-lite }:
+buildRosPackage {
+  pname = "ros-noetic-jackal-tutorials";
+  version = "0.8.0-r2";
+
+  src = fetchurl {
+    url = "https://github.com/clearpath-gbp/jackal-release/archive/release/noetic/jackal_tutorials/0.8.0-2.tar.gz";
+    name = "0.8.0-2.tar.gz";
+    sha256 = "eff451cf2f44bc793ea7178a92b719ffc092b93ad61500e1b48c191f7d499820";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ rosdoc-lite ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Jackal's tutorials.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/jderobot-drones/default.nix
+++ b/distros/noetic/jderobot-drones/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
+{ lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-circuit-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop, tello-driver }:
 buildRosPackage {
   pname = "ros-noetic-jderobot-drones";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/jderobot_drones/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "77b06ac7a019f69390e1c3ec7f63fda32f2611bbd2bcc646aad9e0dd97062008";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/jderobot_drones/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "4993de1fb338d286572a2d737cae4977737658febd1aecaf82ae96637531a1ee";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ drone-assets drone-wrapper rqt-drone-teleop rqt-ground-robot-teleop ];
+  propagatedBuildInputs = [ drone-assets drone-circuit-assets drone-wrapper rqt-drone-teleop rqt-ground-robot-teleop tello-driver ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/leo-bringup/default.nix
+++ b/distros/noetic/leo-bringup/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, leo-description, robot-state-publisher, rosbridge-server, rosserial-python, sensor-msgs, web-video-server, xacro }:
+buildRosPackage {
+  pname = "ros-noetic-leo-bringup";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_bringup/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "439d51236941302eb886b10982e8155d712caffe832b0fe1efda5eac21fcbb56";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ geometry-msgs leo-description robot-state-publisher rosbridge-server rosserial-python sensor-msgs web-video-server xacro ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Scripts and launch files for starting basic Leo Rover functionalities.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/leo-fw/default.nix
+++ b/distros/noetic/leo-fw/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, python3Packages, rosgraph, rosmon-msgs, rosnode, rospy, rosservice, std-srvs }:
+buildRosPackage {
+  pname = "ros-noetic-leo-fw";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_fw/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "ea6d85b60e0fc3cba87c02afb908effaac46f6fe1353744a6e670b27e56eaacd";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ python3Packages.rospkg python3Packages.whichcraft rosgraph rosmon-msgs rosnode rospy rosservice std-srvs ];
+  nativeBuildInputs = [ catkin python3Packages.setuptools ];
+
+  meta = {
+    description = ''Firmware binary releases and update script for Leo Rover'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/leo-robot/default.nix
+++ b/distros/noetic/leo-robot/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, leo, leo-bringup, leo-fw }:
+buildRosPackage {
+  pname = "ros-noetic-leo-robot";
+  version = "1.2.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/fictionlab-gbp/leo_robot-release/archive/release/noetic/leo_robot/1.2.1-1.tar.gz";
+    name = "1.2.1-1.tar.gz";
+    sha256 = "3bb65090341100981479eb4f998afb8980f87f3455ff8e91e255e9d1f3173da4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ leo leo-bringup leo-fw ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Metapackage of software to install on Leo Rover.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "13448a827747b404a950c49df14ba9adec5d38b60d62dde4e3add13f337d213a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "22c5f108d6be26bdc8dc34c00b8f459a6e3cf4709276817b57b00e6252bb306c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/moveit-opw-kinematics-plugin/default.nix
+++ b/distros/noetic/moveit-opw-kinematics-plugin/default.nix
@@ -1,0 +1,33 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, eigen-conversions, moveit-core, moveit-resources-fanuc-moveit-config, moveit-ros-planning, opw-kinematics, pluginlib, roscpp, rostest }:
+buildRosPackage {
+  pname = "ros-noetic-moveit-opw-kinematics-plugin";
+  version = "0.3.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/JeroenDM/moveit_opw_kinematics_plugin-release/archive/release/noetic/moveit_opw_kinematics_plugin/0.3.1-2.tar.gz";
+    name = "0.3.1-2.tar.gz";
+    sha256 = "c1222455493b3d0d601d777ea264e4ef6b5f9ee6b3c6ad330eb2fa871ae54fbf";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ eigen-conversions opw-kinematics ];
+  checkInputs = [ moveit-resources-fanuc-moveit-config moveit-ros-planning rostest ];
+  propagatedBuildInputs = [ moveit-core pluginlib roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''<p>
+      MoveIt kinematics plugin for industrial robots.
+    </p>
+    <p>
+      This plugin uses an analytical inverse kinematic library, opw_kinematics,
+      to calculate the inverse kinematics for industrial robots with 6 degrees of freedom,
+      two parallel joints, and a spherical wrist.
+    </p>'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/noetic/nodelet-core/default.nix
+++ b/distros/noetic/nodelet-core/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, nodelet-topic-tools }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-core";
-  version = "1.10.1-r1";
+  version = "1.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "8e6b9ffcfb0abe296423f61201306683174fba537fce06e84d4a28218bec3f23";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_core/1.10.2-1.tar.gz";
+    name = "1.10.2-1.tar.gz";
+    sha256 = "e0d132be009c5e023db662b72ed0ba76cb986b51f2603aee36dd15ce084ab8b6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet-topic-tools/default.nix
+++ b/distros/noetic/nodelet-topic-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, boost, catkin, dynamic-reconfigure, message-filters, nodelet, pluginlib, roscpp }:
 buildRosPackage {
   pname = "ros-noetic-nodelet-topic-tools";
-  version = "1.10.1-r1";
+  version = "1.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "425324f1b12a552edc960f8a003f4ca8a986e56cf36e0848b489fb7327412838";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet_topic_tools/1.10.2-1.tar.gz";
+    name = "1.10.2-1.tar.gz";
+    sha256 = "c05691304366f3249aac1cb411f3d29c45908bb72a30e917df319391bc67ed76";
   };
 
   buildType = "catkin";

--- a/distros/noetic/nodelet/default.nix
+++ b/distros/noetic/nodelet/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bondcpp, boost, catkin, cmake-modules, message-generation, message-runtime, pluginlib, rosconsole, roscpp, rospy, std-msgs, util-linux }:
 buildRosPackage {
   pname = "ros-noetic-nodelet";
-  version = "1.10.1-r1";
+  version = "1.10.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.10.1-1.tar.gz";
-    name = "1.10.1-1.tar.gz";
-    sha256 = "e5fc828f77cb9bc673340bae8e29fde4d16be54ceec4ef23153e29bc9aa0c00b";
+    url = "https://github.com/ros-gbp/nodelet_core-release/archive/release/noetic/nodelet/1.10.2-1.tar.gz";
+    name = "1.10.2-1.tar.gz";
+    sha256 = "71cd76bda95fa2bcb3938a4b1700faa2dcbaf741e0ba2494934e560b4c5ee92c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "9973c4e460483bea8ab2fe76f976fb9faf9708ee05d42ed408877d507c85889b";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "0f39ce926508512bcdfbb4bc5c3bb85bdae880926080b5e5e9e7cf7f00ce7233";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7dcd2bc2cd5afced604837687f56a436fc3ddd1195402ee25721773bf42d14dc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "493a5e7f5174e4db0b9065f656cdc41558e5b3b37166791136a2c3bf9ada628a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-phidgets-analog-outputs";
+  version = "1.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "11fdb823ce48393ccd28ecf1eb3cc1dd8040bea571f39b0d87b5f269290aad92";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ nodelet phidgets-api phidgets-msgs roscpp roslaunch std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Driver for the Phidgets Analog Output devices'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "82c3c565bca2961eadb2acc1d543bd1a8369579859ee668016f9edda4a3cc5bc";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "875c61236a2d3d493d14ff125851c160c24f42deafcb02dc626304c04ae9499e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "92813a56daf204152b99a1d41b67093ccda583ae6f878bbe7d7fa6c5d2ce7114";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "d0ba2bceea038f3405dcd7ccd7e6547d7a8ab98900b3e1f4d41b30f52a70a70e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "82b8e84fab49ae6f80529cc0f18fe3124548ba34b8f1fc5e3d359a3694c66f67";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "9cc2f5304a8ecb01e65d1c0edf70a559e078fecd34676549645add6ed3e7e349";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "f5cac996d9547056119ed4af8495d511f868d89121f0cb2098f348648ef7a2bb";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "89d9e577bb8b9c166834e7a5ba31eb421cbc1b7c7cb755eb7b1fa021610dcb1d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "0f2f44967ed4f81e33e6ba841c2293b2196ccd3e5dab4c7eec0f7ddffc5136c2";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "77a1630f1467cee9bf96e8b831c4e12e8d95f710d0edec78c1454ae3dd721c8e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "46053584a6ca253e2a530e85166bb92f81a82587fc080b89a4808da202c4d574";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "702c6a7dbd53bdeb546e068275f34368ada8c1f7ff8f27a34bc82b346b3d5554";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "d14222ef6400806227923f5e6414e59100c05c73874c0ac88de53dc26ea0e205";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "4499560825d29cae1009b8ba07db6141ddcfdc399c662301dbbb95f49645cc35";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a5758231079a6729f9c64926031db941dd0ff0efd0704baf45d1c31fc755dbfd";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "43a0a178a08520d45e0e228d78ebdb09660887ce8879c7047012f494a40b4e90";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "87d56112414a32f4e10c118e46ffbed311366c780604733c960d3d30f46a8cd6";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "45b9abdf7d5dea528528d44d50062a1738da9356a620096c8fd5ce3595630e86";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "a8c2cd6af1a49a18bd30abbd3778bd91ecdeb04e75a89b4afeb5e425b996db01";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "e8bf989729254c001671bd0a3bfecf8024d5c9184c147847745865a4fdcfe066";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "499c1bf8bf2d771b102881cd05fd1cde6c0224c85bb49d88cd968ea03f2e6af2";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2c9ec42c52b8ef017867fac29d9b11c2888bdcf483176a420e3f60769f3e8a9c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.2-r1";
+  version = "1.0.3-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.2-1.tar.gz";
-    name = "1.0.2-1.tar.gz";
-    sha256 = "7ce183c877cfd658a29b64dd24533651816043ab3c84eba33820d38fb56ea134";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.3-1.tar.gz";
+    name = "1.0.3-1.tar.gz";
+    sha256 = "2d79450020d11642e3b0b7a4add3b9b2cb650f381f8501782421f127c3a25bd1";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-msgs/default.nix
+++ b/distros/noetic/plotjuggler-msgs/default.nix
@@ -5,15 +5,15 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-msgs";
-  version = "0.1.1-r1";
+  version = "0.2.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/noetic/plotjuggler_msgs/0.1.1-1.tar.gz";
-    name = "0.1.1-1.tar.gz";
-    sha256 = "400aab24ff30654a6c55e81d6b6739b9cc86bf2caefa5343a10dfbf92958351a";
+    url = "https://github.com/facontidavide/plotjuggler_msgs-release/archive/release/noetic/plotjuggler_msgs/0.2.1-1.tar.gz";
+    name = "0.2.1-1.tar.gz";
+    sha256 = "2af067089b7ea6584191410dd4bf8eda374b2d67fbc75f57e42b7581ff4928b9";
   };
 
-  buildType = "catkin";
+  buildType = "ament_cmake";
   propagatedBuildInputs = [ message-generation message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.3.0-r1";
+  version = "3.3.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.0-1.tar.gz";
-    name = "3.3.0-1.tar.gz";
-    sha256 = "36339200b6c76256e09ee0cbd414464bb0db63c946f15d0b6a4666af4a52811b";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.1-1.tar.gz";
+    name = "3.3.1-1.tar.gz";
+    sha256 = "6f1df262098c0b07c1fd672cb732e96376530f46760ff0c44f774204f5a97bf5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-common/default.nix
+++ b/distros/noetic/rm-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, control-msgs, controller-manager-msgs, dynamic-reconfigure, eigen, geometry-msgs, realtime-tools, rm-msgs, roscpp, roslint, tf }:
 buildRosPackage {
   pname = "ros-noetic-rm-common";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "3b416613a6cd85b83de05616a3e7d1e12c1ae98afd778b68e7b5d364415dab6c";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_common/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "8a385e0dccb4cbca7d1f7ffee9ac9a52a98ad261cce2a4f81974ec147079a298";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-control/default.nix
+++ b/distros/noetic/rm-control/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rm-common, rm-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, rm-common, rm-description, rm-gazebo, rm-hw, rm-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-control";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "badd44a2c96c661235de0304340dabb8f3e552489c7ae695d94edab2090baaf8";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_control/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "cced513a80e500ac41365668df44ef4df96f78c2a016b6b6fc4636f00fe1f3f5";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rm-common rm-msgs ];
+  propagatedBuildInputs = [ rm-common rm-description rm-gazebo rm-hw rm-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rm-dbus/default.nix
+++ b/distros/noetic/rm-dbus/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, rm-common, roscpp, roslint }:
+buildRosPackage {
+  pname = "ros-noetic-rm-dbus";
+  version = "0.1.7-r3";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_dbus/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "513ff4146b0c5f95cace971c65735d9f38bf7816387044bd3488b4cacf7b4893";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ rm-common roscpp roslint ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A package that uses dbus to read remote control information'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-description/default.nix
+++ b/distros/noetic/rm-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rm-description";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "9efff0393a8fd9a0ad6fe81a918f2ab1abaa31a2684bddf8bae58be2ffe9bd72";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_description/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "ce1edcca5d7d79f4efb39108eb0ff9e1a7348a270c601e0c81abb57298c80bd7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-gazebo/default.nix
+++ b/distros/noetic/rm-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo, gazebo-ros, gazebo-ros-control, rm-common, rm-description, roboticsgroup-upatras-gazebo-plugins, roscpp, roslint }:
 buildRosPackage {
   pname = "ros-noetic-rm-gazebo";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "8b4d10fcf5aec733eb27ca415dffbe4705e754707e621f9e9c5a8c4ceccfce3b";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_gazebo/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "483da5a38f0a7d3a4534c4e6980aac1c6876acff5148e891e8866b98d2afe4be";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rm-hw/default.nix
+++ b/distros/noetic/rm-hw/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, controller-interface, controller-manager, hardware-interface, joint-limits-interface, realtime-tools, rm-common, rm-msgs, roscpp, roslint, transmission-interface, urdf }:
+buildRosPackage {
+  pname = "ros-noetic-rm-hw";
+  version = "0.1.7-r3";
+
+  src = fetchurl {
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_hw/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "d75b09754f020e9536cba1101f76ab0524171188abbc8dc7be8783154e9864d6";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ controller-interface controller-manager hardware-interface joint-limits-interface realtime-tools rm-common rm-msgs roscpp roslint transmission-interface urdf ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS control warped interface for RoboMaster motor and some robot hardware'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/rm-msgs/default.nix
+++ b/distros/noetic/rm-msgs/default.nix
@@ -5,17 +5,16 @@
 { lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rm-msgs";
-  version = "0.1.1-r5";
+  version = "0.1.7-r3";
 
   src = fetchurl {
-    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.1-5.tar.gz";
-    name = "0.1.1-5.tar.gz";
-    sha256 = "818f207b30dc64bd121e80eab1e6339d09049e993160ffe5ff26fb8f8b64cdab";
+    url = "https://github.com/rm-controls/rm_control-release/archive/release/noetic/rm_msgs/0.1.7-3.tar.gz";
+    name = "0.1.7-3.tar.gz";
+    sha256 = "5cbfcb09b9b23668ecbe61880c234908ad0c86754819dbfd7cb4a970b8d729b9";
   };
 
   buildType = "catkin";
-  buildInputs = [ message-generation ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-runtime std-msgs ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs geometry-msgs message-generation message-runtime std-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/robot-state-publisher/default.nix
+++ b/distros/noetic/robot-state-publisher/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, kdl-parser, orocos-kdl, rosbag, rosconsole, roscpp, rostest, rostime, sensor-msgs, tf, tf2-kdl, tf2-ros, urdfdom-headers }:
 buildRosPackage {
   pname = "ros-noetic-robot-state-publisher";
-  version = "1.15.0-r1";
+  version = "1.15.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.0-1.tar.gz";
-    name = "1.15.0-1.tar.gz";
-    sha256 = "1a12e4672ace312f3ba8ca281b50c211d7060cd0cc532dac395ea5061844880b";
+    url = "https://github.com/ros-gbp/robot_state_publisher-release/archive/release/noetic/robot_state_publisher/1.15.2-1.tar.gz";
+    name = "1.15.2-1.tar.gz";
+    sha256 = "9939e39eb22755515c60d7d1941f9775c44725dbd10e79c18fc558c4a5b6af94";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-bus-manager";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.0-3/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.0-3.tar.gz";
-    sha256 = "05103139bc34325a0b3cfb2eb67e9730d49ed74da51fd9d8ffd271dfacb88df1";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.1-1/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-1.tar.gz";
+    sha256 = "4168fd039123557f655a441cf1be69d2af4e58667523fbbc3d50d2197e0f2ce5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-description";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.0-3/bota_driver-release-release-noetic-rokubimini_description-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.0-3.tar.gz";
-    sha256 = "da529a6ebdaee1693d151b3b60566d2cd69a5fbfdd0bc76c4c089d5a11acee34";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.1-1/bota_driver-release-release-noetic-rokubimini_description-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.1-1.tar.gz";
+    sha256 = "5e3c817e6ae03f7a9d6a26cc531432640bfaf47f7951ad83f0556c19b94e310e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
+{ lib, buildRosPackage, fetchurl, catkin, ethercat-grant, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-ethercat";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.0-3/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.0-3.tar.gz";
-    sha256 = "d92e8223000be4d87f5be597201f7f9f574492ea417f41186f8b6469d82ec18b";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.1-1/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-1.tar.gz";
+    sha256 = "5e7a046ebe1148a8d4d71639807d90e1307bd5aa5874cafdb0dd34933a5ec83d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
+  propagatedBuildInputs = [ ethercat-grant rokubimini rokubimini-bus-manager rokubimini-msgs soem ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-msgs";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.0-3/bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.0-3.tar.gz";
-    sha256 = "506e071f627848773cd93981e1a6f13f807e83920af9125d3f03eeb874ce3f9c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.1-1/bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-1.tar.gz";
+    sha256 = "72425590ddc6ded508477bc5fddabdaf13317dff11080d032dcba291ec728a75";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-serial";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.0-3/bota_driver-release-release-noetic-rokubimini_serial-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.0-3.tar.gz";
-    sha256 = "aad86d31c9a93561c5ba70db388b52aa4bf54661002b866a1f36380b02b984cc";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.1-1/bota_driver-release-release-noetic-rokubimini_serial-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.1-1.tar.gz";
+    sha256 = "6c45ce3bd8dc83e376091b34f0e1d5deefcb85057cb5dea0ba393ebfe4c9048e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini";
-  version = "0.6.0-r3";
+  version = "0.6.1-r1";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.0-3/bota_driver-release-release-noetic-rokubimini-0.6.0-3.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini-0.6.0-3.tar.gz";
-    sha256 = "e18f529bf993ec5cad60b8488a38aa38cd8a9924c4d0c2cc5641048503665986";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.1-1/bota_driver-release-release-noetic-rokubimini-0.6.1-1.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini-0.6.1-1.tar.gz";
+    sha256 = "deaa93a7ef78b1cdba89ea0a0e0738301697509ee6f213d94d0008de194341b2";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rqt-drone-teleop/default.nix
+++ b/distros/noetic/rqt-drone-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-drone-teleop";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_drone_teleop/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "296fdabffa7365e21fb7ab133efc32756463f189bf49a349e5ea6d1d511b6155";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_drone_teleop/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "e52d610e8f680a7e23c9193ec5324db85da8414de03da0a79bf5ce34666d327f";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ drone-wrapper geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  propagatedBuildInputs = [ drone-wrapper geometry-msgs python3Packages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rqt-ground-robot-teleop/default.nix
+++ b/distros/noetic/rqt-ground-robot-teleop/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, python3Packages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rqt-ground-robot-teleop";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_ground_robot_teleop/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "3bb3ec22c82992e457654fa2bbca60688ae872e5dba98701d2f749d9d12d9f8c";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/rqt_ground_robot_teleop/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "dea8cd9bf3da1bf7f9539c1a63583fdf546cfac5e55133bdda90a9dd5d21e28d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ geometry-msgs pythonPackages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
+  propagatedBuildInputs = [ geometry-msgs python3Packages.rospkg roslib rospy rqt-gui rqt-gui-py sensor-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/rtabmap-ros/default.nix
+++ b/distros/noetic/rtabmap-ros/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, apriltag-ros, catkin, class-loader, compressed-depth-image-transport, compressed-image-transport, costmap-2d, cv-bridge, dynamic-reconfigure, eigen-conversions, find-object-2d, genmsg, geometry-msgs, image-geometry, image-transport, laser-geometry, message-filters, message-generation, message-runtime, move-base-msgs, nav-msgs, nodelet, octomap-msgs, pcl, pcl-conversions, pcl-ros, pluginlib, roscpp, rosgraph-msgs, rospy, rtabmap, rviz, sensor-msgs, std-msgs, std-srvs, stereo-msgs, tf, tf-conversions, tf2-ros, theora-image-transport, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rtabmap-ros";
-  version = "0.20.10-r1";
+  version = "0.20.14-r1";
 
   src = fetchurl {
-    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.10-1.tar.gz";
-    name = "0.20.10-1.tar.gz";
-    sha256 = "4385208a6c891fd32d9017f0ce6ccc556d58a319ea7cdb3fdafdbffa3a291cbe";
+    url = "https://github.com/introlab/rtabmap_ros-release/archive/release/noetic/rtabmap_ros/0.20.14-1.tar.gz";
+    name = "0.20.14-1.tar.gz";
+    sha256 = "3def585ea3acd32d4767c993376708b51544c4e6f027a69b5481872ea270e39d";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation pcl ];
-  propagatedBuildInputs = [ class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros visualization-msgs ];
+  propagatedBuildInputs = [ apriltag-ros class-loader compressed-depth-image-transport compressed-image-transport costmap-2d cv-bridge dynamic-reconfigure eigen-conversions find-object-2d geometry-msgs image-geometry image-transport laser-geometry message-filters message-runtime move-base-msgs nav-msgs nodelet octomap-msgs pcl-conversions pcl-ros pluginlib roscpp rosgraph-msgs rospy rtabmap rviz sensor-msgs std-msgs std-srvs stereo-msgs tf tf-conversions tf2-ros theora-image-transport visualization-msgs ];
   nativeBuildInputs = [ catkin genmsg ];
 
   meta = {

--- a/distros/noetic/rviz/default.nix
+++ b/distros/noetic/rviz/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, assimp, catkin, cmake-modules, eigen, geometry-msgs, image-transport, interactive-markers, laser-geometry, libGL, libGLU, libyamlcpp, map-msgs, media-export, message-filters, message-generation, message-runtime, nav-msgs, ogre1_9, pluginlib, python-qt-binding, qt5, resource-retriever, rosbag, rosconsole, roscpp, roslib, rospy, rostest, rosunit, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-ros, tinyxml-2, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rviz";
-  version = "1.14.9-r2";
+  version = "1.14.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.9-2.tar.gz";
-    name = "1.14.9-2.tar.gz";
-    sha256 = "612a7d4a5dedc61354a8d0db0b19447e1e64f401feb2a9b3a826fb644826343f";
+    url = "https://github.com/ros-gbp/rviz-release/archive/release/noetic/rviz/1.14.10-1.tar.gz";
+    name = "1.14.10-1.tar.gz";
+    sha256 = "e55513ec8a0219e94812f70145357f9d3f0a3d80d71e267de2394bf11d028b83";
   };
 
   buildType = "catkin";
   buildInputs = [ cmake-modules eigen message-generation urdfdom urdfdom-headers ];
   checkInputs = [ rostest rosunit ];
-  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-eigen tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs ];
+  propagatedBuildInputs = [ assimp geometry-msgs image-transport interactive-markers laser-geometry libGL libGLU libyamlcpp map-msgs media-export message-filters message-runtime nav-msgs ogre1_9 pluginlib python-qt-binding qt5.qtbase resource-retriever rosbag rosconsole roscpp roslib rospy sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-ros tinyxml-2 urdf visualization-msgs ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/tello-driver/default.nix
+++ b/distros/noetic/tello-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-noetic-tello-driver";
+  version = "1.4.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/noetic/tello_driver/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "54774c8bb9bc3b962475b47a5ccd8d6b7b93b2d22140169a9ba0691c4f1dfb05";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs mavros mavros-msgs rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tello_driver package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/urdfdom-py/default.nix
+++ b/distros/noetic/urdfdom-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, python3Packages, rospy }:
 buildRosPackage {
   pname = "ros-noetic-urdfdom-py";
-  version = "0.4.5-r1";
+  version = "0.4.6-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/noetic/urdfdom_py/0.4.5-1.tar.gz";
-    name = "0.4.5-1.tar.gz";
-    sha256 = "47ce495037d7c5f0203508ff7f624957607c80c8dcede64fb308a04b755f0028";
+    url = "https://github.com/ros-gbp/urdfdom_py-release/archive/release/noetic/urdfdom_py/0.4.6-1.tar.gz";
+    name = "0.4.6-1.tar.gz";
+    sha256 = "fbaedbb3631b3c3e1573db77770ab2e40ff9eeb74a7564ab8a1fbb8df5bb6ead";
   };
 
   buildType = "catkin";

--- a/distros/noetic/xacro/default.nix
+++ b/distros/noetic/xacro/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roslaunch, roslint, rostest }:
 buildRosPackage {
   pname = "ros-noetic-xacro";
-  version = "1.14.9-r1";
+  version = "1.14.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.9-1.tar.gz";
-    name = "1.14.9-1.tar.gz";
-    sha256 = "d25f54c72871d94ad902660bc0c2eeec5fa879f043af7cddd14589b5d7bb1da7";
+    url = "https://github.com/ros-gbp/xacro-release/archive/release/noetic/xacro/1.14.10-1.tar.gz";
+    name = "1.14.10-1.tar.gz";
+    sha256 = "b0401ffd159765ee71f2c17cd5caccf48cb4a2e3067cf3bc65c190ba828e2c35";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 0c9bc531da293ff0723733948cadf21d4c44fbc4.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *examples-tf2-py 0.13.11-r1 --> 0.13.12-r1*
* *geometry2 0.13.11-r1 --> 0.13.12-r1*
* *launch-ros 0.11.3-r1 --> 0.11.4-r1*
* *launch-testing-ros 0.11.3-r1 --> 0.11.4-r1*
* *plotjuggler 3.3.0-r1 --> 3.3.1-r2*
* *plotjuggler-msgs 0.1.2-r1 --> 0.2.1-r1*
* *plotjuggler-ros 1.5.0-r1 --> 1.6.1-r1*
* *rclpy 1.0.6-r1 --> 1.0.7-r1*
* *ros2action 0.9.9-r1 --> 0.9.10-r1*
* *ros2cli 0.9.9-r1 --> 0.9.10-r1*
* *ros2component 0.9.9-r1 --> 0.9.10-r1*
* *ros2interface 0.9.9-r1 --> 0.9.10-r1*
* *ros2launch 0.11.3-r1 --> 0.11.4-r1*
* *ros2lifecycle 0.9.9-r1 --> 0.9.10-r1*
* *ros2lifecycle-test-fixtures 0.9.9-r1 --> 0.9.10-r1*
* *ros2multicast 0.9.9-r1 --> 0.9.10-r1*
* *ros2node 0.9.9-r1 --> 0.9.10-r1*
* *ros2param 0.9.9-r1 --> 0.9.10-r1*
* *ros2pkg 0.9.9-r1 --> 0.9.10-r1*
* *ros2run 0.9.9-r1 --> 0.9.10-r1*
* *ros2service 0.9.9-r1 --> 0.9.10-r1*
* *ros2topic 0.9.9-r1 --> 0.9.10-r1*
* *rqt-runtime-monitor 1.0.0-r1*
* *rviz-assimp-vendor 8.2.3-r1 --> 8.2.4-r1*
* *rviz-common 8.2.3-r1 --> 8.2.4-r1*
* *rviz-default-plugins 8.2.3-r1 --> 8.2.4-r1*
* *rviz-ogre-vendor 8.2.3-r1 --> 8.2.4-r1*
* *rviz-rendering 8.2.3-r1 --> 8.2.4-r1*
* *rviz-rendering-tests 8.2.3-r1 --> 8.2.4-r1*
* *rviz-visual-testing-framework 8.2.3-r1 --> 8.2.4-r1*
* *rviz2 8.2.3-r1 --> 8.2.4-r1*
* *simple-launch 1.0.6-r1 --> 1.1.0-r1*
* *tf2 0.13.11-r1 --> 0.13.12-r1*
* *tf2-bullet 0.13.11-r1 --> 0.13.12-r1*
* *tf2-eigen 0.13.11-r1 --> 0.13.12-r1*
* *tf2-eigen-kdl 0.13.11-r1 --> 0.13.12-r1*
* *tf2-geometry-msgs 0.13.11-r1 --> 0.13.12-r1*
* *tf2-kdl 0.13.11-r1 --> 0.13.12-r1*
* *tf2-msgs 0.13.11-r1 --> 0.13.12-r1*
* *tf2-py 0.13.11-r1 --> 0.13.12-r1*
* *tf2-ros 0.13.11-r1 --> 0.13.12-r1*
* *tf2-sensor-msgs 0.13.11-r1 --> 0.13.12-r1*
* *tf2-tools 0.13.11-r1 --> 0.13.12-r1*

Galactic Changes:
-----------------
* *controller-interface 1.0.0-r1*
* *controller-manager 1.0.0-r1*
* *controller-manager-msgs 1.0.0-r1*
* *diff-drive-controller 1.0.0-r1*
* *effort-controllers 1.0.0-r1*
* *force-torque-sensor-broadcaster 1.0.0-r1*
* *forward-command-controller 1.0.0-r1*
* *geometric-shapes 2.1.0-r2 --> 2.1.1-r1*
* *gripper-controllers 1.0.0-r1*
* *hardware-interface 1.0.0-r1*
* *imu-sensor-broadcaster 1.0.0-r1*
* *joint-state-broadcaster 1.0.0-r1*
* *joint-trajectory-controller 1.0.0-r1*
* *moveit-msgs 2.1.0-r1 --> 2.1.1-r1*
* *position-controllers 1.0.0-r1*
* *ros2-control 1.0.0-r1*
* *ros2-control-test-assets 1.0.0-r1*
* *ros2-controllers 1.0.0-r1*
* *ros2controlcli 1.0.0-r1*
* *rqt-runtime-monitor 1.0.0-r1*
* *srdfdom 2.0.2-r1 --> 2.0.3-r1*
* *transmission-interface 1.0.0-r1*
* *velocity-controllers 1.0.0-r1*
* *warehouse-ros 2.0.3-r1 --> 2.0.4-r1*

Melodic Changes:
----------------
* *bota-driver 0.6.0-r5 --> 0.6.1-r1*
* *bota-driver-testing 0.6.1-r1*
* *bota-node 0.6.0-r5 --> 0.6.1-r1*
* *bota-signal-handler 0.6.0-r5 --> 0.6.1-r1*
* *bota-worker 0.6.0-r5 --> 0.6.1-r1*
* *cpu-temperature-diagnostics 0.0.1-r1*
* *dbw-fca 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-can 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-description 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-joystick-demo 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-msgs 1.2.0-r1 --> 1.2.1-r1*
* *dbw-mkz 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-can 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-description 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-joystick-demo 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-msgs 1.4.0-r1 --> 1.4.1-r1*
* *dbw-polaris 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-can 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-description 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-joystick-demo 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-msgs 1.0.0-r1 --> 1.0.1-r1*
* *end-effector 1.0.4-r1*
* *inorbit-republisher 0.2.1-r1*
* *jackal-control 0.7.6-r1 --> 0.7.7-r1*
* *jackal-description 0.7.6-r1 --> 0.7.7-r1*
* *jackal-msgs 0.7.6-r1 --> 0.7.7-r1*
* *jackal-navigation 0.7.6-r1 --> 0.7.7-r1*
* *jackal-tutorials 0.7.6-r1 --> 0.7.7-r1*
* *leo-bringup 1.2.0-r1 --> 1.2.1-r1*
* *leo-fw 1.2.0-r1 --> 1.2.1-r1*
* *leo-robot 1.2.0-r1 --> 1.2.1-r1*
* *marti-can-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-common-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-dbw-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-nav-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-perception-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-sensor-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-status-msgs 0.10.0-r1 --> 0.10.0-r2*
* *marti-visualization-msgs 0.10.0-r1 --> 0.10.0-r2*
* *plotjuggler 3.3.0-r1 --> 3.3.1-r1*
* *plotjuggler-msgs 0.1.1-r1 --> 0.2.1-r1*
* *rokubimini 0.6.0-r5 --> 0.6.1-r1*
* *rokubimini-bus-manager 0.6.0-r5 --> 0.6.1-r1*
* *rokubimini-description 0.6.0-r5 --> 0.6.1-r1*
* *rokubimini-ethercat 0.6.0-r5 --> 0.6.1-r1*
* *rokubimini-msgs 0.6.0-r5 --> 0.6.1-r1*
* *rokubimini-serial 0.6.0-r5 --> 0.6.1-r1*
* *rosee-msg 1.0.2-r1*
* *rosfmt 6.2.0-r1 --> 7.0.0-r1*
* *rtabmap-ros 0.20.9-r2 --> 0.20.14-r1*
* *rviz 1.13.19-r1 --> 1.13.20-r1*
* *sbg-driver 3.0.0-r1 --> 3.1.0-r1*
* *urdfdom-py 0.4.5-r1 --> 0.4.6-r1*
* *xacro 1.13.13-r2 --> 1.13.14-r1*

Noetic Changes:
---------------
* *bota-driver 0.6.0-r3 --> 0.6.1-r1*
* *bota-driver-testing 0.6.1-r1*
* *bota-node 0.6.0-r3 --> 0.6.1-r1*
* *bota-signal-handler 0.6.0-r3 --> 0.6.1-r1*
* *bota-worker 0.6.0-r3 --> 0.6.1-r1*
* *cmvision 0.5.0-r2*
* *dbw-fca 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-can 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-description 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-joystick-demo 1.2.0-r1 --> 1.2.1-r1*
* *dbw-fca-msgs 1.2.0-r1 --> 1.2.1-r1*
* *dbw-mkz 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-can 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-description 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-joystick-demo 1.4.0-r1 --> 1.4.1-r1*
* *dbw-mkz-msgs 1.4.0-r1 --> 1.4.1-r1*
* *dbw-polaris 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-can 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-description 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-joystick-demo 1.0.0-r1 --> 1.0.1-r1*
* *dbw-polaris-msgs 1.0.0-r1 --> 1.0.1-r1*
* *drone-assets 1.4.0-r1 --> 1.4.2-r1*
* *drone-circuit-assets 1.4.2-r1*
* *drone-wrapper 1.4.0-r1 --> 1.4.2-r1*
* *husky-control 0.6.0-r2*
* *husky-description 0.6.0-r2*
* *husky-desktop 0.6.0-r2*
* *husky-gazebo 0.6.0-r2*
* *husky-msgs 0.6.0-r2*
* *husky-navigation 0.6.0-r2*
* *husky-simulator 0.6.0-r2*
* *husky-viz 0.6.0-r2*
* *jackal-control 0.8.0-r2*
* *jackal-description 0.8.0-r2*
* *jackal-msgs 0.8.0-r2*
* *jackal-navigation 0.8.0-r2*
* *jackal-tutorials 0.8.0-r2*
* *jderobot-drones 1.4.0-r1 --> 1.4.2-r1*
* *leo-bringup 1.2.1-r1*
* *leo-fw 1.2.1-r1*
* *leo-robot 1.2.1-r1*
* *libphidget22 1.0.2-r1 --> 1.0.3-r1*
* *moveit-opw-kinematics-plugin 0.3.1-r2*
* *nodelet 1.10.1-r1 --> 1.10.2-r1*
* *nodelet-core 1.10.1-r1 --> 1.10.2-r1*
* *nodelet-topic-tools 1.10.1-r1 --> 1.10.2-r1*
* *phidgets-accelerometer 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-analog-inputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-analog-outputs 1.0.3-r1*
* *phidgets-api 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-digital-inputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-digital-outputs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-drivers 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-gyroscope 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-high-speed-encoder 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-ik 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-magnetometer 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-motors 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-msgs 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-spatial 1.0.2-r1 --> 1.0.3-r1*
* *phidgets-temperature 1.0.2-r1 --> 1.0.3-r1*
* *plotjuggler 3.3.0-r1 --> 3.3.1-r1*
* *plotjuggler-msgs 0.1.1-r1 --> 0.2.1-r1*
* *rm-common 0.1.1-r5 --> 0.1.7-r3*
* *rm-control 0.1.1-r5 --> 0.1.7-r3*
* *rm-dbus 0.1.7-r3*
* *rm-description 0.1.1-r5 --> 0.1.7-r3*
* *rm-gazebo 0.1.1-r5 --> 0.1.7-r3*
* *rm-hw 0.1.7-r3*
* *rm-msgs 0.1.1-r5 --> 0.1.7-r3*
* *robot-state-publisher 1.15.0-r1 --> 1.15.2-r1*
* *rokubimini 0.6.0-r3 --> 0.6.1-r1*
* *rokubimini-bus-manager 0.6.0-r3 --> 0.6.1-r1*
* *rokubimini-description 0.6.0-r3 --> 0.6.1-r1*
* *rokubimini-ethercat 0.6.0-r3 --> 0.6.1-r1*
* *rokubimini-msgs 0.6.0-r3 --> 0.6.1-r1*
* *rokubimini-serial 0.6.0-r3 --> 0.6.1-r1*
* *rqt-drone-teleop 1.4.0-r1 --> 1.4.2-r1*
* *rqt-ground-robot-teleop 1.4.0-r1 --> 1.4.2-r1*
* *rtabmap-ros 0.20.10-r1 --> 0.20.14-r1*
* *rviz 1.14.9-r2 --> 1.14.10-r1*
* *tello-driver 1.4.2-r1*
* *urdfdom-py 0.4.5-r1 --> 0.4.6-r1*
* *xacro 1.14.9-r1 --> 1.14.10-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] wiimote

