### PR TITLE
rosdistro sync, Fri Oct 15 13:21:26 2021

### DIFF
--- a/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-foxy-aws-robomaker-small-warehouse-world";
-  version = "1.0.1-r1";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "26033a906fb2648570cc63ae226c4f1dcc22385737d110204f72cac118ed9bea";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "186aeccb81a6a5d0cf66bc81d17d679ce8d5c249325dc52abfd61bc1ed262683";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.2-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "f503676f1f84b55b0b5d89c90257b93870cc519391b17c2f4642470c72a44e3d";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d2ab33b5abb26344f38b80fcb9e5d8de7d79ff4a9ec965e9607aeea5dfec5a68";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -728,6 +728,8 @@ self: super: {
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
+ mppic = self.callPackage ./mppic {};
+
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
@@ -1658,13 +1660,19 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
+ velodyne-description = self.callPackage ./velodyne-description {};
+
  velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-gazebo-plugins = self.callPackage ./velodyne-gazebo-plugins {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
 
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ velodyne-simulator = self.callPackage ./velodyne-simulator {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 
@@ -1677,6 +1685,8 @@ self: super: {
  vrxperience-msgs = self.callPackage ./vrxperience-msgs {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/foxy/geometry-tutorials/default.nix
+++ b/distros/foxy/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-geometry-tutorials";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cdc7c3cc9a32f805b6a871f001e9fa925cc01f11186d3a7e6370dcfe16ef71cd";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5a29ad0953292cb6a4c228f73bf492e603a757eeedc464c328ef8e0e235368fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "d80e6c494ea8dd37b138d70a5c5d6126bd4cde26c022f53f0f373552beedf93d";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "1e60c7233b60f43ee2f9bc2ac8090a59872a87736d3f9a1d757053412092b05b";
   };
 
   buildType = "cmake";

--- a/distros/foxy/mppic/default.nix
+++ b/distros/foxy/mppic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, geometry-msgs, nav2-bringup, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-mppic";
+  version = "0.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/artofnothingness/mppic-release/archive/release/foxy/mppic/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "1ba13c06c16a18b1c830205f64406fe6f5df722e841e1fca42488044bf3558c8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs nav2-bringup nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''mppic'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dbc51d2c80485d3a7d6c47f4966f5357ec354020021b7c2bf7e1d629af999802";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "3cb31ef6684f4871f9eac4e2fb23dd7fe3690da73f0cf206659a473173399fad";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "973139e7962c803ddfe0ff1153250370fe304dbbef5b1fb3479262b923454827";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "ecbce1ad75ee15c9f6f2ac49405cd13d7a210cce5b0dded7da8ebb5d5e917426";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "26f437bfa3b8757d567eb7f05eaa31b29b664cf84f751f06f645ce3b09c594ef";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "1d98a593a6b6dbdb506b10fb4945b40ee41bd3a2086f942f17e71f36da2f7fc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dff7ebf930bb222ef291ddfbb6f3a10a6ce5837e0306b11fe3cd1c34ece82e58";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "57122c9197708e6c77a0173628e145b5d2a6451d0cc78a9197140988886d701a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "25de944535e55d84a603296b66d1a5cf1148c26f1cbb10d1323623f35ccac149";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "cc043b924372dfcbf1e64e40e5826ce4b698c5849ac17d5062c69ce3fcb8fd91";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "4a34d713c0b5e3aad8034db5b32e93cf58ed21bfee2070449813f3e630ac1a7f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "24e8ccb0bca945f16455e7c7d325fbfb6e9ffb8e64a2bbddf9e0ffdbf9bb8a7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "ae58b014d67e43f8334cef764d2fbc581eecffbf704960a9f86a3b17b8428557";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "fc0a8727c0d7dcf5b6862fc33a83ce31d0fbd794740529d624b37797b9b07e06";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-tools/default.nix
+++ b/distros/foxy/rviz-visual-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-tools";
-  version = "4.0.1-r1";
+  version = "4.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/foxy/rviz_visual_tools/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "4e98d0c32fc79b3653c36870c6df9388a808c5e98774810843aade792152d413";
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/foxy/rviz_visual_tools/4.0.2-2.tar.gz";
+    name = "4.0.2-2.tar.gz";
+    sha256 = "7551beb8595d313a64e3610f8411a3d3f7aa8f7daf7aecb8f17b3a955ea95be3";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dafc94e5a219d3c1fc0a238a73076c2a01c31a2fc5df7171a3bdab7077365dbf";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "55587f11823cf9524b0977756b8ce51549ff36574957abb3732f450d690dd58e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtle-tf2-cpp/default.nix
+++ b/distros/foxy/turtle-tf2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-cpp";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "95c28fe2c391de9a609a38c038e37f31c03f703e46dfffc8a8a80e7cb9f2a07c";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "02ee422d0cbe4096072a5d33a32132e614e88f2643dd871d616ab43c7071dc58";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros message-filters rclcpp tf2 tf2-geometry-msgs tf2-ros turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/turtle-tf2-py/default.nix
+++ b/distros/foxy/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "ba9d9454c7cb589b6ebcdc264520597bfbcd511974f3d2582a06f6505cbee3b4";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "07dc427ef64910124657ae6dc8a985d859b8c7d32836c63125f23cb08932fd52";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/velodyne-description/default.nix
+++ b/distros/foxy/velodyne-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-description";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "4b7559bf190462d753547aceb48555ee90913dec126fc06dc11e639cba738c76";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-ros urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and meshes describing Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-gazebo-plugins/default.nix
+++ b/distros/foxy/velodyne-gazebo-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-ros, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-gazebo-plugins";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "2be2447a76ab8b99834eb37ef7a8382fde6c0518a02cb46eefc22c74548f4ab5";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-dev gazebo-msgs gazebo-ros rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo plugin to provide simulated data from Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-simulator/default.nix
+++ b/distros/foxy/velodyne-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-description, velodyne-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-simulator";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "63eba5c4ffc36bbff609ef6f73c439801fe532a649ae0a30bdfe7d58c281aab1";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-description velodyne-gazebo-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage allowing easy installation of Velodyne simulation components.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/warehouse-ros-sqlite/default.nix
+++ b/distros/foxy/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-foxy-warehouse-ros-sqlite";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros_sqlite-release/archive/release/foxy/warehouse_ros_sqlite/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d99bd59ef67f8480b45c7df251fc9f50c43c096b295f7bb6da2d752d3ee58ff4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost sqlite3-vendor ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/dolly-follow/default.nix
+++ b/distros/galactic/dolly-follow/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-follow";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_follow/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0224d85d222d6225530f3c15671accd9bd853744bea7e7e10bb8fd3b368051d1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Follow node for Dolly, the robot sheep.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly-gazebo/default.nix
+++ b/distros/galactic/dolly-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, gazebo-ros-pkgs, ros2launch, rviz2 }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-gazebo";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_gazebo/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f62bc4a2a9713375423b01f40d3b172571c26fb37f4b587dee56890127674f71";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow gazebo-ros-pkgs ros2launch rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Gazebo simulation with Dolly robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly-ignition/default.nix
+++ b/distros/galactic/dolly-ignition/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, ros-ign-bridge, ros-ign-gazebo, ros2launch, rviz2 }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-ignition";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_ignition/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a1e54f1fa28af34717e210b375edbd8f300806949251f9858875255c297aca7d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow ros-ign-bridge ros-ign-gazebo ros2launch rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Ignition simulation with Dolly robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly/default.nix
+++ b/distros/galactic/dolly/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, dolly-gazebo, dolly-ignition }:
+buildRosPackage {
+  pname = "ros-galactic-dolly";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6ca3ebd5b6817abbbfcb70a93a576ddd15d89ac4f70cd183e2724be9ef77eb8b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow dolly-gazebo dolly-ignition ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta-package for Dolly, the robot sheep.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -236,6 +236,14 @@ self: super: {
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
+ dolly = self.callPackage ./dolly {};
+
+ dolly-follow = self.callPackage ./dolly-follow {};
+
+ dolly-gazebo = self.callPackage ./dolly-gazebo {};
+
+ dolly-ignition = self.callPackage ./dolly-ignition {};
+
  domain-bridge = self.callPackage ./domain-bridge {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
@@ -563,6 +571,8 @@ self: super: {
  moveit-ros = self.callPackage ./moveit-ros {};
 
  moveit-ros-benchmarks = self.callPackage ./moveit-ros-benchmarks {};
+
+ moveit-ros-control-interface = self.callPackage ./moveit-ros-control-interface {};
 
  moveit-ros-move-group = self.callPackage ./moveit-ros-move-group {};
 
@@ -1445,6 +1455,8 @@ self: super: {
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/galactic/geometry-tutorials/default.nix
+++ b/distros/galactic/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-geometry-tutorials";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "5cefc15dadbb18e4ec2745610625d85fcbb228ff5b2a16cbc22c3d2259e33fc3";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "f3d5c1efce5667e1642b2919b5519e15b77c933f58b7dd4df86dbbbdc98ac5f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "a746c031bc8ee4301fa7751c1d1accdb9f51908cc9559e2a379c8baf66eb3e0c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "41be2a65a6ec733113d72e02d774755dd36469110e804feaebb748fc5046f4b0";
   };
 
   buildType = "cmake";

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "4c31ac5c4d676f4359da29b8e1f474cf29d5354ec3a0215c0528ce0b9d19a3e8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ce8610d297c71e3ccc3e3b8e8607ec8d1fd1768892a5b22d5a0a3100c9a4099c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "5cc16a50baaa0bcf203412f25e4ff711d879d0566740f9c1c6fa32b4bbe0c5b5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e669ea81fbc3f4d2597b93cb406804a450bc7f5d88d41ea53f5f42f99445d80f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl tf2-kdl ];
-  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
 
   meta = {

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "59aafca8938975ab28d77fa66a70031a6334610957ff86cde37a5bf36b48c413";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3d57602be541ef159a4756bb66e61d8d6c8cc8b253ee0cdee9d77169af7168e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9df49e6a7e9ac04a38384acae4eca45556fd480d04f295891366920f9ccacd82";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "1635bde0fb6adb34273bfc34cc26157e6a0bb4d91a4814486ce76aa3dd364237";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a6fe405d45026ad8baf0ebe2328e46d77eac67820dbedee52447d866367f9ab2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "41fcfc56c151cb3ed089a4e06b09cd42437d251614a56b1d283f3caba20a979b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "2029cc947e7d5475c8331d9db037f8ffca1c6ab6104ef8623a8fe890702dc31f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4d79ae71be92e2daee0b8268583f70d5a1a3babe7feb65bc522fe0114bcc0dcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "5b51ee65c8cc3f59b3781c183447a67d0a7e0da49d072edc2338c10a2780c27c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "255565e3ec512e1fe4175496630f708198bb413228a9dcdd1b70d4101bf2c095";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-control-interface/default.nix
+++ b/distros/galactic/moveit-ros-control-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-control-interface";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "962814f2291a20860a3f95422508386e19c57e58234fec5bae74cff931f81b08";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager-msgs moveit-core moveit-simple-controller-manager pluginlib rclcpp-action trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros_control controller manager interface for MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "707758332928010cc691bcad596f3ebc4a5a7229d5184708107dd7b27bd028ba";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3c4c4b10323bb03dc78de3817c638a899608d2b648b0573df80d8c21a4017d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "1a781133b06a0116b809796d550368ebd617f448c524ababad29649cf080cad4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "013bf00ef24e5384962c66114f903927c7cb171f3a763379de57800899e48e33";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-core moveit-msgs octomap pluginlib rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "00b31598f20c410627d74a4fca7d92f50884c9e8ebb34c6cce5a87fa47e72b76";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "01d26bdaa904d4fec0b6d52da8449dec7fcddb6b66a63c4794e375b0806e6a43";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "ce71992ce90db93e0343df991614c4a628bbb3b640fe9ff28175cd066e5e7d1b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2672c269e47295de9d06e46b810f3236008da55fefa3dd780a49a48d4c74338c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "444941c55f8dad7a854ac19c58cfba10a80157e8935cdbdf3717fb1b39f56b7f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "433237ef6c7258fa500b8e002a8cb11062d7a2e05d0f60f05a130e411d0df30c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "853f8505107e186be829df34b912aea8563320cd59e0bb39bbfc035a6791eace";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "74cf72d6dac5714b5f05f5e36a6d6c45e3f835e2ea412b8c1f95222134c4db74";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "7d55bfacdfce11470b243df4feefe1f751ceab19714c20262fc88b0448079f3a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "70a5a013b869eed5c6f830de215b27d57ddb296c3b8ee793c49aa7468145f12b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a760de0684ad98e7f73d3e344cf716ab56bdbc9798277bb47711dfb0c6970412";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d7b39368b88e4102499c207844610589349d6cc6630b26c666e6406ce57ffa72";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d534a57cb5ce32682d8f7a46d15618106cffd882a2be838c99d66384ff04b11b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "00e3932121074361ad5da8f1fd76ed92c5fb7717a0454244872034f2ba8872d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "89e2063e90e8003cee6c2fe99e4ab933e1f41980d779abe87dc2d3043a64b8db";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "120d3781bbdf962e1d2b3d90719e029c63c536ecfa9e1e1bc3ec2893bada3ce2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "582ad27bf9605bcf6d4eac6360dbd61913719d46dd0d0d0fe833f23d5789611f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d3c851259300b7055cc207dee676928ebbc9dfe776cc6051c99eb7c913b3c658";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "e53081d26a7d9c5e76d6501f4e58c63ac519d0bee51e3aabc6873ac2bc54b922";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3ed83dc851cf10276a4ba3442f8f058329b8ebac38775bdad4bd24ee2261e13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "62618f2c1090c3372152f3e333b4dbdd1a59ed0ad76c499a1c5d3cd9076ae61e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6410d0d1cabdfdb4aa1e3364e7452b07ce825496e0a8dcd6f93e29f0c7825ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/rosidl-generator-py/default.nix
+++ b/distros/galactic/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-py";
-  version = "0.11.0-r2";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.0-2.tar.gz";
-    name = "0.11.0-2.tar.gz";
-    sha256 = "337a34b60250160deb02c395ae237b20c3e47a72da6e90ced806031d42451a58";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "ae389bf4aad1ffb74dc5098935fb56f26051ce4c8ca7115e620f896142e1c94c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/run-move-group/default.nix
+++ b/distros/galactic/run-move-group/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-move-group";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a3efb1e1b57a30f40e63982e472e691faf653c8c0d54a62c15e2494a76fd679e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "367043f71529e8e1172b02fe0d64177574d9e7b3d3bda30254b112c36fc220ed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/run-moveit-cpp/default.nix
+++ b/distros/galactic/run-moveit-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-moveit-cpp";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "cb2228caaea30ec8199d0a1efad1107c438f00294f1327900d1e57a2f231e043";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a6353a4474132b4f35df862bbb2707e3caa011e624f0fea02f35fea519c15161";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/run-ompl-constrained-planning/default.nix
+++ b/distros/galactic/run-ompl-constrained-planning/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-ompl-constrained-planning";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "b6f251d9c8dad11feb8677dab6e291f53a257455955f8ab4741b70524b6b8db0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "30db95627c4a9e6f2a33c4053e3916372e498fa9f0cdec4578a05a41305f3c3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface warehouse-ros-mongo ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rviz-visual-tools/default.nix
+++ b/distros/galactic/rviz-visual-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rviz-visual-tools";
-  version = "4.1.0-r1";
+  version = "4.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/galactic/rviz_visual_tools/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "5ee1fc3beccad66f305d997a549466dd48079b82168090f8e8675bde89fef469";
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/galactic/rviz_visual_tools/4.1.1-1.tar.gz";
+    name = "4.1.1-1.tar.gz";
+    sha256 = "6dfb63791f889d842924bb9aafb46232d5c5891522fbd0495b846c82678067a2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/galactic/turtle-tf2-cpp/default.nix
+++ b/distros/galactic/turtle-tf2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-cpp";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "6888a79a8f9b4ca2442f9fd1942b04ab912dbd582e0bf4acd9a7921ccd81971d";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5ee80607c2c683b9247ffa4f8dc2e895e0af238d8a4a93051e17a22d5a61ff0a";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros message-filters rclcpp tf2 tf2-geometry-msgs tf2-ros turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/turtle-tf2-py/default.nix
+++ b/distros/galactic/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "6c3e3d5ccfc070eae63e8529368c0071d747c74511917b6d410ebaf54c2b9189";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0e430ea4379a34cd7c85e0c4a51ef3b41cb290e5a836762200fe0e6ce1d1f15f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/warehouse-ros-sqlite/default.nix
+++ b/distros/galactic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-galactic-warehouse-ros-sqlite";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros_sqlite-release/archive/release/galactic/warehouse_ros_sqlite/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a346d4881cbfa8a11aa6662eb7104239848c4087ab03088b99805725e4dd9540";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost sqlite3-vendor ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/filters/default.nix
+++ b/distros/melodic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-melodic-filters";
-  version = "1.8.1";
+  version = "1.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.1-0.tar.gz";
-    name = "1.8.1-0.tar.gz";
-    sha256 = "850380ab0564923c37a6ee93227fe934647a1c4e5dfb4c5d2502f156b6b17d3f";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.2-1.tar.gz";
+    name = "1.8.2-1.tar.gz";
+    sha256 = "b88bbcf6eb05e6297b7026ce3e6ab28bf80612b7f4059519e8c01f12fb1ac794";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -3052,6 +3052,8 @@ self: super: {
 
  qt-gui-py-common = self.callPackage ./qt-gui-py-common {};
 
+ qt-paramedit = self.callPackage ./qt-paramedit {};
+
  qt-qmake = self.callPackage ./qt-qmake {};
 
  qt-ros = self.callPackage ./qt-ros {};
@@ -3623,6 +3625,8 @@ self: super: {
  rqt-multiplot = self.callPackage ./rqt-multiplot {};
 
  rqt-nav-view = self.callPackage ./rqt-nav-view {};
+
+ rqt-paramedit = self.callPackage ./rqt-paramedit {};
 
  rqt-play-motion-builder = self.callPackage ./rqt-play-motion-builder {};
 

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "903141dc21cd7780916486e7c4b3b59daf4db3c176c3009a872a8c08d59b982c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "4691bfe857b3a7c55693628c9456082763a28a8c965fabafe7a4f8f219aa0a4b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/qt-paramedit/default.nix
+++ b/distros/melodic/qt-paramedit/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt5, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qt-paramedit";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/dornhege/rqt_paramedit-release/archive/release/melodic/qt_paramedit/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5d12d8619f12fb8a6c4490bfdc556e0ba4d8a93458abf1f9950876288913164a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt5.qtbase roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A GUI application for viewing and editing ROS parameters.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rqt-paramedit/default.nix
+++ b/distros/melodic/rqt-paramedit/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt-paramedit, qt5, roscpp, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-melodic-rqt-paramedit";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/dornhege/rqt_paramedit-release/archive/release/melodic/rqt_paramedit/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "41ea3a8828c47d3be448920e3255e9340447a44c84f63b7f4df615d197807f7f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt-paramedit qt5.qtbase roscpp rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt_paramedit - a rqt plugin for editing parameters using qt_paramedit.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/noetic/face-detector/default.nix
+++ b/distros/noetic/face-detector/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, libyamlcpp, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-face-detector";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "74644b234954d858f362cf03a515b03b553f0cdb350df9e6fb741c4614f44b83";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a9da7f39e98a7d7dd118827a9848b1f53ed7316e055e6962c9d7b9425a807c55";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport libyamlcpp message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/people-msgs/default.nix
+++ b/distros/noetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-people-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "23c5aadea89b2d9eb9f8f5bc712313ef205a9db3844d47f25bfe5e167525b840";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f043041d0eaa197f4f6a5774ce9439c20758f7b2bed809439f772faf1a29930c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people-velocity-tracker/default.nix
+++ b/distros/noetic/people-velocity-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-noetic-people-velocity-tracker";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "e01129e7da9a70ca43d9612728c1f44677c8ab050f5af95dc246abbf4f3e64b7";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "74f53f59f4d27e127b40e908bc6dddc8459ffd2799a54ee69331e136c77a34ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people/default.nix
+++ b/distros/noetic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-noetic-people";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "38081a790261ca2b7dc8a6ab0fed886eb53c401af72e5c805aa2c8388d96391c";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "d0a5fb8cdee62113702c3ee9b1174435999684165c08751c91afa57a7e107d8c";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 44fa801babccaa669f11ef774509c855a823d76d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *aws-robomaker-small-warehouse-world 1.0.1-r1 --> 1.0.1-r2*
* *fastrtps 2.0.2-r2 --> 2.1.1-r1*
* *geometry-tutorials 0.3.3-r1 --> 0.3.4-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *mppic 0.2.1-r2*
* *rviz-assimp-vendor 8.2.4-r1 --> 8.2.5-r1*
* *rviz-common 8.2.4-r1 --> 8.2.5-r1*
* *rviz-default-plugins 8.2.4-r1 --> 8.2.5-r1*
* *rviz-ogre-vendor 8.2.4-r1 --> 8.2.5-r1*
* *rviz-rendering 8.2.4-r1 --> 8.2.5-r1*
* *rviz-rendering-tests 8.2.4-r1 --> 8.2.5-r1*
* *rviz-visual-testing-framework 8.2.4-r1 --> 8.2.5-r1*
* *rviz-visual-tools 4.0.1-r1 --> 4.0.2-r2*
* *rviz2 8.2.4-r1 --> 8.2.5-r1*
* *turtle-tf2-cpp 0.3.3-r1 --> 0.3.4-r1*
* *turtle-tf2-py 0.3.3-r1 --> 0.3.4-r1*
* *velodyne-description 2.0.0-r1*
* *velodyne-gazebo-plugins 2.0.0-r1*
* *velodyne-simulator 2.0.0-r1*
* *warehouse-ros-sqlite 1.0.2-r1*

Galactic Changes:
-----------------
* *dolly 0.4.0-r1*
* *dolly-follow 0.4.0-r1*
* *dolly-gazebo 0.4.0-r1*
* *dolly-ignition 0.4.0-r1*
* *geometry-tutorials 0.3.3-r1 --> 0.3.4-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *moveit 2.2.1-r1 --> 2.3.0-r1*
* *moveit-common 2.2.1-r1 --> 2.3.0-r1*
* *moveit-core 2.2.1-r1 --> 2.3.0-r1*
* *moveit-kinematics 2.2.1-r1 --> 2.3.0-r1*
* *moveit-planners 2.2.1-r1 --> 2.3.0-r1*
* *moveit-planners-ompl 2.2.1-r1 --> 2.3.0-r1*
* *moveit-plugins 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-benchmarks 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-control-interface 2.3.0-r1*
* *moveit-ros-move-group 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-occupancy-map-monitor 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-perception 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-planning 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-planning-interface 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-robot-interaction 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-visualization 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-warehouse 2.2.1-r1 --> 2.3.0-r1*
* *moveit-runtime 2.2.1-r1 --> 2.3.0-r1*
* *moveit-servo 2.2.1-r1 --> 2.3.0-r1*
* *moveit-simple-controller-manager 2.2.1-r1 --> 2.3.0-r1*
* *rosidl-generator-py 0.11.0-r2 --> 0.11.1-r1*
* *run-move-group 2.2.1-r1 --> 2.3.0-r1*
* *run-moveit-cpp 2.2.1-r1 --> 2.3.0-r1*
* *run-ompl-constrained-planning 2.2.1-r1 --> 2.3.0-r1*
* *rviz-visual-tools 4.1.0-r1 --> 4.1.1-r1*
* *turtle-tf2-cpp 0.3.3-r1 --> 0.3.4-r1*
* *turtle-tf2-py 0.3.3-r1 --> 0.3.4-r1*
* *warehouse-ros-sqlite 1.0.2-r1*

Melodic Changes:
----------------
* *filters 1.8.1 --> 1.8.2-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *qt-paramedit 1.0.1-r1*
* *rqt-paramedit 1.0.1-r1*

Noetic Changes:
---------------
* *face-detector 1.4.0-r1 --> 1.4.2-r1*
* *people 1.4.0-r1 --> 1.4.2-r1*
* *people-msgs 1.4.0-r1 --> 1.4.2-r1*
* *people-velocity-tracker 1.4.0-r1 --> 1.4.2-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] wiimote

