### PR TITLE
rosdistro sync, Fri Oct 22 13:28:24 2021

### DIFF
--- a/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
+++ b/distros/foxy/aws-robomaker-small-warehouse-world/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, gazebo, gazebo-plugins, gazebo-ros }:
 buildRosPackage {
   pname = "ros-foxy-aws-robomaker-small-warehouse-world";
-  version = "1.0.1-r1";
+  version = "1.0.1-r2";
 
   src = fetchurl {
-    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-1.tar.gz";
-    name = "1.0.1-1.tar.gz";
-    sha256 = "26033a906fb2648570cc63ae226c4f1dcc22385737d110204f72cac118ed9bea";
+    url = "https://github.com/aws-gbp/aws_robomaker_small_warehouse_world-release/archive/release/foxy/aws_robomaker_small_warehouse_world/1.0.1-2.tar.gz";
+    name = "1.0.1-2.tar.gz";
+    sha256 = "186aeccb81a6a5d0cf66bc81d17d679ce8d5c249325dc52abfd61bc1ed262683";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/fastrtps/default.nix
+++ b/distros/foxy/fastrtps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, asio, cmake, fastcdr, foonathan-memory-vendor, openssl, tinyxml-2 }:
 buildRosPackage {
   pname = "ros-foxy-fastrtps";
-  version = "2.0.2-r2";
+  version = "2.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.0.2-2.tar.gz";
-    name = "2.0.2-2.tar.gz";
-    sha256 = "f503676f1f84b55b0b5d89c90257b93870cc519391b17c2f4642470c72a44e3d";
+    url = "https://github.com/ros2-gbp/fastrtps-release/archive/release/foxy/fastrtps/2.1.1-1.tar.gz";
+    name = "2.1.1-1.tar.gz";
+    sha256 = "d2ab33b5abb26344f38b80fcb9e5d8de7d79ff4a9ec965e9607aeea5dfec5a68";
   };
 
   buildType = "cmake";

--- a/distros/foxy/generated.nix
+++ b/distros/foxy/generated.nix
@@ -728,6 +728,8 @@ self: super: {
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
 
+ mppic = self.callPackage ./mppic {};
+
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
  multires-image = self.callPackage ./multires-image {};
@@ -829,6 +831,10 @@ self: super: {
  pacmod-msgs = self.callPackage ./pacmod-msgs {};
 
  pal-gazebo-worlds = self.callPackage ./pal-gazebo-worlds {};
+
+ pal-statistics = self.callPackage ./pal-statistics {};
+
+ pal-statistics-msgs = self.callPackage ./pal-statistics-msgs {};
 
  pcl-conversions = self.callPackage ./pcl-conversions {};
 
@@ -1658,13 +1664,19 @@ self: super: {
 
  velodyne = self.callPackage ./velodyne {};
 
+ velodyne-description = self.callPackage ./velodyne-description {};
+
  velodyne-driver = self.callPackage ./velodyne-driver {};
+
+ velodyne-gazebo-plugins = self.callPackage ./velodyne-gazebo-plugins {};
 
  velodyne-laserscan = self.callPackage ./velodyne-laserscan {};
 
  velodyne-msgs = self.callPackage ./velodyne-msgs {};
 
  velodyne-pointcloud = self.callPackage ./velodyne-pointcloud {};
+
+ velodyne-simulator = self.callPackage ./velodyne-simulator {};
 
  vision-msgs = self.callPackage ./vision-msgs {};
 
@@ -1677,6 +1689,8 @@ self: super: {
  vrxperience-msgs = self.callPackage ./vrxperience-msgs {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/foxy/geometry-tutorials/default.nix
+++ b/distros/foxy/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-foxy-geometry-tutorials";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "cdc7c3cc9a32f805b6a871f001e9fa925cc01f11186d3a7e6370dcfe16ef71cd";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/geometry_tutorials/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5a29ad0953292cb6a4c228f73bf492e603a757eeedc464c328ef8e0e235368fb";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/mavlink/default.nix
+++ b/distros/foxy/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-foxy-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "d80e6c494ea8dd37b138d70a5c5d6126bd4cde26c022f53f0f373552beedf93d";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/foxy/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "1e60c7233b60f43ee2f9bc2ac8090a59872a87736d3f9a1d757053412092b05b";
   };
 
   buildType = "cmake";

--- a/distros/foxy/mppic/default.nix
+++ b/distros/foxy/mppic/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, geometry-msgs, nav2-bringup, nav2-common, nav2-core, nav2-costmap-2d, nav2-msgs, nav2-util, pluginlib, rclcpp, tf2, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-mppic";
+  version = "0.2.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/artofnothingness/mppic-release/archive/release/foxy/mppic/0.2.1-2.tar.gz";
+    name = "0.2.1-2.tar.gz";
+    sha256 = "1ba13c06c16a18b1c830205f64406fe6f5df722e841e1fca42488044bf3558c8";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ geometry-msgs nav2-bringup nav2-common nav2-core nav2-costmap-2d nav2-msgs nav2-util pluginlib rclcpp tf2 visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''mppic'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/pal-statistics-msgs/default.nix
+++ b/distros/foxy/pal-statistics-msgs/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, rosidl-default-generators, rosidl-default-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-foxy-pal-statistics-msgs";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics_msgs/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "d907b657f75cbb629c29a141b38204742d23005953f4d3087f4ecfe06c616234";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ rosidl-default-runtime std-msgs ];
+  nativeBuildInputs = [ rosidl-default-generators ];
+
+  meta = {
+    description = ''Statistics msgs package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/pal-statistics/default.nix
+++ b/distros/foxy/pal-statistics/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gmock, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, pal-statistics-msgs, rclcpp, rclpy }:
+buildRosPackage {
+  pname = "ros-foxy-pal-statistics";
+  version = "2.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/pal-gbp/pal_statistics-release/archive/release/foxy/pal_statistics/2.0.0-1.tar.gz";
+    name = "2.0.0-1.tar.gz";
+    sha256 = "a09f8f5b7fa4882ea67599f47e16900cfa10263f6a797d0d40f09bd498531f0a";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ boost pal-statistics-msgs rclcpp rclpy ];
+  nativeBuildInputs = [ ament-cmake-auto ];
+
+  meta = {
+    description = ''The pal_statistics package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/foxy/plotjuggler-ros/default.nix
+++ b/distros/foxy/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, binutils, boost, diagnostic-msgs, fastcdr, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rclcpp, rcpputils, rosbag2, rosbag2-transport, sensor-msgs, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler-ros";
-  version = "1.6.1-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.6.1-1.tar.gz";
-    name = "1.6.1-1.tar.gz";
-    sha256 = "0c87da7bacd74e464639baf32ca805b9332b22dc9429461a563142b96ad803ab";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/foxy/plotjuggler_ros/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "6c668508000d06a3274d79cae605ce96df80dc52f33fc832a0e0ece041161749";
   };
 
   buildType = "catkin";

--- a/distros/foxy/plotjuggler/default.nix
+++ b/distros/foxy/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, binutils, boost, cppzmq, qt5 }:
 buildRosPackage {
   pname = "ros-foxy-plotjuggler";
-  version = "3.3.1-r2";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.3.1-2.tar.gz";
-    name = "3.3.1-2.tar.gz";
-    sha256 = "f5d60df50cef6a96b323b028d6f09a96fac3e94b7807c005c35d123e5f4419f3";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/foxy/plotjuggler/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "9cc146e0c81b020190d91d980726e4eb615617ec55f92b51491d5b38683ddb7f";
   };
 
   buildType = "catkin";

--- a/distros/foxy/pmb2-2dnav-gazebo/default.nix
+++ b/distros/foxy/pmb2-2dnav-gazebo/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, pmb2-2dnav, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-2dnav-gazebo";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_2dnav_gazebo/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "588064ee3de24260efde52b106b49951a1e1c07aa28d396a7712bfd57c3ba579";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_2dnav_gazebo/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "cb0cd5657a62eb893314ffe69deaca91b90e651e840eb8263bf192c8a180c4c6";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pmb2-bringup/default.nix
+++ b/distros/foxy/pmb2-bringup/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, joy, joy-teleop, launch-pal, pmb2-controller-configuration, pmb2-description, robot-state-publisher, twist-mux }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-bringup";
-  version = "4.0.2-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_bringup/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "2af111ebb9b45c6d67ef871874f8203a7f73dbb5707986d44190603758f5f84d";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_bringup/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "eb378424ce6b8046bc7abb2fe6c3298af2bbb33e569c2ded2c9871020ab1657c";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pmb2-controller-configuration/default.nix
+++ b/distros/foxy/pmb2-controller-configuration/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, controller-manager, diff-drive-controller, imu-sensor-broadcaster, joint-state-controller }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-controller-configuration";
-  version = "4.0.2-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_controller_configuration/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "df7f3da06a7daf015f35ae2bd63c5bd880ae94d492f2c06659656ea45b1618e1";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_controller_configuration/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "c16a5f264c729b2aee71f9ce04097ca84915cbf0744e18c7f94982f286141531";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pmb2-description/default.nix
+++ b/distros/foxy/pmb2-description/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-ros, launch-testing-ament-cmake, urdf-test, xacro }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-python, ament-lint-auto, ament-lint-common, joint-state-publisher-gui, launch, launch-pal, launch-ros, launch-testing-ament-cmake, pmb2-controller-configuration, urdf-test, xacro }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-description";
-  version = "4.0.2-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_description/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "dc7291c700d7a875e96fbeefa45fd6d8450f3412bf104321a9c7fc8a6da9ac02";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_description/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "2bc1f8479f255e37d44a47a89847e4f98f8a14e42f6e12bebccd5c2e771851b0";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common launch-testing-ament-cmake urdf-test ];
-  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-pal launch-ros xacro ];
+  propagatedBuildInputs = [ joint-state-publisher-gui launch launch-pal launch-ros pmb2-controller-configuration xacro ];
   nativeBuildInputs = [ ament-cmake-auto ament-cmake-python ];
 
   meta = {

--- a/distros/foxy/pmb2-gazebo/default.nix
+++ b/distros/foxy/pmb2-gazebo/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, launch-pal, pal-gazebo-worlds, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-lint-auto, ament-lint-common, gazebo-plugins, gazebo-ros, gazebo-ros2-control, launch-pal, pal-gazebo-worlds, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-gazebo";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_gazebo/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "735644418c80be5265f5f6b67159752ab940292fcd4a0ae1ce59617a5daeea8d";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_gazebo/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "f2bd33f70cd2db2de754ba928f551100d6e61c3548ac6c81a541aa00c65584b2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ gazebo-plugins gazebo-ros launch-pal pal-gazebo-worlds pmb2-bringup pmb2-controller-configuration pmb2-description ];
+  propagatedBuildInputs = [ gazebo-plugins gazebo-ros gazebo-ros2-control launch-pal pal-gazebo-worlds pmb2-bringup pmb2-controller-configuration pmb2-description ];
   nativeBuildInputs = [ ament-cmake-auto ];
 
   meta = {

--- a/distros/foxy/pmb2-robot/default.nix
+++ b/distros/foxy/pmb2-robot/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, pmb2-bringup, pmb2-controller-configuration, pmb2-description }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-robot";
-  version = "4.0.2-r1";
+  version = "4.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_robot/4.0.2-1.tar.gz";
-    name = "4.0.2-1.tar.gz";
-    sha256 = "93fbb7b4b7f0fc2182c93e8f04fbccfec92c660bd8d740c0806f756f7cec23bb";
+    url = "https://github.com/pal-gbp/pmb2_robot-gbp/archive/release/foxy/pmb2_robot/4.0.4-1.tar.gz";
+    name = "4.0.4-1.tar.gz";
+    sha256 = "cbb1425c6e135dee80443f4422de0819b2f16e2d0e41a45398bb25a274127aa4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/pmb2-simulation/default.nix
+++ b/distros/foxy/pmb2-simulation/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, pmb2-2dnav-gazebo, pmb2-gazebo }:
 buildRosPackage {
   pname = "ros-foxy-pmb2-simulation";
-  version = "3.0.1-r1";
+  version = "3.0.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_simulation/3.0.1-1.tar.gz";
-    name = "3.0.1-1.tar.gz";
-    sha256 = "7aefc5cc3823c9708f06e7d7de0eefd54879665620bdb55f5c7f5e7f75a8eec4";
+    url = "https://github.com/pal-gbp/pmb2_simulation-gbp/archive/release/foxy/pmb2_simulation/3.0.2-1.tar.gz";
+    name = "3.0.2-1.tar.gz";
+    sha256 = "c27c8f87c8118b62dcd47150f7030cffa6d4b00d76029f945699dae19fb55e2d";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-assimp-vendor/default.nix
+++ b/distros/foxy/rviz-assimp-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, assimp }:
 buildRosPackage {
   pname = "ros-foxy-rviz-assimp-vendor";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dbc51d2c80485d3a7d6c47f4966f5357ec354020021b7c2bf7e1d629af999802";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_assimp_vendor/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "3cb31ef6684f4871f9eac4e2fb23dd7fe3690da73f0cf206659a473173399fad";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-common/default.nix
+++ b/distros/foxy/rviz-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, message-filters, pluginlib, qt5, rclcpp, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor, rviz-rendering, sensor-msgs, std-msgs, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, yaml-cpp-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-common";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "973139e7962c803ddfe0ff1153250370fe304dbbef5b1fb3479262b923454827";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_common/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "ecbce1ad75ee15c9f6f2ac49405cd13d7a210cce5b0dded7da8ebb5d5e917426";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-default-plugins/default.nix
+++ b/distros/foxy/rviz-default-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, geometry-msgs, interactive-markers, laser-geometry, map-msgs, nav-msgs, pluginlib, qt5, rclcpp, resource-retriever, rviz-common, rviz-ogre-vendor, rviz-rendering, rviz-rendering-tests, rviz-visual-testing-framework, tf2, tf2-geometry-msgs, tf2-ros, tinyxml-vendor, urdf, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-default-plugins";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "26f437bfa3b8757d567eb7f05eaa31b29b664cf84f751f06f645ce3b09c594ef";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_default_plugins/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "1d98a593a6b6dbdb506b10fb4945b40ee41bd3a2086f942f17e71f36da2f7fc4";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-ogre-vendor/default.nix
+++ b/distros/foxy/rviz-ogre-vendor/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, freetype, git, libGL, libGLU, pkg-config, xorg }:
 buildRosPackage {
   pname = "ros-foxy-rviz-ogre-vendor";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dff7ebf930bb222ef291ddfbb6f3a10a6ce5837e0306b11fe3cd1c34ece82e58";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_ogre_vendor/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "57122c9197708e6c77a0173628e145b5d2a6451d0cc78a9197140988886d701a";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering-tests/default.nix
+++ b/distros/foxy/rviz-rendering-tests/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, qt5, resource-retriever, rviz-rendering }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering-tests";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "25de944535e55d84a603296b66d1a5cf1148c26f1cbb10d1323623f35ccac149";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering_tests/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "cc043b924372dfcbf1e64e40e5826ce4b698c5849ac17d5062c69ce3fcb8fd91";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-rendering/default.nix
+++ b/distros/foxy/rviz-rendering/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, ament-index-cpp, eigen, eigen3-cmake-module, qt5, resource-retriever, rviz-assimp-vendor, rviz-ogre-vendor }:
 buildRosPackage {
   pname = "ros-foxy-rviz-rendering";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "4a34d713c0b5e3aad8034db5b32e93cf58ed21bfee2070449813f3e630ac1a7f";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_rendering/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "24e8ccb0bca945f16455e7c7d325fbfb6e9ffb8e64a2bbddf9e0ffdbf9bb8a7e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-testing-framework/default.nix
+++ b/distros/foxy/rviz-visual-testing-framework/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-gmock, ament-cmake-gtest, ament-cmake-lint-cmake, ament-cmake-uncrustify, qt5, rviz-common }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-testing-framework";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "ae58b014d67e43f8334cef764d2fbc581eecffbf704960a9f86a3b17b8428557";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz_visual_testing_framework/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "fc0a8727c0d7dcf5b6862fc33a83ce31d0fbd794740529d624b37797b9b07e06";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/rviz-visual-tools/default.nix
+++ b/distros/foxy/rviz-visual-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz-visual-tools";
-  version = "4.0.1-r1";
+  version = "4.0.2-r2";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/foxy/rviz_visual_tools/4.0.1-1.tar.gz";
-    name = "4.0.1-1.tar.gz";
-    sha256 = "4e98d0c32fc79b3653c36870c6df9388a808c5e98774810843aade792152d413";
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/foxy/rviz_visual_tools/4.0.2-2.tar.gz";
+    name = "4.0.2-2.tar.gz";
+    sha256 = "7551beb8595d313a64e3610f8411a3d3f7aa8f7daf7aecb8f17b3a955ea95be3";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/foxy/rviz2/default.nix
+++ b/distros/foxy/rviz2/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-lint-cmake, ament-cmake-uncrustify, geometry-msgs, qt5, rclcpp, rviz-common, rviz-default-plugins, rviz-ogre-vendor, sensor-msgs }:
 buildRosPackage {
   pname = "ros-foxy-rviz2";
-  version = "8.2.4-r1";
+  version = "8.2.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.4-1.tar.gz";
-    name = "8.2.4-1.tar.gz";
-    sha256 = "dafc94e5a219d3c1fc0a238a73076c2a01c31a2fc5df7171a3bdab7077365dbf";
+    url = "https://github.com/ros2-gbp/rviz-release/archive/release/foxy/rviz2/8.2.5-1.tar.gz";
+    name = "8.2.5-1.tar.gz";
+    sha256 = "55587f11823cf9524b0977756b8ce51549ff36574957abb3732f450d690dd58e";
   };
 
   buildType = "ament_cmake";

--- a/distros/foxy/turtle-tf2-cpp/default.nix
+++ b/distros/foxy/turtle-tf2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-cpp";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "95c28fe2c391de9a609a38c038e37f31c03f703e46dfffc8a8a80e7cb9f2a07c";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_cpp/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "02ee422d0cbe4096072a5d33a32132e614e88f2643dd871d616ab43c7071dc58";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros message-filters rclcpp tf2 tf2-geometry-msgs tf2-ros turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/foxy/turtle-tf2-py/default.nix
+++ b/distros/foxy/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-foxy-turtle-tf2-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "ba9d9454c7cb589b6ebcdc264520597bfbcd511974f3d2582a06f6505cbee3b4";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/foxy/turtle_tf2_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "07dc427ef64910124657ae6dc8a985d859b8c7d32836c63125f23cb08932fd52";
   };
 
   buildType = "ament_python";

--- a/distros/foxy/velodyne-description/default.nix
+++ b/distros/foxy/velodyne-description/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-ros, urdf, xacro }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-description";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_description/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "f4da2cfab2110941bdefa94690341f3a7a9fd3941398784873e573ae0dec7185";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-ros urdf xacro ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''URDF and meshes describing Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-gazebo-plugins/default.nix
+++ b/distros/foxy/velodyne-gazebo-plugins/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, gazebo-dev, gazebo-msgs, gazebo-ros, rclcpp, sensor-msgs, tf2 }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-gazebo-plugins";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_gazebo_plugins/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "133b902dd1174c7f3243222967bda7ed7adfceeca4d206fdc2ec9fdbafc2a26a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ gazebo-dev gazebo-msgs gazebo-ros rclcpp sensor-msgs tf2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Gazebo plugin to provide simulated data from Velodyne laser scanners.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/velodyne-simulator/default.nix
+++ b/distros/foxy/velodyne-simulator/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, velodyne-description, velodyne-gazebo-plugins }:
+buildRosPackage {
+  pname = "ros-foxy-velodyne-simulator";
+  version = "2.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/DataspeedInc-release/velodyne_simulator-release/archive/release/foxy/velodyne_simulator/2.0.1-1.tar.gz";
+    name = "2.0.1-1.tar.gz";
+    sha256 = "53fe6864147b15b56c11a80dbf079d5d71253db52b43eea7bb31dbc679b641ba";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ velodyne-description velodyne-gazebo-plugins ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Metapackage allowing easy installation of Velodyne simulation components.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/foxy/warehouse-ros-sqlite/default.nix
+++ b/distros/foxy/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-foxy-warehouse-ros-sqlite";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros_sqlite-release/archive/release/foxy/warehouse_ros_sqlite/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "d99bd59ef67f8480b45c7df251fc9f50c43c096b295f7bb6da2d752d3ee58ff4";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost sqlite3-vendor ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/dolly-follow/default.nix
+++ b/distros/galactic/dolly-follow/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, rclcpp, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-follow";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_follow/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "0224d85d222d6225530f3c15671accd9bd853744bea7e7e10bb8fd3b368051d1";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ geometry-msgs rclcpp sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Follow node for Dolly, the robot sheep.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly-gazebo/default.nix
+++ b/distros/galactic/dolly-gazebo/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, gazebo-ros-pkgs, ros2launch, rviz2 }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-gazebo";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_gazebo/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "f62bc4a2a9713375423b01f40d3b172571c26fb37f4b587dee56890127674f71";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow gazebo-ros-pkgs ros2launch rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Gazebo simulation with Dolly robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly-ignition/default.nix
+++ b/distros/galactic/dolly-ignition/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, ros-ign-bridge, ros-ign-gazebo, ros2launch, rviz2 }:
+buildRosPackage {
+  pname = "ros-galactic-dolly-ignition";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly_ignition/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "a1e54f1fa28af34717e210b375edbd8f300806949251f9858875255c297aca7d";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow ros-ign-bridge ros-ign-gazebo ros2launch rviz2 ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Launch Ignition simulation with Dolly robot.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/dolly/default.nix
+++ b/distros/galactic/dolly/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, dolly-follow, dolly-gazebo, dolly-ignition }:
+buildRosPackage {
+  pname = "ros-galactic-dolly";
+  version = "0.4.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/chapulina/dolly-release/archive/release/galactic/dolly/0.4.0-1.tar.gz";
+    name = "0.4.0-1.tar.gz";
+    sha256 = "6ca3ebd5b6817abbbfcb70a93a576ddd15d89ac4f70cd183e2724be9ef77eb8b";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ dolly-follow dolly-gazebo dolly-ignition ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Meta-package for Dolly, the robot sheep.'';
+    license = with lib.licenses; [ asl20 ];
+  };
+}

--- a/distros/galactic/generated.nix
+++ b/distros/galactic/generated.nix
@@ -236,6 +236,14 @@ self: super: {
 
  diff-drive-controller = self.callPackage ./diff-drive-controller {};
 
+ dolly = self.callPackage ./dolly {};
+
+ dolly-follow = self.callPackage ./dolly-follow {};
+
+ dolly-gazebo = self.callPackage ./dolly-gazebo {};
+
+ dolly-ignition = self.callPackage ./dolly-ignition {};
+
  domain-bridge = self.callPackage ./domain-bridge {};
 
  domain-coordinator = self.callPackage ./domain-coordinator {};
@@ -456,6 +464,8 @@ self: super: {
 
  lanelet2-validation = self.callPackage ./lanelet2-validation {};
 
+ laser-filters = self.callPackage ./laser-filters {};
+
  laser-geometry = self.callPackage ./laser-geometry {};
 
  laser-proc = self.callPackage ./laser-proc {};
@@ -564,6 +574,8 @@ self: super: {
 
  moveit-ros-benchmarks = self.callPackage ./moveit-ros-benchmarks {};
 
+ moveit-ros-control-interface = self.callPackage ./moveit-ros-control-interface {};
+
  moveit-ros-move-group = self.callPackage ./moveit-ros-move-group {};
 
  moveit-ros-occupancy-map-monitor = self.callPackage ./moveit-ros-occupancy-map-monitor {};
@@ -585,6 +597,8 @@ self: super: {
  moveit-servo = self.callPackage ./moveit-servo {};
 
  moveit-simple-controller-manager = self.callPackage ./moveit-simple-controller-manager {};
+
+ moveit-visual-tools = self.callPackage ./moveit-visual-tools {};
 
  mrt-cmake-modules = self.callPackage ./mrt-cmake-modules {};
 
@@ -763,6 +777,8 @@ self: super: {
  pluginlib = self.callPackage ./pluginlib {};
 
  point-cloud-msg-wrapper = self.callPackage ./point-cloud-msg-wrapper {};
+
+ pointcloud-to-laserscan = self.callPackage ./pointcloud-to-laserscan {};
 
  position-controllers = self.callPackage ./position-controllers {};
 
@@ -1210,6 +1226,8 @@ self: super: {
 
  rviz-visual-tools = self.callPackage ./rviz-visual-tools {};
 
+ sbg-driver = self.callPackage ./sbg-driver {};
+
  sdformat-test-files = self.callPackage ./sdformat-test-files {};
 
  sdformat-urdf = self.callPackage ./sdformat-urdf {};
@@ -1445,6 +1463,8 @@ self: super: {
  visualization-msgs = self.callPackage ./visualization-msgs {};
 
  warehouse-ros = self.callPackage ./warehouse-ros {};
+
+ warehouse-ros-sqlite = self.callPackage ./warehouse-ros-sqlite {};
 
  webots-ros2 = self.callPackage ./webots-ros2 {};
 

--- a/distros/galactic/geometry-tutorials/default.nix
+++ b/distros/galactic/geometry-tutorials/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake }:
 buildRosPackage {
   pname = "ros-galactic-geometry-tutorials";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "5cefc15dadbb18e4ec2745610625d85fcbb228ff5b2a16cbc22c3d2259e33fc3";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/geometry_tutorials/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "f3d5c1efce5667e1642b2919b5519e15b77c933f58b7dd4df86dbbbdc98ac5f4";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/laser-filters/default.nix
+++ b/distros/galactic/laser-filters/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake-auto, ament-cmake-gtest, angles, filters, laser-geometry, message-filters, pluginlib, rclcpp, rclcpp-lifecycle, sensor-msgs, tf2, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-laser-filters";
+  version = "2.0.3-r1";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/laser_filters-release/archive/release/galactic/laser_filters/2.0.3-1.tar.gz";
+    name = "2.0.3-1.tar.gz";
+    sha256 = "0c6d30bec2b450434b58cd09edf1084b2f0d2ab732012f6163821604126dac4f";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ ament-cmake-auto ];
+  checkInputs = [ ament-cmake-gtest ];
+  propagatedBuildInputs = [ angles filters laser-geometry message-filters pluginlib rclcpp rclcpp-lifecycle sensor-msgs tf2 tf2-ros ];
+
+  meta = {
+    description = ''Assorted filters designed to operate on 2D planar laser scanners,
+    which use the sensor_msgs/LaserScan type.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/mavlink/default.nix
+++ b/distros/galactic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, cmake, python3, python3Packages, ros-environment }:
 buildRosPackage {
   pname = "ros-galactic-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "a746c031bc8ee4301fa7751c1d1accdb9f51908cc9559e2a379c8baf66eb3e0c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/galactic/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "41be2a65a6ec733113d72e02d774755dd36469110e804feaebb748fc5046f4b0";
   };
 
   buildType = "cmake";

--- a/distros/galactic/moveit-common/default.nix
+++ b/distros/galactic/moveit-common/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common }:
 buildRosPackage {
   pname = "ros-galactic-moveit-common";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "4c31ac5c4d676f4359da29b8e1f474cf29d5354ec3a0215c0528ce0b9d19a3e8";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_common/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "ce8610d297c71e3ccc3e3b8e8607ec8d1fd1768892a5b22d5a0a3100c9a4099c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-core/default.nix
+++ b/distros/galactic/moveit-core/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, angles, assimp, boost, bullet, common-interfaces, eigen, eigen-stl-containers, eigen3-cmake-module, fcl, geometric-shapes, geometry-msgs, kdl-parser, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, octomap, octomap-msgs, orocos-kdl, pkg-config, pluginlib, pybind11-vendor, random-numbers, rclcpp, ruckig, sensor-msgs, shape-msgs, srdfdom, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-kdl, trajectory-msgs, urdf, urdfdom, urdfdom-headers, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-core";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "5cc16a50baaa0bcf203412f25e4ff711d879d0566740f9c1c6fa32b4bbe0c5b5";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_core/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "e669ea81fbc3f4d2597b93cb406804a450bc7f5d88d41ea53f5f42f99445d80f";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-index-cpp ament-lint-auto ament-lint-common angles moveit-resources-panda-moveit-config moveit-resources-pr2-description orocos-kdl tf2-kdl ];
-  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
+  propagatedBuildInputs = [ angles assimp boost bullet common-interfaces eigen eigen-stl-containers eigen3-cmake-module fcl geometric-shapes geometry-msgs kdl-parser moveit-msgs octomap octomap-msgs pluginlib pybind11-vendor random-numbers rclcpp ruckig sensor-msgs shape-msgs srdfdom std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs urdf urdfdom urdfdom-headers visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module pkg-config ];
 
   meta = {

--- a/distros/galactic/moveit-kinematics/default.nix
+++ b/distros/galactic/moveit-kinematics/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, class-loader, eigen, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-description, moveit-resources-fanuc-moveit-config, moveit-resources-panda-description, moveit-resources-panda-moveit-config, moveit-ros-planning, orocos-kdl, pluginlib, pythonPackages, ros-testing, tf2, tf2-kdl, urdfdom }:
 buildRosPackage {
   pname = "ros-galactic-moveit-kinematics";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "59aafca8938975ab28d77fa66a70031a6334610957ff86cde37a5bf36b48c413";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_kinematics/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3d57602be541ef159a4756bb66e61d8d6c8cc8b253ee0cdee9d77169af7168e2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners-ompl/default.nix
+++ b/distros/galactic/moveit-planners-ompl/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, llvmPackages, moveit-common, moveit-core, moveit-msgs, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-resources-pr2-description, moveit-ros-planning, ompl, pluginlib, rclcpp, tf2-eigen, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners-ompl";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "9df49e6a7e9ac04a38384acae4eca45556fd480d04f295891366920f9ccacd82";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners_ompl/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "1635bde0fb6adb34273bfc34cc26157e6a0bb4d91a4814486ce76aa3dd364237";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-planners/default.nix
+++ b/distros/galactic/moveit-planners/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-planners-ompl }:
 buildRosPackage {
   pname = "ros-galactic-moveit-planners";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a6fe405d45026ad8baf0ebe2328e46d77eac67820dbedee52447d866367f9ab2";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_planners/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "41fcfc56c151cb3ed089a4e06b09cd42437d251614a56b1d283f3caba20a979b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-plugins/default.nix
+++ b/distros/galactic/moveit-plugins/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-simple-controller-manager }:
 buildRosPackage {
   pname = "ros-galactic-moveit-plugins";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "2029cc947e7d5475c8331d9db037f8ffca1c6ab6104ef8623a8fe890702dc31f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_plugins/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "4d79ae71be92e2daee0b8268583f70d5a1a3babe7feb65bc522fe0114bcc0dcb";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-benchmarks/default.nix
+++ b/distros/galactic/moveit-ros-benchmarks/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, boost, moveit-common, moveit-ros-planning, moveit-ros-warehouse, pluginlib, rclcpp, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-benchmarks";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "5b51ee65c8cc3f59b3781c183447a67d0a7e0da49d072edc2338c10a2780c27c";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_benchmarks/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "255565e3ec512e1fe4175496630f708198bb413228a9dcdd1b70d4101bf2c095";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-control-interface/default.nix
+++ b/distros/galactic/moveit-ros-control-interface/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager-msgs, moveit-common, moveit-core, moveit-simple-controller-manager, pluginlib, rclcpp-action, trajectory-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-ros-control-interface";
+  version = "2.3.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_control_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "962814f2291a20860a3f95422508386e19c57e58234fec5bae74cff931f81b08";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ moveit-common ];
+  checkInputs = [ ament-lint-auto ament-lint-common ];
+  propagatedBuildInputs = [ controller-manager-msgs moveit-core moveit-simple-controller-manager pluginlib rclcpp-action trajectory-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''ros_control controller manager interface for MoveIt'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit-ros-move-group/default.nix
+++ b/distros/galactic/moveit-ros-move-group/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-kinematics, moveit-resources-fanuc-moveit-config, moveit-ros-occupancy-map-monitor, moveit-ros-planning, pluginlib, rclcpp, rclcpp-action, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-move-group";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "707758332928010cc691bcad596f3ebc4a5a7229d5184708107dd7b27bd028ba";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_move_group/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3c4c4b10323bb03dc78de3817c638a899608d2b648b0573df80d8c21a4017d0e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
+++ b/distros/galactic/moveit-ros-occupancy-map-monitor/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, geometric-shapes, moveit-common, moveit-core, moveit-msgs, octomap, pluginlib, rclcpp, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-occupancy-map-monitor";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "1a781133b06a0116b809796d550368ebd617f448c524ababad29649cf080cad4";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_occupancy_map_monitor/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "013bf00ef24e5384962c66114f903927c7cb171f3a763379de57800899e48e33";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
+  checkInputs = [ ament-cmake-gmock ament-lint-auto ament-lint-common ];
   propagatedBuildInputs = [ eigen eigen3-cmake-module geometric-shapes moveit-core moveit-msgs octomap pluginlib rclcpp tf2-ros ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-perception/default.nix
+++ b/distros/galactic/moveit-ros-perception/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, cv-bridge, eigen, freeglut, glew, image-transport, libGL, libGLU, llvmPackages, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-ros-occupancy-map-monitor, moveit-ros-planning, object-recognition-msgs, pluginlib, rclcpp, sensor-msgs, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-perception";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "00b31598f20c410627d74a4fca7d92f50884c9e8ebb34c6cce5a87fa47e72b76";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_perception/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "01d26bdaa904d4fec0b6d52da8449dec7fcddb6b66a63c4794e375b0806e6a43";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning-interface/default.nix
+++ b/distros/galactic/moveit-ros-planning-interface/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, eigen, eigen3-cmake-module, geometry-msgs, moveit-common, moveit-core, moveit-msgs, moveit-planners-ompl, moveit-resources-fanuc-moveit-config, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning, moveit-ros-warehouse, moveit-simple-controller-manager, python3, rclcpp, rclcpp-action, rclpy, ros-testing, rviz2, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning-interface";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "ce71992ce90db93e0343df991614c4a628bbb3b640fe9ff28175cd066e5e7d1b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning_interface/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "2672c269e47295de9d06e46b810f3236008da55fefa3dd780a49a48d4c74338c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-planning/default.nix
+++ b/distros/galactic/moveit-ros-planning/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gmock, ament-cmake-gtest, ament-index-cpp, ament-lint-auto, ament-lint-common, eigen, eigen3-cmake-module, message-filters, moveit-common, moveit-core, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-occupancy-map-monitor, pluginlib, rclcpp, rclcpp-action, srdfdom, tf2, tf2-eigen, tf2-geometry-msgs, tf2-msgs, tf2-ros, urdf }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-planning";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "444941c55f8dad7a854ac19c58cfba10a80157e8935cdbdf3717fb1b39f56b7f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_planning/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "433237ef6c7258fa500b8e002a8cb11062d7a2e05d0f60f05a130e411d0df30c";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
-  checkInputs = [ ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
+  checkInputs = [ ament-cmake-gmock ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ];
   propagatedBuildInputs = [ ament-index-cpp eigen eigen3-cmake-module message-filters moveit-core moveit-msgs moveit-ros-occupancy-map-monitor pluginlib rclcpp rclcpp-action srdfdom tf2 tf2-eigen tf2-geometry-msgs tf2-msgs tf2-ros urdf ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 

--- a/distros/galactic/moveit-ros-robot-interaction/default.nix
+++ b/distros/galactic/moveit-ros-robot-interaction/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, interactive-markers, moveit-common, moveit-ros-planning, rclcpp, tf2, tf2-eigen, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-robot-interaction";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "853f8505107e186be829df34b912aea8563320cd59e0bb39bbfc035a6791eace";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_robot_interaction/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "74cf72d6dac5714b5f05f5e36a6d6c45e3f835e2ea412b8c1f95222134c4db74";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-visualization/default.nix
+++ b/distros/galactic/moveit-ros-visualization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, class-loader, eigen, geometric-shapes, interactive-markers, moveit-common, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-warehouse, object-recognition-msgs, ogre1_9, pkg-config, pluginlib, qt5, rclcpp, rclpy, rviz2, tf2-eigen }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-visualization";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "7d55bfacdfce11470b243df4feefe1f751ceab19714c20262fc88b0448079f3a";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_visualization/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "70a5a013b869eed5c6f830de215b27d57ddb296c3b8ee793c49aa7468145f12b";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros-warehouse/default.nix
+++ b/distros/galactic/moveit-ros-warehouse/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-core, moveit-ros-planning, rclcpp, tf2-eigen, tf2-ros, warehouse-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros-warehouse";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a760de0684ad98e7f73d3e344cf716ab56bdbc9798277bb47711dfb0c6970412";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros_warehouse/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d7b39368b88e4102499c207844610589349d6cc6630b26c666e6406ce57ffa72";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-ros/default.nix
+++ b/distros/galactic/moveit-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-ros-benchmarks, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-robot-interaction, moveit-ros-visualization, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-ros";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "d534a57cb5ce32682d8f7a46d15618106cffd882a2be838c99d66384ff04b11b";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_ros/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "00e3932121074361ad5da8f1fd76ed92c5fb7717a0454244872034f2ba8872d5";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-runtime/default.nix
+++ b/distros/galactic/moveit-runtime/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros-move-group, moveit-ros-planning, moveit-ros-planning-interface, moveit-ros-warehouse }:
 buildRosPackage {
   pname = "ros-galactic-moveit-runtime";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "89e2063e90e8003cee6c2fe99e4ab933e1f41980d779abe87dc2d3043a64b8db";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_runtime/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "120d3781bbdf962e1d2b3d90719e029c63c536ecfa9e1e1bc3ec2893bada3ce2";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-servo/default.nix
+++ b/distros/galactic/moveit-servo/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-lint-auto, ament-lint-common, control-msgs, control-toolbox, geometry-msgs, gripper-controllers, joint-state-broadcaster, joint-trajectory-controller, joy, moveit-common, moveit-msgs, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, ros-testing, sensor-msgs, std-msgs, std-srvs, tf2-eigen, tf2-ros, trajectory-msgs }:
 buildRosPackage {
   pname = "ros-galactic-moveit-servo";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "582ad27bf9605bcf6d4eac6360dbd61913719d46dd0d0d0fe833f23d5789611f";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_servo/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "d3c851259300b7055cc207dee676928ebbc9dfe776cc6051c99eb7c913b3c658";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common moveit-resources-panda-moveit-config ros-testing ];
-  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
+  propagatedBuildInputs = [ control-msgs control-toolbox geometry-msgs gripper-controllers joint-state-broadcaster joint-trajectory-controller joy moveit-msgs moveit-ros-planning-interface robot-state-publisher sensor-msgs std-msgs std-srvs tf2-eigen tf2-ros trajectory-msgs ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/moveit-simple-controller-manager/default.nix
+++ b/distros/galactic/moveit-simple-controller-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, control-msgs, moveit-common, moveit-core, pluginlib, rclcpp, rclcpp-action }:
 buildRosPackage {
   pname = "ros-galactic-moveit-simple-controller-manager";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "e53081d26a7d9c5e76d6501f4e58c63ac519d0bee51e3aabc6873ac2bc54b922";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit_simple_controller_manager/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "3ed83dc851cf10276a4ba3442f8f058329b8ebac38775bdad4bd24ee2261e13e";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/moveit-visual-tools/default.nix
+++ b/distros/galactic/moveit-visual-tools/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, geometry-msgs, graph-msgs, moveit-common, moveit-core, moveit-ros-planning, rclcpp, rviz-visual-tools, std-msgs, tf2-eigen, tf2-ros, trajectory-msgs, visualization-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-moveit-visual-tools";
+  version = "4.0.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/moveit_visual_tools-release/archive/release/galactic/moveit_visual_tools/4.0.0-1.tar.gz";
+    name = "4.0.0-1.tar.gz";
+    sha256 = "9c1b9b19df75dfff79dcdd6e4140f9728f94e027038d13e6db319b1328970dc9";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ geometry-msgs graph-msgs moveit-common moveit-core moveit-ros-planning rclcpp rviz-visual-tools std-msgs tf2-eigen tf2-ros trajectory-msgs visualization-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Helper functions for displaying and debugging MoveIt data in Rviz via published markers'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/moveit/default.nix
+++ b/distros/galactic/moveit/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-core, moveit-planners, moveit-plugins, moveit-ros }:
 buildRosPackage {
   pname = "ros-galactic-moveit";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "62618f2c1090c3372152f3e333b4dbdd1a59ed0ad76c499a1c5d3cd9076ae61e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/moveit/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "6410d0d1cabdfdb4aa1e3364e7452b07ce825496e0a8dcd6f93e29f0c7825ebc";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/pointcloud-to-laserscan/default.nix
+++ b/distros/galactic/pointcloud-to-laserscan/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-cppcheck, ament-cmake-cpplint, ament-cmake-flake8, ament-cmake-lint-cmake, ament-cmake-pep257, ament-cmake-uncrustify, ament-cmake-xmllint, ament-lint-auto, laser-geometry, launch, launch-ros, message-filters, rclcpp, rclcpp-components, sensor-msgs, tf2, tf2-ros, tf2-sensor-msgs }:
+buildRosPackage {
+  pname = "ros-galactic-pointcloud-to-laserscan";
+  version = "2.0.1-r2";
+
+  src = fetchurl {
+    url = "https://github.com/ros2-gbp/pointcloud_to_laserscan-release/archive/release/galactic/pointcloud_to_laserscan/2.0.1-2.tar.gz";
+    name = "2.0.1-2.tar.gz";
+    sha256 = "7530f5123ae61a4f78aea7d78a235773440bd1e293ead09d60494db7e9433e1f";
+  };
+
+  buildType = "ament_cmake";
+  checkInputs = [ ament-cmake-cppcheck ament-cmake-cpplint ament-cmake-flake8 ament-cmake-lint-cmake ament-cmake-pep257 ament-cmake-uncrustify ament-cmake-xmllint ament-lint-auto ];
+  propagatedBuildInputs = [ laser-geometry launch launch-ros message-filters rclcpp rclcpp-components sensor-msgs tf2 tf2-ros tf2-sensor-msgs ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Converts a 3D Point Cloud into a 2D laser scan. This is useful for making devices like the Kinect appear like a laser scanner for 2D-based algorithms (e.g. laser-based SLAM).'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/galactic/rosidl-generator-py/default.nix
+++ b/distros/galactic/rosidl-generator-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-pytest, ament-index-python, ament-lint-auto, ament-lint-common, python-cmake-module, python3Packages, pythonPackages, rmw, rosidl-cli, rosidl-cmake, rosidl-generator-c, rosidl-generator-cpp, rosidl-parser, rosidl-runtime-c, rosidl-typesupport-c, rosidl-typesupport-fastrtps-c, rosidl-typesupport-interface, rosidl-typesupport-introspection-c, rpyutils, test-interface-files }:
 buildRosPackage {
   pname = "ros-galactic-rosidl-generator-py";
-  version = "0.11.0-r2";
+  version = "0.11.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.0-2.tar.gz";
-    name = "0.11.0-2.tar.gz";
-    sha256 = "337a34b60250160deb02c395ae237b20c3e47a72da6e90ced806031d42451a58";
+    url = "https://github.com/ros2-gbp/rosidl_python-release/archive/release/galactic/rosidl_generator_py/0.11.1-1.tar.gz";
+    name = "0.11.1-1.tar.gz";
+    sha256 = "ae389bf4aad1ffb74dc5098935fb56f26051ce4c8ca7115e620f896142e1c94c";
   };
 
   buildType = "ament_cmake";

--- a/distros/galactic/run-move-group/default.nix
+++ b/distros/galactic/run-move-group/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-move-group";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "a3efb1e1b57a30f40e63982e472e691faf653c8c0d54a62c15e2494a76fd679e";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_move_group/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "367043f71529e8e1172b02fe0d64177574d9e7b3d3bda30254b112c36fc220ed";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/run-moveit-cpp/default.nix
+++ b/distros/galactic/run-moveit-cpp/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-moveit-cpp";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "cb2228caaea30ec8199d0a1efad1107c438f00294f1327900d1e57a2f231e043";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_moveit_cpp/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "a6353a4474132b4f35df862bbb2707e3caa011e624f0fea02f35fea519c15161";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/run-ompl-constrained-planning/default.nix
+++ b/distros/galactic/run-ompl-constrained-planning/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, moveit-common, moveit-ros-planning-interface, warehouse-ros-mongo }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, controller-manager, moveit-common, moveit-resources-panda-moveit-config, moveit-ros-move-group, moveit-ros-planning-interface, robot-state-publisher, rviz2, tf2-ros, warehouse-ros-mongo }:
 buildRosPackage {
   pname = "ros-galactic-run-ompl-constrained-planning";
-  version = "2.2.1-r1";
+  version = "2.3.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.2.1-1.tar.gz";
-    name = "2.2.1-1.tar.gz";
-    sha256 = "b6f251d9c8dad11feb8677dab6e291f53a257455955f8ab4741b70524b6b8db0";
+    url = "https://github.com/moveit/moveit2-release/archive/release/galactic/run_ompl_constrained_planning/2.3.0-1.tar.gz";
+    name = "2.3.0-1.tar.gz";
+    sha256 = "30db95627c4a9e6f2a33c4053e3916372e498fa9f0cdec4578a05a41305f3c3a";
   };
 
   buildType = "ament_cmake";
   buildInputs = [ moveit-common ];
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ moveit-ros-planning-interface warehouse-ros-mongo ];
+  propagatedBuildInputs = [ controller-manager moveit-resources-panda-moveit-config moveit-ros-move-group moveit-ros-planning-interface robot-state-publisher rviz2 tf2-ros warehouse-ros-mongo ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/rviz-visual-tools/default.nix
+++ b/distros/galactic/rviz-visual-tools/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-gtest, ament-index-python, ament-lint-auto, ament-lint-common, eigen, eigen-stl-containers, eigen3-cmake-module, geometry-msgs, interactive-markers, launch, launch-ros, pluginlib, qt5, rclcpp, rclcpp-components, rviz-ogre-vendor, rviz2, sensor-msgs, shape-msgs, std-msgs, tf2, tf2-eigen, tf2-geometry-msgs, trajectory-msgs, visualization-msgs }:
 buildRosPackage {
   pname = "ros-galactic-rviz-visual-tools";
-  version = "4.1.0-r1";
+  version = "4.1.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/galactic/rviz_visual_tools/4.1.0-1.tar.gz";
-    name = "4.1.0-1.tar.gz";
-    sha256 = "5ee1fc3beccad66f305d997a549466dd48079b82168090f8e8675bde89fef469";
+    url = "https://github.com/PickNikRobotics/rviz_visual_tools-release/archive/release/galactic/rviz_visual_tools/4.1.1-1.tar.gz";
+    name = "4.1.1-1.tar.gz";
+    sha256 = "6dfb63791f889d842924bb9aafb46232d5c5891522fbd0495b846c82678067a2";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-cmake-gtest ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros qt5.qtbase qt5.qtx11extras rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
+  propagatedBuildInputs = [ ament-index-python eigen eigen-stl-containers eigen3-cmake-module geometry-msgs interactive-markers launch launch-ros pluginlib qt5.qtbase rclcpp rclcpp-components rviz-ogre-vendor rviz2 sensor-msgs shape-msgs std-msgs tf2 tf2-eigen tf2-geometry-msgs trajectory-msgs visualization-msgs ];
   nativeBuildInputs = [ ament-cmake eigen3-cmake-module ];
 
   meta = {

--- a/distros/galactic/sbg-driver/default.nix
+++ b/distros/galactic/sbg-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, boost, geometry-msgs, nav-msgs, rclcpp, rosidl-default-generators, rosidl-default-runtime, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-galactic-sbg-driver";
+  version = "3.1.0-r1";
+
+  src = fetchurl {
+    url = "https://github.com/SBG-Systems/sbg_ros2-release/archive/release/galactic/sbg_driver/3.1.0-1.tar.gz";
+    name = "3.1.0-1.tar.gz";
+    sha256 = "47a6675c2ade91d0bd6367ba292223874da95535f44abca55cc2d3caf60e101a";
+  };
+
+  buildType = "ament_cmake";
+  propagatedBuildInputs = [ boost geometry-msgs nav-msgs rclcpp rosidl-default-runtime sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ ament-cmake rosidl-default-generators ];
+
+  meta = {
+    description = ''ROS driver package for communication with the SBG navigation systems.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/galactic/turtle-tf2-cpp/default.nix
+++ b/distros/galactic/turtle-tf2-cpp/default.nix
@@ -2,20 +2,20 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, rclcpp, tf2, tf2-ros, turtlesim }:
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-lint-auto, ament-lint-common, geometry-msgs, launch, launch-ros, message-filters, rclcpp, tf2, tf2-geometry-msgs, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-cpp";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "6888a79a8f9b4ca2442f9fd1942b04ab912dbd582e0bf4acd9a7921ccd81971d";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_cpp/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "5ee80607c2c683b9247ffa4f8dc2e895e0af238d8a4a93051e17a22d5a61ff0a";
   };
 
   buildType = "ament_cmake";
   checkInputs = [ ament-lint-auto ament-lint-common ];
-  propagatedBuildInputs = [ geometry-msgs launch launch-ros rclcpp tf2 tf2-ros turtlesim ];
+  propagatedBuildInputs = [ geometry-msgs launch launch-ros message-filters rclcpp tf2 tf2-geometry-msgs tf2-ros turtlesim ];
   nativeBuildInputs = [ ament-cmake ];
 
   meta = {

--- a/distros/galactic/turtle-tf2-py/default.nix
+++ b/distros/galactic/turtle-tf2-py/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, ament-copyright, ament-flake8, ament-pep257, geometry-msgs, launch, launch-ros, pythonPackages, rclpy, tf-transformations, tf2-ros, turtlesim }:
 buildRosPackage {
   pname = "ros-galactic-turtle-tf2-py";
-  version = "0.3.3-r1";
+  version = "0.3.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.3-1.tar.gz";
-    name = "0.3.3-1.tar.gz";
-    sha256 = "6c3e3d5ccfc070eae63e8529368c0071d747c74511917b6d410ebaf54c2b9189";
+    url = "https://github.com/ros-gbp/geometry_tutorials-release/archive/release/galactic/turtle_tf2_py/0.3.4-1.tar.gz";
+    name = "0.3.4-1.tar.gz";
+    sha256 = "0e430ea4379a34cd7c85e0c4a51ef3b41cb290e5a836762200fe0e6ce1d1f15f";
   };
 
   buildType = "ament_python";

--- a/distros/galactic/warehouse-ros-sqlite/default.nix
+++ b/distros/galactic/warehouse-ros-sqlite/default.nix
@@ -1,0 +1,26 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, ament-cmake, ament-cmake-copyright, ament-cmake-gtest, ament-lint-auto, ament-lint-common, boost, class-loader, geometry-msgs, rclcpp, sqlite, sqlite3-vendor, warehouse-ros }:
+buildRosPackage {
+  pname = "ros-galactic-warehouse-ros-sqlite";
+  version = "1.0.2-r1";
+
+  src = fetchurl {
+    url = "https://github.com/moveit/warehouse_ros_sqlite-release/archive/release/galactic/warehouse_ros_sqlite/1.0.2-1.tar.gz";
+    name = "1.0.2-1.tar.gz";
+    sha256 = "a346d4881cbfa8a11aa6662eb7104239848c4087ab03088b99805725e4dd9540";
+  };
+
+  buildType = "ament_cmake";
+  buildInputs = [ boost sqlite3-vendor ];
+  checkInputs = [ ament-cmake-copyright ament-cmake-gtest ament-lint-auto ament-lint-common geometry-msgs ];
+  propagatedBuildInputs = [ class-loader rclcpp sqlite warehouse-ros ];
+  nativeBuildInputs = [ ament-cmake ];
+
+  meta = {
+    description = ''Implementation of warehouse_ros for sqlite'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/drone-assets/default.nix
+++ b/distros/melodic/drone-assets/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-drone-assets";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "78de68ca2619e7015c587d3e930b31883ad12eb22d840960e36681fb5e25b77d";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_assets/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "07c8ebaa41c032be699feada64d7820da7690e3660dbcc2c1b62fc4b8d7061d2";
   };
 
   buildType = "catkin";

--- a/distros/melodic/drone-wrapper/default.nix
+++ b/distros/melodic/drone-wrapper/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, gazebo-ros, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-drone-wrapper";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "3f57d28446b812c2ac8222fa15e39d7ccf03a1ed7e4da881803549b5cd0038f3";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/drone_wrapper/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "847a199fcc75336e2bf187ac70eba6cfe68fbff54fe21683696efa917d655ef8";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ cv-bridge gazebo-ros geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
+  propagatedBuildInputs = [ cv-bridge geometry-msgs mavros mavros-msgs rospy sensor-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/filters/default.nix
+++ b/distros/melodic/filters/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, pluginlib, rosconsole, roscpp, roslib, rostest }:
 buildRosPackage {
   pname = "ros-melodic-filters";
-  version = "1.8.1";
+  version = "1.8.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.1-0.tar.gz";
-    name = "1.8.1-0.tar.gz";
-    sha256 = "850380ab0564923c37a6ee93227fe934647a1c4e5dfb4c5d2502f156b6b17d3f";
+    url = "https://github.com/ros-gbp/filters-release/archive/release/melodic/filters/1.8.2-1.tar.gz";
+    name = "1.8.2-1.tar.gz";
+    sha256 = "b88bbcf6eb05e6297b7026ce3e6ab28bf80612b7f4059519e8c01f12fb1ac794";
   };
 
   buildType = "catkin";

--- a/distros/melodic/generated.nix
+++ b/distros/melodic/generated.nix
@@ -2104,6 +2104,12 @@ self: super: {
 
  microstrain-3dmgx2-imu = self.callPackage ./microstrain-3dmgx2-imu {};
 
+ microstrain-inertial-driver = self.callPackage ./microstrain-inertial-driver {};
+
+ microstrain-inertial-examples = self.callPackage ./microstrain-inertial-examples {};
+
+ microstrain-inertial-msgs = self.callPackage ./microstrain-inertial-msgs {};
+
  microstrain-mips = self.callPackage ./microstrain-mips {};
 
  mikrotik-swos-tools = self.callPackage ./mikrotik-swos-tools {};
@@ -3052,6 +3058,8 @@ self: super: {
 
  qt-gui-py-common = self.callPackage ./qt-gui-py-common {};
 
+ qt-paramedit = self.callPackage ./qt-paramedit {};
+
  qt-qmake = self.callPackage ./qt-qmake {};
 
  qt-ros = self.callPackage ./qt-ros {};
@@ -3624,6 +3632,8 @@ self: super: {
 
  rqt-nav-view = self.callPackage ./rqt-nav-view {};
 
+ rqt-paramedit = self.callPackage ./rqt-paramedit {};
+
  rqt-play-motion-builder = self.callPackage ./rqt-play-motion-builder {};
 
  rqt-plot = self.callPackage ./rqt-plot {};
@@ -3999,6 +4009,8 @@ self: super: {
  teleop-twist-joy = self.callPackage ./teleop-twist-joy {};
 
  teleop-twist-keyboard = self.callPackage ./teleop-twist-keyboard {};
+
+ tello-driver = self.callPackage ./tello-driver {};
 
  teraranger = self.callPackage ./teraranger {};
 

--- a/distros/melodic/jderobot-drones/default.nix
+++ b/distros/melodic/jderobot-drones/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-assets, drone-wrapper, rqt-drone-teleop, rqt-ground-robot-teleop }:
 buildRosPackage {
   pname = "ros-melodic-jderobot-drones";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "08cf45db506da549d05fc5797096eaf30e9abc5ce5afebbb41729b48cf62f35e";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/jderobot_drones/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "14890516849b7dd4ffa62e27fca940f25965f3364cfd6d9b83e87b55db7863dc";
   };
 
   buildType = "catkin";

--- a/distros/melodic/mavlink/default.nix
+++ b/distros/melodic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python, pythonPackages }:
 buildRosPackage {
   pname = "ros-melodic-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "903141dc21cd7780916486e7c4b3b59daf4db3c176c3009a872a8c08d59b982c";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/melodic/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "4691bfe857b3a7c55693628c9456082763a28a8c965fabafe7a4f8f219aa0a4b";
   };
 
   buildType = "cmake";

--- a/distros/melodic/microstrain-inertial-driver/default.nix
+++ b/distros/melodic/microstrain-inertial-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-melodic-microstrain-inertial-driver";
+  version = "2.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_driver/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "cc8be1871ac28751841e4ed673e2a4d287b1b5b08032dafd75a5ffa4df4e8f69";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ curl jq message-generation roslint ];
+  propagatedBuildInputs = [ cmake-modules diagnostic-aggregator diagnostic-updater geometry-msgs message-runtime microstrain-inertial-msgs nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2 tf2-geometry-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The ros_mscl package provides a driver for the LORD/Microstrain inertial products.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/microstrain-inertial-examples/default.nix
+++ b/distros/melodic/microstrain-inertial-examples/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-microstrain-inertial-examples";
+  version = "2.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_examples/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "9a8115be6c5402bcede175dc5a16fee30882b81cf26e05a69139f96ef16b91b7";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ roslint ];
+  propagatedBuildInputs = [ cmake-modules microstrain-inertial-msgs roscpp rospy sensor-msgs std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''Example listener for Parker LORD Sensing inertial device driver ros_mscl (C++).'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/microstrain-inertial-msgs/default.nix
+++ b/distros/melodic/microstrain-inertial-msgs/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-microstrain-inertial-msgs";
+  version = "2.0.5-r1";
+
+  src = fetchurl {
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/melodic/microstrain_inertial_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "2023fa36096dfef2411900c4173b29c290c7e2f24d00a0729230dd051a007341";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime std-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A package that contains ROS message corresponding to microstrain message types.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/qt-paramedit/default.nix
+++ b/distros/melodic/qt-paramedit/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt5, roscpp }:
+buildRosPackage {
+  pname = "ros-melodic-qt-paramedit";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/dornhege/rqt_paramedit-release/archive/release/melodic/qt_paramedit/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "5d12d8619f12fb8a6c4490bfdc556e0ba4d8a93458abf1f9950876288913164a";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt5.qtbase roscpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''A GUI application for viewing and editing ROS parameters.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/rqt-drone-teleop/default.nix
+++ b/distros/melodic/rqt-drone-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, drone-wrapper, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-drone-teleop";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "87489e35b416d29a2012f318da05b9090e02589ca580c98e6d4a287fb4150486";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_drone_teleop/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "451f60036c35e5e57a74fcbf5129acbb42c4459286f886f6ba1cc3e51c4db7dd";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-ground-robot-teleop/default.nix
+++ b/distros/melodic/rqt-ground-robot-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, pythonPackages, roslib, rospy, rqt-gui, rqt-gui-py, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-rqt-ground-robot-teleop";
-  version = "1.3.8-r1";
+  version = "1.3.9-r1";
 
   src = fetchurl {
-    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.8-1.tar.gz";
-    name = "1.3.8-1.tar.gz";
-    sha256 = "889e5838ef66a6a37cf69424708b51bdbe3ce73e1407d6d41d7dcfde40ddfcbe";
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/rqt_ground_robot_teleop/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "e35de51c03c4cda07e7bcac3c7891d12ef7d6b24b3c468ed295df04d359499f1";
   };
 
   buildType = "catkin";

--- a/distros/melodic/rqt-paramedit/default.nix
+++ b/distros/melodic/rqt-paramedit/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, qt-paramedit, qt5, roscpp, rqt-gui, rqt-gui-cpp }:
+buildRosPackage {
+  pname = "ros-melodic-rqt-paramedit";
+  version = "1.0.1-r1";
+
+  src = fetchurl {
+    url = "https://github.com/dornhege/rqt_paramedit-release/archive/release/melodic/rqt_paramedit/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "41ea3a8828c47d3be448920e3255e9340447a44c84f63b7f4df615d197807f7f";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ qt-paramedit qt5.qtbase roscpp rqt-gui rqt-gui-cpp ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''rqt_paramedit - a rqt plugin for editing parameters using qt_paramedit.'';
+    license = with lib.licenses; [ bsdOriginal ];
+  };
+}

--- a/distros/melodic/tello-driver/default.nix
+++ b/distros/melodic/tello-driver/default.nix
@@ -1,0 +1,24 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, cv-bridge, geometry-msgs, mavros, mavros-msgs, rospy, sensor-msgs }:
+buildRosPackage {
+  pname = "ros-melodic-tello-driver";
+  version = "1.3.9-r1";
+
+  src = fetchurl {
+    url = "https://github.com/JdeRobot/drones-release/archive/release/melodic/tello_driver/1.3.9-1.tar.gz";
+    name = "1.3.9-1.tar.gz";
+    sha256 = "669e86532e3a89d0f4b2a21e1e61193f8db66984608f3e592332f390e0660cb4";
+  };
+
+  buildType = "catkin";
+  propagatedBuildInputs = [ cv-bridge geometry-msgs mavros mavros-msgs rospy sensor-msgs ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''The tello_driver package'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/melodic/ublox-gps/default.nix
+++ b/distros/melodic/ublox-gps/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, rtcm-msgs, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-gps";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "a55576ce6b61e9a6b3d08bff772d646169aaed410be63fbe8be6acad2b3e53c5";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_gps/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "ac19d9ba729337ae2b8bc7c3466c2042c3e26d960f4ea6862b6a362d7a5cec4d";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-updater roscpp roscpp-serialization tf ublox-msgs ublox-serialization ];
+  propagatedBuildInputs = [ diagnostic-updater roscpp roscpp-serialization rtcm-msgs tf ublox-msgs ublox-serialization ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/melodic/ublox-msgs/default.nix
+++ b/distros/melodic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-msgs";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "f8f9b32a80cb9f7c1e1beee8ceface2b8ad0cd77abeb80493d2cd3eeb26a8e74";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "59386408efdc588104e4e2a02cd698f428b3ae7bfc27e5d1918f15101e60cd9c";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox-serialization/default.nix
+++ b/distros/melodic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox-serialization";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "6c7f0f6d3715245ad583814a58e636106b37cf5e33e4a9452c931ad42930b4ae";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox_serialization/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "8da0916388a541cc8fd9508af13950edc16fb6da5517390f23cd1332d10dc069";
   };
 
   buildType = "catkin";

--- a/distros/melodic/ublox/default.nix
+++ b/distros/melodic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-melodic-ublox";
-  version = "1.4.1-r1";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.4.1-1.tar.gz";
-    name = "1.4.1-1.tar.gz";
-    sha256 = "88fc16b1221df1f68aecbf5f0edfc0a763fe28055442f5f730c8c7c648a240a8";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/melodic/ublox/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "e7ae5c8870070c6229a4a3ff637088e3e8060220889dfed4a9a6a3f563a94d6d";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-common-urdf/default.nix
+++ b/distros/melodic/uos-common-urdf/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-plugins, urdf, xacro }:
 buildRosPackage {
   pname = "ros-melodic-uos-common-urdf";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_common_urdf/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "41c678b2d59e49d1eb379276f10f0a81a48bb3b8d8c0057ff523311efcf74712";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_common_urdf/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "649e62977084896ee211f71a8dfe3771d6a1e20846242c172a190539a27d25c3";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-diffdrive-teleop/default.nix
+++ b/distros/melodic/uos-diffdrive-teleop/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, ps3joy, roscpp, sensor-msgs }:
 buildRosPackage {
   pname = "ros-melodic-uos-diffdrive-teleop";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_diffdrive_teleop/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "ed2ad1015d480ccef3959ab73923dd4100fb7f549e5827e15a56a3bfdc31c593";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_diffdrive_teleop/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "97046be610e69043ee9998448c35c4427b8acfab629215481681f528de564b75";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-freespace/default.nix
+++ b/distros/melodic/uos-freespace/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, roscpp, sensor-msgs, tf }:
 buildRosPackage {
   pname = "ros-melodic-uos-freespace";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_freespace/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "094436bef80668f6373054bfe27b1da1151870f89a9fb3f1682dbe12289410df";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_freespace/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "3564c0d97b94ca9fba2a23a4f35d699d491bbd796883f11fa14cc07607f9933b";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-gazebo-worlds/default.nix
+++ b/distros/melodic/uos-gazebo-worlds/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gazebo-ros }:
 buildRosPackage {
   pname = "ros-melodic-uos-gazebo-worlds";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_gazebo_worlds/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "0f1469768073221cf8a8e529515771c3190b98a165f7520affb304d332321c39";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_gazebo_worlds/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "944340682e6216565bf271134cbcdad800f6689f86818a50a92e29f717008833";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-maps/default.nix
+++ b/distros/melodic/uos-maps/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin }:
 buildRosPackage {
   pname = "ros-melodic-uos-maps";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_maps/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "31a5e6d9a32f503c309b3affeb2ec5034ca6b874603c53702be6d7b965c65c38";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_maps/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "2ab21963ff350773c0f0f8bc4b3db7a038aaa614e8655d5a24c85f0f052d6441";
   };
 
   buildType = "catkin";

--- a/distros/melodic/uos-tools/default.nix
+++ b/distros/melodic/uos-tools/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, uos-common-urdf, uos-diffdrive-teleop, uos-freespace, uos-gazebo-worlds, uos-maps }:
 buildRosPackage {
   pname = "ros-melodic-uos-tools";
-  version = "1.0.0-r1";
+  version = "1.0.1-r1";
 
   src = fetchurl {
-    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_tools/1.0.0-1.tar.gz";
-    name = "1.0.0-1.tar.gz";
-    sha256 = "9344f44a6c6c074f29f225c67b60535d298d9b7301bce5c589809df92ed0b7d1";
+    url = "https://github.com/uos-gbp/uos-tools/archive/release/melodic/uos_tools/1.0.1-1.tar.gz";
+    name = "1.0.1-1.tar.gz";
+    sha256 = "ab16981ee26882e551d9587b934b63e5eb7f255f726013d5b5f6bf3c6a3b0c0b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver-testing/default.nix
+++ b/distros/noetic/bota-driver-testing/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, geometry-msgs, gtest, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial, rosgraph-msgs, rostest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver-testing";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver_testing/0.6.1-1/bota_driver-release-release-noetic-bota_driver_testing-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_driver_testing-0.6.1-1.tar.gz";
-    sha256 = "ac50c8e4df53bcde4aa759a249b37ffde265f8382aa38eddf13b4ef00bd164eb";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver_testing/0.6.1-2/bota_driver-release-release-noetic-bota_driver_testing-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver_testing-0.6.1-2.tar.gz";
+    sha256 = "1b24dff517d15502be681786d9080ef32b006f8f7a4bd7e9a577e5f041b27430";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-driver/default.nix
+++ b/distros/noetic/bota-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, rokubimini, rokubimini-bus-manager, rokubimini-ethercat, rokubimini-msgs, rokubimini-serial }:
 buildRosPackage {
   pname = "ros-noetic-bota-driver";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.1-1/bota_driver-release-release-noetic-bota_driver-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_driver-0.6.1-1.tar.gz";
-    sha256 = "1054bd95ac5a372efbce8182f1deb70b620dd3a2eac2e78a8988f5c1c935516c";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_driver/0.6.1-2/bota_driver-release-release-noetic-bota_driver-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_driver-0.6.1-2.tar.gz";
+    sha256 = "fc37fb62eaab0862d7c694feb2988a5a53dce33354bf03eee68693e9606d9fab";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-node/default.nix
+++ b/distros/noetic/bota-node/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-signal-handler, bota-worker, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-node";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.1-1/bota_driver-release-release-noetic-bota_node-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_node-0.6.1-1.tar.gz";
-    sha256 = "57da1a9bddd29243710018d23153ef1e4632267ce6a01878dfb77e64fee8256a";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_node/0.6.1-2/bota_driver-release-release-noetic-bota_node-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_node-0.6.1-2.tar.gz";
+    sha256 = "3972167a99dec308b955c57ab11a0a8c93dcecf4405a5cad982ee098bf0d254a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-signal-handler/default.nix
+++ b/distros/noetic/bota-signal-handler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-signal-handler";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.1-1/bota_driver-release-release-noetic-bota_signal_handler-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.1-1.tar.gz";
-    sha256 = "7dc49e99b76064c8e35f714e631b047dd48556b7456691bead648c8a14e86926";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_signal_handler/0.6.1-2/bota_driver-release-release-noetic-bota_signal_handler-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_signal_handler-0.6.1-2.tar.gz";
+    sha256 = "703a2887c917d76e463aa11b76d2079e7821da7f59b43b0d5002442a4d236036";
   };
 
   buildType = "catkin";

--- a/distros/noetic/bota-worker/default.nix
+++ b/distros/noetic/bota-worker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, gtest, roscpp, rosunit }:
 buildRosPackage {
   pname = "ros-noetic-bota-worker";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.1-1/bota_driver-release-release-noetic-bota_worker-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-bota_worker-0.6.1-1.tar.gz";
-    sha256 = "c58f317cfb01f213c11fa9e8e0f8c0b9a032e1283dd035fd86226c066ed5127e";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/bota_worker/0.6.1-2/bota_driver-release-release-noetic-bota_worker-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-bota_worker-0.6.1-2.tar.gz";
+    sha256 = "6d8b25afa5ccb58f705ff0cc1a8e19ad2998442a21f94b382fd8013b4b3377cf";
   };
 
   buildType = "catkin";

--- a/distros/noetic/face-detector/default.nix
+++ b/distros/noetic/face-detector/default.nix
@@ -2,21 +2,21 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
+{ lib, buildRosPackage, fetchurl, actionlib, actionlib-msgs, catkin, cv-bridge, dynamic-reconfigure, geometry-msgs, image-geometry, image-transport, libyamlcpp, message-filters, message-generation, message-runtime, people-msgs, rosbag, roscpp, roslaunch, roslib, roslint, rospy, rostest, sensor-msgs, std-msgs, std-srvs, stereo-image-proc, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-face-detector";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "74644b234954d858f362cf03a515b03b553f0cdb350df9e6fb741c4614f44b83";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/face_detector/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "a9da7f39e98a7d7dd118827a9848b1f53ed7316e055e6962c9d7b9425a807c55";
   };
 
   buildType = "catkin";
   buildInputs = [ message-generation ];
   checkInputs = [ roslaunch roslint rostest stereo-image-proc ];
-  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
+  propagatedBuildInputs = [ actionlib actionlib-msgs cv-bridge dynamic-reconfigure geometry-msgs image-geometry image-transport libyamlcpp message-filters message-runtime people-msgs rosbag roscpp roslib rospy sensor-msgs std-msgs std-srvs stereo-image-proc stereo-msgs tf ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/generated.nix
+++ b/distros/noetic/generated.nix
@@ -2572,6 +2572,8 @@ self: super: {
 
  sainsmart-relay-usb = self.callPackage ./sainsmart-relay-usb {};
 
+ sbg-driver = self.callPackage ./sbg-driver {};
+
  sbpl = self.callPackage ./sbpl {};
 
  sbpl-lattice-planner = self.callPackage ./sbpl-lattice-planner {};

--- a/distros/noetic/libphidget22/default.nix
+++ b/distros/noetic/libphidget22/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libusb1 }:
 buildRosPackage {
   pname = "ros-noetic-libphidget22";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "22c5f108d6be26bdc8dc34c00b8f459a6e3cf4709276817b57b00e6252bb306c";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/libphidget22/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "806e09a99be47f8209d1b5b3513d9a16c9a4c29706f8e668c9d3f4375dd59176";
   };
 
   buildType = "catkin";

--- a/distros/noetic/mavlink/default.nix
+++ b/distros/noetic/mavlink/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake, python3, python3Packages }:
 buildRosPackage {
   pname = "ros-noetic-mavlink";
-  version = "2021.9.9-r1";
+  version = "2021.10.10-r1";
 
   src = fetchurl {
-    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.9.9-1.tar.gz";
-    name = "2021.9.9-1.tar.gz";
-    sha256 = "62c1ad4018d5b32801fdabaf7d8f47dc8fa865ab75f45a6dd503a766dc6ae169";
+    url = "https://github.com/mavlink/mavlink-gbp-release/archive/release/noetic/mavlink/2021.10.10-1.tar.gz";
+    name = "2021.10.10-1.tar.gz";
+    sha256 = "ccffca40b4dfd61f8432314912ee2671478744a1edae7d514be57ca87a0f16fe";
   };
 
   buildType = "cmake";

--- a/distros/noetic/microstrain-inertial-driver/default.nix
+++ b/distros/noetic/microstrain-inertial-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, curl, diagnostic-aggregator, diagnostic-updater, geometry-msgs, jq, message-generation, message-runtime, microstrain-inertial-msgs, nav-msgs, roscpp, roslint, sensor-msgs, std-msgs, std-srvs, tf2, tf2-geometry-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-driver";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "566e9aed61cd9d142928bf23b191fba150bbfbafcbd6ca8ff868b0fb81b723e0";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_driver/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "7e5a38d105071c1a302574d8eff766c45ef94e49da0168680e927e24e3057a4e";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-examples/default.nix
+++ b/distros/noetic/microstrain-inertial-examples/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, cmake-modules, microstrain-inertial-msgs, roscpp, roslint, rospy, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-examples";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "9ceaf2d2e047ff48696d2dd3fc237faa7218355bbf113fe2b43c9ae89c7a4e1c";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_examples/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "c6356c1d62d204dc8c0460268992a5b888a3295954b63cddf8869487a18c9fc5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/microstrain-inertial-msgs/default.nix
+++ b/distros/noetic/microstrain-inertial-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-microstrain-inertial-msgs";
-  version = "2.0.4-r1";
+  version = "2.0.5-r1";
 
   src = fetchurl {
-    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.0.4-1.tar.gz";
-    name = "2.0.4-1.tar.gz";
-    sha256 = "de3fbb346b055ef899ce4f46a1eb97c3e203fdde8733ca5ebd5d03313ed17e7c";
+    url = "https://github.com/LORD-MicroStrain/microstrain_inertial-release/archive/release/noetic/microstrain_inertial_msgs/2.0.5-1.tar.gz";
+    name = "2.0.5-1.tar.gz";
+    sha256 = "c5d476ee4f6aa3e4d9b5c59bc60028bc6d0da3c80b3f1efeea7238f3116f670c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people-msgs/default.nix
+++ b/distros/noetic/people-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-people-msgs";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "23c5aadea89b2d9eb9f8f5bc712313ef205a9db3844d47f25bfe5e167525b840";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_msgs/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "f043041d0eaa197f4f6a5774ce9439c20758f7b2bed809439f772faf1a29930c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people-velocity-tracker/default.nix
+++ b/distros/noetic/people-velocity-tracker/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, easy-markers, geometry-msgs, kalman-filter, leg-detector, people-msgs, roslaunch, roslib, roslint, rospy }:
 buildRosPackage {
   pname = "ros-noetic-people-velocity-tracker";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "e01129e7da9a70ca43d9612728c1f44677c8ab050f5af95dc246abbf4f3e64b7";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people_velocity_tracker/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "74f53f59f4d27e127b40e908bc6dddc8459ffd2799a54ee69331e136c77a34ed";
   };
 
   buildType = "catkin";

--- a/distros/noetic/people/default.nix
+++ b/distros/noetic/people/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, face-detector, leg-detector, people-msgs, people-tracking-filter, people-velocity-tracker }:
 buildRosPackage {
   pname = "ros-noetic-people";
-  version = "1.4.0-r1";
+  version = "1.4.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.0-1.tar.gz";
-    name = "1.4.0-1.tar.gz";
-    sha256 = "38081a790261ca2b7dc8a6ab0fed886eb53c401af72e5c805aa2c8388d96391c";
+    url = "https://github.com/OSUrobotics/people-release/archive/release/noetic/people/1.4.2-1.tar.gz";
+    name = "1.4.2-1.tar.gz";
+    sha256 = "d0a5fb8cdee62113702c3ee9b1174435999684165c08751c91afa57a7e107d8c";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-accelerometer/default.nix
+++ b/distros/noetic/phidgets-accelerometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-accelerometer";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "0f39ce926508512bcdfbb4bc5c3bb85bdae880926080b5e5e9e7cf7f00ce7233";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_accelerometer/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "9727a7b444899b9f7c2e0a5a24c4963e2bd6e21a582fe07876b90eca8e8c202f";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-inputs/default.nix
+++ b/distros/noetic/phidgets-analog-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-inputs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "493a5e7f5174e4db0b9065f656cdc41558e5b3b37166791136a2c3bf9ada628a";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_inputs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d2f570c460eda9d845679a2eac374c0cb3d5964a46015f50bd7cf08d236d3bcb";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-analog-outputs/default.nix
+++ b/distros/noetic/phidgets-analog-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-analog-outputs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "11fdb823ce48393ccd28ecf1eb3cc1dd8040bea571f39b0d87b5f269290aad92";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_analog_outputs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "7ed1418505107f24f34145f24f712f6eb56c287e5f68cf4e3ed23a331f0a11dd";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-api/default.nix
+++ b/distros/noetic/phidgets-api/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22 }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-api";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "875c61236a2d3d493d14ff125851c160c24f42deafcb02dc626304c04ae9499e";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_api/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "45071f52a6739e7cee0c90ba66d3c47d1fc99ef83b9c3bacd363c9fb0050e43a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-inputs/default.nix
+++ b/distros/noetic/phidgets-digital-inputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-inputs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "d0ba2bceea038f3405dcd7ccd7e6547d7a8ab98900b3e1f4d41b30f52a70a70e";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_inputs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "d4da941af4858e285196bd8775b01206e07e25f86bc117687d5a8dda4b96abd3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-digital-outputs/default.nix
+++ b/distros/noetic/phidgets-digital-outputs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-digital-outputs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "9cc2f5304a8ecb01e65d1c0edf70a559e078fecd34676549645add6ed3e7e349";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_digital_outputs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "4ea1d736ca2f3cea82a69813271f67efc6fef6ef1760675bdc88de153c8624aa";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-drivers/default.nix
+++ b/distros/noetic/phidgets-drivers/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, libphidget22, phidgets-accelerometer, phidgets-analog-inputs, phidgets-api, phidgets-digital-inputs, phidgets-digital-outputs, phidgets-gyroscope, phidgets-high-speed-encoder, phidgets-ik, phidgets-magnetometer, phidgets-motors, phidgets-msgs, phidgets-spatial, phidgets-temperature }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-drivers";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "89d9e577bb8b9c166834e7a5ba31eb421cbc1b7c7cb755eb7b1fa021610dcb1d";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_drivers/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "e4c35d6314101680fe8ae9e236b7dbd8da81047fb234db66dc6a70a5bc39f964";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-gyroscope/default.nix
+++ b/distros/noetic/phidgets-gyroscope/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-gyroscope";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "77a1630f1467cee9bf96e8b831c4e12e8d95f710d0edec78c1454ae3dd721c8e";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_gyroscope/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "a61696b21a19d3e04ca7c11168f03833ef8876e8325ab93bcb51a18c4d511777";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-high-speed-encoder/default.nix
+++ b/distros/noetic/phidgets-high-speed-encoder/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, pluginlib, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-high-speed-encoder";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "702c6a7dbd53bdeb546e068275f34368ada8c1f7ff8f27a34bc82b346b3d5554";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_high_speed_encoder/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "fea1d7fa183d9486db34c847d6c762752a12c35645e00894f20d4017036bd513";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-ik/default.nix
+++ b/distros/noetic/phidgets-ik/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-analog-inputs, phidgets-digital-inputs, phidgets-digital-outputs, roslaunch }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-ik";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "4499560825d29cae1009b8ba07db6141ddcfdc399c662301dbbb95f49645cc35";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_ik/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "07cc130db6cf7e60f0df08327aa5847e4abb7057c2233842c029458653c00b78";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-magnetometer/default.nix
+++ b/distros/noetic/phidgets-magnetometer/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-magnetometer";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "43a0a178a08520d45e0e228d78ebdb09660887ce8879c7047012f494a40b4e90";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_magnetometer/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "cce08918a421de2700306136c5444bf596ab035d8d1f328a7c9e313db1d94986";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-motors/default.nix
+++ b/distros/noetic/phidgets-motors/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, phidgets-msgs, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-motors";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "45b9abdf7d5dea528528d44d50062a1738da9356a620096c8fd5ce3595630e86";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_motors/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "1cfab052c00cd1b71db8140a92db6f667942b3952816740f2e40eb5ae36521d6";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-msgs/default.nix
+++ b/distros/noetic/phidgets-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-msgs";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "e8bf989729254c001671bd0a3bfecf8024d5c9184c147847745865a4fdcfe066";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_msgs/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "da4ac36447679992d0aec4c802fb33a8f5efb1d75af3b2a5d706d8e033b92014";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-spatial/default.nix
+++ b/distros/noetic/phidgets-spatial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, imu-filter-madgwick, nodelet, phidgets-api, pluginlib, roscpp, roslaunch, sensor-msgs, std-msgs, std-srvs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-spatial";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2c9ec42c52b8ef017867fac29d9b11c2888bdcf483176a420e3f60769f3e8a9c";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_spatial/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "17d87ddae46879a5dc801a4385a2581cc928f749870b6aa69ef0705edca948ef";
   };
 
   buildType = "catkin";

--- a/distros/noetic/phidgets-temperature/default.nix
+++ b/distros/noetic/phidgets-temperature/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, nodelet, phidgets-api, roscpp, roslaunch, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-phidgets-temperature";
-  version = "1.0.3-r1";
+  version = "1.0.4-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.3-1.tar.gz";
-    name = "1.0.3-1.tar.gz";
-    sha256 = "2d79450020d11642e3b0b7a4add3b9b2cb650f381f8501782421f127c3a25bd1";
+    url = "https://github.com/ros-drivers-gbp/phidgets_drivers-release/archive/release/noetic/phidgets_temperature/1.0.4-1.tar.gz";
+    name = "1.0.4-1.tar.gz";
+    sha256 = "313bda644a067e12605534832360fd4dcc324a1ee91e86f93882419e8d7220bc";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler-ros/default.nix
+++ b/distros/noetic/plotjuggler-ros/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, diagnostic-msgs, geometry-msgs, nav-msgs, plotjuggler, plotjuggler-msgs, qt5, rosbag-storage, roscpp, roscpp-serialization, sensor-msgs, tf, tf2-msgs, tf2-ros }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler-ros";
-  version = "1.5.0-r1";
+  version = "1.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.5.0-1.tar.gz";
-    name = "1.5.0-1.tar.gz";
-    sha256 = "3cf6215a67353ddfa11e9aa5a016d7d255364790f5b8f3dd0e3f0c462d59116c";
+    url = "https://github.com/PlotJuggler/plotjuggler-ros-plugins-release/archive/release/noetic/plotjuggler_ros/1.6.2-1.tar.gz";
+    name = "1.6.2-1.tar.gz";
+    sha256 = "ef49fc91f289756de5241a7c64a67b90762bc4b7d6c42a9eda9f5bc5f14dd6b7";
   };
 
   buildType = "catkin";

--- a/distros/noetic/plotjuggler/default.nix
+++ b/distros/noetic/plotjuggler/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, binutils, boost, catkin, cppzmq, qt5, roslib }:
 buildRosPackage {
   pname = "ros-noetic-plotjuggler";
-  version = "3.3.1-r1";
+  version = "3.3.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.1-1.tar.gz";
-    name = "3.3.1-1.tar.gz";
-    sha256 = "6f1df262098c0b07c1fd672cb732e96376530f46760ff0c44f774204f5a97bf5";
+    url = "https://github.com/facontidavide/plotjuggler-release/archive/release/noetic/plotjuggler/3.3.2-1.tar.gz";
+    name = "3.3.2-1.tar.gz";
+    sha256 = "3b7b7202186e8d6ef69c360a6ab8992fe9c4dffde89957e68cccfdfc8d8746b9";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rc-genicam-driver/default.nix
+++ b/distros/noetic/rc-genicam-driver/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, curl, diagnostic-updater, dynamic-reconfigure, geometry-msgs, image-transport, message-generation, message-runtime, nodelet, protobuf, rc-common-msgs, rc-genicam-api, roscpp, sensor-msgs, stereo-msgs, tf }:
 buildRosPackage {
   pname = "ros-noetic-rc-genicam-driver";
-  version = "0.6.1-r1";
+  version = "0.6.2-r1";
 
   src = fetchurl {
-    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.6.1-1.tar.gz";
-    name = "0.6.1-1.tar.gz";
-    sha256 = "e0dc37a674633294d6df15e21bd4b152830b25e9b1ac15e39d40f2c2ea6da670";
+    url = "https://github.com/roboception-gbp/rc_genicam_driver_ros-release/archive/release/noetic/rc_genicam_driver/0.6.2-1.tar.gz";
+    name = "0.6.2-1.tar.gz";
+    sha256 = "21cd16cab196500eec1db9999ffa2db433bba99cb7d7802a51d2f3cf6602753a";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-bus-manager/default.nix
+++ b/distros/noetic/rokubimini-bus-manager/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, bota-node, catkin, rokubimini }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-bus-manager";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.1-1/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-1.tar.gz";
-    sha256 = "4168fd039123557f655a441cf1be69d2af4e58667523fbbc3d50d2197e0f2ce5";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_bus_manager/0.6.1-2/bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_bus_manager-0.6.1-2.tar.gz";
+    sha256 = "14d90b2200315a19356acaaaa3af332783e845b93c41e9d7dd02ff8c4d45c02b";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-description/default.nix
+++ b/distros/noetic/rokubimini-description/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, sensor-msgs, std-msgs, xacro }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-description";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.1-1/bota_driver-release-release-noetic-rokubimini_description-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.1-1.tar.gz";
-    sha256 = "5e3c817e6ae03f7a9d6a26cc531432640bfaf47f7951ad83f0556c19b94e310e";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_description/0.6.1-2/bota_driver-release-release-noetic-rokubimini_description-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_description-0.6.1-2.tar.gz";
+    sha256 = "dd660bfd5bad54b0c7c76a041109fc63b3709c3490db1884b04e1d80ee6bf042";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-ethercat/default.nix
+++ b/distros/noetic/rokubimini-ethercat/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ethercat-grant, rokubimini, rokubimini-bus-manager, rokubimini-msgs, soem }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-ethercat";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.1-1/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-1.tar.gz";
-    sha256 = "5e7a046ebe1148a8d4d71639807d90e1307bd5aa5874cafdb0dd34933a5ec83d";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_ethercat/0.6.1-2/bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_ethercat-0.6.1-2.tar.gz";
+    sha256 = "f45d85861851179df943fb6dd0908004d15513782b1b8aaa51fcc35b7f188124";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-msgs/default.nix
+++ b/distros/noetic/rokubimini-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, sensor-msgs, std-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-msgs";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.1-1/bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-1.tar.gz";
-    sha256 = "72425590ddc6ded508477bc5fddabdaf13317dff11080d032dcba291ec728a75";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_msgs/0.6.1-2/bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_msgs-0.6.1-2.tar.gz";
+    sha256 = "c8910a1731b77ae3022d2d5fa117f5240b704094427c0d72e5a3921edd480b81";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini-serial/default.nix
+++ b/distros/noetic/rokubimini-serial/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, avrdude, catkin, rokubimini, rokubimini-bus-manager, rokubimini-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini-serial";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.1-1/bota_driver-release-release-noetic-rokubimini_serial-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.1-1.tar.gz";
-    sha256 = "6c45ce3bd8dc83e376091b34f0e1d5deefcb85057cb5dea0ba393ebfe4c9048e";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini_serial/0.6.1-2/bota_driver-release-release-noetic-rokubimini_serial-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini_serial-0.6.1-2.tar.gz";
+    sha256 = "4e4dcc7306c6f3e9e302009d1533eeb9d62bb85419f2af604c2f1fab95c4aca5";
   };
 
   buildType = "catkin";

--- a/distros/noetic/rokubimini/default.nix
+++ b/distros/noetic/rokubimini/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, eigen, geometry-msgs, gtest, roscpp, rosunit, sensor-msgs }:
 buildRosPackage {
   pname = "ros-noetic-rokubimini";
-  version = "0.6.1-r1";
+  version = "0.6.1-r2";
 
   src = fetchurl {
-    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.1-1/bota_driver-release-release-noetic-rokubimini-0.6.1-1.tar.gz";
-    name = "bota_driver-release-release-noetic-rokubimini-0.6.1-1.tar.gz";
-    sha256 = "deaa93a7ef78b1cdba89ea0a0e0738301697509ee6f213d94d0008de194341b2";
+    url = "https://gitlab.com/botasys/bota_driver-release/-/archive/release/noetic/rokubimini/0.6.1-2/bota_driver-release-release-noetic-rokubimini-0.6.1-2.tar.gz";
+    name = "bota_driver-release-release-noetic-rokubimini-0.6.1-2.tar.gz";
+    sha256 = "3fe0e1c467cb038b1a6294e5326c831797396b4cc1ccb2fe5b5db2540e9e8dd3";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
+++ b/distros/noetic/ros-industrial-cmake-boilerplate/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, clang, cmake, cppcheck, gtest, include-what-you-use, lcov }:
 buildRosPackage {
   pname = "ros-noetic-ros-industrial-cmake-boilerplate";
-  version = "0.2.11-r1";
+  version = "0.2.12-r1";
 
   src = fetchurl {
-    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.11-1.tar.gz";
-    name = "0.2.11-1.tar.gz";
-    sha256 = "4471935a9ef992e8830fc007517492889d9867367285d3bf542eb22156440178";
+    url = "https://github.com/ros-industrial-release/ros_industrial_cmake_boilerplate-release/archive/release/noetic/ros_industrial_cmake_boilerplate/0.2.12-1.tar.gz";
+    name = "0.2.12-1.tar.gz";
+    sha256 = "e5be9fe0af76ea66f796c769ff8a89f3e84e6f7b4da68a9a9e0fafd89dbf6c82";
   };
 
   buildType = "cmake";

--- a/distros/noetic/sbg-driver/default.nix
+++ b/distros/noetic/sbg-driver/default.nix
@@ -1,0 +1,25 @@
+
+# Copyright 2021 Open Source Robotics Foundation
+# Distributed under the terms of the BSD license
+
+{ lib, buildRosPackage, fetchurl, catkin, geometry-msgs, message-generation, message-runtime, nav-msgs, roscpp, sensor-msgs, std-msgs, std-srvs, tf2-geometry-msgs, tf2-msgs, tf2-ros }:
+buildRosPackage {
+  pname = "ros-noetic-sbg-driver";
+  version = "3.1.1-r7";
+
+  src = fetchurl {
+    url = "https://github.com/SBG-Systems/sbg_ros_driver-release/archive/release/noetic/sbg_driver/3.1.1-7.tar.gz";
+    name = "3.1.1-7.tar.gz";
+    sha256 = "4be93a16debf3e9d4a33389e9f9897a43200b94667b286a6a6dca1660de00514";
+  };
+
+  buildType = "catkin";
+  buildInputs = [ message-generation ];
+  propagatedBuildInputs = [ geometry-msgs message-runtime nav-msgs roscpp sensor-msgs std-msgs std-srvs tf2-geometry-msgs tf2-msgs tf2-ros ];
+  nativeBuildInputs = [ catkin ];
+
+  meta = {
+    description = ''ROS driver package for communication with the SBG navigation systems.'';
+    license = with lib.licenses; [ mit ];
+  };
+}

--- a/distros/noetic/ublox-gps/default.nix
+++ b/distros/noetic/ublox-gps/default.nix
@@ -2,19 +2,19 @@
 # Copyright 2021 Open Source Robotics Foundation
 # Distributed under the terms of the BSD license
 
-{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, tf, ublox-msgs, ublox-serialization }:
+{ lib, buildRosPackage, fetchurl, catkin, diagnostic-updater, roscpp, roscpp-serialization, rtcm-msgs, tf, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-gps";
-  version = "1.4.1-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_gps/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "9424ea29b192475b9fea1fedfc744e5affffda51020fe3c48e914d57d99b4b9e";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_gps/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "b71af92497d916723093c3d7b5d12427d6907df0b7615a0c4462922fe4090853";
   };
 
   buildType = "catkin";
-  propagatedBuildInputs = [ diagnostic-updater roscpp roscpp-serialization tf ublox-msgs ublox-serialization ];
+  propagatedBuildInputs = [ diagnostic-updater roscpp roscpp-serialization rtcm-msgs tf ublox-msgs ublox-serialization ];
   nativeBuildInputs = [ catkin ];
 
   meta = {

--- a/distros/noetic/ublox-msgs/default.nix
+++ b/distros/noetic/ublox-msgs/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, message-generation, message-runtime, sensor-msgs, std-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-msgs";
-  version = "1.4.1-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_msgs/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "1ad2f25900e26c8d672d2d87eda24d430a0b02bad9c10467309e0d38ce56f401";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_msgs/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "9fc88ab1605cd2996a97bcbe81ad844a8e8d51d4827f67d4c1ab0a72784d881d";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox-serialization/default.nix
+++ b/distros/noetic/ublox-serialization/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, roscpp, roscpp-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox-serialization";
-  version = "1.4.1-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_serialization/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "99b1445d71dce681e50a7d50580a74bf104e1c09a549d30b46f6e18e1e8146cb";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox_serialization/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "20074e162992ec6207586b72344c2ab8dab07cad30d63af6e705a25a8fb01378";
   };
 
   buildType = "catkin";

--- a/distros/noetic/ublox/default.nix
+++ b/distros/noetic/ublox/default.nix
@@ -5,12 +5,12 @@
 { lib, buildRosPackage, fetchurl, catkin, ublox-gps, ublox-msgs, ublox-serialization }:
 buildRosPackage {
   pname = "ros-noetic-ublox";
-  version = "1.4.1-r2";
+  version = "1.5.0-r1";
 
   src = fetchurl {
-    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox/1.4.1-2.tar.gz";
-    name = "1.4.1-2.tar.gz";
-    sha256 = "5a4fed44385f67d457cc2bc6d2cc352cc59efc83e646fe1238ffb2dfe6088953";
+    url = "https://github.com/KumarRobotics/ublox-release/archive/release/noetic/ublox/1.5.0-1.tar.gz";
+    name = "1.5.0-1.tar.gz";
+    sha256 = "264d5744cdc540b4320713806a0e33004b691071eeeb3d742ec49e0e4a1268e1";
   };
 
   buildType = "catkin";


### PR DESCRIPTION
Superflore Nix generator began regeneration of all packages  from ROS distro ['foxy', 'galactic', 'melodic', 'noetic'] from nix-ros-overlay commit 44fa801babccaa669f11ef774509c855a823d76d.
This pull request was generated by running the following command:

```
superflore-gen-nix --tar-archive-dir /home/runner/work/_temp/tar --output-repository-path . --upstream-branch staging --all
```

Changes:
========
Foxy Changes:
-------------
* *aws-robomaker-small-warehouse-world 1.0.1-r1 --> 1.0.1-r2*
* *fastrtps 2.0.2-r2 --> 2.1.1-r1*
* *geometry-tutorials 0.3.3-r1 --> 0.3.4-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *mppic 0.2.1-r2*
* *pal-statistics 2.0.0-r1*
* *pal-statistics-msgs 2.0.0-r1*
* *plotjuggler 3.3.1-r2 --> 3.3.2-r1*
* *plotjuggler-ros 1.6.1-r1 --> 1.6.2-r1*
* *pmb2-2dnav-gazebo 3.0.1-r1 --> 3.0.2-r1*
* *pmb2-bringup 4.0.2-r1 --> 4.0.4-r1*
* *pmb2-controller-configuration 4.0.2-r1 --> 4.0.4-r1*
* *pmb2-description 4.0.2-r1 --> 4.0.4-r1*
* *pmb2-gazebo 3.0.1-r1 --> 3.0.2-r1*
* *pmb2-robot 4.0.2-r1 --> 4.0.4-r1*
* *pmb2-simulation 3.0.1-r1 --> 3.0.2-r1*
* *rviz-assimp-vendor 8.2.4-r1 --> 8.2.5-r1*
* *rviz-common 8.2.4-r1 --> 8.2.5-r1*
* *rviz-default-plugins 8.2.4-r1 --> 8.2.5-r1*
* *rviz-ogre-vendor 8.2.4-r1 --> 8.2.5-r1*
* *rviz-rendering 8.2.4-r1 --> 8.2.5-r1*
* *rviz-rendering-tests 8.2.4-r1 --> 8.2.5-r1*
* *rviz-visual-testing-framework 8.2.4-r1 --> 8.2.5-r1*
* *rviz-visual-tools 4.0.1-r1 --> 4.0.2-r2*
* *rviz2 8.2.4-r1 --> 8.2.5-r1*
* *turtle-tf2-cpp 0.3.3-r1 --> 0.3.4-r1*
* *turtle-tf2-py 0.3.3-r1 --> 0.3.4-r1*
* *velodyne-description 2.0.1-r1*
* *velodyne-gazebo-plugins 2.0.1-r1*
* *velodyne-simulator 2.0.1-r1*
* *warehouse-ros-sqlite 1.0.2-r1*

Galactic Changes:
-----------------
* *dolly 0.4.0-r1*
* *dolly-follow 0.4.0-r1*
* *dolly-gazebo 0.4.0-r1*
* *dolly-ignition 0.4.0-r1*
* *geometry-tutorials 0.3.3-r1 --> 0.3.4-r1*
* *laser-filters 2.0.3-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *moveit 2.2.1-r1 --> 2.3.0-r1*
* *moveit-common 2.2.1-r1 --> 2.3.0-r1*
* *moveit-core 2.2.1-r1 --> 2.3.0-r1*
* *moveit-kinematics 2.2.1-r1 --> 2.3.0-r1*
* *moveit-planners 2.2.1-r1 --> 2.3.0-r1*
* *moveit-planners-ompl 2.2.1-r1 --> 2.3.0-r1*
* *moveit-plugins 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-benchmarks 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-control-interface 2.3.0-r1*
* *moveit-ros-move-group 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-occupancy-map-monitor 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-perception 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-planning 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-planning-interface 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-robot-interaction 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-visualization 2.2.1-r1 --> 2.3.0-r1*
* *moveit-ros-warehouse 2.2.1-r1 --> 2.3.0-r1*
* *moveit-runtime 2.2.1-r1 --> 2.3.0-r1*
* *moveit-servo 2.2.1-r1 --> 2.3.0-r1*
* *moveit-simple-controller-manager 2.2.1-r1 --> 2.3.0-r1*
* *moveit-visual-tools 4.0.0-r1*
* *pointcloud-to-laserscan 2.0.1-r2*
* *rosidl-generator-py 0.11.0-r2 --> 0.11.1-r1*
* *run-move-group 2.2.1-r1 --> 2.3.0-r1*
* *run-moveit-cpp 2.2.1-r1 --> 2.3.0-r1*
* *run-ompl-constrained-planning 2.2.1-r1 --> 2.3.0-r1*
* *rviz-visual-tools 4.1.0-r1 --> 4.1.1-r1*
* *sbg-driver 3.1.0-r1*
* *turtle-tf2-cpp 0.3.3-r1 --> 0.3.4-r1*
* *turtle-tf2-py 0.3.3-r1 --> 0.3.4-r1*
* *warehouse-ros-sqlite 1.0.2-r1*

Melodic Changes:
----------------
* *drone-assets 1.3.8-r1 --> 1.3.9-r1*
* *drone-wrapper 1.3.8-r1 --> 1.3.9-r1*
* *filters 1.8.1 --> 1.8.2-r1*
* *jderobot-drones 1.3.8-r1 --> 1.3.9-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *microstrain-inertial-driver 2.0.5-r1*
* *microstrain-inertial-examples 2.0.5-r1*
* *microstrain-inertial-msgs 2.0.5-r1*
* *qt-paramedit 1.0.1-r1*
* *rqt-drone-teleop 1.3.8-r1 --> 1.3.9-r1*
* *rqt-ground-robot-teleop 1.3.8-r1 --> 1.3.9-r1*
* *rqt-paramedit 1.0.1-r1*
* *tello-driver 1.3.9-r1*
* *ublox 1.4.1-r1 --> 1.5.0-r1*
* *ublox-gps 1.4.1-r1 --> 1.5.0-r1*
* *ublox-msgs 1.4.1-r1 --> 1.5.0-r1*
* *ublox-serialization 1.4.1-r1 --> 1.5.0-r1*
* *uos-common-urdf 1.0.0-r1 --> 1.0.1-r1*
* *uos-diffdrive-teleop 1.0.0-r1 --> 1.0.1-r1*
* *uos-freespace 1.0.0-r1 --> 1.0.1-r1*
* *uos-gazebo-worlds 1.0.0-r1 --> 1.0.1-r1*
* *uos-maps 1.0.0-r1 --> 1.0.1-r1*
* *uos-tools 1.0.0-r1 --> 1.0.1-r1*

Noetic Changes:
---------------
* *bota-driver 0.6.1-r1 --> 0.6.1-r2*
* *bota-driver-testing 0.6.1-r1 --> 0.6.1-r2*
* *bota-node 0.6.1-r1 --> 0.6.1-r2*
* *bota-signal-handler 0.6.1-r1 --> 0.6.1-r2*
* *bota-worker 0.6.1-r1 --> 0.6.1-r2*
* *face-detector 1.4.0-r1 --> 1.4.2-r1*
* *libphidget22 1.0.3-r1 --> 1.0.4-r1*
* *mavlink 2021.9.9-r1 --> 2021.10.10-r1*
* *microstrain-inertial-driver 2.0.4-r1 --> 2.0.5-r1*
* *microstrain-inertial-examples 2.0.4-r1 --> 2.0.5-r1*
* *microstrain-inertial-msgs 2.0.4-r1 --> 2.0.5-r1*
* *people 1.4.0-r1 --> 1.4.2-r1*
* *people-msgs 1.4.0-r1 --> 1.4.2-r1*
* *people-velocity-tracker 1.4.0-r1 --> 1.4.2-r1*
* *phidgets-accelerometer 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-analog-inputs 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-analog-outputs 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-api 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-digital-inputs 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-digital-outputs 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-drivers 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-gyroscope 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-high-speed-encoder 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-ik 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-magnetometer 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-motors 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-msgs 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-spatial 1.0.3-r1 --> 1.0.4-r1*
* *phidgets-temperature 1.0.3-r1 --> 1.0.4-r1*
* *plotjuggler 3.3.1-r1 --> 3.3.2-r1*
* *plotjuggler-ros 1.5.0-r1 --> 1.6.2-r1*
* *rc-genicam-driver 0.6.1-r1 --> 0.6.2-r1*
* *rokubimini 0.6.1-r1 --> 0.6.1-r2*
* *rokubimini-bus-manager 0.6.1-r1 --> 0.6.1-r2*
* *rokubimini-description 0.6.1-r1 --> 0.6.1-r2*
* *rokubimini-ethercat 0.6.1-r1 --> 0.6.1-r2*
* *rokubimini-msgs 0.6.1-r1 --> 0.6.1-r2*
* *rokubimini-serial 0.6.1-r1 --> 0.6.1-r2*
* *ros-industrial-cmake-boilerplate 0.2.11-r1 --> 0.2.12-r1*
* *sbg-driver 3.1.1-r7*
* *ublox 1.4.1-r2 --> 1.5.0-r1*
* *ublox-gps 1.4.1-r2 --> 1.5.0-r1*
* *ublox-msgs 1.4.1-r2 --> 1.5.0-r1*
* *ublox-serialization 1.4.1-r2 --> 1.5.0-r1*


Missing Dependencies:
=====================
 * [ ] ament_python
 * [ ] atlas
 * [ ] bullet-extras
 * [ ] coinor-libcbc-dev
 * [ ] coinor-libcgl-dev
 * [ ] coinor-libclp-dev
 * [ ] coinor-libcoinutils-dev
 * [ ] coinor-libipopt-dev
 * [ ] collada-dom
 * [ ] epydoc
 * [ ] festival
 * [ ] gcc-avr
 * [ ] gurumdds-2.7
 * [ ] ignition-common4
 * [ ] ignition-edifice
 * [ ] ignition-gazebo3
 * [ ] ignition-gazebo5
 * [ ] ignition-gui5
 * [ ] ignition-msgs7
 * [ ] ignition-rendering5
 * [ ] ignition-transport10
 * [ ] julius-voxforge
 * [ ] jupyter-notebook
 * [ ] libcoin80-dev
 * [ ] libftdipp-dev
 * [ ] liblcm
 * [ ] liblcm-dev
 * [ ] libmongoclient-dev
 * [ ] libopenni-dev
 * [ ] liborocos-bfl
 * [ ] liborocos-bfl-dev
 * [ ] libxxf86vm
 * [ ] mapnik-utils
 * [ ] ml_classifiers
 * [ ] nlopt
 * [ ] ocl-icd-opencl-dev
 * [ ] openni_launch
 * [ ] postgresql-postgis
 * [ ] ps3joy
 * [ ] pydrive-pip
 * [ ] pyqt5-dev-tools
 * [ ] python-catkin-lint
 * [ ] python-catkin-tools
 * [ ] python-chainercv-pip
 * [ ] python-cwiid
 * [ ] python-dialogflow-pip
 * [ ] python-fcn-pip
 * [ ] python-gdown-pip
 * [ ] python-google-cloud-texttospeech-pip
 * [ ] python-libpgm-pip
 * [ ] python-mapnik
 * [ ] python-omniorb
 * [ ] python-pcapy
 * [ ] python-pixel-ring-pip
 * [ ] python-pyassimp
 * [ ] python-pygithub3
 * [ ] python-qt5-bindings-qsci
 * [ ] python-requests-oauthlib
 * [ ] python-slacker-cli
 * [ ] python-speechrecognition-pip
 * [ ] python3-babeltrace
 * [ ] python3-catkin-lint
 * [ ] python3-catkin-tools
 * [ ] python3-flask-cors
 * [ ] python3-ifcfg
 * [ ] python3-lttng
 * [ ] python3-nose-yanc
 * [ ] python3-pyassimp
 * [ ] python3-websocket
 * [ ] qb_device_gazebo
 * [ ] qb_device_hardware_interface
 * [ ] roseus
 * [ ] rviz
 * [ ] wiimote

